### PR TITLE
PHPLIB-205: Support providing collation per operation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,15 @@ env:
     - MONGO_REPO_TYPE="precise/mongodb-enterprise/"
     - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
   matrix:
-    - DRIVER_VERSION=stable SERVER_VERSION=2.6
-    - DRIVER_VERSION=stable SERVER_VERSION=3.0
-    - DRIVER_VERSION=stable SERVER_VERSION=3.2
+    - DRIVER_VERSION=1.2.0alpha3 SERVER_VERSION=2.6
+    - DRIVER_VERSION=1.2.0alpha3 SERVER_VERSION=3.0
+    - DRIVER_VERSION=1.2.0alpha3 SERVER_VERSION=3.2
 
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: DRIVER_VERSION=1.1.0 SERVER_VERSION=3.2
     - php: 7.0
-      env: DRIVER_VERSION=stable SERVER_VERSION=2.4
+      env: DRIVER_VERSION=1.2.0alpha3 SERVER_VERSION=2.4
     - php: 7.0
       env: DRIVER_VERSION=devel SERVER_VERSION=3.2
   exclude:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "ext-mongodb": "^1.1.0"
+        "ext-mongodb": "^1.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/src/Exception/UnsupportedException.php
+++ b/src/Exception/UnsupportedException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace MongoDB\Exception;
+
+class UnsupportedException extends RuntimeException implements Exception
+{
+    /**
+     * Thrown when collations are not supported by a server.
+     *
+     * @return self
+     */
+    public static function collationNotSupported()
+    {
+        return new static('Collations are not supported by the server executing this operation');
+    }
+}

--- a/src/Operation/DeleteMany.php
+++ b/src/Operation/DeleteMany.php
@@ -5,6 +5,7 @@ namespace MongoDB\Operation;
 use MongoDB\DeleteResult;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for deleting multiple document with the delete command.
@@ -21,6 +22,11 @@ class DeleteMany implements Executable
      * Constructs a delete command.
      *
      * Supported options:
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
      *
@@ -41,6 +47,7 @@ class DeleteMany implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return DeleteResult
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/src/Operation/DeleteOne.php
+++ b/src/Operation/DeleteOne.php
@@ -5,6 +5,7 @@ namespace MongoDB\Operation;
 use MongoDB\DeleteResult;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for deleting a single document with the delete command.
@@ -21,6 +22,11 @@ class DeleteOne implements Executable
      * Constructs a delete command.
      *
      * Supported options:
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
      *
@@ -41,6 +47,7 @@ class DeleteOne implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return DeleteResult
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -4,6 +4,7 @@ namespace MongoDB\Operation;
 
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for finding a single document with the find command.
@@ -22,6 +23,11 @@ class FindOne implements Executable
      * Constructs a find command for finding a single document.
      *
      * Supported options:
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * comment (string): Attaches a comment to the query. If "$comment" also
      *    exists in the modifiers document, this option will take precedence.
@@ -75,6 +81,7 @@ class FindOne implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return array|object|null
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -4,6 +4,7 @@ namespace MongoDB\Operation;
 
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for deleting a document with the findAndModify command.
@@ -20,6 +21,11 @@ class FindOneAndDelete implements Executable
      * Constructs a findAndModify command for deleting a document.
      *
      * Supported options:
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * maxTimeMS (integer): The maximum amount of time to allow the query to
      *    run.
@@ -68,6 +74,7 @@ class FindOneAndDelete implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return object|null
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -4,6 +4,7 @@ namespace MongoDB\Operation;
 
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for replacing a document with the findAndModify command.
@@ -26,6 +27,11 @@ class FindOneAndReplace implements Executable
      *
      *  * bypassDocumentValidation (boolean): If true, allows the write to opt
      *    out of document level validation.
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * maxTimeMS (integer): The maximum amount of time to allow the query to
      *    run.
@@ -108,6 +114,7 @@ class FindOneAndReplace implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return object|null
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -4,6 +4,7 @@ namespace MongoDB\Operation;
 
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for updating a document with the findAndModify command.
@@ -26,6 +27,11 @@ class FindOneAndUpdate implements Executable
      *
      *  * bypassDocumentValidation (boolean): If true, allows the write to opt
      *    out of document level validation.
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * maxTimeMS (integer): The maximum amount of time to allow the query to
      *    run.
@@ -108,6 +114,7 @@ class FindOneAndUpdate implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return object|null
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -5,6 +5,7 @@ namespace MongoDB\Operation;
 use MongoDB\UpdateResult;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for replacing a single document with the update command.
@@ -24,6 +25,11 @@ class ReplaceOne implements Executable
      *
      *  * bypassDocumentValidation (boolean): If true, allows the write to opt
      *    out of document level validation.
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * upsert (boolean): When true, a new document is created if no document
      *    matches the query. The default is false.
