### PR TITLE
Various documentation updates

### DIFF
--- a/docs/reference/bson.txt
+++ b/docs/reference/bson.txt
@@ -138,7 +138,7 @@ database, and reads it back as an object of the same type:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->persons;
+   $collection = (new MongoDB\Client)->test->persons;
 
    $result = $collection->insertOne(new Person('Bob'));
 
@@ -219,7 +219,7 @@ everything as a PHP array:
        ]
    );
 
-   $document = $client->demo->zips->findOne(['_id' => '94301']);
+   $document = $client->test->zips->findOne(['_id' => '94301']);
 
    var_dump($document);
 

--- a/docs/reference/method/MongoDBClient-dropDatabase.txt
+++ b/docs/reference/method/MongoDBClient-dropDatabase.txt
@@ -46,7 +46,7 @@ Errors/Exceptions
 Example
 -------
 
-The following example drops the ``demo`` database:
+The following example drops the ``test`` database:
 
 .. code-block:: php
 
@@ -54,7 +54,7 @@ The following example drops the ``demo`` database:
 
    $client = new MongoDB\Client;
 
-   $result = $client->dropDatabase('demo');
+   $result = $client->dropDatabase('test');
 
    var_dump($result);
 
@@ -64,7 +64,7 @@ The output would then resemble::
      ["storage":"ArrayObject":private]=>
      array(2) {
        ["dropped"]=>
-       string(4) "demo"
+       string(4) "test"
        ["ok"]=>
        float(1)
      }

--- a/docs/reference/method/MongoDBClient-selectCollection.txt
+++ b/docs/reference/method/MongoDBClient-selectCollection.txt
@@ -49,7 +49,7 @@ overridden via the ``$options`` parameter.
 Example
 -------
 
-The following example selects the ``users`` collection in the ``demo`` database:
+The following example selects the ``users`` collection in the ``test`` database:
 
 .. code-block:: php
 
@@ -57,9 +57,9 @@ The following example selects the ``users`` collection in the ``demo`` database:
 
    $client = new MongoDB\Client;
 
-   $collection = $client->selectCollection('demo', 'users');
+   $collection = $client->selectCollection('test', 'users');
 
-The following example selects the ``users`` collection in the ``demo`` database
+The following example selects the ``users`` collection in the ``test`` database
 with a custom read preference:
 
 .. code-block:: php
