### PR TITLE
adds a link to the generated API reference to the toc

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -70,5 +70,6 @@ this documentation:
       /tutorial
       /upgrade
       /reference
+      API <http://mongodb.github.io/mongo-php-library/api/>
 
 .. /getting-started


### PR DESCRIPTION
This is consistent with the other drivers tables of contents 😺 