### PR TITLE
PHPLIB-304 and PHPLIB-282: Deprecate inline result methods for aggregate and drop support for MongoDB 2.4

### DIFF
--- a/docs/includes/apiargs-MongoDBCollection-method-aggregate-option.yaml
+++ b/docs/includes/apiargs-MongoDBCollection-method-aggregate-option.yaml
@@ -16,11 +16,6 @@ description: |
   Specifies the initial batch size for the cursor. A batchSize of ``0`` means an
   empty first batch and is useful for quickly returning a cursor or failure
   message without doing significant server-side work.
-
-  .. note::
-
-     This is not supported for inline aggregation results (i.e. ``useCursor``
-     option is ``false`` or the server version is < 2.6).
 interface: phpmethod
 operation: ~
 optional: true
@@ -83,12 +78,6 @@ type: boolean
 description: |
   Indicates whether the command will request that the server provide results
   using a cursor. The default is ``true``.
-
-  For MongoDB version 2.6 or later, ``useCursor`` allows users to turn off
-  cursors if necessary to aid in replica set or shard cluster upgrades.
-
-  ``useCursor`` is ignored for MongoDB versions prior to 2.6 as aggregation
-  cursors are not available.
 interface: phpmethod
 operation: ~
 optional: true

--- a/docs/includes/apiargs-MongoDBCollection-method-createIndex-option.yaml
+++ b/docs/includes/apiargs-MongoDBCollection-method-createIndex-option.yaml
@@ -69,12 +69,8 @@ arg_name: option
 name: 2dsphereIndexVersion
 type: integer
 description: |