@@ -62,6 +68,7 @@ class ReplaceOne implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return UpdateResult
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -5,6 +5,7 @@ namespace MongoDB\Operation;
 use MongoDB\UpdateResult;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for updating multiple documents with the update command.
@@ -24,6 +25,11 @@ class UpdateMany implements Executable
      *
      *  * bypassDocumentValidation (boolean): If true, allows the write to opt
      *    out of document level validation.
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * upsert (boolean): When true, a new document is created if no document
      *    matches the query. The default is false.
@@ -62,6 +68,7 @@ class UpdateMany implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return UpdateResult
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -5,6 +5,7 @@ namespace MongoDB\Operation;
 use MongoDB\UpdateResult;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 
 /**
  * Operation for updating a single document with the update command.
@@ -24,6 +25,11 @@ class UpdateOne implements Executable
      *
      *  * bypassDocumentValidation (boolean): If true, allows the write to opt
      *    out of document level validation.
+     *
+     *  * collation (document): Collation specification.
+     *
+     *    This is not supported for server versions < 3.4 and will result in an
+     *    exception at execution time if used.
      *
      *  * upsert (boolean): When true, a new document is created if no document
      *    matches the query. The default is false.
@@ -62,6 +68,7 @@ class UpdateOne implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return UpdateResult
+     * @throws UnsupportedException if collation is used and unsupported
      */
     public function execute(Server $server)
     {

--- a/tests/Operation/AggregateTest.php
+++ b/tests/Operation/AggregateTest.php
@@ -49,6 +49,10 @@ class AggregateTest extends TestCase
             $options[][] = ['bypassDocumentValidation' => $value];
         }
 
+        foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['collation' => $value];
+        }
+
         foreach ($this->getInvalidIntegerValues() as $value) {
             $options[][] = ['maxTimeMS' => $value];
         }

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -99,6 +99,23 @@ class BulkWriteTest extends TestCase
 
     /**
      * @expectedException MongoDB\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Expected \$operations\[0\]\["deleteMany"\]\[1\]\["collation"\] to have type "array or object" but found "[\w ]+"/
+     * @dataProvider provideInvalidDocumentValues
+     */
+    public function testDeleteManyCollationOptionTypeCheck($collation)
+    {
+        new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
+            [BulkWrite::DELETE_MANY => [['x' => 1], ['collation' => $collation]]],
+        ]);
+    }
+
+    public function provideInvalidDocumentValues()
+    {
+        return $this->wrapValuesForDataProvider($this->getInvalidDocumentValues());
+    }
+
+    /**
+     * @expectedException MongoDB\Exception\InvalidArgumentException
      * @expectedExceptionMessage Missing first argument for $operations[0]["deleteOne"]
      */
     public function testDeleteOneFilterArgumentMissing()
@@ -117,6 +134,18 @@ class BulkWriteTest extends TestCase
     {
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_ONE => [$document]],
+        ]);
+    }
+
+    /**
+     * @expectedException MongoDB\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Expected \$operations\[0\]\["deleteOne"\]\[1\]\["collation"\] to have type "array or object" but found "[\w ]+"/
+     * @dataProvider provideInvalidDocumentValues
+     */
+    public function testDeleteOneCollationOptionTypeCheck($collation)
+    {
+        new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
+            [BulkWrite::DELETE_ONE => [['x' => 1], ['collation' => $collation]]],
         ]);
     }
 
@@ -179,6 +208,18 @@ class BulkWriteTest extends TestCase
 
     /**
      * @expectedException MongoDB\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Expected \$operations\[0\]\["replaceOne"\]\[2\]\["collation"\] to have type "array or object" but found "[\w ]+"/
+     * @dataProvider provideInvalidDocumentValues
+     */
+    public function testReplaceOneCollationOptionTypeCheck($collation)
+    {
+        new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
+            [BulkWrite::REPLACE_ONE => [['x' => 1], ['y' => 1], ['collation' => $collation]]],
+        ]);
+    }
+
+    /**
+     * @expectedException MongoDB\Exception\InvalidArgumentException
      * @expectedExceptionMessageRegExp /Expected \$operations\[0\]\["replaceOne"\]\[2\]\["upsert"\] to have type "boolean" but found "[\w ]+"/
      * @dataProvider provideInvalidBooleanValues
      */
@@ -187,6 +228,11 @@ class BulkWriteTest extends TestCase
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [['x' => 1], ['y' => 1], ['upsert' => $upsert]]],
         ]);
