### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-mongodb": "^1.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": { "MongoDB\\": "src/" },

--- a/tests/Model/CachingIteratorTest.php
+++ b/tests/Model/CachingIteratorTest.php
@@ -4,8 +4,9 @@ namespace MongoDB\Tests\Model;
 
 use MongoDB\Model\CachingIterator;
 use Exception;
+use PHPUnit\Framework\TestCase;
 
-class CachingIteratorTest extends \PHPUnit_Framework_TestCase
+class CachingIteratorTest extends TestCase
 {
     /**
      * Sanity check for all following tests.

--- a/tests/PedantryTest.php
+++ b/tests/PedantryTest.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Tests;
 
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -11,7 +12,7 @@ use RegexIterator;
 /**
  * Pedantic tests that have nothing to do with functional correctness.
  */
-class PedantryTest extends \PHPUnit_Framework_TestCase
+class PedantryTest extends BaseTestCase
 {
     /**
      * @dataProvider provideProjectClassNames

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,10 +5,11 @@ namespace MongoDB\Tests;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionClass;
 use stdClass;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
     public function provideInvalidDocumentValues()
     {


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).