### PR TITLE
Add PHPStan to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
     - php: 7.0
       env:
         - SERVER_VERSION=3.4.11
+    - php: 7.0
+      script: vendor/bin/phpstan analyse -l 0 src
 
 before_install:
   - pip install "mongo-orchestration>=0.6.7,<1.0" --user `whoami`

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "ext-mongodb": "^1.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36"
+        "phpunit/phpunit": "^4.8.36",
+        "phpstan/phpstan": "^0.9.2"
     },
     "autoload": {
         "psr-4": { "MongoDB\\": "src/" },

--- a/src/Client.php
+++ b/src/Client.php
@@ -262,7 +262,7 @@ class Client
      *
      * @see http://php.net/manual/en/mongodb-driver-manager.startsession.php
      * @param array  $options      Session options
-     * @return MongoDB\Driver\Session
+     * @return \MongoDB\Driver\Session
      */
     public function startSession(array $options = [])
     {


### PR DESCRIPTION
As suggested by @jmikola in #457, this PR adds `PHPStan` to `Travis CI`.

There is only 1 remain error to bump to level 1:
```bash
 ------ ----------------------------------------------- 
  Line   src/Operation/MapReduce.php                    
 ------ ----------------------------------------------- 
  158    Class MongoDB\Operation\Javascript not found.  
 ------ ----------------------------------------------- 
```