### PR TITLE
removed collectionName attribute in GridFSbucket construct signature

### DIFF
--- a/docs/reference/method/MongoDBGridFSBucket__construct.txt
+++ b/docs/reference/method/MongoDBGridFSBucket__construct.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function __construct(MongoDB\Driver\Manager $manager, $databaseName, $collectionName, array $options = [])
+      function __construct(MongoDB\Driver\Manager $manager, $databaseName, array $options = [])
 
    This constructor has the following parameters:
 


### PR DESCRIPTION
I saw on the mongodb docs that this was false, you can verify in the code.