### PR TITLE
Add accessor for gridFS buckets in database class

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -9,6 +9,7 @@ use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\GridFS\Bucket;
 use MongoDB\Model\CollectionInfoIterator;
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\DatabaseCommand;
@@ -260,6 +261,26 @@ class Database
         ];
 
         return new Collection($this->manager, $this->databaseName, $collectionName, $options);
+    }
+
+    /**
+     * Select a GridFS bucket within this database.
+     *
+     * @see Bucket::__construct() for supported options
+     * @param string $bucketName Name of the bucket to select (defaults to 'fs')
+     * @param array  $options    Bucket constructor options
+     * @return Bucket
+     */
+    public function selectGridFSBucket($bucketName = 'fs', array $options = [])
+    {
+        $options += [
+            'bucketName' => $bucketName,
+            'readConcern' => $this->readConcern,
+            'readPreference' => $this->readPreference,
+            'writeConcern' => $this->writeConcern,
+        ];
+
+        return new Bucket($this->manager, $this->databaseName, $options);
     }
 
     /**


### PR DESCRIPTION
Similar to `Database::selectCollection`, the new `selectGridFSBucket` method returns a `MongoDB\GridFS\Bucket` instance with the correct options set. Instantiating this class directly isn't feasible since the manager isn't exposed in the `MongoDB\Client` class.

A note about tests: I was going to add functional tests similar to those for `selectCollection` but can't really test anything since neither the `Bucket` class nor the `CollectionWrapper` store their options, instead relying on the `Collection` objects for the files and chunks collection to store these properly. I wasn't sure about exposing those objects in a `__debugInfo` method, so I decided to leave them out and let you guys decide how to best deal with it.