### PR TITLE
PHPLIB-275: BulkWrite::insert() always returns the ID in 1.3.0+

### DIFF
--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -311,14 +311,7 @@ class BulkWrite implements Executable
                     break;
 
                 case self::INSERT_ONE:
-                    $insertedId = $bulk->insert($args[0]);
-
-                    if ($insertedId !== null) {
-                        $insertedIds[$i] = $insertedId;
-                    } else {
-                        $insertedIds[$i] = \MongoDB\extract_id_from_inserted_document($args[0]);
-                    }
-
+                    $insertedIds[$i] = $bulk->insert($args[0]);
                     break;
 
                 case self::REPLACE_ONE:

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -127,13 +127,7 @@ class InsertMany implements Executable
         $insertedIds = [];
 
         foreach ($this->documents as $i => $document) {
-            $insertedId = $bulk->insert($document);
-
-            if ($insertedId !== null) {
-                $insertedIds[$i] = $insertedId;
-            } else {
-                $insertedIds[$i] = \MongoDB\extract_id_from_inserted_document($document);
-            }
+            $insertedIds[$i] = $bulk->insert($document);
         }
 
         $writeConcern = isset($this->options['writeConcern']) ? $this->options['writeConcern'] : null;

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -102,10 +102,6 @@ class InsertOne implements Executable
         $bulk = new Bulk($options);
         $insertedId = $bulk->insert($this->document);
 
-        if ($insertedId === null) {
-            $insertedId = \MongoDB\extract_id_from_inserted_document($this->document);
-        }
-
         $writeConcern = isset($this->options['writeConcern']) ? $this->options['writeConcern'] : null;
         $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $writeConcern);
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -47,27 +47,6 @@ function apply_type_map_to_document($document, array $typeMap)
 }
 
 /**
- * Extracts an ID from an inserted document.
- *
- * This function is used when BulkWrite::insert() does not return a generated
- * ID, which means that the ID should be fetched from an array offset, public
- * property, or in the data returned by bsonSerialize().
- *
- * @internal
- * @see https://jira.mongodb.org/browse/PHPC-382
- * @param array|object $document Inserted document
- * @return mixed
- */
-function extract_id_from_inserted_document($document)
-{
-    if ($document instanceof Serializable) {
-        return extract_id_from_inserted_document($document->bsonSerialize());
-    }
-
-    return is_array($document) ? $document['_id'] : $document->_id;
-}
-
-/**
  * Generate an index name from a key specification.
  *
  * @internal


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-275