### PR TITLE
PHPLIB-299: Ensure Travis uses expected server versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ before_script:
   - ulimit -c unlimited -S
 
 script:
-  - ./vendor/bin/phpunit --debug || RESULT=$?
-  - for i in $(find ./ -maxdepth 1 -name 'core*' -print); do gdb `php -r 'echo PHP_BINARY;'` core* -ex "thread apply all bt" -ex "set pagination 0" -batch; done;
-  - if [[ ${RESULT} != 0 ]]; then exit $RESULT ; fi;
+  - vendor/bin/phpunit -v
+
+after_failure:
+  - find . -name 'core*' -exec ${TRAVIS_BUILD_DIR}/.travis/debug-core.sh {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ addons:
     packages:
       - gdb
 
+cache:
+  directories:
+    - ${HOME}/.cache/pip
+
 env:
   global:
     - DRIVER_VERSION=1.4.0RC1
@@ -53,6 +57,9 @@ before_script:
 
 script:
   - vendor/bin/phpunit -v
+
+before_cache:
+  - rm -f ${HOME}/.cache/pip/log/debug.log
 
 after_failure:
   - find . -name 'core*' -exec ${TRAVIS_BUILD_DIR}/.travis/debug-core.sh {} \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,50 @@
 language: php
 dist: trusty
-sudo: false 
-
-services:
-  - mongodb
+sudo: false
 
 addons:
   apt:
-    packages: &common_packages
+    packages:
       - gdb
 
 env:
   global:
     - DRIVER_VERSION=1.4.0RC1
-    - SERVER_VERSION=3.4
+    - SERVER_VERSION=3.6.2
 
 matrix:
   fast_finish: true
   include:
     - php: 5.5
-      addons: &common_addons
-        apt:
-          sources: [ mongodb-3.4-precise ]
-          packages: [ mongodb-org, *common_packages ]
     - php: 5.6
-      addons: *common_addons
     - php: 7.0
-      addons: *common_addons
     - php: 7.1
-      addons: *common_addons
     - php: 7.2
-      addons: *common_addons
     - php: 7.0
       env:
-        - SERVER_VERSION=2.6
-      addons:
-        apt:
-          sources: [ mongodb-upstart ]
-          packages: [ mongodb-org, *common_packages ]
+        - SERVER_VERSION=2.6.12
     - php: 7.0
       env:
-        - SERVER_VERSION=3.0
-      addons:
-        apt:
-          sources: [ mongodb-3.0-precise ]
-          packages: [ mongodb-org, *common_packages ]
+        - SERVER_VERSION=3.0.15
     - php: 7.0
       env:
-        - SERVER_VERSION=3.2
-      addons:
-        apt:
-          sources: [ mongodb-3.2-precise ]
-          packages: [ mongodb-org, *common_packages ]
+        - SERVER_VERSION=3.2.18
+    - php: 7.0
+      env:
+        - SERVER_VERSION=3.4.11
+
+before_install:
+  - pip install "mongo-orchestration>=0.6.7,<1.0" --user `whoami`
+  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${SERVER_VERSION}.tgz
+  - tar zxf mongodb-linux-x86_64-${SERVER_VERSION}.tgz
+  - export PATH=${PWD}/mongodb-linux-x86_64-${SERVER_VERSION}/bin/:${PATH}
+  - mongod --version
+  - mongo-orchestration --version
+  - export MO_PATH=`python -c 'import mongo_orchestration; from os import path; print(path.dirname(mongo_orchestration.__file__));'`
 
 before_script:
-  - mongod --version
+  - mongo-orchestration start
+  - pushd ${MO_PATH} && ${TRAVIS_BUILD_DIR}/.travis/mo.sh configurations/servers/clean.json start && popd
   - pecl install -f mongodb-${DRIVER_VERSION}
   - php --ri mongodb
   - composer install --dev --no-interaction --prefer-source
@@ -66,3 +56,6 @@ script:
 
 after_failure:
   - find . -name 'core*' -exec ${TRAVIS_BUILD_DIR}/.travis/debug-core.sh {} \;
+
+after_script:
+  - mongo-orchestration stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 cache:
   directories:
     - ${HOME}/.cache/pip
+    - ${HOME}/.composer/cache/files
 
 env:
   global:
@@ -51,7 +52,7 @@ before_script:
   - pushd ${MO_PATH} && ${TRAVIS_BUILD_DIR}/.travis/mo.sh configurations/servers/clean.json start && popd
   - pecl install -f mongodb-${DRIVER_VERSION}
   - php --ri mongodb
-  - composer install --dev --no-interaction --prefer-source
+  - composer install --no-interaction --no-progress --no-suggest
   - ulimit -c
   - ulimit -c unlimited -S
 

--- a/.travis/debug-core.sh
+++ b/.travis/debug-core.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
+    # https://www.ics.uci.edu/~pattis/common/handouts/macmingweclipse/allexperimental/mac-gdb-install.html
+    echo "Cannot debug core files on macOS: ${1}"
+    exit 1
+fi
+
+PHP_BINARY=`which php`
+gdb -batch -ex "bt full" -ex "quit" "${PHP_BINARY}" "${1}"

--- a/.travis/mo.sh
+++ b/.travis/mo.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Copyright 2012-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function eval_params {
+    local params=$(sed -e 's|["]|\\\"|g' $1)
+    echo $(eval echo \"$params\")
+} 
+
+function r {
+    echo $1| cut -d'/' -f 2
+}
+
+function a {
+    echo $(cd $(dirname $1); pwd)/$(basename $1)
+}
+
+function id {
+    local id_line=$(grep id $1 | head -n 1)
+    echo $(expr "$id_line" : '.*: *"\(.*\)" *,*')
+}
+
+function get {
+    echo "GET $1 $(curl --header 'Accept: application/json' --include --silent --request GET $1)"
+}
+
+function post {
+    echo "POST $1 $(curl --header 'Accept: application/json' --include --silent --request POST --data "$2" $1)"
+}
+
+function delete {
+    echo "DELETE $1 $(curl --header 'Accept: application/json' --include --silent --request DELETE $1)"
+}
+
+function code {
+   expr "$1" : '.*HTTP/1.[01] \([0-9]*\)'
+}
+
+function usage {
+    echo "usage: $0 configurations/cluster/file.json action"
+    echo "cluster: servers|replica_sets|sharded_clusters"
+    echo "action: start|status|stop"
+    exit 1
+}
+
+SSL_FILES=$(a ./ssl-files)
+BASE_URL=${MONGO_ORCHESTRATION:-'http://localhost:8889'}
+
+if [ $# -ne 2 ]; then usage; fi
+if [ ! -f "$1" ]; then echo "configuration file '$1' not found"; exit 1; fi
+
+ID=$(id $1)
+if [ ! "$ID" ]; then echo "id field not found in configuration file '$1'"; exit 1; fi
+R=$(r $1)
+
+GET=$(get $BASE_URL/$R/$ID)
+HTTP_CODE=$(code "$GET")
+EXIT_CODE=0
+
+case $2 in
+start)
+    if [ "$HTTP_CODE" != "200" ]
+    then
+        WORKSPACE=~/tmp/orchestrations
+        rm -fr $WORKSPACE
+        mkdir $WORKSPACE
+        LOGPATH=$WORKSPACE
+        DBPATH=$WORKSPACE
+        POST_DATA=$(eval_params $1)
+        echo "DBPATH=$DBPATH"
+        echo "LOGPATH=$LOGPATH"
+        echo "POST_DATA='$POST_DATA'"
+        echo
+        POST=$(post $BASE_URL/$R "$POST_DATA")
+        echo "$POST"
+        HTTP_CODE=$(code "$POST")
+        if [ "$HTTP_CODE" != 200 ]; then EXIT_CODE=1; fi
+    else
+        echo "$GET"
+    fi
+    ;;
+stop)
+    if [ "$HTTP_CODE" == "200" ]
+    then
+        DELETE=$(delete $BASE_URL/$R/$ID)
+        echo "$DELETE"
+        HTTP_CODE=$(code "$DELETE")
+        if [ "$HTTP_CODE" != 204 ]; then EXIT_CODE=1; fi
+    else
+        echo "$GET"
+    fi
+    ;;
+status)
+    if [ "$HTTP_CODE" == "200" ]
+    then
+        echo "$GET"
+    else
+        echo "$GET"
+        EXIT_CODE=1
+    fi
+    ;;
+*)
+    usage
+    ;;
+esac
+exit $EXIT_CODE

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -154,7 +154,12 @@ class FindFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('maxAwaitTimeMS option is not supported');
         }
 
