### PR TITLE
PHPLIB-225 Ensure that users can distinguish duplicate key write errors

### DIFF
--- a/src/Exception/DuplicateKeyException.php
+++ b/src/Exception/DuplicateKeyException.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright 2015-2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Exception;
+
+class DuplicateKeyException extends \MongoDB\Driver\Exception\BulkWriteException implements Exception
+{
+    /**
+     * Thrown when inserting a document with a key that is already present in the database.
+     *
+     * @param string $key Key of inserted document
+     * @return self
+     */
+    public static function duplicateKeyInsertion($key)
+    {
+        return new static(sprintf('The key (%s) of this document is already present in the database.', $key));
+    }
+}

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -21,7 +21,7 @@ use MongoDB\InsertOneResult;
 use MongoDB\Driver\BulkWrite as Bulk;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\BulkWriteException as BulkWriteException;
+use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Exception\DuplicateKeyException;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -21,6 +21,8 @@ use MongoDB\InsertOneResult;
 use MongoDB\Driver\BulkWrite as Bulk;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\WriteConcern;
+use MongoDB\Driver\Exception\BulkWriteException as BulkWriteException;
+use MongoDB\Exception\DuplicateKeyException;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 
@@ -103,7 +105,14 @@ class InsertOne implements Executable
         $insertedId = $bulk->insert($this->document);
 
         $writeConcern = isset($this->options['writeConcern']) ? $this->options['writeConcern'] : null;
-        $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $writeConcern);
+        try {
+            $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $writeConcern);
+            return new InsertOneResult($writeResult, $insertedId);
+       } catch (BulkWriteException $e) {
+            if ($e->getCode() == "E11000") {
+                throw DuplicateKeyException::duplicateKeyInsertion($insertedId);
+            }
+        }
 
         return new InsertOneResult($writeResult, $insertedId);
     }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-225

I only made changes to InsertOne because the Jira ticket said to consult with other drivers before handling the multi-statement case.