### PR TITLE
Add WriteConcern getter

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -695,6 +695,16 @@ class Collection
     }
 
     /**
+     * Return the WriteConcern
+     * 
+     * @return WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * Return the collection namespace.
      *
      * @see https://docs.mongodb.org/manual/reference/glossary/#term-namespace


### PR DESCRIPTION
Hi,

I made a MongoDB Object Document Mapper for PHP (You can see it [here](https://github.com/JoffreyPoreeCoding/MongoDB-ODM)) and I need to know WriteConcern of collection to check if insert/update/delete result have to be acknowledged.

I add a simple WriteConcern getter in Collection class of your library.

Hope that it will be OK.