### PR TITLE
PHPLIB-151: Use IPv4 localhost address for default URI

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -28,7 +28,7 @@ class Client
      * @param array  $options       Additional connection string options
      * @param array  $driverOptions Driver-specific options
      */
-    public function __construct($uri = 'mongodb://localhost:27017', array $options = [], array $driverOptions = [])
+    public function __construct($uri = 'mongodb://127.0.0.1:27017', array $options = [], array $driverOptions = [])
     {
         $this->manager = new Manager($uri, $options, $driverOptions);
         $this->uri = (string) $uri;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -15,7 +15,7 @@ class ClientTest extends TestCase
     {
         $client = new Client();
 
-        $this->assertEquals('mongodb://localhost:27017', (string) $client);
+        $this->assertEquals('mongodb://127.0.0.1:27017', (string) $client);
     }
 
     public function testToString()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-151

This should help avoid failed IPv6 connections when "localhost" resolves to an IPv6 literal and mongod does not have `net.ipv6}} enabled to listen for IPv6.