### PR TITLE
BSONDocument should allow property access by default

### DIFF
--- a/src/Model/BSONDocument.php
+++ b/src/Model/BSONDocument.php
@@ -17,6 +17,19 @@ use ArrayObject;
 class BSONDocument extends ArrayObject implements Serializable, Unserializable
 {
     /**
+     * Constructor.
+     *
+     * This overrides the parent constructor to allow property access of entries
+     * by default.
+     *
+     * @see http://php.net/arrayobject.construct
+     */
+    public function __construct($input = [], $flags = ArrayObject::ARRAY_AS_PROPS, $iterator_class = 'ArrayIterator')
+    {
+        parent::__construct($input, $flags, $iterator_class);
+    }
+
+    /**
      * Serialize the document to BSON.
      *
      * @see http://php.net/mongodb-bson-serializable.bsonserialize
@@ -35,6 +48,6 @@ class BSONDocument extends ArrayObject implements Serializable, Unserializable
      */
     public function bsonUnserialize(array $data)
     {
-        self::__construct($data, ArrayObject::ARRAY_AS_PROPS);
+        parent::__construct($data, ArrayObject::ARRAY_AS_PROPS);
     }
 }

--- a/tests/Model/BSONArrayTest.php
+++ b/tests/Model/BSONArrayTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MongoDB\Tests;
+
+use MongoDB\Model\BSONArray;
+
+class BSONArrayTest extends TestCase
+{
+    public function testBsonSerializeReindexesKeys()
+    {
+        $data = [0 => 'foo', 2 => 'bar'];
+
+        $array = new BSONArray($data);
+        $this->assertSame($data, $array->getArrayCopy());
+        $this->assertSame(['foo', 'bar'], $array->bsonSerialize());
+    }
+}

--- a/tests/Model/BSONDocumentTest.php
+++ b/tests/Model/BSONDocumentTest.php
@@ -7,6 +7,13 @@ use ArrayObject;
 
 class BSONDocumentTest extends TestCase
 {
+    public function testConstructorDefaultsToPropertyAccess()
+    {
+        $document = new BSONDocument(['foo' => 'bar']);
+        $this->assertEquals(ArrayObject::ARRAY_AS_PROPS, $document->getFlags());
+        $this->assertSame('bar', $document->foo);
+    }
+
     public function testBsonSerializeCastsToObject()
     {
         $data = [0 => 'foo', 2 => 'bar'];

--- a/tests/Model/BSONDocumentTest.php
+++ b/tests/Model/BSONDocumentTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MongoDB\Tests;
+
+use MongoDB\Model\BSONDocument;
+use ArrayObject;
+
+class BSONDocumentTest extends TestCase
+{
+    public function testBsonSerializeCastsToObject()
+    {
+        $data = [0 => 'foo', 2 => 'bar'];
+
+        $document = new BSONDocument($data);
+        $this->assertSame($data, $document->getArrayCopy());
+        $this->assertEquals((object) [0 => 'foo', 2 => 'bar'], $document->bsonSerialize());
+    }
+}


### PR DESCRIPTION
This was previously done during unserialization, but not the constructor.