### PR TITLE
Remove PHP 5.4 and add PHP 7.1 and 7.2 to CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,57 +1,72 @@
 language: php
+dist: trusty
+sudo: false 
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
+services:
+  - mongodb
 
 env:
   global:
-    - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
-    - MONGO_REPO_URI="http://repo.mongodb.com/apt/ubuntu"
-    - MONGO_REPO_TYPE="precise/mongodb-enterprise/"
-    - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
-  matrix:
-    - DRIVER_VERSION=1.2.0 SERVER_VERSION=2.6
-    - DRIVER_VERSION=1.2.0 SERVER_VERSION=3.0
-    - DRIVER_VERSION=1.2.0 SERVER_VERSION=3.2
+    - DRIVER_VERSION=stable SERVER_VERSION=3.4
+
+addons:
+  apt:
+    packages: &common_packages
+      - gdb
 
 matrix:
   fast_finish: true
   include:
+    - php: 5.5
+      env: &common_env DRIVER_VERSION=stable SERVER_VERSION=3.4
+      addons: &common_addons
+        apt: 
+          sources: [ mongodb-3.4-precise ]
+          packages: [ mongodb-org, *common_packages ]
+    - php: 5.6
+      env: *common_env
+      addons: *common_addons
+    - php: 7.0
+      env: *common_env
+      addons: *common_addons
+    - php: 7.1
+      env: *common_env
+      addons: *common_addons
+    - php: 7.2
+      env: *common_env
+      addons: *common_addons
     - php: 7.0
       env: DRIVER_VERSION=1.2.0 SERVER_VERSION=2.4
+      addons:
+        apt:
+          sources: [ mongodb-upstart ]
+          packages: [ mongodb-10gen, *common_packages ]
     - php: 7.0
-      env: DRIVER_VERSION=devel SERVER_VERSION=3.2
-  exclude:
-    - php: 5.4
-      env: DRIVER_VERSION=stable SERVER_VERSION=2.6
-    - php: 5.4
-      env: DRIVER_VERSION=stable SERVER_VERSION=3.0
-    - php: 5.5
-      env: DRIVER_VERSION=stable SERVER_VERSION=2.6
-    - php: 5.5
-      env: DRIVER_VERSION=stable SERVER_VERSION=3.0
-
-before_install:
-  - sudo apt-key adv --keyserver ${KEY_SERVER} --recv 7F0CEB10
-  - sudo apt-key adv --keyserver ${KEY_SERVER} --recv EA312927
-  - echo "deb ${MONGO_REPO_URI} ${MONGO_REPO_TYPE}${SERVER_VERSION} multiverse" | sudo tee ${SOURCES_LOC}
-  - sudo apt-get update -qq
-
-install:
-  - if dpkg --compare-versions ${SERVER_VERSION} le "2.4"; then export SERVER_PACKAGE=mongodb-10gen-enterprise; else export SERVER_PACKAGE=mongodb-enterprise; fi
-  - sudo apt-get install ${SERVER_PACKAGE}
-  - sudo apt-get -y install gdb
+      env: DRIVER_VERSION=1.2.0 SERVER_VERSION=2.6
+      addons:
+        apt:
+          sources: [ mongodb-upstart ]
+          packages: [ mongodb-org, *common_packages ]
+    - php: 7.0
+      env: DRIVER_VERSION=1.2.0 SERVER_VERSION=3.0
+      addons:
+        apt:
+          sources: [ mongodb-3.0-precise ]
+          packages: [ mongodb-org, *common_packages ]
+    - php: 7.0
+      env: DRIVER_VERSION=1.2.0 SERVER_VERSION=3.2
+      addons:
+        apt:
+          sources: [ mongodb-3.2-precise ]
+          packages: [ mongodb-org, *common_packages ]
+    - php: 7.0
+      env: DRIVER_VERSION=devel SERVER_VERSION=3.4
+      addons: *common_addons
 
 before_script:
-  - phpenv config-rm xdebug.ini
-  - if dpkg --compare-versions ${SERVER_VERSION} le "2.4"; then export SERVER_SERVICE=mongodb; else export SERVER_SERVICE=mongod; fi
-  - if ! nc -z localhost 27017; then sudo service ${SERVER_SERVICE} start; fi
   - mongod --version
+  - mongo --eval 'var v = db.runCommand({buildInfo:1}).versionArray; if ((v[0] == 3 && v[1] >= 4) || v[0] >= 4) db.adminCommand({setFeatureCompatibilityVersion:"3.4"});'
   - pecl install -f mongodb-${DRIVER_VERSION}
-  - if [ "$(php -v | grep 'PHP 5.4')" ]; then echo 'extension = mongodb.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - php --ri mongodb
   - composer install --dev --no-interaction --prefer-source
   - ulimit -c


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-279

This also switches to container-based build environments, which allow installing multiple versions of MongoDB via the apt addon.

/cc @alcaeus: I based this on https://github.com/doctrine/mongodb/pull/301 but found a way to still test MongoDB 2.4 (if you care about that sort of thing ^_^).