### PR TITLE
all the unused "use" have been removed

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB;
 
-use MongoDB\Collection;
 use MongoDB\Driver\Cursor;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadConcern;

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -11,7 +11,6 @@ use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\Exception\CorruptFileException;
 use MongoDB\GridFS\Exception\FileNotFoundException;
-use MongoDB\Operation\Find;
 use stdClass;
 
 /**

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Command;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Command;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Command;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 

--- a/tests/Collection/CrudSpec/FindOneAndReplaceFunctionalTest.php
+++ b/tests/Collection/CrudSpec/FindOneAndReplaceFunctionalTest.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Tests\Collection\CrudSpec;
 
-use MongoDB\Collection;
 use MongoDB\Operation\FindOneAndReplace;
 
 /**

--- a/tests/Collection/CrudSpec/FindOneAndUpdateFunctionalTest.php
+++ b/tests/Collection/CrudSpec/FindOneAndUpdateFunctionalTest.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Tests\Collection\CrudSpec;
 
-use MongoDB\Collection;
 use MongoDB\Operation\FindOneAndUpdate;
 
 /**

--- a/tests/Operation/DropIndexesFunctionalTest.php
+++ b/tests/Operation/DropIndexesFunctionalTest.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\DropIndexes;
 use MongoDB\Operation\ListIndexes;

--- a/tests/Operation/ListCollectionsFunctionalTest.php
+++ b/tests/Operation/ListCollectionsFunctionalTest.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\Driver\Server;
 use MongoDB\Operation\DropDatabase;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\ListCollections;


### PR DESCRIPTION
Found and removed all unused "use" as  the second step of last pull request (from both src and tests folders).
Now there should be no more unused "use".