### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=5.4",
-        "ext-mongodb": "^1.2.0"
+        "ext-mongodb": ">=1.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": ">=4.8"
     },
     "autoload": {
         "psr-4": { "MongoDB\\": "src/" },


### PR DESCRIPTION
```
  Problem 1
    - Installation request for mongodb/mongodb 1.1.2 -> satisfiable by mongodb/mongodb[1.1.2].
    - mongodb/mongodb 1.1.2 requires ext-mongodb ^1.2.0 -> the requested PHP extension mongodb has the wrong version (1.1.5) installed.
  Problem 2
    - mongodb/mongodb 1.1.2 requires ext-mongodb ^1.2.0 -> the requested PHP extension mongodb has the wrong version (1.1.5) installed.
    - moloquent/moloquent dev-master requires mongodb/mongodb ^1.0.0 -> satisfiable by mongodb/mongodb[1.1.2].
    - Installation request for moloquent/moloquent dev-master -> satisfiable by moloquent/moloquent[dev-master].
```