-        $maxAwaitTimeMS = 10;
+        $maxAwaitTimeMS = 100;
+
+        /* Calculate an approximate pivot to use for time assertions. We will
+         * assert that the duration of blocking responses is greater than this
+         * value, and vice versa. */
+        $pivot = ($maxAwaitTimeMS * 0.001) * 0.9;
 
         // Create a capped collection.
         $databaseName = $this->getDatabaseName();
@@ -183,7 +188,7 @@ class FindFunctionalTest extends FunctionalTestCase
         $startTime = microtime(true);
         $it->rewind();
         $duration = microtime(true) - $startTime;
-        $this->assertLessThan($maxAwaitTimeMS * 0.001, $duration);
+        $this->assertLessThan($pivot, $duration);
 
         $this->assertTrue($it->valid());
         $this->assertSameDocument(['_id' => 1], $it->current());
@@ -193,7 +198,7 @@ class FindFunctionalTest extends FunctionalTestCase
         $startTime = microtime(true);
         $it->next();
         $duration = microtime(true) - $startTime;
-        $this->assertLessThan($maxAwaitTimeMS * 0.001, $duration);
+        $this->assertLessThan($pivot, $duration);
 
         $this->assertTrue($it->valid());
         $this->assertSameDocument(['_id' => 2], $it->current());
