### PR TITLE
PHPLIB-186: Implement Manager accessors for core classes

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -91,6 +91,16 @@ class Client
     }
 
     /**
+     * Return the manager.
+     *
+     * @return Manager
+     */
+    public function getManager()
+    {
+        return $this->manager;
+    }
+
+    /**
      * Return the connection string (i.e. URI).
      *
      * @return string

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -557,6 +557,16 @@ class Collection
     }
 
     /**
+     * Return the manager.
+     *
+     * @return Manager
+     */
+    public function getManager()
+    {
+        return $this->manager;
+    }
+
+    /**
      * Return the collection name.
      *
      * @return string

--- a/src/Database.php
+++ b/src/Database.php
@@ -219,6 +219,16 @@ class Database
     }
 
     /**
+     * Return the manager.
+     *
+     * @return Manager
+     */
+    public function getManager()
+    {
+        return $this->manager;
+    }
+
+    /**
      * Returns the database name.
      *
      * @return string


### PR DESCRIPTION
Could be useful to get the manager from the Database class to instantiate the Collection class with the same manager. Example : 

```php
<?php

namespace App\Users;

use MongoDB;

class Users extends MongoDB\Collection
{

	//Get the Database class from the dependency injection engine (just for the example)
	public function __construct(MongoDB\Database $mongoDB)
	{
		parent::construct(
			$mongoDB->getManager(),
			$mongoDB->getDatabaseName(),
			"users"
		);
	}

	//Can now decorate the collection with specific methods :)

}
``` 