### PR TITLE
Fix example 1

### DIFF
--- a/docs/reference/method/MongoDBDatabase-selectCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-selectCollection.txt
@@ -57,7 +57,7 @@ The following example selects the ``users`` collection in the ``test`` database:
 
    $db = (new MongoDB\Client)->test;
 
-   $collection = $db->selectCollection('test', 'users');
+   $collection = $db->selectCollection('users');
 
 The following example selects the ``users`` collection in the ``test``
 database with a custom read preference:


### PR DESCRIPTION
The call is made following the MongoDB\Client::selectCollection() signature instead of the MongoDB\Database::selectCollection() signature