@@ -206,7 +211,7 @@ class FindFunctionalTest extends FunctionalTestCase
         $startTime = microtime(true);
         $it->next();
         $duration = microtime(true) - $startTime;
-        $this->assertGreaterThanOrEqual($maxAwaitTimeMS * 0.001, $duration);
+        $this->assertGreaterThan($pivot, $duration);
         $this->assertLessThan(0.5, $duration);
 
         $this->assertFalse($it->valid());

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -380,6 +380,11 @@ class WatchFunctionalTest extends FunctionalTestCase
          * ensure we see the write. */
         $maxAwaitTimeMS = 100;
 
+        /* Calculate an approximate pivot to use for time assertions. We will
+         * assert that the duration of blocking responses is greater than this
+         * value, and vice versa. */
+        $pivot = ($maxAwaitTimeMS * 0.001) * 0.9;
+
         $operation = new Watch($this->manager, $this->getDatabaseName(), $this->getCollectionName(), [], ['maxAwaitTimeMS' => $maxAwaitTimeMS]);
         $changeStream = $operation->execute($this->getPrimaryServer());
 
@@ -391,7 +396,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $startTime = microtime(true);
         $changeStream->rewind();
         $duration = microtime(true) - $startTime;
-        $this->assertGreaterThanOrEqual($maxAwaitTimeMS * 0.001, $duration);
+        $this->assertGreaterThan($pivot, $duration);
         $this->assertLessThan(0.5, $duration);
 
         $this->assertFalse($changeStream->valid());
@@ -401,7 +406,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $startTime = microtime(true);
         $changeStream->next();
         $duration = microtime(true) - $startTime;
-        $this->assertGreaterThanOrEqual($maxAwaitTimeMS * 0.001, $duration);
+        $this->assertGreaterThan($pivot, $duration);
         $this->assertLessThan(0.5, $duration);
 
         $this->assertFalse($changeStream->valid());
@@ -413,7 +418,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $startTime = microtime(true);
         $changeStream->next();
         $duration = microtime(true) - $startTime;
-        $this->assertLessThan($maxAwaitTimeMS * 0.001, $duration);
+        $this->assertLessThan($pivot, $duration);
         $this->assertTrue($changeStream->valid());
     }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-299

While implementing this PR, I realized that we can cache the result of `pecl install mongodb` and avoid spending time recompiling the extension for each job. I've opened [PHPLIB-324](https://jira.mongodb.org/browse/PHPLIB-324) to track that task.