### PR TITLE
PHPLIB-281: Allow empty pipeline array for aggregation

### DIFF
--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -111,10 +111,6 @@ class Aggregate implements Executable
      */
     public function __construct($databaseName, $collectionName, array $pipeline, array $options = [])
     {
-        if (empty($pipeline)) {
-            throw new InvalidArgumentException('$pipeline is empty');
-        }
-
         $expectedIndex = 0;
 
         foreach ($pipeline as $i => $operation) {

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -53,6 +53,22 @@ class AggregateFunctionalTest extends FunctionalTestCase
         );
     }
 
+    public function testEmptyPipelineReturnsAllDocuments()
+    {
+        $this->createFixtures(3);
+
+        $operation = new Aggregate($this->getDatabaseName(), $this->getCollectionName(), []);
+        $results = iterator_to_array($operation->execute($this->getPrimaryServer()));
+
+        $expectedDocuments = [
+            (object) ['_id' => 1, 'x' => (object) ['foo' => 'bar']],
+            (object) ['_id' => 2, 'x' => (object) ['foo' => 'bar']],
+            (object) ['_id' => 3, 'x' => (object) ['foo' => 'bar']],
+        ];
+
+        $this->assertEquals($expectedDocuments, $results);
+    }
+
     /**
      * @expectedException MongoDB\Driver\Exception\RuntimeException
      */

--- a/tests/Operation/AggregateTest.php
+++ b/tests/Operation/AggregateTest.php
@@ -8,15 +8,6 @@ class AggregateTest extends TestCase
 {
     /**
      * @expectedException MongoDB\Exception\InvalidArgumentException
-     * @expectedExceptionMessage $pipeline is empty
-     */
-    public function testConstructorPipelineArgumentMustNotBeEmpty()
-    {
-        new Aggregate($this->getDatabaseName(), $this->getCollectionName(), []);
-    }
-
-    /**
-     * @expectedException MongoDB\Exception\InvalidArgumentException
      * @expectedExceptionMessage $pipeline is not a list (unexpected index: "1")
      */
     public function testConstructorPipelineArgumentMustBeAList()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-281

Fixes https://github.com/mongodb/mongo-php-library/issues/398