+    }
+
+    public function provideInvalidBooleanValues()
+    {
+        return $this->wrapValuesForDataProvider($this->getInvalidBooleanValues());
     }
 
     /**
@@ -243,6 +289,18 @@ class BulkWriteTest extends TestCase
     {
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [['_id' => ['$gt' => 1]], ['x' => 1]]],
+        ]);
+    }
+
+    /**
+     * @expectedException MongoDB\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Expected \$operations\[0\]\["updateMany"\]\[2\]\["collation"\] to have type "array or object" but found "[\w ]+"/
+     * @dataProvider provideInvalidDocumentValues
+     */
+    public function testUpdateManyCollationOptionTypeCheck($collation)
+    {
+        new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
+            [BulkWrite::UPDATE_MANY => [['x' => 1], ['$set' => ['x' => 1]], ['collation' => $collation]]],
         ]);
     }
 
@@ -317,6 +375,18 @@ class BulkWriteTest extends TestCase
 
     /**
      * @expectedException MongoDB\Exception\InvalidArgumentException
+     * @expectedExceptionMessageRegExp /Expected \$operations\[0\]\["updateOne"\]\[2\]\["collation"\] to have type "array or object" but found "[\w ]+"/
+     * @dataProvider provideInvalidDocumentValues
+     */
+    public function testUpdateOneCollationOptionTypeCheck($collation)
+    {
+        new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
+            [BulkWrite::UPDATE_ONE => [['x' => 1], ['$set' => ['x' => 1]], ['collation' => $collation]]],
+        ]);
+    }
+
+    /**
+     * @expectedException MongoDB\Exception\InvalidArgumentException
      * @expectedExceptionMessageRegExp /Expected \$operations\[0\]\["updateOne"\]\[2\]\["upsert"\] to have type "boolean" but found "[\w ]+"/
      * @dataProvider provideInvalidBooleanValues
      */
@@ -339,11 +409,6 @@ class BulkWriteTest extends TestCase
             [[BulkWrite::INSERT_ONE => [['x' => 1]]]],
             $options
         );
-    }
-
-    public function provideInvalidBooleanValues()
-    {
-        return $this->wrapValuesForDataProvider($this->getInvalidBooleanValues());
     }
 
     public function provideInvalidConstructorOptions()

--- a/tests/Operation/CountTest.php
+++ b/tests/Operation/CountTest.php
@@ -28,6 +28,10 @@ class CountTest extends TestCase
     {
         $options = [];
 
+        foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['collation' => $value];
+        }
+
         foreach ($this->getInvalidHintValues() as $value) {
             $options[][] = ['hint' => $value];
         }

--- a/tests/Operation/CreateCollectionTest.php
+++ b/tests/Operation/CreateCollectionTest.php
@@ -27,6 +27,10 @@ class CreateCollectionTest extends TestCase
             $options[][] = ['capped' => $value];
         }
 
+        foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['collation' => $value];
+        }
+
         foreach ($this->getInvalidIntegerValues() as $value) {
             $options[][] = ['flags' => $value];
         }

--- a/tests/Operation/DeleteTest.php
+++ b/tests/Operation/DeleteTest.php
@@ -43,6 +43,10 @@ class DeleteTest extends TestCase
     {
         $options = [];
 
+        foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['collation' => $value];
+        }
+
         foreach ($this->getInvalidWriteConcernValues() as $value) {
             $options[][] = ['writeConcern' => $value];
         }

--- a/tests/Operation/DistinctTest.php
+++ b/tests/Operation/DistinctTest.php
@@ -28,6 +28,10 @@ class DistinctTest extends TestCase
     {
         $options = [];
 
+        foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['collation' => $value];
+        }
+
         foreach ($this->getInvalidIntegerValues() as $value) {
             $options[][] = ['maxTimeMS' => $value];
         }

--- a/tests/Operation/FindAndModifyTest.php
+++ b/tests/Operation/FindAndModifyTest.php
@@ -24,6 +24,10 @@ class FindAndModifyTest extends TestCase
         }
 
         foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['collation' => $value];
+        }
+
+        foreach ($this->getInvalidDocumentValues() as $value) {
             $options[][] = ['fields' => $value];
         }
 

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -36,6 +36,10 @@ class FindTest extends TestCase
             $options[][] = ['batchSize' => $value];
         }
 
+        foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['collation' => $value];
+        }
+
         foreach ($this->getInvalidStringValues() as $value) {
             $options[][] = ['comment' => $value];
         }

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -43,6 +43,10 @@ class UpdateTest extends TestCase
             $options[][] = ['bypassDocumentValidation' => $value];
         }
 
+        foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['collation' => $value];
+        }
+
         foreach ($this->getInvalidBooleanValues() as $value) {
             $options[][] = ['multi' => $value];
         }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-205

This bumps the extension requirement to 1.2.0. Composer allows dev versions with the "^" operator, so this will accept 1.2.0alpha3, which introduces a "collation" option for Query and BulkWrite methods.