### PR TITLE
PHPLIB-271: Implement accessors for options on core classes

### DIFF
--- a/docs/reference/bson.txt
+++ b/docs/reference/bson.txt
@@ -74,6 +74,19 @@ default:
        'root' => 'MongoDB\Model\BSONDocument',
    ]
 
+The type map above will convert BSON documents and arrays to
+:phpclass:`MongoDB\\Model\\BSONDocument` and
+:phpclass:`MongoDB\\Model\\BSONArray` objects, respectively. The ``root`` and
+``document`` keys are used to distinguish the top-level BSON document from
+embedded documents, respectively.
+
+A type map may specify any class that implements
+:php:`MongoDB\\BSON\\Unserializable <mongodb-bson-unserializable>` as well as
+``"array"``, ``"stdClass``", and ``"object"`` (``"stdClass``" and ``"object"``
+are aliases of one another).
+
+.. seealso:: :php:`Deserialization from BSON <manual/en/mongodb.persistence.deserialization.php>` in the PHP manual
+
 ``Persistable`` Classes
 -----------------------
 

--- a/docs/reference/bson.txt
+++ b/docs/reference/bson.txt
@@ -50,6 +50,8 @@ BSON Classes
    serialize as a document type (:php:`object casting
    <types.type-juggling#language.types.typecasting>` is used internally).
 
+.. _php-type-map:
+
 Type Maps
 ---------
 

--- a/docs/reference/class/MongoDBClient.txt
+++ b/docs/reference/class/MongoDBClient.txt
@@ -32,6 +32,10 @@ Methods
    /reference/method/MongoDBClient__get
    /reference/method/MongoDBClient-dropDatabase
    /reference/method/MongoDBClient-getManager
+   /reference/method/MongoDBClient-getReadConcern
+   /reference/method/MongoDBClient-getReadPreference
+   /reference/method/MongoDBClient-getTypeMap
+   /reference/method/MongoDBClient-getWriteConcern
    /reference/method/MongoDBClient-listDatabases
    /reference/method/MongoDBClient-selectCollection
    /reference/method/MongoDBClient-selectDatabase

--- a/docs/reference/class/MongoDBCollection.txt
+++ b/docs/reference/class/MongoDBCollection.txt
@@ -80,6 +80,10 @@ Methods
    /reference/method/MongoDBCollection-getDatabaseName
    /reference/method/MongoDBCollection-getManager
    /reference/method/MongoDBCollection-getNamespace
+   /reference/method/MongoDBCollection-getReadConcern
+   /reference/method/MongoDBCollection-getReadPreference
+   /reference/method/MongoDBCollection-getTypeMap
+   /reference/method/MongoDBCollection-getWriteConcern
    /reference/method/MongoDBCollection-insertMany
    /reference/method/MongoDBCollection-insertOne
    /reference/method/MongoDBCollection-listIndexes

--- a/docs/reference/class/MongoDBDatabase.txt
+++ b/docs/reference/class/MongoDBDatabase.txt
@@ -51,6 +51,10 @@ Methods
    /reference/method/MongoDBDatabase-dropCollection
    /reference/method/MongoDBDatabase-getDatabaseName
    /reference/method/MongoDBDatabase-getManager
+   /reference/method/MongoDBDatabase-getReadConcern
+   /reference/method/MongoDBDatabase-getReadPreference
+   /reference/method/MongoDBDatabase-getTypeMap
+   /reference/method/MongoDBDatabase-getWriteConcern
    /reference/method/MongoDBDatabase-listCollections
    /reference/method/MongoDBDatabase-selectCollection
    /reference/method/MongoDBDatabase-selectGridFSBucket

--- a/docs/reference/class/MongoDBGridFSBucket.txt
+++ b/docs/reference/class/MongoDBGridFSBucket.txt
@@ -45,6 +45,10 @@ Methods
    /reference/method/MongoDBGridFSBucket-getDatabaseName
    /reference/method/MongoDBGridFSBucket-getFileDocumentForStream
    /reference/method/MongoDBGridFSBucket-getFileIdForStream
+   /reference/method/MongoDBGridFSBucket-getReadConcern
+   /reference/method/MongoDBGridFSBucket-getReadPreference
+   /reference/method/MongoDBGridFSBucket-getTypeMap
+   /reference/method/MongoDBGridFSBucket-getWriteConcern
    /reference/method/MongoDBGridFSBucket-openDownloadStream
    /reference/method/MongoDBGridFSBucket-openDownloadStreamByName
    /reference/method/MongoDBGridFSBucket-openUploadStream

--- a/docs/reference/method/MongoDBClient-getReadConcern.txt
+++ b/docs/reference/method/MongoDBClient-getReadConcern.txt
@@ -1,6 +1,6 @@
-========================================
+=================================
 MongoDB\\Client::getReadConcern()
-========================================
+=================================
 
 .. default-domain:: mongodb
 
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Client::getReadConcern()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
-   :phpclass:`Client <MongoDB\\Client>`.
-
-   Returns the default read concern of this client.
+   Returns the read concern for this client.
 
    .. code-block:: php
 
@@ -37,16 +33,24 @@ Example
 
    <?php
 
-   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
-   $client = new MongoDB\Client(
-       'mongodb://127.0.0.1/',
-       ['readConcernLevel' => MongoDB\Driver\ReadConcern::MAJORITY]
-   );
+   $client = new MongoDB\Client('mongodb://127.0.0.1/', [
+       'readConcernLevel' => 'majority',
+   ]);
 
-   MongoDB\Driver\ReadConcern::MAJORITY === $client->getReadConcern()->getLevel(); // true
+   var_dump($client->getReadConcern());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\ReadConcern)#5 (1) {
+     ["level"]=>
+     string(8) "majority"
+   }
 
 See Also
 --------
 
+- :manual:`Read Concern </reference/read-concern>` in the MongoDB manual
+- :php:`MongoDB\\Driver\\ReadConcern::isDefault() <mongodb-driver-readconcern.isdefault>`
 - :phpmethod:`MongoDB\\Collection::getReadConcern()`
 - :phpmethod:`MongoDB\\Database::getReadConcern()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getReadConcern()`

--- a/docs/reference/method/MongoDBClient-getReadConcern.txt
+++ b/docs/reference/method/MongoDBClient-getReadConcern.txt
@@ -1,0 +1,52 @@
+========================================
+MongoDB\\Client::getReadConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Client::getReadConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
+   :phpclass:`Client <MongoDB\\Client>`.
+
+   Returns the default read concern of this client.
+
+   .. code-block:: php
+
+      function getReadConcern(): MongoDB\Driver\ReadConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+   $client = new MongoDB\Client(
+       'mongodb://127.0.0.1/',
+       ['readConcernLevel' => MongoDB\Driver\ReadConcern::MAJORITY]
+   );
+
+   MongoDB\Driver\ReadConcern::MAJORITY === $client->getReadConcern()->getLevel(); // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Collection::getReadConcern()`
+- :phpmethod:`MongoDB\\Database::getReadConcern()`

