### PR TITLE
PHPLIB-229: Count and Distinct don't need Server to construct commands

### DIFF
--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -130,7 +130,7 @@ class Count implements Executable
 
         $readPreference = isset($this->options['readPreference']) ? $this->options['readPreference'] : null;
 
-        $cursor = $server->executeCommand($this->databaseName, $this->createCommand($server), $readPreference);
+        $cursor = $server->executeCommand($this->databaseName, $this->createCommand(), $readPreference);
         $result = current($cursor->toArray());
 
         // Older server versions may return a float
@@ -144,10 +144,9 @@ class Count implements Executable
     /**
      * Create the count command.
      *
-     * @param Server $server
      * @return Command
      */
-    private function createCommand(Server $server)
+    private function createCommand()
     {
         $cmd = ['count' => $this->collectionName];
 

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -120,10 +120,9 @@ class Distinct implements Executable
     /**
      * Create the distinct command.
      *
-     * @param Server $server
      * @return Command
      */
-    private function createCommand(Server $server)
+    private function createCommand()
     {
         $cmd = [
             'distinct' => $this->collectionName,
@@ -142,7 +141,7 @@ class Distinct implements Executable
             $cmd['maxTimeMS'] = $this->options['maxTimeMS'];
         }
 
-        if (isset($this->options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern)) {
+        if (isset($this->options['readConcern'])) {
             $cmd['readConcern'] = \MongoDB\read_concern_as_document($this->options['readConcern']);
         }
 


### PR DESCRIPTION
This should have been done in 8dcc778422a5370196fc8436ef80958d724ca9da.