### PR TITLE
Remove library version from Composer install examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ https://jira.mongodb.org/secure/CreateIssue.jspa?pid=12483&issuetype=1
 
 This library may be installed or upgraded with:
 
-    composer require "mongodb/mongodb=^1.0.0"
+    composer require mongodb/mongodb
 
 Installation instructions for the PHP and HHVM driver may be found in the [PHP.net documentation](http://php.net/manual/en/mongodb.installation.php).
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The preferred method of installing this library is with
 [Composer](https://getcomposer.org/) by running the following from your project
 root:
 
-    $ composer require "mongodb/mongodb=^1.0.0"
+    $ composer require mongodb/mongodb
 
 ## Reporting Issues
 

--- a/docs/tutorial/install-php-library.txt
+++ b/docs/tutorial/install-php-library.txt
@@ -33,7 +33,7 @@ root:
 
 .. code-block:: sh
 
-   composer require "mongodb/mongodb=^1.0.0"
+   composer require mongodb/mongodb
 
 While not recommended, you may also manually install the package via
 the source tarballs attached to the `GitHub releases


### PR DESCRIPTION
By default, Composer installs the most recent stable version and declares a requirement with the caret operator (allowing any newer versions up to but not including the next major version).

Supersedes https://github.com/mongodb/mongo-php-library/pull/314.

PHP.net manual updated in: http://svn.php.net/viewvc?view=revision&revision=341423