--- a/docs/reference/method/MongoDBClient-getReadPreference.txt
+++ b/docs/reference/method/MongoDBClient-getReadPreference.txt
@@ -1,0 +1,59 @@
+========================================
+MongoDB\\Client::getReadPreference()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Client::getReadPreference()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
+   :phpclass:`Client <MongoDB\\Client>`.
+
+   Returns the default read preference of this client.
+
+   .. code-block:: php
+
+      function getReadPreference(): MongoDB\Driver\ReadPreference
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $client = new MongoDB\Client(
+       'test',
+       [
+           'readPreference' => MongoDB\Driver\ReadPreference::RP_PRIMARY,
+           'readPreferenceTags' => ['foo' => 'bar', 'spam' => 'egg'],
+           'maxStalenessSeconds' => 150,
+       ]
+   );
+
+   $readPreference = $client->getReadPreference();
+
+   MongoDB\Driver\ReadPreference::RP_PRIMARY === $readPreference->getMode(); // true
+   ['foo' => 'bar', 'spam' => 'egg'] === $readPreference->getTags(); // true
+   150 = $readPreference->getMaxStalenessSeconds(); // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Collection::getReadPreference()`
+- :phpmethod:`MongoDB\\Database::getReadPreference()`

--- a/docs/reference/method/MongoDBClient-getReadPreference.txt
+++ b/docs/reference/method/MongoDBClient-getReadPreference.txt
@@ -1,6 +1,6 @@
-========================================
+====================================
 MongoDB\\Client::getReadPreference()
-========================================
+====================================
 
 .. default-domain:: mongodb
 
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Client::getReadPreference()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
-   :phpclass:`Client <MongoDB\\Client>`.
-
-   Returns the default read preference of this client.
+   Returns the read preference for this client.
 
    .. code-block:: php
 
@@ -28,7 +24,8 @@ Definition
 Return Values
 -------------
 
-A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>`
+object.
 
 Example
 -------
@@ -37,23 +34,23 @@ Example
 
    <?php
 
-   $client = new MongoDB\Client(
-       'test',
-       [
-           'readPreference' => MongoDB\Driver\ReadPreference::RP_PRIMARY,
-           'readPreferenceTags' => ['foo' => 'bar', 'spam' => 'egg'],
-           'maxStalenessSeconds' => 150,
-       ]
-   );
+   $client = new MongoDB\Client('mongodb://127.0.0.1/', [
+       'readPreference' => 'primaryPreferred',
+   ]);
 
-   $readPreference = $client->getReadPreference();
+   var_dump($client->getReadPreference());
 
-   MongoDB\Driver\ReadPreference::RP_PRIMARY === $readPreference->getMode(); // true
-   ['foo' => 'bar', 'spam' => 'egg'] === $readPreference->getTags(); // true
-   150 = $readPreference->getMaxStalenessSeconds(); // true
+The output would then resemble::
+
+   object(MongoDB\Driver\ReadPreference)#5 (1) {
+     ["mode"]=>
+     string(16) "primaryPreferred"
+   }
 
 See Also
 --------
 
+- :manual:`Read Preference </reference/read-preference>` in the MongoDB manual
 - :phpmethod:`MongoDB\\Collection::getReadPreference()`
 - :phpmethod:`MongoDB\\Database::getReadPreference()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getReadPreference()`

--- a/docs/reference/method/MongoDBClient-getTypeMap.txt
+++ b/docs/reference/method/MongoDBClient-getTypeMap.txt
@@ -1,6 +1,6 @@
-========================================
+=============================
 MongoDB\\Client::getTypeMap()
-========================================
+=============================
 
 .. default-domain:: mongodb
 
@@ -15,7 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Client::getTypeMap()
 
-   Accessor for the type map used by this :phpclass:`Client <MongoDB\\Client>`.
+   Returns the type map for this client.
 
    .. code-block:: php
 
@@ -24,7 +24,7 @@ Definition
 Return Values
 -------------
 
-A type map array.
+A :ref:`type map <php-type-map>` array.
 
 Example
 -------
@@ -33,12 +33,17 @@ Example
 
    <?php
 
-   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
-   $client = new MongoDB\Client('mongodb://127.0.0.1/', [], ['typeMap' => $typeMap]);
-   $client->getTypeMap() === $typeMap; //true
+   $client = new MongoDB\Client('mongodb://127.0.0.1/', [], [
+       'typeMap' => [
+           'root' => 'array',
+           'document' => 'array',
+           'array' => 'array',
+       ],
+   ]);
+
    var_dump($client->getTypeMap());
 
-The output will be as follows:
+The output would then resemble::
 
    array(3) {
      ["root"]=>
@@ -52,5 +57,7 @@ The output will be as follows:
 See Also
 --------
 
+- :doc:`/reference/bson`
 - :phpmethod:`MongoDB\\Collection::getTypeMap()`
 - :phpmethod:`MongoDB\\Database::getTypeMap()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getTypeMap()`

--- a/docs/reference/method/MongoDBClient-getTypeMap.txt
+++ b/docs/reference/method/MongoDBClient-getTypeMap.txt
@@ -1,0 +1,56 @@
+========================================
+MongoDB\\Client::getTypeMap()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Client::getTypeMap()
+
+   Accessor for the type map used by this :phpclass:`Client <MongoDB\\Client>`.
+
+   .. code-block:: php
+
+      function getTypeMap(): array
+
+Return Values
+-------------
+
+A type map array.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
+   $client = new MongoDB\Client('mongodb://127.0.0.1/', [], ['typeMap' => $typeMap]);
+   $client->getTypeMap() === $typeMap; //true
+   var_dump($client->getTypeMap());
+
+The output will be as follows:
+
+   array(3) {
+     ["root"]=>
+     string(5) "array"
+     ["document"]=>
+     string(5) "array"
+     ["array"]=>
+     string(5) "array"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Collection::getTypeMap()`
+- :phpmethod:`MongoDB\\Database::getTypeMap()`

--- a/docs/reference/method/MongoDBClient-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBClient-getWriteConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Client::getWriteConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Client::getWriteConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
+   :phpclass:`Client <MongoDB\\Client>`.
+
+   Returns the default write concern of this client.
+
+   .. code-block:: php
+
+      function getWriteConcern(): MongoDB\Driver\WriteConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $client = new MongoDB\Client('mongodb://127.0.0.1', ['w' => 1, 'wTimeoutMS' => 100, 'journal' => true]);
+   $writeConcern = $client->getWriteConcern();
+   1 === $writeConcern->getW(); // true
+   100 === $writeConcern->getWtimeout(); // true
+   $writeConcern->getJournal(); // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Collection::getWriteConcern()`
+- :phpmethod:`MongoDB\\Database::getWriteConcern()`

