### PR TITLE
Fixed error when filename is not specified when reading file

### DIFF
--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -354,7 +354,7 @@ class Bucket
 
         $context = stream_context_create(['gridfs' => $options]);
 
-        return fopen(sprintf('gridfs://%s/%s', $this->databaseName, $file->filename), 'r', false, $context);
+        return fopen(sprintf('gridfs://%s/%s', $this->databaseName, isset($file->filename) ? $file->filename : ''), 'r', false, $context);
     }
 
     private function registerStreamWrapper(Manager $manager)


### PR DESCRIPTION
When trying to read file with GridFS\Bucket::openDownloadStream() sub-method openDownloadStreamByFile() is directly accessing $file->filename property which is (according to https://docs.mongodb.org/manual/core/gridfs/#gridfs-collections) optional and is not needed for reading files from GridFS. This PR will fix error notice when this property is not set.