### PR TITLE
PHPLIB-229: Declare read concern wire version for Find operation

### DIFF
--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -26,6 +26,7 @@ class Find implements Executable
     const TAILABLE_AWAIT = 3;
 
     private static $wireVersionForCollation = 5;
+    private static $wireVersionForReadConcern = 4;
 
     private $databaseName;
     private $collectionName;


### PR DESCRIPTION
This property was missing from 8dcc778422a5370196fc8436ef80958d724ca9da.