--- a/docs/reference/method/MongoDBClient-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBClient-getWriteConcern.txt
@@ -1,6 +1,6 @@
-========================================
+==================================
 MongoDB\\Client::getWriteConcern()
-========================================
+==================================
 
 .. default-domain:: mongodb
 
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Client::getWriteConcern()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
-   :phpclass:`Client <MongoDB\\Client>`.
-
-   Returns the default write concern of this client.
+   Returns the write concern for this client.
 
    .. code-block:: php
 
@@ -28,7 +24,8 @@ Definition
 Return Values
 -------------
 
-A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>`
+object.
 
 Example
 -------
@@ -37,14 +34,24 @@ Example
 
    <?php
 
-   $client = new MongoDB\Client('mongodb://127.0.0.1', ['w' => 1, 'wTimeoutMS' => 100, 'journal' => true]);
-   $writeConcern = $client->getWriteConcern();
-   1 === $writeConcern->getW(); // true
-   100 === $writeConcern->getWtimeout(); // true
-   $writeConcern->getJournal(); // true
+   $client = new MongoDB\Client('mongodb://127.0.0.1/', [
+       'journal' => true,
+   ]);
+
+   var_dump($client->getWriteConcern());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\WriteConcern)#4 (1) {
+     ["j"]=>
+     bool(true)
+   }
 
 See Also
 --------
 
+- :manual:`Write Concern </reference/read-concern>` in the MongoDB manual
+- :php:`MongoDB\\Driver\\WriteConcern::isDefault() <mongodb-driver-writeconcern.isdefault>`
 - :phpmethod:`MongoDB\\Collection::getWriteConcern()`
 - :phpmethod:`MongoDB\\Database::getWriteConcern()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getWriteConcern()`

--- a/docs/reference/method/MongoDBCollection-getReadConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getReadConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Collection::getReadConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Collection::getReadConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
+   :phpclass:`Collection <MongoDB\\Collection>`.
+
+   Returns the default read concern of this collection.
+
+   .. code-block:: php
+
+      function getReadConcern(): MongoDB\Driver\ReadConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+   $collection = (new MongoDB\Client)->test->selectCollection('test', ['readConcern' => $readConcern]);
+
+   $collection->getReadConcern() === $readConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadConcern()`
+- :phpmethod:`MongoDB\\Database::getReadConcern()`
+- :phpmethod:`MongoDB\\GridFS\Bucket::getReadConcern()`

--- a/docs/reference/method/MongoDBCollection-getReadConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getReadConcern.txt
@@ -1,6 +1,6 @@
-========================================
+=====================================
 MongoDB\\Collection::getReadConcern()
-========================================
+=====================================
 
 .. default-domain:: mongodb
 
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Collection::getReadConcern()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
-   :phpclass:`Collection <MongoDB\\Collection>`.
-
-   Returns the default read concern of this collection.
+   Returns the read concern for this collection.
 
    .. code-block:: php
 
@@ -37,14 +33,24 @@ Example
 
    <?php
 
-   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
-   $collection = (new MongoDB\Client)->test->selectCollection('test', ['readConcern' => $readConcern]);
+   $collection = (new MongoDB\Client)->selectCollection('test', 'users', [
+      'readConcern' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
+   ]);
 
-   $collection->getReadConcern() === $readConcern; // true
+   var_dump($collection->getReadConcern());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\ReadConcern)#5 (1) {
+     ["level"]=>
+     string(8) "majority"
+   }
 
 See Also
 --------
 
+- :manual:`Read Concern </reference/read-concern>` in the MongoDB manual
+- :php:`MongoDB\\Driver\\ReadConcern::isDefault() <mongodb-driver-readconcern.isdefault>`
 - :phpmethod:`MongoDB\\Client::getReadConcern()`
 - :phpmethod:`MongoDB\\Database::getReadConcern()`
-- :phpmethod:`MongoDB\\GridFS\Bucket::getReadConcern()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getReadConcern()`

--- a/docs/reference/method/MongoDBCollection-getReadPreference.txt
+++ b/docs/reference/method/MongoDBCollection-getReadPreference.txt
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Collection::getReadPreference()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
-   :phpclass:`Collection <MongoDB\\Collection>`.
-
-   Returns the default read preference of this collection.
+   Returns the read preference for this collection.
 
    .. code-block:: php
 
@@ -28,7 +24,8 @@ Definition
 Return Values
 -------------
 
-A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>`
+object.
 
 Example
 -------
@@ -37,17 +34,23 @@ Example
 
    <?php
 
-   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-   $collection = (new MongoDB\Client)->test->selectCollection(
-       'test',
-       ['readPreference' => $readPreference]
-   );
+   $collection = (new MongoDB\Client)->selectCollection('test', 'users', [
+       'readPreference' => new MongoDB\Driver\ReadPreference('primaryPreferred'),
+   ]);
 
-   $collection->getReadPreference() === $readPreference; // true
+   var_dump($collection->getReadPreference());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\ReadPreference)#5 (1) {
+     ["mode"]=>
+     string(16) "primaryPreferred"
+   }
 
 See Also
 --------
 
+- :manual:`Read Preference </reference/read-preference>` in the MongoDB manual
 - :phpmethod:`MongoDB\\Client::getReadPreference()`
 - :phpmethod:`MongoDB\\Database::getReadPreference()`
 - :phpmethod:`MongoDB\\GridFS\\Bucket::getReadPreference()`

--- a/docs/reference/method/MongoDBCollection-getReadPreference.txt
+++ b/docs/reference/method/MongoDBCollection-getReadPreference.txt
@@ -1,0 +1,53 @@
+========================================
+MongoDB\\Collection::getReadPreference()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Collection::getReadPreference()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
+   :phpclass:`Collection <MongoDB\\Collection>`.
+
+   Returns the default read preference of this collection.
+
+   .. code-block:: php
+
+      function getReadPreference(): MongoDB\Driver\ReadPreference
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+   $collection = (new MongoDB\Client)->test->selectCollection(
+       'test',
+       ['readPreference' => $readPreference]
+   );
+
+   $collection->getReadPreference() === $readPreference; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadPreference()`
+- :phpmethod:`MongoDB\\Database::getReadPreference()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getReadPreference()`

