### PR TITLE
Minor dockblock typo

### DIFF
--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -115,7 +115,6 @@ class CachingIterator implements Countable, Iterator
     }
 
     /**
-     * 
      * @see http://php.net/iterator.valid
      * @return boolean
      */


### PR DESCRIPTION
Others methods on this class doesn't have this extra space either :)