### PR TITLE
PHPLIB-215: Accessor method for GridFS stream file document

### DIFF
--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -21,8 +21,8 @@ class ReadableStream
     private $chunkOffset = 0;
     private $chunksIterator;
     private $collectionWrapper;
+    private $file;
     private $firstCheck = true;
-    private $id;
     private $iteratorEmpty = false;
     private $length;
     private $numChunks;
@@ -44,15 +44,15 @@ class ReadableStream
             throw new CorruptFileException('file.length is not an integer > 0');
         }
 
-        if ( ! isset($file->_id) && ! array_key_exists('_id', (array) $file)) {
+        if ( ! isset($file->_id) && ! property_exists($file, '_id')) {
             throw new CorruptFileException('file._id does not exist');
         }
 
-        $this->id = $file->_id;
+        $this->file = $file;
         $this->chunkSize = $file->chunkSize;
         $this->length = $file->length;
 
-        $this->chunksIterator = $collectionWrapper->getChunksIteratorByFilesId($this->id);
+        $this->chunksIterator = $collectionWrapper->getChunksIteratorByFilesId($file->_id);
         $this->collectionWrapper = $collectionWrapper;
         $this->numChunks = ceil($this->length / $this->chunkSize);
         $this->initEmptyBuffer();
@@ -69,9 +69,7 @@ class ReadableStream
         return [
             'bucketName' => $this->collectionWrapper->getBucketName(),
             'databaseName' => $this->collectionWrapper->getDatabaseName(),
-            'id' => $this->id,
-            'chunkSize' => $this->chunkSize,
-            'length' => $this->length,
+            'file' => $this->file,
         ];
     }
 
@@ -130,13 +128,13 @@ class ReadableStream
     }
 
     /**
-     * Return the stream's ID (i.e. file document identifier).
+     * Return the stream's file document.
      *
-     * @return integer
+     * @return stdClass
      */
-    public function getId()
+    public function getFile()
     {
-        return $this->id;
+        return $this->file;
     }
 
     /**

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -22,9 +22,14 @@ class StreamWrapper
     private $protocol;
     private $stream;
 
-    public function getId()
+    /**
+     * Return the stream's file document.
+     *
+     * @return stdClass
+     */
+    public function getFile()
     {
-        return $this->stream->getId();
+        return $this->stream->getFile();
     }
 
     /**

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -127,13 +127,13 @@ class WritableStream
     }
 
     /**
-     * Return the stream's ID (i.e. file document identifier).
+     * Return the stream's file document.
      *
-     * @return integer
+     * @return stdClass
      */
-    public function getId()
+    public function getFile()
     {
-        return $this->file['_id'];
+        return (object) $this->file;
     }
 
     /**

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -62,7 +62,7 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
         $stream->close();
 
         $fileDocument = $this->filesCollection->findOne(
-            ['_id' => $stream->getId()],
+            ['_id' => $stream->getFile()->_id],
             ['projection' => ['md5' => 1, '_id' => 0]]
         );
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-215

This adds Bucket::getFileDocumentForStream() and Bucket::getFileIdForStream() methods, the latter of which was renamed from getIdFromStream().

Additionally, this replaces the getId() method in both internal stream classes with a getFile() method. The debug output for ReadableStream has also been simplified to include the entire file document instead of ID, chunkSize, and length.