--- a/docs/reference/method/MongoDBCollection-getTypeMap.txt
+++ b/docs/reference/method/MongoDBCollection-getTypeMap.txt
@@ -1,6 +1,6 @@
-========================================
+=================================
 MongoDB\\Collection::getTypeMap()
-========================================
+=================================
 
 .. default-domain:: mongodb
 
@@ -15,7 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Collection::getTypeMap()
 
-   Accessor for the type map used by this :phpclass:`Collection <MongoDB\\Collection>`.
+   Returns the type map for this collection.
 
    .. code-block:: php
 
@@ -24,7 +24,7 @@ Definition
 Return Values
 -------------
 
-A type map array.
+A :ref:`type map <php-type-map>` array.
 
 Example
 -------
@@ -33,13 +33,17 @@ Example
 
    <?php
 
-   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
-   $collection = (new MongoDB\Client)->test->selectCollection('test', ['typeMap' => $typeMap]);
+   $collection = (new MongoDB\Client)->selectCollection('test', 'users', [
+       'typeMap' => [
+           'root' => 'array',
+           'document' => 'array',
+           'array' => 'array',
+       ],
+   ]);
 
-   $collection->getTypeMap() === $typeMap; //true
    var_dump($collection->getTypeMap());
 
-The output will be as follows:
+The output would then resemble::
 
    array(3) {
      ["root"]=>
@@ -53,6 +57,7 @@ The output will be as follows:
 See Also
 --------
 
+- :doc:`/reference/bson`
 - :phpmethod:`MongoDB\\Client::getTypeMap()`
 - :phpmethod:`MongoDB\\Database::getTypeMap()`
 - :phpmethod:`MongoDB\\GridFS\\Bucket::getTypeMap()`

--- a/docs/reference/method/MongoDBCollection-getTypeMap.txt
+++ b/docs/reference/method/MongoDBCollection-getTypeMap.txt
@@ -1,0 +1,58 @@
+========================================
+MongoDB\\Collection::getTypeMap()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Collection::getTypeMap()
+
+   Accessor for the type map used by this :phpclass:`Collection <MongoDB\\Collection>`.
+
+   .. code-block:: php
+
+      function getTypeMap(): array
+
+Return Values
+-------------
+
+A type map array.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
+   $collection = (new MongoDB\Client)->test->selectCollection('test', ['typeMap' => $typeMap]);
+
+   $collection->getTypeMap() === $typeMap; //true
+   var_dump($collection->getTypeMap());
+
+The output will be as follows:
+
+   array(3) {
+     ["root"]=>
+     string(5) "array"
+     ["document"]=>
+     string(5) "array"
+     ["array"]=>
+     string(5) "array"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getTypeMap()`
+- :phpmethod:`MongoDB\\Database::getTypeMap()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getTypeMap()`

--- a/docs/reference/method/MongoDBCollection-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getWriteConcern.txt
@@ -1,6 +1,6 @@
-========================================
+======================================
 MongoDB\\Collection::getWriteConcern()
-========================================
+======================================
 
 .. default-domain:: mongodb
 
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Collection::getWriteConcern()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
-   :phpclass:`Collection <MongoDB\\Collection>`.
-
-   Returns the default write concern of this collection.
+   Returns the write concern for this collection.
 
    .. code-block:: php
 
@@ -28,7 +24,8 @@ Definition
 Return Values
 -------------
 
-A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>`
+object.
 
 Example
 -------
@@ -37,14 +34,26 @@ Example
 
    <?php
 
-   $writeConcern = new MongoDB\Driver\WriteConcern(2);
-   $collection = (new MongoDB\Client)->test->selectCollection('test', ['writeConcern' => $writeConcern]);
+   $collection = (new MongoDB\Client)->selectCollection('test', 'users', [
+      'writeConcern' => new MongoDB\Driver\WriteConcern(1, 0, true),
+   ]);
 
-   $collection->getWriteConcern() === $writeConcern; // true
+   var_dump($collection->getWriteConcern());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\WriteConcern)#5 (2) {
+     ["w"]=>
+     int(1)
+     ["j"]=>
+     bool(true)
+   }
 
 See Also
 --------
 
+- :manual:`Write Concern </reference/read-concern>` in the MongoDB manual
+- :php:`MongoDB\\Driver\\WriteConcern::isDefault() <mongodb-driver-writeconcern.isdefault>`
 - :phpmethod:`MongoDB\\Client::getWriteConcern()`
 - :phpmethod:`MongoDB\\Database::getWriteConcern()`
 - :phpmethod:`MongoDB\\GridFS\\Bucket::getWriteConcern()`

--- a/docs/reference/method/MongoDBCollection-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getWriteConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Collection::getWriteConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Collection::getWriteConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
+   :phpclass:`Collection <MongoDB\\Collection>`.
+
+   Returns the default write concern of this collection.
+
+   .. code-block:: php
+
+      function getWriteConcern(): MongoDB\Driver\WriteConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $writeConcern = new MongoDB\Driver\WriteConcern(2);
+   $collection = (new MongoDB\Client)->test->selectCollection('test', ['writeConcern' => $writeConcern]);
+
+   $collection->getWriteConcern() === $writeConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getWriteConcern()`
+- :phpmethod:`MongoDB\\Database::getWriteConcern()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getWriteConcern()`

--- a/docs/reference/method/MongoDBDatabase-getReadConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadConcern.txt
@@ -1,6 +1,6 @@
-========================================
+===================================
 MongoDB\\Database::getReadConcern()
-========================================
+===================================
 
 .. default-domain:: mongodb
 
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Database::getReadConcern()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
-   :phpclass:`Database <MongoDB\\Database>`.
-
-   Returns the default read concern of this database.
+   Returns the read concern for this database.
 
    .. code-block:: php
 
@@ -37,14 +33,24 @@ Example
 
    <?php
 
-   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
-   $database = (new MongoDB\Client)->selectDatabase('test', ['readConcern' => $readConcern]);
+   $database = (new MongoDB\Client)->selectDatabase('test', [
+      'readConcern' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
+   ]);
 
-   $database->getReadConcern() === $readConcern; // true
+   var_dump($database->getReadConcern());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\ReadConcern)#5 (1) {
+     ["level"]=>
+     string(8) "majority"
+   }
 
 See Also
 --------
 
+- :manual:`Read Concern </reference/read-concern>` in the MongoDB manual
+- :php:`MongoDB\\Driver\\ReadConcern::isDefault() <mongodb-driver-readconcern.isdefault>`
 - :phpmethod:`MongoDB\\Client::getReadConcern()`
 - :phpmethod:`MongoDB\\Collection::getReadConcern()`
-- :phpmethod:`MongoDB\\GridFS\Bucket::getReadConcern()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getReadConcern()`

--- a/docs/reference/method/MongoDBDatabase-getReadConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Database::getReadConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Database::getReadConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
+   :phpclass:`Database <MongoDB\\Database>`.
+
+   Returns the default read concern of this database.
+
+   .. code-block:: php
+
+      function getReadConcern(): MongoDB\Driver\ReadConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+   $database = (new MongoDB\Client)->selectDatabase('test', ['readConcern' => $readConcern]);
+
+   $database->getReadConcern() === $readConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadConcern()`
+- :phpmethod:`MongoDB\\Collection::getReadConcern()`
+- :phpmethod:`MongoDB\\GridFS\Bucket::getReadConcern()`

