### PR TITLE
PHPLIB-271: implemented accessors for options on core classes

### DIFF
--- a/docs/reference/class/MongoDBClient.txt
+++ b/docs/reference/class/MongoDBClient.txt
@@ -32,6 +32,10 @@ Methods
    /reference/method/MongoDBClient__get
    /reference/method/MongoDBClient-dropDatabase
    /reference/method/MongoDBClient-getManager
+   /reference/method/MongoDBClient-getReadConcern
+   /reference/method/MongoDBClient-getReadPreference
+   /reference/method/MongoDBClient-getTypeMap
+   /reference/method/MongoDBClient-getWriteConcern
    /reference/method/MongoDBClient-listDatabases
    /reference/method/MongoDBClient-selectCollection
    /reference/method/MongoDBClient-selectDatabase

--- a/docs/reference/class/MongoDBCollection.txt
+++ b/docs/reference/class/MongoDBCollection.txt
@@ -80,6 +80,10 @@ Methods
    /reference/method/MongoDBCollection-getDatabaseName
    /reference/method/MongoDBCollection-getManager
    /reference/method/MongoDBCollection-getNamespace
+   /reference/method/MongoDBCollection-getReadConcern
+   /reference/method/MongoDBCollection-getReadPreference
+   /reference/method/MongoDBCollection-getTypeMap
+   /reference/method/MongoDBCollection-getWriteConcern
    /reference/method/MongoDBCollection-insertMany
    /reference/method/MongoDBCollection-insertOne
    /reference/method/MongoDBCollection-listIndexes

--- a/docs/reference/class/MongoDBDatabase.txt
+++ b/docs/reference/class/MongoDBDatabase.txt
@@ -51,6 +51,10 @@ Methods
    /reference/method/MongoDBDatabase-dropCollection
    /reference/method/MongoDBDatabase-getDatabaseName
    /reference/method/MongoDBDatabase-getManager
+   /reference/method/MongoDBDatabase-getReadConcern
+   /reference/method/MongoDBDatabase-getReadPreference
+   /reference/method/MongoDBDatabase-getTypeMap
+   /reference/method/MongoDBDatabase-getWriteConcern
    /reference/method/MongoDBDatabase-listCollections
    /reference/method/MongoDBDatabase-selectCollection
    /reference/method/MongoDBDatabase-selectGridFSBucket

--- a/docs/reference/class/MongoDBGridFSBucket.txt
+++ b/docs/reference/class/MongoDBGridFSBucket.txt
@@ -45,6 +45,10 @@ Methods
    /reference/method/MongoDBGridFSBucket-getDatabaseName
    /reference/method/MongoDBGridFSBucket-getFileDocumentForStream
    /reference/method/MongoDBGridFSBucket-getFileIdForStream
+   /reference/method/MongoDBGridFSBucket-getReadConcern
+   /reference/method/MongoDBGridFSBucket-getReadPreference
+   /reference/method/MongoDBGridFSBucket-getTypeMap
+   /reference/method/MongoDBGridFSBucket-getWriteConcern
    /reference/method/MongoDBGridFSBucket-openDownloadStream
    /reference/method/MongoDBGridFSBucket-openDownloadStreamByName
    /reference/method/MongoDBGridFSBucket-openUploadStream

--- a/docs/reference/method/MongoDBClient-getReadConcern.txt
+++ b/docs/reference/method/MongoDBClient-getReadConcern.txt
@@ -1,0 +1,52 @@
+========================================
+MongoDB\\Client::getReadConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Client::getReadConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
+   :phpclass:`Client <MongoDB\\Client>`.
+
+   Returns the default read concern of this client.
+
+   .. code-block:: php
+
+      function getReadConcern(): MongoDB\Driver\ReadConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+   $client = new MongoDB\Client(
+       'mongodb://127.0.0.1/',
+       ['readConcernLevel' => MongoDB\Driver\ReadConcern::MAJORITY]
+   );
+
+   MongoDB\Driver\ReadConcern::MAJORITY === $client->getReadConcern()->getLevel(); // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Collection::getReadConcern()`
+- :phpmethod:`MongoDB\\Database::getReadConcern()`

