### PR TITLE
PHPLIB-153: Add Database::command() helper

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -136,6 +136,31 @@ class Database
     }
 
     /**
+     * This is the method to issue database commands.
+     *
+     * @param array|object $command A database command to send
+     * @param ReadPreference|null $readPreference Default read preference to apply
+     * @return Cursor
+     */
+    public function executeCommand($command, ReadPreference $readPreference = null)
+    {
+        if ( ! is_array($command) && ! is_object($command)) {
+            throw new InvalidArgumentTypeException('"command" parameter', $command, 'array or object');
+        }
+
+        if ( ! $command instanceof Command) {
+            $command = new Command($command);
+        }
+
+        if ( ! isset($readPreference)) {
+            $readPreference = $this->readPreference;
+        }
+
+        $server = $this->manager->selectServer($readPreference);
+        return $server->executeCommand($this->databaseName, $command);
+    }
+
+    /**
      * Returns the database name.
      *
      * @return string

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -6,6 +6,7 @@ use MongoDB\Database;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
+use MongoDB\Driver\Command;
 
 /**
  * Functional tests for the Database class.
@@ -75,6 +76,19 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $commandResult = $this->database->drop();
         $this->assertCommandSucceeded($commandResult);
         $this->assertCollectionCount($this->getNamespace(), 0);
+    }
+
+    public function testCommand()
+    {
+        $command = new Command(['isMaster' => 1]);
+        $readPreference = new ReadPreference(ReadPreference::RP_PRIMARY);
+        $cursor = $this->database->executeCommand($command, $readPreference);
+        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);
+        $document = current($cursor->toArray());
+        $this->assertCommandSucceeded($document);
+        $this->assertArrayHasKey('ismaster', $document);
+        $this->assertTrue($document['ismaster']);
     }
 
     public function testSelectCollectionInheritsReadPreferenceAndWriteConcern()

--- a/tests/Database/FunctionalTestCase.php
+++ b/tests/Database/FunctionalTestCase.php
@@ -10,6 +10,9 @@ use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
+    /**
+     * @var $database Database
+     */
     protected $database;
 
     public function setUp()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-153

----

Add method to issue database commands. According to legacy PHP driver. http://php.net/manual/ru/mongodb.command.php

I did not find any contribution conditions. Please let me know if I need to create seperate branches for this.