--- a/docs/reference/method/MongoDBDatabase-getReadPreference.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadPreference.txt
@@ -1,6 +1,6 @@
-========================================
+======================================
 MongoDB\\Database::getReadPreference()
-========================================
+======================================
 
 .. default-domain:: mongodb
 
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Database::getReadPreference()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
-   :phpclass:`Database <MongoDB\\Database>`.
-
-   Returns the default read preference of this database.
+   Returns the read preference for this database.
 
    .. code-block:: php
 
@@ -28,7 +24,8 @@ Definition
 Return Values
 -------------
 
-A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>`
+object.
 
 Example
 -------
@@ -37,17 +34,23 @@ Example
 
    <?php
 
-   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-   $database = (new MongoDB\Client)->selectDatabase(
-       'test',
-       ['readPreference' => $readPreference]
-   );
+   $database = (new MongoDB\Client)->selectDatabase('test', [
+       'readPreference' => new MongoDB\Driver\ReadPreference('primaryPreferred'),
+   ]);
 
-   $database->getReadPreference() === $readPreference; // true
+   var_dump($database->getReadPreference());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\ReadPreference)#5 (1) {
+     ["mode"]=>
+     string(16) "primaryPreferred"
+   }
 
 See Also
 --------
 
+- :manual:`Read Preference </reference/read-preference>` in the MongoDB manual
 - :phpmethod:`MongoDB\\Client::getReadPreference()`
 - :phpmethod:`MongoDB\\Collection::getReadPreference()`
 - :phpmethod:`MongoDB\\GridFS\\Bucket::getReadPreference()`

--- a/docs/reference/method/MongoDBDatabase-getReadPreference.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadPreference.txt
@@ -1,0 +1,53 @@
+========================================
+MongoDB\\Database::getReadPreference()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Database::getReadPreference()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
+   :phpclass:`Database <MongoDB\\Database>`.
+
+   Returns the default read preference of this database.
+
+   .. code-block:: php
+
+      function getReadPreference(): MongoDB\Driver\ReadPreference
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+   $database = (new MongoDB\Client)->selectDatabase(
+       'test',
+       ['readPreference' => $readPreference]
+   );
+
+   $database->getReadPreference() === $readPreference; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadPreference()`
+- :phpmethod:`MongoDB\\Collection::getReadPreference()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getReadPreference()`

--- a/docs/reference/method/MongoDBDatabase-getTypeMap.txt
+++ b/docs/reference/method/MongoDBDatabase-getTypeMap.txt
@@ -1,0 +1,58 @@
+========================================
+MongoDB\\Database::getTypeMap()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Database::getTypeMap()
+
+   Accessor for the type map used by this :phpclass:`Database <MongoDB\\Database>`.
+
+   .. code-block:: php
+
+      function getTypeMap(): array
+
+Return Values
+-------------
+
+A type map array.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
+   $database = (new MongoDB\Client)->selectDatabase('test', ['typeMap' => $typeMap]);
+
+   $database->getTypeMap() === $typeMap; //true
+   var_dump($database->getTypeMap());
+
+The output will be as follows:
+
+   array(3) {
+     ["root"]=>
+     string(5) "array"
+     ["document"]=>
+     string(5) "array"
+     ["array"]=>
+     string(5) "array"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getTypeMap()`
+- :phpmethod:`MongoDB\\Collection::getTypeMap()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getTypeMap()`

--- a/docs/reference/method/MongoDBDatabase-getTypeMap.txt
+++ b/docs/reference/method/MongoDBDatabase-getTypeMap.txt
@@ -1,6 +1,6 @@
-========================================
+===============================
 MongoDB\\Database::getTypeMap()
-========================================
+===============================
 
 .. default-domain:: mongodb
 
@@ -15,7 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Database::getTypeMap()
 
-   Accessor for the type map used by this :phpclass:`Database <MongoDB\\Database>`.
+   Returns the type map for this database.
 
    .. code-block:: php
 
@@ -24,7 +24,7 @@ Definition
 Return Values
 -------------
 
-A type map array.
+A :ref:`type map <php-type-map>` array.
 
 Example
 -------
@@ -33,13 +33,17 @@ Example
 
    <?php
 
-   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
-   $database = (new MongoDB\Client)->selectDatabase('test', ['typeMap' => $typeMap]);
+   $database = (new MongoDB\Client)->selectDatabase('test', [
+       'typeMap' => [
+           'root' => 'array',
+           'document' => 'array',
+           'array' => 'array',
+       ],
+   ]);
 
-   $database->getTypeMap() === $typeMap; //true
    var_dump($database->getTypeMap());
 
-The output will be as follows:
+The output would then resemble::
 
    array(3) {
      ["root"]=>
@@ -53,6 +57,7 @@ The output will be as follows:
 See Also
 --------
 
+- :doc:`/reference/bson`
 - :phpmethod:`MongoDB\\Client::getTypeMap()`
 - :phpmethod:`MongoDB\\Collection::getTypeMap()`
 - :phpmethod:`MongoDB\\GridFS\\Bucket::getTypeMap()`

--- a/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
@@ -1,6 +1,6 @@
-========================================
+====================================
 MongoDB\\Database::getWriteConcern()
-========================================
+====================================
 
 .. default-domain:: mongodb
 
@@ -15,11 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\Database::getWriteConcern()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
-   :phpclass:`Database <MongoDB\\Database>`.
-
-   Returns the default write concern of this database.
+   Returns the write concern for this database.
 
    .. code-block:: php
 
@@ -28,7 +24,8 @@ Definition
 Return Values
 -------------
 
-A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>`
+object.
 
 Example
 -------
@@ -37,14 +34,26 @@ Example
 
    <?php
 
-   $writeConcern = new MongoDB\Driver\WriteConcern(2);
-   $database = (new MongoDB\Client)->selectDatabase('test', ['writeConcern' => $writeConcern]);
+   $database = (new MongoDB\Client)->selectDatabase('test', [
+      'writeConcern' => new MongoDB\Driver\WriteConcern(1, 0, true),
+   ]);
 
-   $database->getWriteConcern() === $writeConcern; // true
+   var_dump($database->getWriteConcern());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\WriteConcern)#5 (2) {
+     ["w"]=>
+     int(1)
+     ["j"]=>
+     bool(true)
+   }
 
 See Also
 --------
 