--- a/docs/reference/method/MongoDBClient-getReadPreference.txt
+++ b/docs/reference/method/MongoDBClient-getReadPreference.txt
@@ -1,0 +1,59 @@
+========================================
+MongoDB\\Client::getReadPreference()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Client::getReadPreference()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
+   :phpclass:`Client <MongoDB\\Client>`.
+
+   Returns the default read preference of this client.
+
+   .. code-block:: php
+
+      function getReadPreference(): MongoDB\Driver\ReadPreference
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $client = new MongoDB\Client(
+       'test',
+       [
+           'readPreference' => MongoDB\Driver\ReadPreference::RP_PRIMARY,
+           'readPreferenceTags' => ['foo' => 'bar', 'spam' => 'egg'],
+           'maxStalenessSeconds' => 150,
+       ]
+   );
+
+   $readPreference = $client->getReadPreference();
+
+   MongoDB\Driver\ReadPreference::RP_PRIMARY === $readPreference->getMode(); // true
+   ['foo' => 'bar', 'spam' => 'egg'] === $readPreference->getTags(); // true
+   150 = $readPreference->getMaxStalenessSeconds(); // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Collection::getReadPreference()`
+- :phpmethod:`MongoDB\\Database::getReadPreference()`

--- a/docs/reference/method/MongoDBClient-getTypeMap.txt
+++ b/docs/reference/method/MongoDBClient-getTypeMap.txt
@@ -1,0 +1,56 @@
+========================================
+MongoDB\\Client::getTypeMap()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Client::getTypeMap()
+
+   Accessor for the type map used by this :phpclass:`Client <MongoDB\\Client>`.
+
+   .. code-block:: php
+
+      function getTypeMap(): array
+
+Return Values
+-------------
+
+A type map array.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
+   $client = new MongoDB\Client('mongodb://127.0.0.1/', [], ['typeMap' => $typeMap]);
+   $client->getTypeMap() === $typeMap; //true
+   var_dump($client->getTypeMap());
+
+The output will be as follows:
+
+   array(3) {
+     ["root"]=>
+     string(5) "array"
+     ["document"]=>
+     string(5) "array"
+     ["array"]=>
+     string(5) "array"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Collection::getTypeMap()`
+- :phpmethod:`MongoDB\\Database::getTypeMap()`

--- a/docs/reference/method/MongoDBClient-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBClient-getWriteConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Client::getWriteConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Client::getWriteConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
+   :phpclass:`Client <MongoDB\\Client>`.
+
+   Returns the default write concern of this client.
+
+   .. code-block:: php
+
+      function getWriteConcern(): MongoDB\Driver\WriteConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $client = new MongoDB\Client('mongodb://127.0.0.1', ['w' => 1, 'wTimeoutMS' => 100, 'journal' => true]);
+   $writeConcern = $client->getWriteConcern();
+   1 === $writeConcern->getW(); // true
+   100 === $writeConcern->getWtimeout(); // true
+   $writeConcern->getJournal(); // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Collection::getWriteConcern()`
+- :phpmethod:`MongoDB\\Database::getWriteConcern()`

--- a/docs/reference/method/MongoDBCollection-getReadConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getReadConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Collection::getReadConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Collection::getReadConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
+   :phpclass:`Collection <MongoDB\\Collection>`.
+
+   Returns the default read concern of this collection.
+
+   .. code-block:: php
+
+      function getReadConcern(): MongoDB\Driver\ReadConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+   $collection = (new MongoDB\Client)->test->selectCollection('test', ['readConcern' => $readConcern]);
+
+   $collection->getReadConcern() === $readConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadConcern()`
+- :phpmethod:`MongoDB\\Database::getReadConcern()`
+- :phpmethod:`MongoDB\\GridFS\Bucket::getReadConcern()`

--- a/docs/reference/method/MongoDBCollection-getReadPreference.txt
+++ b/docs/reference/method/MongoDBCollection-getReadPreference.txt
@@ -1,0 +1,53 @@
+========================================
+MongoDB\\Collection::getReadPreference()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Collection::getReadPreference()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
+   :phpclass:`Collection <MongoDB\\Collection>`.
+
+   Returns the default read preference of this collection.
+
+   .. code-block:: php
+
+      function getReadPreference(): MongoDB\Driver\ReadPreference
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+   $collection = (new MongoDB\Client)->test->selectCollection(
+       'test',
+       ['readPreference' => $readPreference]
+   );
+
+   $collection->getReadPreference() === $readPreference; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadPreference()`
+- :phpmethod:`MongoDB\\Database::getReadPreference()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getReadPreference()`

--- a/docs/reference/method/MongoDBCollection-getTypeMap.txt
+++ b/docs/reference/method/MongoDBCollection-getTypeMap.txt
@@ -1,0 +1,58 @@
+========================================
+MongoDB\\Collection::getTypeMap()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Collection::getTypeMap()
+
+   Accessor for the type map used by this :phpclass:`Collection <MongoDB\\Collection>`.
+
+   .. code-block:: php
+
+      function getTypeMap(): array
+
+Return Values
+-------------
+
+A type map array.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
+   $collection = (new MongoDB\Client)->test->selectCollection('test', ['typeMap' => $typeMap]);
+
+   $collection->getTypeMap() === $typeMap; //true
+   var_dump($collection->getTypeMap());
+
+The output will be as follows:
+
+   array(3) {
+     ["root"]=>
+     string(5) "array"
+     ["document"]=>
+     string(5) "array"
+     ["array"]=>
+     string(5) "array"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getTypeMap()`
+- :phpmethod:`MongoDB\\Database::getTypeMap()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getTypeMap()`

--- a/docs/reference/method/MongoDBCollection-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getWriteConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Collection::getWriteConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Collection::getWriteConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
+   :phpclass:`Collection <MongoDB\\Collection>`.
+
+   Returns the default write concern of this collection.
+
+   .. code-block:: php
+
+      function getWriteConcern(): MongoDB\Driver\WriteConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $writeConcern = new MongoDB\Driver\WriteConcern(2);
+   $collection = (new MongoDB\Client)->test->selectCollection('test', ['writeConcern' => $writeConcern]);
+
+   $collection->getWriteConcern() === $writeConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getWriteConcern()`
+- :phpmethod:`MongoDB\\Database::getWriteConcern()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getWriteConcern()`

--- a/docs/reference/method/MongoDBDatabase-getReadConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Database::getReadConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Database::getReadConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
+   :phpclass:`Database <MongoDB\\Database>`.
+
+   Returns the default read concern of this database.
+
+   .. code-block:: php
+
+      function getReadConcern(): MongoDB\Driver\ReadConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+   $database = (new MongoDB\Client)->selectDatabase('test', ['readConcern' => $readConcern]);
+
+   $database->getReadConcern() === $readConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadConcern()`
+- :phpmethod:`MongoDB\\Collection::getReadConcern()`
+- :phpmethod:`MongoDB\\GridFS\Bucket::getReadConcern()`

--- a/docs/reference/method/MongoDBDatabase-getReadPreference.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadPreference.txt
@@ -1,0 +1,53 @@
+========================================
+MongoDB\\Database::getReadPreference()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Database::getReadPreference()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
+   :phpclass:`Database <MongoDB\\Database>`.
+
+   Returns the default read preference of this database.
+
+   .. code-block:: php
+
+      function getReadPreference(): MongoDB\Driver\ReadPreference
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+   $database = (new MongoDB\Client)->selectDatabase(
+       'test',
+       ['readPreference' => $readPreference]
+   );
+
+   $database->getReadPreference() === $readPreference; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadPreference()`
+- :phpmethod:`MongoDB\\Collection::getReadPreference()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getReadPreference()`

--- a/docs/reference/method/MongoDBDatabase-getTypeMap.txt
+++ b/docs/reference/method/MongoDBDatabase-getTypeMap.txt
@@ -1,0 +1,58 @@
+========================================
+MongoDB\\Database::getTypeMap()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Database::getTypeMap()
+
+   Accessor for the type map used by this :phpclass:`Database <MongoDB\\Database>`.
+
+   .. code-block:: php
+
+      function getTypeMap(): array
+
+Return Values
+-------------
+
+A type map array.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
+   $database = (new MongoDB\Client)->selectDatabase('test', ['typeMap' => $typeMap]);
+
+   $database->getTypeMap() === $typeMap; //true
+   var_dump($database->getTypeMap());
+
+The output will be as follows:
+
+   array(3) {
+     ["root"]=>
+     string(5) "array"
+     ["document"]=>
+     string(5) "array"
+     ["array"]=>
+     string(5) "array"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getTypeMap()`
+- :phpmethod:`MongoDB\\Collection::getTypeMap()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getTypeMap()`

--- a/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Database::getWriteConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Database::getWriteConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
+   :phpclass:`Database <MongoDB\\Database>`.
+
+   Returns the default write concern of this database.
+
+   .. code-block:: php
+
+      function getWriteConcern(): MongoDB\Driver\WriteConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $writeConcern = new MongoDB\Driver\WriteConcern(2);
+   $database = (new MongoDB\Client)->selectDatabase('test', ['writeConcern' => $writeConcern]);
+
+   $database->getWriteConcern() === $writeConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getWriteConcern()`
+- :phpmethod:`MongoDB\\Collection::getWriteConcern()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getWriteConcern()`

--- a/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\GridFS\Bucket::getReadConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\Bucket::getReadConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
+   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+
+   Returns the default read concern of this bucket.
+
+   .. code-block:: php
+
+      function getReadConcern(): MongoDB\Driver\ReadConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['readConcern' => $readConcern]);
+
+   $bucket->getReadConcern() === $readConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadConcern()`
+- :phpmethod:`MongoDB\\Collection::getReadConcern()`
+- :phpmethod:`MongoDB\\Database::getReadConcern()`

--- a/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\GridFS\Bucket::getReadPreference()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\Bucket::getReadPreference()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
+   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+
+   Returns the default read preference of this bucket.
+
+   .. code-block:: php
+
+      function getReadPreference(): MongoDB\Driver\ReadPreference
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['readPreference' => $readPreference]);
+
+   $bucket->getReadPreference() === $readPreference; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadPreference()`
+- :phpmethod:`MongoDB\\Collection::getReadPreference()`
+- :phpmethod:`MongoDB\\Database::getReadPreference()`

--- a/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
@@ -1,0 +1,58 @@
+========================================
+MongoDB\\GridFS\Bucket::getTypeMap()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\Bucket::getTypeMap()
+
+   Accessor for the type map used by this :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+
+   .. code-block:: php
+
+      function getTypeMap(): array
+
+Return Values
+-------------
+
+A type map array.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['typeMap' => $typeMap]);
+
+   $bucket->getTypeMap() === $typeMap; //true
+   var_dump($bucket->getTypeMap());
+
+The output will be as follows:
+
+   array(3) {
+     ["root"]=>
+     string(5) "array"
+     ["document"]=>
+     string(5) "array"
+     ["array"]=>
+     string(5) "array"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getTypeMap()`
+- :phpmethod:`MongoDB\\Collection::getTypeMap()`
+- :phpmethod:`MongoDB\\Database::getTypeMap()`

--- a/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\GridFS\Bucket::getWriteConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\Bucket::getWriteConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
+   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+
+   Returns the default write concern of this bucket.
+
+   .. code-block:: php
+
+      function getWriteConcern(): MongoDB\Driver\WriteConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $writeConcern = new MongoDB\Driver\WriteConcern(2);
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['writeConcern' => $writeConcern]);
+
+   $bucket->getWriteConcern() === $writeConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getWriteConcern()`
+- :phpmethod:`MongoDB\\Collection::getWriteConcern()`
+- :phpmethod:`MongoDB\\Database::getWriteConcern()`

--- a/src/Client.php
+++ b/src/Client.php
@@ -164,6 +164,46 @@ class Client
     }
 
     /**
+     * Return the client default ReadConcern
+     *
+     * @return \MongoDB\Driver\ReadConcern
+     */
+    public function getReadConcern()
+    {
+        return $this->manager->getReadConcern();
+    }
+
+    /**
+     * Return the client default ReadPreference
+     *
+     * @return ReadPreference
+     */
+    public function getReadPreference()
+    {
+        return $this->manager->getReadPreference();
+    }
+
+    /**
+     * Return the client default type map
+     *
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
+    /**
+     * Return the client default WriteConcern
+     *
+     * @return \MongoDB\Driver\WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * List databases.
      *
      * @see ListDatabases::__construct() for supported options

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -706,6 +706,46 @@ class Collection
     }
 
     /**
+     * Return the collection default ReadConcern
+     *
+     * @return ReadConcern
+     */
+    public function getReadConcern()
+    {
+        return $this->readConcern;
+    }
+
+    /**
+     * Return the collection default ReadPreference
+     *
+     * @return ReadPreference
+     */
+    public function getReadPreference()
+    {
+        return $this->readPreference;
+    }
+
+    /**
+     * Return the collection default type map
+     *
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
+    /**
+     * Return the collection default WriteConcern
+     *
+     * @return WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * Inserts multiple documents.
      *
      * @see InsertMany::__construct() for supported options

--- a/src/Database.php
+++ b/src/Database.php
@@ -282,6 +282,46 @@ class Database
     }
 
     /**
+     * Return the database default ReadConcern
+     *
+     * @return ReadConcern
+     */
+    public function getReadConcern()
+    {
+        return $this->readConcern;
+    }
+
+    /**
+     * Return the database default ReadPreference
+     *
+     * @return ReadPreference
+     */
+    public function getReadPreference()
+    {
+        return $this->readPreference;
+    }
+
+    /**
+     * Return the database default type map
+     *
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
+    /**
+     * Return the database default WriteConcern
+     *
+     * @return WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * Returns information for all collections in this database.
      *
      * @see ListCollections::__construct() for supported options

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -331,6 +331,46 @@ class Bucket
     }
 
     /**
+     * Return the bucket default ReadConcern
+     *
+     * @return ReadConcern
+     */
+    public function getReadConcern()
+    {
+        return $this->readConcern;
+    }
+
+    /**
+     * Return the bucket default ReadPreference
+     *
+     * @return ReadPreference
+     */
+    public function getReadPreference()
+    {
+        return $this->readPreference;
+    }
+
+    /**
+     * Return the bucket default type map
+     *
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
+    /**
+     * Return the bucket default WriteConcern
+     *
+     * @return WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * Opens a readable stream for reading a GridFS file.
      *
      * @param mixed $id File ID


### PR DESCRIPTION
Closes #375 

Unfortunately, I was not able to build documentation using `giza` due to such an error:

```
Exception occurred:
  File "<my mongo docs lib>/build/docs-tools/sphinxext/intermanual.py", line 149, in _strip_basic_auth
    url_parts = parse.urlsplit(url)
AttributeError: 'Module_six_moves_urllib_parse' object has no attribute 'urlsplit'
```

So, documentation pages may be not ok.
