### PR TITLE
Fix order of ResumeTokenException methods

### DIFF
--- a/src/Exception/ResumeTokenException.php
+++ b/src/Exception/ResumeTokenException.php
@@ -20,16 +20,6 @@ namespace MongoDB\Exception;
 class ResumeTokenException extends \Exception
 {
     /**
-     * Thrown when a resume token is not found in a change document.
-     *
-     * @return self
-     */
-    public static function notFound()
-    {
-        return new static('Resume token not found in change document');
-    }
-
-    /**
      * Thrown when a resume token has an invalid type.
      *
      * @param mixed $value Actual value (used to derive the type)
@@ -38,5 +28,15 @@ class ResumeTokenException extends \Exception
     public static function invalidType($value)
     {
         return new static(sprintf('Expected resume token to have type "array or object" but found "%s"', gettype($value)));
+    }
+
+    /**
+     * Thrown when a resume token is not found in a change document.
+     *
+     * @return self
+     */
+    public static function notFound()
+    {
+        return new static('Resume token not found in change document');
     }
 }


### PR DESCRIPTION
Missed this before merging https://github.com/mongodb/mongo-php-library/pull/480.

Thank you, PedantryTest.