+- :manual:`Write Concern </reference/read-concern>` in the MongoDB manual
+- :php:`MongoDB\\Driver\\WriteConcern::isDefault() <mongodb-driver-writeconcern.isdefault>`
 - :phpmethod:`MongoDB\\Client::getWriteConcern()`
 - :phpmethod:`MongoDB\\Collection::getWriteConcern()`
 - :phpmethod:`MongoDB\\GridFS\\Bucket::getWriteConcern()`

--- a/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\Database::getWriteConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Database::getWriteConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
+   :phpclass:`Database <MongoDB\\Database>`.
+
+   Returns the default write concern of this database.
+
+   .. code-block:: php
+
+      function getWriteConcern(): MongoDB\Driver\WriteConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $writeConcern = new MongoDB\Driver\WriteConcern(2);
+   $database = (new MongoDB\Client)->selectDatabase('test', ['writeConcern' => $writeConcern]);
+
+   $database->getWriteConcern() === $writeConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getWriteConcern()`
+- :phpmethod:`MongoDB\\Collection::getWriteConcern()`
+- :phpmethod:`MongoDB\\GridFS\\Bucket::getWriteConcern()`

--- a/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
@@ -1,6 +1,6 @@
-========================================
-MongoDB\\GridFS\Bucket::getReadConcern()
-========================================
+=========================================
+MongoDB\\GridFS\\Bucket::getReadConcern()
+=========================================
 
 .. default-domain:: mongodb
 
@@ -13,13 +13,9 @@ MongoDB\\GridFS\Bucket::getReadConcern()
 Definition
 ----------
 
-.. phpmethod:: MongoDB\\GridFS\Bucket::getReadConcern()
+.. phpmethod:: MongoDB\\GridFS\\Bucket::getReadConcern()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
-   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
-
-   Returns the default read concern of this bucket.
+   Returns the read concern for this GridFS bucket.
 
    .. code-block:: php
 
@@ -37,14 +33,25 @@ Example
 
    <?php
 
-   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
-   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['readConcern' => $readConcern]);
+   $database = (new MongoDB\Client)->selectDatabase('test');
+   $bucket = $database->selectGridFSBucket([
+      'readConcern' => new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY),
+   ]);
 
-   $bucket->getReadConcern() === $readConcern; // true
+   var_dump($bucket->getReadConcern());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\ReadConcern)#3 (1) {
+     ["level"]=>
+     string(8) "majority"
+   }
 
 See Also
 --------
 
+- :manual:`Read Concern </reference/read-concern>` in the MongoDB manual
+- :php:`MongoDB\\Driver\\ReadConcern::isDefault() <mongodb-driver-readconcern.isdefault>`
 - :phpmethod:`MongoDB\\Client::getReadConcern()`
 - :phpmethod:`MongoDB\\Collection::getReadConcern()`
 - :phpmethod:`MongoDB\\Database::getReadConcern()`

--- a/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\GridFS\Bucket::getReadConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\Bucket::getReadConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` used by this
+   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+
+   Returns the default read concern of this bucket.
+
+   .. code-block:: php
+
+      function getReadConcern(): MongoDB\Driver\ReadConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadConcern <class.mongodb-driver-readconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readConcern = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['readConcern' => $readConcern]);
+
+   $bucket->getReadConcern() === $readConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadConcern()`
+- :phpmethod:`MongoDB\\Collection::getReadConcern()`
+- :phpmethod:`MongoDB\\Database::getReadConcern()`

--- a/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
@@ -1,6 +1,6 @@
-========================================
-MongoDB\\GridFS\Bucket::getReadPreference()
-========================================
+============================================
+MongoDB\\GridFS\\Bucket::getReadPreference()
+============================================
 
 .. default-domain:: mongodb
 
@@ -13,13 +13,9 @@ MongoDB\\GridFS\Bucket::getReadPreference()
 Definition
 ----------
 
-.. phpmethod:: MongoDB\\GridFS\Bucket::getReadPreference()
+.. phpmethod:: MongoDB\\GridFS\\Bucket::getReadPreference()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
-   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
-
-   Returns the default read preference of this bucket.
+   Returns the read preference for this GridFS bucket.
 
    .. code-block:: php
 
@@ -28,7 +24,8 @@ Definition
 Return Values
 -------------
 
-A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>`
+object.
 
 Example
 -------
@@ -37,14 +34,24 @@ Example
 
    <?php
 
-   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
-   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['readPreference' => $readPreference]);
+   $database = (new MongoDB\Client)->selectDatabase('test');
+   $bucket = $database->selectGridFSBucket([
+      'readPreference' => new MongoDB\Driver\ReadPreference('primaryPreferred'),
+   ]);
 
-   $bucket->getReadPreference() === $readPreference; // true
+   var_dump($bucket->getReadPreference());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\ReadPreference)#3 (1) {
+     ["mode"]=>
+     string(16) "primaryPreferred"
+   }
 
 See Also
 --------
 
+- :manual:`Read Preference </reference/read-preference>` in the MongoDB manual
 - :phpmethod:`MongoDB\\Client::getReadPreference()`
 - :phpmethod:`MongoDB\\Collection::getReadPreference()`
 - :phpmethod:`MongoDB\\Database::getReadPreference()`

--- a/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\GridFS\Bucket::getReadPreference()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\Bucket::getReadPreference()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` used by this
+   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+
+   Returns the default read preference of this bucket.
+
+   .. code-block:: php
+
+      function getReadPreference(): MongoDB\Driver\ReadPreference
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\ReadPreference <class.mongodb-driver-readpreference>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $readPreference = new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::RP_PRIMARY);
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['readPreference' => $readPreference]);
+
+   $bucket->getReadPreference() === $readPreference; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getReadPreference()`
+- :phpmethod:`MongoDB\\Collection::getReadPreference()`
+- :phpmethod:`MongoDB\\Database::getReadPreference()`

--- a/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
@@ -1,6 +1,6 @@
-========================================
-MongoDB\\GridFS\Bucket::getTypeMap()
-========================================
+=====================================
+MongoDB\\GridFS\\Bucket::getTypeMap()
+=====================================
 
 .. default-domain:: mongodb
 
@@ -13,9 +13,9 @@ MongoDB\\GridFS\Bucket::getTypeMap()
 Definition
 ----------
 
-.. phpmethod:: MongoDB\\GridFS\Bucket::getTypeMap()
+.. phpmethod:: MongoDB\\GridFS\\Bucket::getTypeMap()
 
