### PR TITLE
fixed $maxTimeMS and $comments in Find query

### DIFF
--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -218,11 +218,11 @@ class Find implements Executable
         $modifiers = empty($this->options['modifiers']) ? [] : (array) $this->options['modifiers'];
 
         if (isset($this->options['comment'])) {
-            $modifiers['$comment'] = $options['comment'];
+            $modifiers['$comment'] = $this->options['comment'];
         }
 
         if (isset($this->options['maxTimeMS'])) {
-            $modifiers['$maxTimeMS'] = $options['maxTimeMS'];
+            $modifiers['$maxTimeMS'] = $this->options['maxTimeMS'];
         }
 
         if ( ! empty($modifiers)) {


### PR DESCRIPTION
The values get set to null, which is causing exceptions within the driver because the timeout is not a number.  Currently working around it by explicitly setting the modifiers with $maxTimeMS.