### PR TITLE
PHPLIB-342: Change streams should use the same session when resuming

### DIFF
--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -110,6 +110,12 @@ class Watch implements Executable
             }
         }
 
+        if ( ! isset($options['session'])) {
+            try {
+                $options['session'] = $manager->startSession();
+            } catch (DriverRuntimeException $e) {}
+        }
+
         $this->databaseName = (string) $databaseName;
         $this->collectionName = (string) $collectionName;
         $this->pipeline = $pipeline;


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-342

I marked this [WIP] because I'll update `WatchFunctionalTest` to verify that the `lsid`s of all aggregates and getMores are the same after [PHPC-1152](https://jira.mongodb.org/browse/PHPC-1152) is merged.