### PR TITLE
PHPLIB-325: Apply Collection typeMap to change streams

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -967,6 +967,10 @@ class Collection
             $options['readConcern'] = $this->readConcern;
         }
 
+        if ( ! isset($options['typeMap'])) {
+            $options['typeMap'] = $this->typeMap;
+        }
+
         $operation = new Watch($this->manager, $this->databaseName, $this->collectionName, $pipeline, $options);
 
         return $operation->execute($server);


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-325

I tested this locally why subbing in PHPLIB's default type map in all of the WatchFunctionalTest options arguments. My only concern was that resume token extraction still works, but I then realized that the existing type map test in WatchFunctionalTest already covered that, too.