-   Accessor for the type map used by this :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+   Returns the type map for this GridFS bucket.
 
    .. code-block:: php
 
@@ -24,7 +24,7 @@ Definition
 Return Values
 -------------
 
-A type map array.
+A :ref:`type map <php-type-map>` array.
 
 Example
 -------
@@ -33,13 +33,18 @@ Example
 
    <?php
 
-   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
-   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['typeMap' => $typeMap]);
+   $database = (new MongoDB\Client)->selectDatabase('test');
+   $bucket = $database->selectGridFSBucket([
+       'typeMap' => [
+           'root' => 'array',
+           'document' => 'array',
+           'array' => 'array',
+       ],
+   ]);
 
-   $bucket->getTypeMap() === $typeMap; //true
    var_dump($bucket->getTypeMap());
 
-The output will be as follows:
+The output would then resemble::
 
    array(3) {
      ["root"]=>
@@ -53,6 +58,7 @@ The output will be as follows:
 See Also
 --------
 
+- :doc:`/reference/bson`
 - :phpmethod:`MongoDB\\Client::getTypeMap()`
 - :phpmethod:`MongoDB\\Collection::getTypeMap()`
 - :phpmethod:`MongoDB\\Database::getTypeMap()`

--- a/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
@@ -1,0 +1,58 @@
+========================================
+MongoDB\\GridFS\Bucket::getTypeMap()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\Bucket::getTypeMap()
+
+   Accessor for the type map used by this :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+
+   .. code-block:: php
+
+      function getTypeMap(): array
+
+Return Values
+-------------
+
+A type map array.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $typeMap = ['root' => 'array', 'document' => 'array', 'array' => 'array'];
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['typeMap' => $typeMap]);
+
+   $bucket->getTypeMap() === $typeMap; //true
+   var_dump($bucket->getTypeMap());
+
+The output will be as follows:
+
+   array(3) {
+     ["root"]=>
+     string(5) "array"
+     ["document"]=>
+     string(5) "array"
+     ["array"]=>
+     string(5) "array"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getTypeMap()`
+- :phpmethod:`MongoDB\\Collection::getTypeMap()`
+- :phpmethod:`MongoDB\\Database::getTypeMap()`

--- a/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
@@ -1,0 +1,50 @@
+========================================
+MongoDB\\GridFS\Bucket::getWriteConcern()
+========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\Bucket::getWriteConcern()
+
+   Accessor for the
+   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
+   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
+
+   Returns the default write concern of this bucket.
+
+   .. code-block:: php
+
+      function getWriteConcern(): MongoDB\Driver\WriteConcern
+
+Return Values
+-------------
+
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+
+Example
+-------
+
+.. code-block:: php
+
+   <?php
+
+   $writeConcern = new MongoDB\Driver\WriteConcern(2);
+   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['writeConcern' => $writeConcern]);
+
+   $bucket->getWriteConcern() === $writeConcern; // true
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Client::getWriteConcern()`
+- :phpmethod:`MongoDB\\Collection::getWriteConcern()`
+- :phpmethod:`MongoDB\\Database::getWriteConcern()`

--- a/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
@@ -1,6 +1,6 @@
-========================================
+=========================================
 MongoDB\\GridFS\Bucket::getWriteConcern()
-========================================
+=========================================
 
 .. default-domain:: mongodb
 
@@ -13,13 +13,9 @@ MongoDB\\GridFS\Bucket::getWriteConcern()
 Definition
 ----------
 
-.. phpmethod:: MongoDB\\GridFS\Bucket::getWriteConcern()
+.. phpmethod:: MongoDB\\GridFS\\Bucket::getWriteConcern()
 
-   Accessor for the
-   :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` used by this
-   :phpclass:`Bucket <MongoDB\\GridFS\Bucket>`.
-
-   Returns the default write concern of this bucket.
+   Returns the write concern for this GridFS bucket.
 
    .. code-block:: php
 
@@ -28,7 +24,8 @@ Definition
 Return Values
 -------------
 
-A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>` object.
+A :php:`MongoDB\\Driver\\WriteConcern <class.mongodb-driver-writeconcern>`
+object.
 
 Example
 -------
@@ -37,14 +34,27 @@ Example
 
    <?php
 
-   $writeConcern = new MongoDB\Driver\WriteConcern(2);
-   $bucket = (new MongoDB\Client)->test->selectGridFSBucket(['writeConcern' => $writeConcern]);
+   $database = (new MongoDB\Client)->selectDatabase('test');
+   $bucket = $database->selectGridFSBucket([
+      'writeConcern' => new MongoDB\Driver\WriteConcern(1, 0, true),
+   ]);
 
-   $bucket->getWriteConcern() === $writeConcern; // true
+   var_dump($bucket->getWriteConcern());
+
+The output would then resemble::
+
+   object(MongoDB\Driver\WriteConcern)#3 (2) {
+     ["w"]=>
+     int(1)
+     ["j"]=>
+     bool(true)
+   }
 
 See Also
 --------
 
+- :manual:`Write Concern </reference/read-concern>` in the MongoDB manual
+- :php:`MongoDB\\Driver\\WriteConcern::isDefault() <mongodb-driver-writeconcern.isdefault>`
 - :phpmethod:`MongoDB\\Client::getWriteConcern()`
 - :phpmethod:`MongoDB\\Collection::getWriteConcern()`
 - :phpmethod:`MongoDB\\Database::getWriteConcern()`

--- a/src/Client.php
+++ b/src/Client.php
@@ -164,6 +164,46 @@ class Client
     }
 
     /**
+     * Return the client default ReadConcern
+     *
+     * @return \MongoDB\Driver\ReadConcern
+     */
+    public function getReadConcern()
+    {
+        return $this->manager->getReadConcern();
+    }
+
+    /**
+     * Return the client default ReadPreference
+     *
+     * @return ReadPreference
+     */
+    public function getReadPreference()
+    {
+        return $this->manager->getReadPreference();
+    }
+
+    /**
+     * Return the client default type map
+     *
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
+    /**
+     * Return the client default WriteConcern
+     *
+     * @return \MongoDB\Driver\WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * List databases.
      *
      * @see ListDatabases::__construct() for supported options

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,7 +18,9 @@
 namespace MongoDB;
 
 use MongoDB\Driver\Manager;
+use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\WriteConcern;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Exception\InvalidArgumentException as DriverInvalidArgumentException;
 use MongoDB\Exception\InvalidArgumentException;
@@ -164,9 +166,10 @@ class Client
     }
 
     /**
-     * Return the client default ReadConcern
+     * Return the read concern for this client.
      *
-     * @return \MongoDB\Driver\ReadConcern
+     * @see http://php.net/manual/en/mongodb-driver-readconcern.isdefault.php
+     * @return ReadConcern
      */
     public function getReadConcern()
     {
@@ -174,7 +177,7 @@ class Client
     }
 
     /**
-     * Return the client default ReadPreference
+     * Return the read preference for this client.
      *
      * @return ReadPreference
      */
