### PR TITLE
Fix namespaces in test classes

### DIFF
--- a/tests/Model/BSONArrayTest.php
+++ b/tests/Model/BSONArrayTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace MongoDB\Tests;
+namespace MongoDB\Tests\Model;
 
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
+use MongoDB\Tests\TestCase;
 
 class BSONArrayTest extends TestCase
 {

--- a/tests/Model/BSONDocumentTest.php
+++ b/tests/Model/BSONDocumentTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace MongoDB\Tests;
+namespace MongoDB\Tests\Model;
 
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
+use MongoDB\Tests\TestCase;
 use ArrayObject;
 
 class BSONDocumentTest extends TestCase

--- a/tests/Model/CollectionInfoTest.php
+++ b/tests/Model/CollectionInfoTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MongoDB\Tests;
+namespace MongoDB\Tests\Model;
 
 use MongoDB\Model\CollectionInfo;
 use MongoDB\Tests\TestCase;

--- a/tests/Model/DatabaseInfoTest.php
+++ b/tests/Model/DatabaseInfoTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MongoDB\Tests;
+namespace MongoDB\Tests\Model;
 
 use MongoDB\Model\DatabaseInfo;
 use MongoDB\Tests\TestCase;

--- a/tests/Model/IndexInfoTest.php
+++ b/tests/Model/IndexInfoTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MongoDB\Tests;
+namespace MongoDB\Tests\Model;
 
 use MongoDB\Model\IndexInfo;
 use MongoDB\Tests\TestCase;

--- a/tests/Model/IndexInputTest.php
+++ b/tests/Model/IndexInputTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MongoDB\Tests;
+namespace MongoDB\Tests\Model;
 
 use MongoDB\Model\IndexInput;
 use MongoDB\Tests\TestCase;

--- a/tests/Model/TypeMapArrayIteratorTest.php
+++ b/tests/Model/TypeMapArrayIteratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace MongoDB\Tests;
+namespace MongoDB\Tests\Model;
 
 use MongoDB\Model\TypeMapArrayIterator;
+use MongoDB\Tests\TestCase;
 
 class TypeMapArrayIteratorTest extends TestCase
 {

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace MongoDB\Tests\Collection;
+namespace MongoDB\Tests\Operation;
 
 use MongoDB\BulkWriteResult;
+use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite as Bulk;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Model\BSONDocument;
@@ -10,12 +11,14 @@ use MongoDB\Operation\BulkWrite;
 
 class BulkWriteFunctionalTest extends FunctionalTestCase
 {
+    private $collection;
     private $omitModifiedCount;
 
     public function setUp()
     {
         parent::setUp();
 
+        $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
         $this->omitModifiedCount = version_compare($this->getServerVersion(), '2.6.0', '<');
     }
 

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -1,14 +1,24 @@
 <?php
 
-namespace MongoDB\Tests\Collection;
+namespace MongoDB\Tests\Operation;
 
 use MongoDB\DeleteResult;
+use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Operation\Delete;
 
 class DeleteFunctionalTest extends FunctionalTestCase
 {
+    private $collection;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
+    }
+
     public function testDeleteOne()
     {
         $this->createFixtures(3);

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MongoDB\Tests\Collection;
+namespace MongoDB\Tests\Operation;
 
+use MongoDB\Collection;
 use MongoDB\InsertManyResult;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Model\BSONDocument;
@@ -9,6 +10,15 @@ use MongoDB\Operation\InsertMany;
 
 class InsertManyFunctionalTest extends FunctionalTestCase
 {
+    private $collection;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
+    }
+
     public function testInsertMany()
     {
         $documents = [

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MongoDB\Tests\Collection;
+namespace MongoDB\Tests\Operation;
 
+use MongoDB\Collection;
 use MongoDB\InsertOneResult;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Model\BSONDocument;
@@ -9,6 +10,15 @@ use MongoDB\Operation\InsertOne;
 
 class InsertOneFunctionalTest extends FunctionalTestCase
 {
+    private $collection;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
+    }
+
     /**
      * @dataProvider provideDocumentWithExistingId
      */

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MongoDB\Tests\Collection;
+namespace MongoDB\Tests\Operation;
 
+use MongoDB\Collection;
 use MongoDB\UpdateResult;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\WriteConcern;
@@ -9,12 +10,14 @@ use MongoDB\Operation\Update;
 
 class UpdateFunctionalTest extends FunctionalTestCase
 {
+    private $collection;
     private $omitModifiedCount;
 
     public function setUp()
     {
         parent::setUp();
 
+        $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
         $this->omitModifiedCount = version_compare($this->getServerVersion(), '2.6.0', '<');
     }
 


### PR DESCRIPTION
The Operation classes were previously relying on `MongoDB\Tests\Collection\FunctionalTestCase`, so they required additional changes to initialize a Collection instance for asserting outcome of write operations.