### PR TITLE
Test ReadableStream::seek() with out-of-range offset

### DIFF
--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -177,4 +177,16 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
 
         $stream->readBytes(-1);
     }
+
+    /**
+     * @expectedException MongoDB\Exception\InvalidArgumentException
+     * @expectedExceptionMessage $offset must be >= 0 and <= 10; given: 11
+     */
+    public function testSeekOutOfRange()
+    {
+        $fileDocument = $this->collectionWrapper->findFileById('length-10');
+        $stream = new ReadableStream($this->collectionWrapper, $fileDocument);
+
+        $stream->seek(11);
+    }
 }


### PR DESCRIPTION
Depends on https://github.com/mongodb/mongo-php-library/pull/457/files#diff-f1209ee81335e16d7fb9c54819f0edb6R178