-  Specifies the :manual:`version of a 2dsphere </core/2dsphere>` index to
-  create.
-
-  MongoDB 2.6 introduced version 2 of 2dsphere indexes. Version 2 is the default
-  version of 2dsphere indexes created in MongoDB 2.6 and later versions.
-  ``2dsphereIndexVersion`` enables you to override the default version 2.
+  Overrides the server's default version for a :manual:`2dsphere
+  </core/2dsphere>` index.
 interface: phpmethod
 operation: ~
 optional: true

--- a/docs/reference/method/MongoDBBulkWriteResult-getModifiedCount.txt
+++ b/docs/reference/method/MongoDBBulkWriteResult-getModifiedCount.txt
@@ -37,10 +37,6 @@ Return Values
 The total number of documents that were modified by all update and replace
 operations in the bulk write.
 
-The modified count is not available on versions of MongoDB before 2.6, which
-used the legacy wire protocol version (i.e. ``OP_UPDATE``). If this is the case,
-the modified count will be ``null``.
-
 Errors/Exceptions
 -----------------
 

--- a/docs/reference/method/MongoDBUpdateResult-getModifiedCount.txt
+++ b/docs/reference/method/MongoDBUpdateResult-getModifiedCount.txt
@@ -35,10 +35,6 @@ Return Values
 
 The number of documents that were modified.
 
-The modified count is not available on versions of MongoDB before 2.6, which
-used the legacy wire protocol version (i.e. ``OP_UPDATE``). If this is the case,
-the modified count will be ``null``.
-
 Errors/Exceptions
 -----------------
 

--- a/src/Model/TypeMapArrayIterator.php
+++ b/src/Model/TypeMapArrayIterator.php
@@ -23,11 +23,6 @@ use MongoDB\Exception\BadMethodCallException;
 /**
  * Iterator for applying a type map to documents in inline command results.
  *
- * This iterator may be used to apply a type map to an array of documents
- * returned by a database command (e.g. aggregate on servers < 2.6) and allows
- * for functional equivalence with commands that return their results via a
- * cursor (e.g. aggregate on servers >= 2.6).
- *
  * @internal
  */
 class TypeMapArrayIterator extends ArrayIterator

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -99,8 +99,8 @@ class Aggregate implements Executable
      *  * useCursor (boolean): Indicates whether the command will request that
      *    the server provide results using a cursor. The default is true.
      *
-     *    For servers >= 2.6, this option allows users to turn off cursors if
-     *    necessary to aid in mongod/mongos upgrades.
+     *    This option allows users to turn off cursors if necessary to aid in
+     *    mongod/mongos upgrades.
      *
      *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern. This only
      *    applies when the $out stage is specified.

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -712,10 +712,6 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
     public function testExample_51_54()
     {
-        if (version_compare($this->getServerVersion(), '2.6.0', '<')) {
-            $this->markTestSkipped('$currentDate update operator is not supported');
-        }
-
         $db = new Database($this->manager, $this->getDatabaseName());
 
         // Start Example 51

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -30,10 +30,6 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
     public function testDefaultWriteConcernIsOmitted()
     {
-        if (version_compare($this->getServerVersion(), '2.6.0', '<')) {
-            $this->markTestSkipped('$out pipeline operator is not supported');
-        }
-
         (new CommandObserver)->observe(
             function() {
                 $operation = new Aggregate(

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -12,14 +12,12 @@ use MongoDB\Operation\BulkWrite;
 class BulkWriteFunctionalTest extends FunctionalTestCase
 {
     private $collection;
-    private $omitModifiedCount;
 
     public function setUp()
     {
         parent::setUp();
 
         $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
-        $this->omitModifiedCount = version_compare($this->getServerVersion(), '2.6.0', '<');
     }
 
     public function testInserts()
@@ -70,7 +68,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
 
         $this->assertInstanceOf('MongoDB\BulkWriteResult', $result);
         $this->assertSame(5, $result->getMatchedCount());
-        $this->omitModifiedCount or $this->assertSame(5, $result->getModifiedCount());
+        $this->assertSame(5, $result->getModifiedCount());
         $this->assertSame(2, $result->getUpsertedCount());
 
         $upsertedIds = $result->getUpsertedIds();
@@ -132,7 +130,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $this->assertSame([2 => 4], $result->getInsertedIds());
 
         $this->assertSame(3, $result->getMatchedCount());
-        $this->omitModifiedCount or $this->assertSame(3, $result->getModifiedCount());
+        $this->assertSame(3, $result->getModifiedCount());
         $this->assertSame(1, $result->getUpsertedCount());
         $this->assertSame([4 => 4], $result->getUpsertedIds());
 

--- a/tests/Operation/CountFunctionalTest.php
+++ b/tests/Operation/CountFunctionalTest.php
@@ -31,10 +31,6 @@ class CountFunctionalTest extends FunctionalTestCase
 
     public function testHintOption()
     {
-        if (version_compare($this->getServerVersion(), '2.6.0', '<')) {
-            $this->markTestSkipped('count command does not support "hint" option');
-        }
-
         $insertMany = new InsertMany($this->getDatabaseName(), $this->getCollectionName(), [
             ['x' => 1],
             ['x' => 2],

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -11,14 +11,12 @@ use MongoDB\Operation\Update;
 class UpdateFunctionalTest extends FunctionalTestCase
 {
     private $collection;
-    private $omitModifiedCount;
 
     public function setUp()
     {
         parent::setUp();
 
         $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
-        $this->omitModifiedCount = version_compare($this->getServerVersion(), '2.6.0', '<');
     }
 
     public function testUpdateOne()
@@ -33,7 +31,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
         $this->assertInstanceOf('MongoDB\UpdateResult', $result);
         $this->assertSame(1, $result->getMatchedCount());
-        $this->omitModifiedCount or $this->assertSame(1, $result->getModifiedCount());
+        $this->assertSame(1, $result->getModifiedCount());
         $this->assertSame(0, $result->getUpsertedCount());
         $this->assertNull($result->getUpsertedId());
 
@@ -59,7 +57,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
         $this->assertInstanceOf('MongoDB\UpdateResult', $result);
         $this->assertSame(2, $result->getMatchedCount());
-        $this->omitModifiedCount or $this->assertSame(2, $result->getModifiedCount());
+        $this->assertSame(2, $result->getModifiedCount());
         $this->assertSame(0, $result->getUpsertedCount());
         $this->assertNull($result->getUpsertedId());
 
@@ -85,7 +83,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
         $this->assertInstanceOf('MongoDB\UpdateResult', $result);
         $this->assertSame(0, $result->getMatchedCount());
-        $this->omitModifiedCount or $this->assertSame(0, $result->getModifiedCount());
+        $this->assertSame(0, $result->getModifiedCount());
         $this->assertSame(1, $result->getUpsertedCount());
         $this->assertSame(5, $result->getUpsertedId());
 
@@ -112,7 +110,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
         $this->assertInstanceOf('MongoDB\UpdateResult', $result);
         $this->assertSame(0, $result->getMatchedCount());
-        $this->omitModifiedCount or $this->assertSame(0, $result->getModifiedCount());
+        $this->assertSame(0, $result->getModifiedCount());
         $this->assertSame(1, $result->getUpsertedCount());
         $this->assertInstanceOf('MongoDB\BSON\ObjectId', $result->getUpsertedId());
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-304