@@ -184,7 +187,7 @@ class Client
     }
 
     /**
-     * Return the client default type map
+     * Return the type map for this client.
      *
      * @return array
      */
@@ -194,9 +197,10 @@ class Client
     }
 
     /**
-     * Return the client default WriteConcern
+     * Return the write concern for this client.
      *
-     * @return \MongoDB\Driver\WriteConcern
+     * @see http://php.net/manual/en/mongodb-driver-writeconcern.isdefault.php
+     * @return WriteConcern
      */
     public function getWriteConcern()
     {

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -706,6 +706,46 @@ class Collection
     }
 
     /**
+     * Return the collection default ReadConcern
+     *
+     * @return ReadConcern
+     */
+    public function getReadConcern()
+    {
+        return $this->readConcern;
+    }
+
+    /**
+     * Return the collection default ReadPreference
+     *
+     * @return ReadPreference
+     */
+    public function getReadPreference()
+    {
+        return $this->readPreference;
+    }
+
+    /**
+     * Return the collection default type map
+     *
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
+    /**
+     * Return the collection default WriteConcern
+     *
+     * @return WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * Inserts multiple documents.
      *
      * @see InsertMany::__construct() for supported options

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -706,8 +706,9 @@ class Collection
     }
 
     /**
-     * Return the collection default ReadConcern
+     * Return the read concern for this collection.
      *
+     * @see http://php.net/manual/en/mongodb-driver-readconcern.isdefault.php
      * @return ReadConcern
      */
     public function getReadConcern()
@@ -716,7 +717,7 @@ class Collection
     }
 
     /**
-     * Return the collection default ReadPreference
+     * Return the read preference for this collection.
      *
      * @return ReadPreference
      */
@@ -726,7 +727,7 @@ class Collection
     }
 
     /**
-     * Return the collection default type map
+     * Return the type map for this collection.
      *
      * @return array
      */
@@ -736,8 +737,9 @@ class Collection
     }
 
     /**
-     * Return the collection default WriteConcern
+     * Return the write concern for this collection.
      *
+     * @see http://php.net/manual/en/mongodb-driver-writeconcern.isdefault.php
      * @return WriteConcern
      */
     public function getWriteConcern()

--- a/src/Database.php
+++ b/src/Database.php
@@ -282,6 +282,46 @@ class Database
     }
 
     /**
+     * Return the database default ReadConcern
+     *
+     * @return ReadConcern
+     */
+    public function getReadConcern()
+    {
+        return $this->readConcern;
+    }
+
+    /**
+     * Return the database default ReadPreference
+     *
+     * @return ReadPreference
+     */
+    public function getReadPreference()
+    {
+        return $this->readPreference;
+    }
+
+    /**
+     * Return the database default type map
+     *
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
+    /**
+     * Return the database default WriteConcern
+     *
+     * @return WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * Returns information for all collections in this database.
      *
      * @see ListCollections::__construct() for supported options

--- a/src/Database.php
+++ b/src/Database.php
@@ -282,8 +282,9 @@ class Database
     }
 
     /**
-     * Return the database default ReadConcern
+     * Return the read concern for this database.
      *
+     * @see http://php.net/manual/en/mongodb-driver-readconcern.isdefault.php
      * @return ReadConcern
      */
     public function getReadConcern()
@@ -292,7 +293,7 @@ class Database
     }
 
     /**
-     * Return the database default ReadPreference
+     * Return the read preference for this database.
      *
      * @return ReadPreference
      */
@@ -302,7 +303,7 @@ class Database
     }
 
     /**
-     * Return the database default type map
+     * Return the type map for this database.
      *
      * @return array
      */
@@ -312,8 +313,9 @@ class Database
     }
 
     /**
-     * Return the database default WriteConcern
+     * Return the write concern for this database.
      *
+     * @see http://php.net/manual/en/mongodb-driver-writeconcern.isdefault.php
      * @return WriteConcern
      */
     public function getWriteConcern()

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -331,8 +331,9 @@ class Bucket
     }
 
     /**
-     * Return the bucket default ReadConcern
+     * Return the read concern for this GridFS bucket.
      *
+     * @see http://php.net/manual/en/mongodb-driver-readconcern.isdefault.php
      * @return ReadConcern
      */
     public function getReadConcern()
@@ -341,7 +342,7 @@ class Bucket
     }
 
     /**
-     * Return the bucket default ReadPreference
+     * Return the read preference for this GridFS bucket.
      *
      * @return ReadPreference
      */
@@ -351,7 +352,7 @@ class Bucket
     }
 
     /**
-     * Return the bucket default type map
+     * Return the type map for this GridFS bucket.
      *
      * @return array
      */
@@ -361,8 +362,9 @@ class Bucket
     }
 
     /**
-     * Return the bucket default WriteConcern
+     * Return the write concern for this GridFS bucket.
      *
+     * @see http://php.net/manual/en/mongodb-driver-writeconcern.isdefault.php
      * @return WriteConcern
      */
     public function getWriteConcern()

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -331,6 +331,46 @@ class Bucket
     }
 
     /**
+     * Return the bucket default ReadConcern
+     *
+     * @return ReadConcern
+     */
+    public function getReadConcern()
+    {
+        return $this->readConcern;
+    }
+
+    /**
+     * Return the bucket default ReadPreference
+     *
+     * @return ReadPreference
+     */
+    public function getReadPreference()
+    {
+        return $this->readPreference;
+    }
+
+    /**
+     * Return the bucket default type map
+     *
+     * @return array
+     */
+    public function getTypeMap()
+    {
+        return $this->typeMap;
+    }
+
+    /**
+     * Return the bucket default WriteConcern
+     *
+     * @return WriteConcern
+     */
+    public function getWriteConcern()
+    {
+        return $this->writeConcern;
+    }
+
+    /**
      * Opens a readable stream for reading a GridFS file.
      *
      * @param mixed $id File ID


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-271

This incorporates @petr-buchin's work in https://github.com/mongodb/mongo-php-library/pull/385.

@petr-buchin: Ultimately, it wasn't necessary to support `null` return values from the read and write concern accessors. In https://github.com/mongodb/mongo-php-library/pull/399, I handled detection of default RC and WC entirely in the operation classes, which means the core classes can freely carry around the default objects from the Manager. Thanks very much for the initial work on this (especially the docs!).