### PR TITLE
Import CorruptFileException in GridFS\Bucket

### DIFF
--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -9,6 +9,7 @@ use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\GridFS\Exception\CorruptFileException;
 use MongoDB\GridFS\Exception\FileNotFoundException;
 use MongoDB\Operation\Find;
 use stdClass;


### PR DESCRIPTION
The method `\MongoDB\GridFS\Bucket::getFileIdForStream()` could be throw `MongoDB\GridFS\Exception\CorruptFileException`, but the exception is not imported.