### PR TITLE
Don't apply typeMap if useCursor is false

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -179,7 +179,7 @@ class Collection
             $options['readPreference'] = new ReadPreference(ReadPreference::RP_PRIMARY);
         }
 
-        if ( ! isset($options['typeMap'])) {
+        if ( ! isset($options['typeMap']) && (! isset($options['useCursor']) || $options['useCursor'])) {
             $options['typeMap'] = $this->typeMap;
         }
 

--- a/tests/Collection/CrudSpec/AggregateFunctionalTest.php
+++ b/tests/Collection/CrudSpec/AggregateFunctionalTest.php
@@ -71,4 +71,25 @@ class AggregateFunctionalTest extends FunctionalTestCase
         $operation = new DropCollection($this->getDatabaseName(), $outputCollection->getCollectionName());
         $operation->execute($this->getPrimaryServer());
     }
+
+    public function testAggregateWithoutCursorDoesNotApplyTypemap()
+    {
+        $pipeline = [
+            ['$group' => [
+                '_id' => null,
+                'count' => ['$sum' => 1]
+            ]]
+        ];
+        $options = ['useCursor' => false];
+        $result = $this->collection->aggregate($pipeline, $options);
+
+        $expected = [
+            [
+                '_id' => null,
+                'count' => 3,
+            ],
+        ];
+
+        $this->assertSameDocuments($expected, $result);
+    }
 }


### PR DESCRIPTION
This fixes an issue where it's not possible to run an aggregation pipeline with `useCursor = false` when a global `typeMap` has been set.