### PR TITLE
PHPLIB-268: Skip maxAwaitTimeMS functional test for older servers

### DIFF
--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -127,6 +127,10 @@ class FindFunctionalTest extends FunctionalTestCase
 
     public function testMaxAwaitTimeMS()
     {
+        if (version_compare($this->getServerVersion(), '3.2.0', '<')) {
+            $this->markTestSkipped('maxAwaitTimeMS option is not supported');
+        }
+
         $maxAwaitTimeMS = 10;
 
         // Create a capped collection.


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-268

On servers before 3.2, the option is ignored, which results in a noticeable delay while running the test suite.