### PR TITLE
PHPLIB-247: Use strings instead of memory stream for GridFS download buffering

### DIFF
--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -22,7 +22,6 @@ use MongoDB\UpdateResult;
 use MongoDB\Driver\Cursor;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadPreference;
-use IteratorIterator;
 use stdClass;
 
 /**
@@ -85,6 +84,27 @@ class CollectionWrapper
     {
         $this->filesCollection->drop(['typeMap' => []]);
         $this->chunksCollection->drop(['typeMap' => []]);
+    }
+
+    /**
+     * Finds GridFS chunk documents for a given file ID and optional offset.
+     *
+     * @param mixed   $id        File ID
+     * @param integer $fromChunk Starting chunk (inclusive)
+     * @return Cursor
+     */
+    public function findChunksByFileId($id, $fromChunk = 0)
+    {
+        return $this->chunksCollection->find(
+            [
+                'files_id' => $id,
+                'n' => ['$gte' => $fromChunk],
+            ],
+            [
+                'sort' => ['n' => 1],
+                'typeMap' => ['root' => 'stdClass'],
+            ]
+        );
     }
 
     /**
@@ -175,25 +195,6 @@ class CollectionWrapper
     public function getBucketName()
     {
         return $this->bucketName;
-    }
-
-    /**
-     * Returns a chunks iterator for a given file ID.
-     *
-     * @param mixed $id
-     * @return IteratorIterator
-     */
-    public function getChunksIteratorByFilesId($id)
-    {
-        $cursor = $this->chunksCollection->find(
-            ['files_id' => $id],
-            [
-                'sort' => ['n' => 1],
-                'typeMap' => ['root' => 'stdClass'],
-            ]
-        );
-
-        return new IteratorIterator($cursor);
     }
 
     /**

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -119,17 +119,17 @@ class StreamWrapper
      * if data is not available to be read.
      * 
      * @see http://php.net/manual/en/streamwrapper.stream-read.php
-     * @param integer $count Number of bytes to read
+     * @param integer $length Number of bytes to read
      * @return string
      */
-    public function stream_read($count)
+    public function stream_read($length)
     {
         if ( ! $this->stream instanceof ReadableStream) {
             return '';
         }
 
         try {
-            return $this->stream->downloadNumBytes($count);
+            return $this->stream->readBytes($length);
         } catch (Exception $e) {
             trigger_error(sprintf('%s: %s', get_class($e), $e->getMessage()), \E_USER_WARNING);
             return false;

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -74,12 +74,12 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideFileIdAndExpectedBytes
      */
-    public function testDownloadNumBytes($fileId, $numBytes, $expectedBytes)
+    public function testReadBytes($fileId, $length, $expectedBytes)
     {
         $fileDocument = $this->collectionWrapper->findFileById($fileId);
         $stream = new ReadableStream($this->collectionWrapper, $fileDocument);
 
-        $this->assertSame($expectedBytes, $stream->downloadNumBytes($numBytes));
+        $this->assertSame($expectedBytes, $stream->readBytes($length));
     }
 
     public function provideFileIdAndExpectedBytes()
@@ -111,14 +111,14 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideFileIdAndExpectedBytes
      */
-    public function testDownloadNumBytesCalledMultipleTimes($fileId, $numBytes, $expectedBytes)
+    public function testReadBytesCalledMultipleTimes($fileId, $length, $expectedBytes)
     {
         $fileDocument = $this->collectionWrapper->findFileById($fileId);
         $stream = new ReadableStream($this->collectionWrapper, $fileDocument);
 
-        for ($i = 0; $i < $numBytes; $i++) {
+        for ($i = 0; $i < $length; $i++) {
             $expectedByte = isset($expectedBytes[$i]) ? $expectedBytes[$i] : '';
-            $this->assertSame($expectedByte, $stream->downloadNumBytes(1));
+            $this->assertSame($expectedByte, $stream->readBytes(1));
         }
     }
 
@@ -126,35 +126,35 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
      * @expectedException MongoDB\GridFS\Exception\CorruptFileException
      * @expectedExceptionMessage Chunk not found for index "2"
      */
-    public function testDownloadNumBytesWithMissingChunk()
+    public function testReadBytesWithMissingChunk()
     {
         $this->chunksCollection->deleteOne(['files_id' => 'length-10', 'n' => 2]);
 
         $fileDocument = $this->collectionWrapper->findFileById('length-10');
         $stream = new ReadableStream($this->collectionWrapper, $fileDocument);
 
-        $stream->downloadNumBytes(10);
+        $stream->readBytes(10);
     }
 
     /**
      * @expectedException MongoDB\GridFS\Exception\CorruptFileException
      * @expectedExceptionMessage Expected chunk to have index "1" but found "2"
      */
-    public function testDownloadNumBytesWithUnexpectedChunkIndex()
+    public function testReadBytesWithUnexpectedChunkIndex()
     {
         $this->chunksCollection->deleteOne(['files_id' => 'length-10', 'n' => 1]);
 
         $fileDocument = $this->collectionWrapper->findFileById('length-10');
         $stream = new ReadableStream($this->collectionWrapper, $fileDocument);
 
-        $stream->downloadNumBytes(10);
+        $stream->readBytes(10);
     }
 
     /**
      * @expectedException MongoDB\GridFS\Exception\CorruptFileException
      * @expectedExceptionMessage Expected chunk to have size "2" but found "1"
      */
-    public function testDownloadNumBytesWithUnexpectedChunkSize()
+    public function testReadBytesWithUnexpectedChunkSize()
     {
         $this->chunksCollection->updateOne(
             ['files_id' => 'length-10', 'n' => 2],
@@ -164,17 +164,17 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         $fileDocument = $this->collectionWrapper->findFileById('length-10');
         $stream = new ReadableStream($this->collectionWrapper, $fileDocument);
 
-        $stream->downloadNumBytes(10);
+        $stream->readBytes(10);
     }
 
     /**
      * @expectedException MongoDB\Exception\InvalidArgumentException
      */
-    public function testDownloadNumBytesWithNegativeReadSize()
+    public function testReadBytesWithNegativeLength()
     {
         $fileDocument = $this->collectionWrapper->findFileById('length-0');
         $stream = new ReadableStream($this->collectionWrapper, $fileDocument);
 
-        $stream->downloadNumBytes(-1);
+        $stream->readBytes(-1);
     }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-247