### PR TITLE
Remove pre-3.0 compat code in FindAndModify

### DIFF
--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -217,17 +217,6 @@ class FindAndModify implements Executable, Explainable
             return null;
         }
 
-        /* Prior to 3.0, findAndModify returns an empty document instead of null
-         * when an upsert is performed and the pre-modified document was
-         * requested.
-         */
-        if ($this->options['upsert'] && ! $this->options['new'] &&
-            isset($result->lastErrorObject->updatedExisting) &&
-            ! $result->lastErrorObject->updatedExisting) {
-
-            return null;
-        }
-
         if ( ! is_object($result->value)) {
             throw new UnexpectedValueException('findAndModify command did not return a "value" document');
         }


### PR DESCRIPTION
PHPLIB 1.4.0 implicitly dropped support for MongoDB 2.6 and earlier, so this is no longer needed. I likely missed this in https://github.com/mongodb/mongo-php-library/commit/9f36faf78fbe51a1474f424ed2ac11fc14149744.