### PR TITLE
PHPLIB-240: FindAndModify should throw for unsupported write concern

### DIFF
--- a/docs/includes/apiargs-MongoDBCollection-method-findOneAndDelete-option.yaml
+++ b/docs/includes/apiargs-MongoDBCollection-method-findOneAndDelete-option.yaml
@@ -18,6 +18,6 @@ source:
   file: apiargs-MongoDBCollection-common-option.yaml
   ref: writeConcern
 post: |
-  This is not supported for server versions prior to 3.2 and will be ignored if
-  used.
+  This is not supported for server versions prior to 3.2 and will result in an
+  exception at execution time if used.
 ...

--- a/docs/includes/apiargs-MongoDBCollection-method-findOneAndReplace-option.yaml
+++ b/docs/includes/apiargs-MongoDBCollection-method-findOneAndReplace-option.yaml
@@ -39,6 +39,6 @@ source:
   file: apiargs-MongoDBCollection-common-option.yaml
   ref: writeConcern
 post: |
-  This is not supported for server versions prior to 3.2 and will be ignored if
-  used.
+  This is not supported for server versions prior to 3.2 and will result in an
+  exception at execution time if used.
 ...

--- a/docs/includes/apiargs-MongoDBCollection-method-findOneAndUpdate-option.yaml
+++ b/docs/includes/apiargs-MongoDBCollection-method-findOneAndUpdate-option.yaml
@@ -39,6 +39,6 @@ source:
   file: apiargs-MongoDBCollection-common-option.yaml
   ref: writeConcern
 post: |
-  This is not supported for server versions prior to 3.2 and will be ignored if
-  used.
+  This is not supported for server versions prior to 3.2 and will result in an
+  exception at execution time if used.
 ...

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -37,8 +37,10 @@ class FindOneAndDelete implements Executable
      *  * sort (document): Determines which document the operation modifies if
      *    the query selects multiple documents.
      *
-     *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern. This option
-     *    is only supported for server versions >= 3.2.
+     *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
+     *
+     *    This is not supported for server versions < 3.2 and will result in an
+     *    exception at execution time if used.
      *
      * @param string       $databaseName   Database name
      * @param string       $collectionName Collection name
@@ -75,7 +77,7 @@ class FindOneAndDelete implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return object|null
-     * @throws UnsupportedException if collation is used and unsupported
+     * @throws UnsupportedException if collation or write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -52,8 +52,10 @@ class FindOneAndReplace implements Executable
      *  * upsert (boolean): When true, a new document is created if no document
      *    matches the query. The default is false.
      *
-     *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern. This option
-     *    is only supported for server versions >= 3.2.
+     *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
+     *
+     *    This is not supported for server versions < 3.2 and will result in an
+     *    exception at execution time if used.
      *
      * @param string       $databaseName   Database name
      * @param string       $collectionName Collection name
@@ -115,7 +117,7 @@ class FindOneAndReplace implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return object|null
-     * @throws UnsupportedException if collation is used and unsupported
+     * @throws UnsupportedException if collation or write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -52,8 +52,10 @@ class FindOneAndUpdate implements Executable
      *  * upsert (boolean): When true, a new document is created if no document
      *    matches the query. The default is false.
      *
-     *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern. This option
-     *    is only supported for server versions >= 3.2.
+     *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
+     *
+     *    This is not supported for server versions < 3.2 and will result in an
+     *    exception at execution time if used.
      *
      * @param string       $databaseName   Database name
      * @param string       $collectionName Collection name
@@ -115,7 +117,7 @@ class FindOneAndUpdate implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return object|null
-     * @throws UnsupportedException if collation is used and unsupported
+     * @throws UnsupportedException if collation or write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-240

This reverts the logic in 21b7d92aef4def00abade10911bae41f1b5ea378, which was to ignore an unsupported write concern for the duration of 1.x. Since the Collection helper methods do not supply a default write concern option if it is not supported, this change will only affect users that were explicitly passing a write concern and relying on the library to ignore it.

While a minor BC break, this changes makes findAndModify consistent with other write commands.