@@ -69,7 +69,7 @@ with a custom read preference:
    $client = new MongoDB\Client;
 
    $collection = $client->selectCollection(
-       'demo',
+       'test',
        'users',
        [
            'readPreference' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),

--- a/docs/reference/method/MongoDBClient-selectDatabase.txt
+++ b/docs/reference/method/MongoDBClient-selectDatabase.txt
@@ -49,7 +49,7 @@ via the ``$options`` parameter.
 Example
 -------
 
-The following example selects the ``demo`` database:
+The following example selects the ``test`` database:
 
 .. code-block:: php
 
@@ -57,9 +57,9 @@ The following example selects the ``demo`` database:
 
    $client = new MongoDB\Client;
 
-   $db = $client->selectDatabase('demo');
+   $db = $client->selectDatabase('test');
 
-The following examples selects the ``demo`` database with a custom read
+The following examples selects the ``test`` database with a custom read
 preference:
 
 .. code-block:: php
@@ -69,7 +69,7 @@ preference:
    $client = new MongoDB\Client;
 
    $db = $client->selectDatabase(
-       'demo',
+       'test',
        [
            'readPreference' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),
        ]

--- a/docs/reference/method/MongoDBClient__get.txt
+++ b/docs/reference/method/MongoDBClient__get.txt
@@ -50,7 +50,7 @@ any options, use the :phpmethod:`MongoDB\\Client::selectDatabase` method.
 Examples
 --------
 
-The following example selects the ``demo`` and ``another-app`` databases:
+The following example selects the ``test`` and ``another-app`` databases:
 
 .. code-block:: php
 
@@ -58,7 +58,7 @@ The following example selects the ``demo`` and ``another-app`` databases:
 
    $client = new MongoDB\Client;
 
-   $demo = $client->demo;
+   $test = $client->test;
    $anotherApp = $client->{'another-app'};
 
 See Also

--- a/docs/reference/method/MongoDBCollection-createIndex.txt
+++ b/docs/reference/method/MongoDBCollection-createIndex.txt
@@ -54,13 +54,13 @@ Create a Compound Index
 
 The following example creates a :manual:`compound index </core/index-compound>`
 on the ``borough`` and ``cuisine`` fields in the ``restaurants`` collection in
-the ``example`` database.
+the ``test`` database.
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->selectCollection('example', 'restaurants');
+   $collection = (new MongoDB\Client)->selectCollection('test', 'restaurants');
 
    $indexName = $collection->createIndex(['borough' => 1, 'cuisine' => 1]);
 
@@ -74,7 +74,7 @@ Create a Partial Index
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The following example adds a :manual:`partial index </core/index-parital>` on
-the ``borough`` field in the ``restaurants`` collection in the ``example``
+the ``borough`` field in the ``restaurants`` collection in the ``test``
 database. The partial index indexes only documents where the ``borough`` field
 exists.
 
@@ -82,7 +82,7 @@ exists.
 
    <?php
 
-   $collection = (new MongoDB\Client)->selectCollection('example, 'restaurants');
+   $collection = (new MongoDB\Client)->selectCollection('test, 'restaurants');
 
    $indexName = $collection->createIndex(
       ['borough' => 1],

--- a/docs/reference/method/MongoDBCollection-createIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-createIndexes.txt
@@ -64,7 +64,7 @@ Example
 -------
 
 The following example creates two indexes on the ``restaurants`` collection in
-the ``example`` database. One index is a compound index on the ``borough`` and
+the ``test`` database. One index is a compound index on the ``borough`` and
 ``cuisine`` fields and the other is 2dsphere index on the ``loc`` field with a
 custom name.
 
@@ -72,7 +72,7 @@ custom name.
 
    <?php
 
-   $collection = (new MongoDB\Client)->selectCollection('example', 'restaurants');
+   $collection = (new MongoDB\Client)->selectCollection('test', 'restaurants');
 
    $indexNames = $collection->createIndexes([
        [ 'key' => [ 'borough' => 1, 'cuisine' => 1] ],

--- a/docs/reference/method/MongoDBCollection-deleteMany.txt
+++ b/docs/reference/method/MongoDBCollection-deleteMany.txt
@@ -59,7 +59,7 @@ that have ``"ny"`` as the value for the ``state`` field:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $collection->insertOne(['name' => 'Bob', 'state' => 'ny']);

--- a/docs/reference/method/MongoDBCollection-deleteOne.txt
+++ b/docs/reference/method/MongoDBCollection-deleteOne.txt
@@ -61,7 +61,7 @@ has ``"ny"`` as the value for the ``state`` field:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $collection->insertOne(['name' => 'Bob', 'state' => 'ny']);

--- a/docs/reference/method/MongoDBCollection-distinct.txt
+++ b/docs/reference/method/MongoDBCollection-distinct.txt
@@ -54,13 +54,13 @@ Return Distinct Values for a Field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example identifies the distinct values for the ``borough`` field
-in the ``restaurants`` collection in the ``example`` database.
+in the ``restaurants`` collection in the ``test`` database.
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $distinct = $collection->distinct('borough');
 
@@ -87,14 +87,14 @@ Return Distinct Values Using a Filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example identifies the distinct values for the ``cuisine`` field
-in the ``restaurants`` collection in the ``example`` database for documents
-where the ``borough`` is ``Queens``:
+in the ``restaurants`` collection in the ``test`` database for documents where
+the ``borough`` is ``Queens``:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $distinct = $collection->distinct('cuisine', ['borough' => 'Queens']);
 

--- a/docs/reference/method/MongoDBCollection-drop.txt
+++ b/docs/reference/method/MongoDBCollection-drop.txt
@@ -46,14 +46,14 @@ Errors/Exceptions
 Example
 -------
 
-The following operation drops the ``restaurants`` collection in the ``example``
+The following operation drops the ``restaurants`` collection in the ``test``
 database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $result = $collection->drop();
 
@@ -65,7 +65,7 @@ The output would then resemble::
      ["storage":"ArrayObject":private]=>
      array(3) {
        ["ns"]=>
-       string(19) "example.restaurants"
+       string(16) "test.restaurants"
        ["nIndexesWas"]=>
        int(3)
        ["ok"]=>

--- a/docs/reference/method/MongoDBCollection-dropIndex.txt
+++ b/docs/reference/method/MongoDBCollection-dropIndex.txt
@@ -47,13 +47,13 @@ Example
 -------
 
 The following drops an indexes with name ``borough_1`` from the ``restaurants``
-collection in the ``example`` database:
+collection in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $result = $collection->dropIndex('borough_1');
 

--- a/docs/reference/method/MongoDBCollection-dropIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-dropIndexes.txt
@@ -48,13 +48,13 @@ Example
 -------
 
 The following drops all indexes from the ``restaurants`` collection in the
-``example`` database:
+``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $result = $collection->dropIndexes();
 

--- a/docs/reference/method/MongoDBCollection-find.txt
+++ b/docs/reference/method/MongoDBCollection-find.txt
@@ -56,7 +56,7 @@ returned. It also limits the results to 5 documents.
 
 .. code-block:: php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $cursor = $collection->find(
        [

--- a/docs/reference/method/MongoDBCollection-findOne.txt
+++ b/docs/reference/method/MongoDBCollection-findOne.txt
@@ -58,7 +58,7 @@ returned.
 
 .. code-block:: php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $restaurant = $collection->findOne(
        [

--- a/docs/reference/method/MongoDBCollection-findOne.txt
+++ b/docs/reference/method/MongoDBCollection-findOne.txt
@@ -51,6 +51,28 @@ Behavior
 Examples
 --------
 
+Matching BSON Types in Query Criteria
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the following example, documents in the ``restaurants`` collection use an
+:manual:`ObjectId </reference/object-id/>` for their identifier (the default)
+and documents in the ``zips`` collection use a string. Since ObjectID is a
+special BSON type, the query criteria for selecting a restaurant must use the
+:php:`MongoDB\\BSON\\ObjectID <class.mongodb-bson-objectid>` class.
+
+.. code-block:: php
+
+   $database = (new MongoDB\Client)->test;
+
+   $zip = $database->zips->findOne(['_id' => '10036']);
+
+   $restaurant = $database->restaurants->findOne([
+       '_id' => new MongoDB\BSON\ObjectID('594d5ef280a846852a4b3f70'),
+   ])
+
+Projecting Fields
+~~~~~~~~~~~~~~~~~
+
 The following example finds a restaurant based on the ``cuisine`` and
 ``borough`` fields and uses a :manual:`projection
 </tutorial/project-fields-from-query-results>` to limit the fields that are

--- a/docs/reference/method/MongoDBCollection-findOneAndDelete.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndDelete.txt
@@ -52,13 +52,13 @@ Examples
 --------
 
 The following example finds and deletes the document with ``restaurant_id`` of
-``"40375376"`` from the ``restaurants`` collection in the ``example`` database:
+``"40375376"`` from the ``restaurants`` collection in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $deletedRestaurant = $collection->findOneAndDelete(
        [ 'restaurant_id' => '40375376' ],

--- a/docs/reference/method/MongoDBCollection-findOneAndReplace.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndReplace.txt
@@ -54,7 +54,7 @@ Examples
 --------
 
 Consider the following document in the ``restaurants`` collection in the
-``example`` database:
+``test`` database:
 
 .. code-block:: javascript
 
@@ -99,7 +99,7 @@ The following operation replaces the document with ``restaurant_id`` of
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->teset->restaurants;
 
    $replacedRestaurant = $collection->findOneAndReplace(
        [ 'restaurant_id' => '41220906' ],

--- a/docs/reference/method/MongoDBCollection-findOneAndUpdate.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndUpdate.txt
@@ -54,14 +54,14 @@ Examples
 --------
 
 The following operation updates the restaurant with ``restaurant_id`` of
-``"40361708"`` in the ``restaurants`` collection in the ``example`` database by
+``"40361708"`` in the ``restaurants`` collection in the ``test`` database by
 setting its building number to ``"761"``:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $updatedRestaurant = $collection->findOneAndUpdate(
        [ 'restaurant_id' => '40361708' ],

--- a/docs/reference/method/MongoDBCollection-getCollectionName.txt
+++ b/docs/reference/method/MongoDBCollection-getCollectionName.txt
@@ -30,13 +30,13 @@ Example
 -------
 
 The following returns the collection name for the ``zips`` collection in the
-``demo`` database.
+``test`` database.
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    echo $collection->getCollectionName();
 

--- a/docs/reference/method/MongoDBCollection-getDatabaseName.txt
+++ b/docs/reference/method/MongoDBCollection-getDatabaseName.txt
@@ -30,19 +30,19 @@ Example
 -------
 
 The following returns the database name for the ``zips`` collection in the
-``demo`` database.
+``test`` database.
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    echo $collection->getDatabaseName();
 
 The output would then resemble::
 
-   demo
+   test
 
 See Also
 --------

--- a/docs/reference/method/MongoDBCollection-getNamespace.txt
+++ b/docs/reference/method/MongoDBCollection-getNamespace.txt
@@ -30,20 +30,20 @@ The namespace of this collection as a string.
 Example
 -------
 
-The following returns the namespace of the ``zips`` collection in the ``demo``
+The following returns the namespace of the ``zips`` collection in the ``test``
 database.
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    echo $collection->getNamespace();
 
 The output would then resemble::
 
-   demo.zips
+   test.zips
 
 See Also
 --------

--- a/docs/reference/method/MongoDBCollection-insertMany.txt
+++ b/docs/reference/method/MongoDBCollection-insertMany.txt
@@ -54,13 +54,13 @@ Example
 .. start-crud-include
 
 The following operation inserts two documents into the ``users`` collection
-in the ``example`` database:
+in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->users;
+   $collection = (new MongoDB\Client)->test->users;
 
    $insertManyResult = $collection->insertMany([
        [

--- a/docs/reference/method/MongoDBCollection-insertOne.txt
+++ b/docs/reference/method/MongoDBCollection-insertOne.txt
@@ -53,13 +53,13 @@ Example
 .. start-crud-include
 
 The following operation inserts a document into the ``users`` collection in the
-``example`` database:
+``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->users;
+   $collection = (new MongoDB\Client)->test->users;
 
    $insertOneResult = $collection->insertOne([
        'username' => 'admin',

--- a/docs/reference/method/MongoDBCollection-listIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-listIndexes.txt
@@ -45,13 +45,13 @@ Example
 -------
 
 The following example lists all of the indexes for the ``restaurants``
-collection in the ``example`` database:
+collection in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    foreach ($collection->listIndexes() as $index) {
       var_dump($index);
@@ -70,7 +70,7 @@ The output would then resemble::
      ["name"]=>
      string(4) "_id_"
      ["ns"]=>
-     string(19) "example.restaurants"
+     string(16) "test.restaurants"
    }
    object(MongoDB\Model\IndexInfo)#12 (4) {
      ["v"]=>
@@ -83,7 +83,7 @@ The output would then resemble::
      ["name"]=>
      string(10) "cuisine_-1"
      ["ns"]=>
-     string(19) "example.restaurants"
+     string(16) "test.restaurants"
    }
    object(MongoDB\Model\IndexInfo)#8 (4) {
      ["v"]=>
@@ -96,7 +96,7 @@ The output would then resemble::
      ["name"]=>
      string(9) "borough_1"
      ["ns"]=>
-     string(19) "example.restaurants"
+     string(16) "test.restaurants"
    }
 
 See Also

--- a/docs/reference/method/MongoDBCollection-replaceOne.txt
+++ b/docs/reference/method/MongoDBCollection-replaceOne.txt
@@ -55,13 +55,13 @@ Example
 -------
 
 The following example replaces the document with ``restaurant_id`` of
-``"40356068"`` in the ``restaurants`` collection in the ``example`` database:
+``"40356068"`` in the ``restaurants`` collection in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $updateResult = $collection->replaceOne(
        [ 'restaurant_id' => '40356068' ],

--- a/docs/reference/method/MongoDBCollection-updateMany.txt
+++ b/docs/reference/method/MongoDBCollection-updateMany.txt
@@ -57,7 +57,7 @@ The following example updates all of the documents with the ``borough`` of
 
 .. code-block:: php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $updateResult = $collection->updateMany(
        [ 'borough' => 'Queens' ],

--- a/docs/reference/method/MongoDBCollection-updateOne.txt
+++ b/docs/reference/method/MongoDBCollection-updateOne.txt
@@ -59,7 +59,7 @@ The following example updates one document with the ``restaurant_id`` of
 
 .. code-block:: php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $updateResult = $collection->updateOne(
        [ 'restaurant_id' => '40356151' ],

--- a/docs/reference/method/MongoDBCollection-withOptions.txt
+++ b/docs/reference/method/MongoDBCollection-withOptions.txt
@@ -49,7 +49,7 @@ preference:
 
    <?php
 
-   $collection = (new MongoDB\Client)->selectCollect('demo', 'restaurants');
+   $collection = (new MongoDB\Client)->selectCollect('test', 'restaurants');
 
    $newCollection = $sourceCollection->withOptions([
        'readPreference' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),

--- a/docs/reference/method/MongoDBCollection-withOptions.txt
+++ b/docs/reference/method/MongoDBCollection-withOptions.txt
@@ -49,7 +49,7 @@ preference:
 
    <?php
 
-   $collection = (new MongoDB\Client)->selectCollect('test', 'restaurants');
+   $collection = (new MongoDB\Client)->selectCollection('test', 'restaurants');
 
    $newCollection = $sourceCollection->withOptions([
        'readPreference' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),

--- a/docs/reference/method/MongoDBDatabase-command.txt
+++ b/docs/reference/method/MongoDBDatabase-command.txt
@@ -51,7 +51,7 @@ result document:
 
    <?php
 
-   $database = (new MongoDB\Client)->example;
+   $database = (new MongoDB\Client)->test;
 
    $cursor = $database->command(['isMaster' => 1]);
 
@@ -92,7 +92,7 @@ multiple result documents:
 
    <?php
 
-   $database = (new MongoDB\Client)->example;
+   $database = (new MongoDB\Client)->test;
 
    $cursor = $database->command(['isMaster' => 1]);
 

--- a/docs/reference/method/MongoDBDatabase-createCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-createCollection.txt
@@ -63,14 +63,14 @@ Errors/Exceptions
 Example
 -------
 
-The following example creates a ``users`` collection in the ``demo``
+The following example creates a ``users`` collection in the ``test``
 database with document validation criteria:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $result = $db->createCollection('users', [
        'validator' => [

--- a/docs/reference/method/MongoDBDatabase-drop.txt
+++ b/docs/reference/method/MongoDBDatabase-drop.txt
@@ -46,13 +46,13 @@ Errors/Exceptions
 Example
 -------
 
-The following example drops the ``demo`` database:
+The following example drops the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $result = $db->drop();
 
@@ -64,7 +64,7 @@ The output would then resemble::
      ["storage":"ArrayObject":private]=>
      array(2) {
        ["dropped"]=>
-       string(4) "demo"
+       string(4) "test"
        ["ok"]=>
        float(1)
      }

--- a/docs/reference/method/MongoDBDatabase-dropCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-dropCollection.txt
@@ -46,13 +46,13 @@ Errors/Exceptions
 Example
 -------
 
-The following example drops the ``users`` collection in the ``demo`` database:
+The following example drops the ``users`` collection in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $result = $db->dropCollection('users');
 
@@ -64,7 +64,7 @@ The output would then resemble::
      ["storage":"ArrayObject":private]=>
      array(3) {
        ["ns"]=>
-       string(10) "demo.users"
+       string(10) "test.users"
        ["nIndexesWas"]=>
        int(1)
        ["ok"]=>

--- a/docs/reference/method/MongoDBDatabase-getDatabaseName.txt
+++ b/docs/reference/method/MongoDBDatabase-getDatabaseName.txt
@@ -35,10 +35,10 @@ The following example prints the name of a database object:
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    echo $db->getDatabaseName();
 
 The output would then resemble::
 
-   demo
+   test

--- a/docs/reference/method/MongoDBDatabase-listCollections.txt
+++ b/docs/reference/method/MongoDBDatabase-listCollections.txt
@@ -39,13 +39,13 @@ database.
 Example
 -------
 
-The following example lists all of the collections in the ``example`` database:
+The following example lists all of the collections in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $database = (new MongoDB\Client)->example;
+   $database = (new MongoDB\Client)->test;
 
    foreach ($database->listCollections() as $collectionInfo) {
        var_dump($collectionInfo);
@@ -76,13 +76,13 @@ The output would then resemble::
    }
 
 The following example lists all collections whose name starts with ``"rest"``
-in the ``example`` database:
+in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $database = (new MongoDB\Client)->example;
+   $database = (new MongoDB\Client)->test;
 
    $collections = $database->listCollections([
        'filter' => [

--- a/docs/reference/method/MongoDBDatabase-selectCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-selectCollection.txt
@@ -49,24 +49,24 @@ overridden via the ``$options`` parameter.
 Example
 -------
 
-The following example selects the ``users`` collection in the ``demo`` database:
+The following example selects the ``users`` collection in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
-   $collection = $db->selectCollection('demo', 'users');
+   $collection = $db->selectCollection('test', 'users');
 
-The following example selects the ``users`` collection in the ``demo``
+The following example selects the ``users`` collection in the ``test``
 database with a custom read preference:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $users = $db->selectCollection(
        'users',

--- a/docs/reference/method/MongoDBDatabase-selectGridFSBucket.txt
+++ b/docs/reference/method/MongoDBDatabase-selectGridFSBucket.txt
@@ -49,25 +49,25 @@ overridden via the ``$options`` parameter.
 Example
 -------
 
-The following example selects the default ``fs.files`` bucket in the ``demo``
+The following example selects the default ``fs.files`` bucket in the ``test``
 database:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $bucket = $db->selectGridFSBucket();
 
-The following example selects the custom ``images.files`` bucket in the ``demo``
+The following example selects the custom ``images.files`` bucket in the ``test``
 database with a custom read preference:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $imagesBucket = $db->selectGridFSBucket([
        'bucketName' => 'images',

--- a/docs/reference/method/MongoDBDatabase-withOptions.txt
+++ b/docs/reference/method/MongoDBDatabase-withOptions.txt
@@ -49,7 +49,7 @@ preference:
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $newDb = $db->withOptions([
        'readPreference' => new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_SECONDARY),

--- a/docs/reference/method/MongoDBDatabase__get.txt
+++ b/docs/reference/method/MongoDBDatabase__get.txt
@@ -50,13 +50,13 @@ Examples
 --------
 
 The following example selects the ``users`` and ``system.profile``
-collections from the ``demo`` database:
+collections from the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $users = $db->users;
    $systemProfile = $db->{'system.profile'};

--- a/docs/tutorial/commands.txt
+++ b/docs/tutorial/commands.txt
@@ -30,13 +30,13 @@ To execute a command on a :program:`mongod` instance, use the
 :phpmethod:`MongoDB\\Database::command()` method. For instance, the following
 operation uses the :manual:`geoNear </reference/command/geoNear>` command to
 search for the three closest documents to longitude ``-74`` and latitude ``40``
-in the ``restos`` collection in the ``example`` database:
+in the ``restos`` collection in the ``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $database = (new MongoDB\Client)->example;
+   $database = (new MongoDB\Client)->test;
 
    $cursor = $database->command([
        'geoNear' => 'restos',
@@ -218,14 +218,14 @@ object on which it is invoked. To execute commands that require a specific read
 preference, specify the read preference in the ``$options`` parameter of the
 method.
 
-The following example adds a user to the ``demo`` database and specifies a
+The following example adds a user to the ``test`` database and specifies a
 custom read preference:
 
 .. code-block:: php
 
    <?php
 
-   $db = (new MongoDB\Client)->demo;
+   $db = (new MongoDB\Client)->test;
 
    $cursor = $db->command(
        [
@@ -267,7 +267,7 @@ document, or access the first result in the array, as in the following:
 
    <?php
 
-   $database = (new MongoDB\Client)->demo;
+   $database = (new MongoDB\Client)->test;
 
    $cursor = $database->command(['ping' => 1]);
 
@@ -290,7 +290,7 @@ Some commands, such as :manual:`listCollections
 </reference/command/listCollections>`, return their results via an iterable
 cursor. To view the results, iterate through the cursor.
 
-The following example lists the collections in the ``demo`` database by
+The following example lists the collections in the ``test`` database by
 iterating through the cursor returned by the ``listCollections`` command using a
 ``foreach`` loop:
 
@@ -298,7 +298,7 @@ iterating through the cursor returned by the ``listCollections`` command using a
 
    <?php
 
-   $database = (new MongoDB\Client)->demo;
+   $database = (new MongoDB\Client)->test;
 
    $cursor = $database->command(['listCollections' => 1]);
 

--- a/docs/tutorial/crud.txt
+++ b/docs/tutorial/crud.txt
@@ -53,7 +53,7 @@ The following example inserts a document while specifying the value for the
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
 
    $insertOneResult = $collection->insertOne(['_id' => 1, 'name' => 'Alice']);
 
@@ -107,7 +107,7 @@ The following example searches for the document with ``_id`` of ``"94301"``:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    $document = $collection->findOne(['_id' => '94301']);
 
@@ -167,7 +167,7 @@ specified city and state values:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    $cursor = $collection->find(['city' => 'JERSEY CITY', 'state' => 'NJ']);
 
@@ -210,7 +210,7 @@ returned. It also limits the results to 5 documents.
 
    <?php
 
-   $collection = (new MongoDB\Client)->example->restaurants;
+   $collection = (new MongoDB\Client)->test->restaurants;
 
    $cursor = $collection->find(
        [
@@ -311,7 +311,7 @@ five most populous zip codes in the United States:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    $cursor = $collection->find(
        [],
@@ -347,7 +347,7 @@ name starts with "garden" and the state is Texas:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    $cursor = $collection->find([
        'city' => new MongoDB\BSON\Regex('^garden', 'i'),
@@ -395,7 +395,7 @@ with them:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    $cursor = $collection->aggregate([
        ['$group' => ['_id' => '$state', 'count' => ['$sum' => 1]]],
@@ -434,7 +434,7 @@ updates to perform. The :phpmethod:`MongoDB\\Collection::updateOne()` reference
 describes each parameter in detail.
 
 The following example inserts two documents into an empty ``users`` collection
-in the ``demo`` database using the :phpmethod:`MongoDB\\Collection::insertOne()`
+in the ``test`` database using the :phpmethod:`MongoDB\\Collection::insertOne()`
 method, and then updates the documents where the value for the ``state`` field
 is ``"ny"`` to include a ``country`` field set to ``"us"``:
 
@@ -442,7 +442,7 @@ is ``"ny"`` to include a ``country`` field set to ``"us"``:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $collection->insertOne(['name' => 'Bob', 'state' => 'ny']);
@@ -470,7 +470,7 @@ value, as in this example:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $collection->insertOne(['name' => 'Bob', 'state' => 'ny']);
@@ -506,7 +506,7 @@ updates to perform. The :phpmethod:`MongoDB\\Collection::updateMany()` reference
 describes each parameter in detail.
 
 The following example inserts three documents into an empty ``users`` collection
-in the ``demo`` database and then uses the :query:`$set` operator to update the
+in the ``test`` database and then uses the :query:`$set` operator to update the
 documents matching the filter criteria to include the ``country`` field with
 value ``"us"``:
 
@@ -514,7 +514,7 @@ value ``"us"``:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $collection->insertOne(['name' => 'Bob', 'state' => 'ny', 'country' => 'us']);
@@ -567,13 +567,13 @@ parameter in detail.
    fields in a document rather than replacing the entire document.
 
 The following example inserts one document into an empty ``users`` collection in
-the ``demo`` database, and then replaces that document with a new one:
+the ``test`` database, and then replaces that document with a new one:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $collection->insertOne(['name' => 'Bob', 'state' => 'ny']);
@@ -609,13 +609,13 @@ When a document is upserted, the ID is accessible via
 
 The following example uses :phpmethod:`MongoDB\\Collection::updateOne()` with
 the ``upsert`` option set to ``true`` and an empty ``users`` collection in the
-``demo`` database, therefore inserting the document into the database:
+``test`` database, therefore inserting the document into the database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $updateResult = $collection->updateOne(
@@ -681,7 +681,7 @@ value is ``"ny"``:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $collection->insertOne(['name' => 'Bob', 'state' => 'ny']);
@@ -715,7 +715,7 @@ value is ``"ny"``:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->users;
+   $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
    $collection->insertOne(['name' => 'Bob', 'state' => 'ny']);

--- a/docs/tutorial/decimal128.txt
+++ b/docs/tutorial/decimal128.txt
@@ -36,7 +36,7 @@ field of a collection named ``inventory``:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->inventory;
+   $collection = (new MongoDB\Client)->test->inventory;
 
    $collection->insertOne([
        '_id' => 1,

--- a/docs/tutorial/example-data.txt
+++ b/docs/tutorial/example-data.txt
@@ -5,23 +5,25 @@ Example Data
 .. default-domain:: mongodb
 
 Some examples in this documentation use example data fixtures from
-`zips.json <http://media.mongodb.org/zips.json>`_. This is a dataset comprised
-of United States postal codes, populations, and geographic locations.
+`zips.json <https://media.mongodb.org/zips.json>`_ and
+`primer-dataset.json <https://raw.githubusercontent.com/mongodb/docs-assets/primer-dataset/primer-dataset.json>`_.
 
 Importing the dataset into MongoDB can be done in several ways. The following
-example uses the :php:`driver <mongodb>` directly:
+example imports the `zips.json` file into a `demo.zips` collection:
+:php:`driver <mongodb>` directly:
 
 .. code-block:: php
 
    <?php
 
-   $file = 'http://media.mongodb.org/zips.json';
-   $zips = file($file, FILE_IGNORE_NEW_LINES);
+   $filename = 'https://media.mongodb.org/zips.json';
+   $lines = file($filename, FILE_IGNORE_NEW_LINES);
 
    $bulk = new MongoDB\Driver\BulkWrite;
 
-   foreach ($zips as $string) {
-       $document = json_decode($string);
+   foreach ($lines as $line) {
+       $bson = MongoDB\BSON\fromJSON($line);
+       $document = MongoDB\BSON\toPHP($bson);
        $bulk->insert($document);
    }
 
@@ -34,9 +36,10 @@ The output would then resemble::
 
    Inserted 29353 documents
 
-You may also import the dataset using :manual:`mongoimport
+You may also import the datasets using :manual:`mongoimport
 </reference/program/mongoimport>`, which is included with MongoDB:
 
 .. code-block:: none
 
    $ mongoimport --db demo --collection zips --file zips.json --drop
+   $ mongoimport --db demo --collection restaurants --file primer-dataset.json --drop

--- a/docs/tutorial/example-data.txt
+++ b/docs/tutorial/example-data.txt
@@ -9,7 +9,7 @@ Some examples in this documentation use example data fixtures from
 `primer-dataset.json <https://raw.githubusercontent.com/mongodb/docs-assets/primer-dataset/primer-dataset.json>`_.
 
 Importing the dataset into MongoDB can be done in several ways. The following
-example imports the `zips.json` file into a `demo.zips` collection:
+example imports the `zips.json` file into a `test.zips` collection:
 :php:`driver <mongodb>` directly:
 
 .. code-block:: php
@@ -29,7 +29,7 @@ example imports the `zips.json` file into a `demo.zips` collection:
 
    $manager = new MongoDB\Driver\Manager('mongodb://127.0.0.1/');
 
-   $result = $manager->executeBulkWrite('demo.zips', $bulk);
+   $result = $manager->executeBulkWrite('test.zips', $bulk);
    printf("Inserted %d documents\n", $result->getInsertedCount());
 
 The output would then resemble::
@@ -41,5 +41,5 @@ You may also import the datasets using :manual:`mongoimport
 
 .. code-block:: none
 
-   $ mongoimport --db demo --collection zips --file zips.json --drop
-   $ mongoimport --db demo --collection restaurants --file primer-dataset.json --drop
+   $ mongoimport --db test --collection zips --file zips.json --drop
+   $ mongoimport --db test --collection restaurants --file primer-dataset.json --drop

--- a/docs/tutorial/gridfs.txt
+++ b/docs/tutorial/gridfs.txt
@@ -50,7 +50,7 @@ To open an upload stream and write to it:
 
    <?php
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openUploadStream('my-file.txt');
 
@@ -64,7 +64,7 @@ To upload the entire contents of a readable stream in one call:
 
    <?php
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $file = fopen('/path/to/my-file.txt', 'rb');
    $bucket->uploadFromStream('my-file.txt', $file);
@@ -84,7 +84,7 @@ To open a download stream and read from it:
    // In practice, $fileId denotes the _id of an existing file in GridFS
    $fileId = new MongoDB\BSON\ObjectId;
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openDownloadStream($fileId);
    $contents = stream_get_contents($stream);
@@ -98,7 +98,7 @@ To download the file all at once and write it to a writable stream:
    // In practice, $fileId denotes the _id of an existing file in GridFS
    $fileId = new MongoDB\BSON\ObjectId;
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $file = fopen('/path/to/my-output-file.txt', 'wb');
 
@@ -133,7 +133,7 @@ particular file:
 
    <?php
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openDownloadStreamByName('my-file.txt', ['revision' => 0]);
    $contents = stream_get_contents($stream);
@@ -150,7 +150,7 @@ You can delete a GridFS file by its ``_id``.
    // In practice, $fileId denotes the _id of an existing file in GridFS
    $fileId = new MongoDB\BSON\ObjectId;
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $bucket->delete($fileId);
 
@@ -165,7 +165,7 @@ about the GridFS files.
 
    <?php
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $cursor = $bucket->find(['filename' => 'my-file.txt']);
 
@@ -183,7 +183,7 @@ the file document for an existing readable or writable GridFS stream.
    // In practice, $fileId denotes the _id of an existing file in GridFS
    $fileId = new MongoDB\BSON\ObjectId;
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openDownloadStream($fileId);
    $metadata = $bucket->getFileDocumentForStream($stream);
@@ -208,7 +208,7 @@ convenience for accessing the ``_id`` property of the object returned by
 
    <?php
 
-   $bucket = (new MongoDB\Client)->example->selectGridFSBucket();
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openDownloadStreamByName('my-file.txt');
    $fileId = $bucket->getFileIdForStream($stream);

--- a/docs/tutorial/indexes.txt
+++ b/docs/tutorial/indexes.txt
@@ -37,7 +37,7 @@ the :phpmethod:`createIndex() <MongoDB\\Collection::createIndex>` method:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    $result = $collection->createIndex(['state' => 1]);
 
@@ -59,13 +59,13 @@ about the indexes in a collection. The
 information about each index. Refer to the method reference for more details.
 
 The following example lists all indexes in the ``zips`` collection in the
-``demo`` database:
+``test`` database:
 
 .. code-block:: php
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    foreach ($collection->listIndexes() as $indexInfo) {
        var_dump($indexInfo);
@@ -84,7 +84,7 @@ The output would resemble::
      ["name"]=>
      string(4) "_id_"
      ["ns"]=>
-     string(9) "demo.zips"
+     string(9) "test.zips"
    }
    object(MongoDB\Model\IndexInfo)#13 (4) {
      ["v"]=>
@@ -97,7 +97,7 @@ The output would resemble::
      ["name"]=>
      string(7) "state_1"
      ["ns"]=>
-     string(9) "demo.zips"
+     string(9) "test.zips"
    }
 
 Drop Indexes
@@ -114,7 +114,7 @@ The following example drops a single index by its name, ``state_1``:
 
    <?php
 
-   $collection = (new MongoDB\Client)->demo->zips;
+   $collection = (new MongoDB\Client)->test->zips;
 
    $result = $collection->dropIndex('state_1');
 


### PR DESCRIPTION
Primarily, this standardizes on using a `test` collection in the docs and adds a code example for querying with a `MongoDB\BSON\ObjectID` (per https://github.com/mongodb/mongo-php-library/issues/217#issuecomment-310609419).