### PR TITLE
Regression tests for find() and aggregate() using primary RP within transaction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.5",
         "ext-hash": "*",
         "ext-json": "*",
-        "ext-mongodb": "^1.5.0"
+        "ext-mongodb": "^1.5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^6.4"

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -10,7 +10,6 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Count;
-use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\MapReduce;
 use MongoDB\Tests\CommandObserver;
 use Exception;
@@ -111,9 +110,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $this->skipIfTransactionsAreNotSupported();
 
         // Collection must be created before the transaction starts
-        $options = ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)];
-        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
-        $operation->execute($this->getPrimaryServer());
+        $this->createCollection();
 
         $session = $this->manager->startSession();
         $session->startTransaction();
@@ -219,9 +216,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $this->skipIfTransactionsAreNotSupported();
 
         // Collection must be created before the transaction starts
-        $options = ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)];
-        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
-        $operation->execute($this->getPrimaryServer());
+        $this->createCollection();
 
         $session = $this->manager->startSession();
         $session->startTransaction();

--- a/tests/Collection/FunctionalTestCase.php
+++ b/tests/Collection/FunctionalTestCase.php
@@ -30,13 +30,4 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
 
         $this->dropCollection();
     }
-
-    private function dropCollection()
-    {
-        $options = version_compare($this->getServerVersion(), '3.4.0', '>=')
-            ? ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]
-            : [];
-
-        $this->collection->drop($options);
-    }
 }

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -1496,14 +1496,4 @@ class DocumentationExamplesTest extends FunctionalTestCase
     {
         $this->assertCollectionCount($this->getDatabaseName() . '.' . $this->getCollectionName(), $count);
     }
-
-    private function dropCollection()
-    {
-        $options = version_compare($this->getServerVersion(), '3.4.0', '>=')
-            ? ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]
-            : [];
-
-        $operation = new DropCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
-        $operation->execute($this->getPrimaryServer());
-    }
 }

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -7,7 +7,6 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Operation\Aggregate;
-use MongoDB\Operation\CreateCollection;
 use MongoDB\Tests\CommandObserver;
 use ArrayIterator;
 use Exception;
@@ -282,9 +281,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
         $this->skipIfTransactionsAreNotSupported();
 
         // Collection must be created before the transaction starts
-        $options = ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)];
-        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
-        $operation->execute($this->getPrimaryServer());
+        $this->createCollection();
 
         $session = $this->manager->startSession();
         $session->startTransaction();

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -3,11 +3,14 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Operation\Aggregate;
+use MongoDB\Operation\CreateCollection;
 use MongoDB\Tests\CommandObserver;
 use ArrayIterator;
+use Exception;
 use stdClass;
 
 class AggregateFunctionalTest extends FunctionalTestCase
@@ -274,12 +277,50 @@ class AggregateFunctionalTest extends FunctionalTestCase
         ];
     }
 
+    public function testReadPreferenceWithinTransaction()
+    {
+        $this->skipIfTransactionsAreNotSupported();
+
+        // Collection must be created before the transaction starts
+        $options = ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)];
+        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
+        $operation->execute($this->getPrimaryServer());
+
+        $session = $this->manager->startSession();
+        $session->startTransaction();
+
+        try {
+            $this->createFixtures(3, ['session' => $session]);
+
+            $pipeline = [['$match' => ['_id' => ['$lt' => 3]]]];
+            $options = [
+                'readPreference' => new ReadPreference('primary'),
+                'session' => $session,
+            ];
+
+            $operation = new Aggregate($this->getDatabaseName(), $this->getCollectionName(), $pipeline, $options);
+            $cursor = $operation->execute($this->getPrimaryServer());
+
+            $expected = [
+                ['_id' => 1, 'x' => ['foo' => 'bar']],
+                ['_id' => 2, 'x' => ['foo' => 'bar']],
+            ];
+
+            $this->assertSameDocuments($expected, $cursor);
+
+            $session->commitTransaction();
+        } finally {
+            $session->endSession();
+        }
+    }
+
     /**
      * Create data fixtures.
      *
      * @param integer $n
+     * @param array   $executeBulkWriteOptions
      */
-    private function createFixtures($n)
+    private function createFixtures($n, array $executeBulkWriteOptions = [])
     {
         $bulkWrite = new BulkWrite(['ordered' => true]);
 
@@ -290,7 +331,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
             ]);
         }
 
-        $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite);
+        $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite, $executeBulkWriteOptions);
 
         $this->assertEquals($n, $result->getInsertedCount());
     }

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -3,11 +3,14 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\WriteConcern;
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
+use Exception;
 use stdClass;
 
 class FindFunctionalTest extends FunctionalTestCase
@@ -217,12 +220,50 @@ class FindFunctionalTest extends FunctionalTestCase
         $this->assertFalse($it->valid());
     }
 
+    public function testReadPreferenceWithinTransaction()
+    {
+        $this->skipIfTransactionsAreNotSupported();
+
+        // Collection must be created before the transaction starts
+        $options = ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)];
+        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
+        $operation->execute($this->getPrimaryServer());
+
+        $session = $this->manager->startSession();
+        $session->startTransaction();
+
+        try {
+            $this->createFixtures(3, ['session' => $session]);
+
+            $filter = ['_id' => ['$lt' => 3]];
+            $options = [
+                'readPreference' => new ReadPreference('primary'),
+                'session' => $session,
+            ];
+
+            $operation = new Find($this->getDatabaseName(), $this->getCollectionName(), $filter, $options);
+            $cursor = $operation->execute($this->getPrimaryServer());
+
+            $expected = [
+                ['_id' => 1, 'x' => ['foo' => 'bar']],
+                ['_id' => 2, 'x' => ['foo' => 'bar']],
+            ];
+
+            $this->assertSameDocuments($expected, $cursor);
+
+            $session->commitTransaction();
+        } finally {
+            $session->endSession();
+        }
+    }
+
     /**
      * Create data fixtures.
      *
      * @param integer $n
+     * @param array   $executeBulkWriteOptions
      */
-    private function createFixtures($n)
+    private function createFixtures($n, array $executeBulkWriteOptions = [])
     {
         $bulkWrite = new BulkWrite(['ordered' => true]);
 
@@ -233,7 +274,7 @@ class FindFunctionalTest extends FunctionalTestCase
             ]);
         }
 
-        $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite);
+        $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite, $executeBulkWriteOptions);
 
         $this->assertEquals($n, $result->getInsertedCount());
     }

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -7,7 +7,6 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\CreateIndexes;
-use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
 use Exception;
@@ -225,9 +224,7 @@ class FindFunctionalTest extends FunctionalTestCase
         $this->skipIfTransactionsAreNotSupported();
 
         // Collection must be created before the transaction starts
-        $options = ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)];
-        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
-        $operation->execute($this->getPrimaryServer());
+        $this->createCollection();
 
         $session = $this->manager->startSession();
         $session->startTransaction();

--- a/tests/Operation/FunctionalTestCase.php
+++ b/tests/Operation/FunctionalTestCase.php
@@ -44,14 +44,4 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
     {
         return $this->manager->startSession();
     }
-
-    private function dropCollection()
-    {
-        $options = version_compare($this->getServerVersion(), '3.4.0', '>=')
-            ? ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]
-            : [];
-
-        $operation = new DropCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
-        $operation->execute($this->getPrimaryServer());
-    }
 }

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -4,7 +4,6 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\BSON\Javascript;
 use MongoDB\Driver\BulkWrite;
-use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\Find;
 use MongoDB\Operation\MapReduce;
@@ -15,8 +14,8 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 {
     public function testDefaultReadConcernIsOmitted()
     {
-        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName());
-        $operation->execute($this->getPrimaryServer());
+        // Collection must exist for mapReduce command
+        $this->createCollection();
 
         (new CommandObserver)->observe(
             function() {
@@ -39,8 +38,8 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
     public function testDefaultWriteConcernIsOmitted()
     {
-        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName());
-        $operation->execute($this->getPrimaryServer());
+        // Collection must exist for mapReduce command
+        $this->createCollection();
 
         (new CommandObserver)->observe(
             function() {

--- a/tests/Operation/ModifyCollectionFunctionalTest.php
+++ b/tests/Operation/ModifyCollectionFunctionalTest.php
@@ -3,15 +3,13 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Operation\ModifyCollection;
-use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\CreateIndexes;
 
 class ModifyCollectionFunctionalTest extends FunctionalTestCase
 {
     public function testCollMod()
     {
-        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName());
-        $operation->execute($this->getPrimaryServer());
+        $this->createCollection();
 
         $indexes = [['key' => ['lastAccess' => 1], 'expireAfterSeconds' => 3]];
         $createIndexes = new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), $indexes);

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -9,9 +9,7 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\ConnectionTimeoutException;
 use MongoDB\Exception\ResumeTokenException;
-use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\DatabaseCommand;
-use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\Watch;
 use MongoDB\Tests\CommandObserver;
@@ -727,8 +725,8 @@ class WatchFunctionalTest extends FunctionalTestCase
 
     public function testSessionFreed()
     {
-        $operation = new CreateCollection($this->getDatabaseName(), $this->getCollectionName());
-        $operation->execute($this->getPrimaryServer());
+        // Create collection so we can drop it later
+        $this->createCollection();
 
         $operation = new Watch($this->manager, $this->getDatabaseName(), $this->getCollectionName(), [], $this->defaultOptions);
         $changeStream = $operation->execute($this->getPrimaryServer());
@@ -740,8 +738,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->assertNotNull($rp->getValue($changeStream));
 
         // Invalidate the cursor to verify that resumeCallable is unset when the cursor is exhausted.
-        $operation = new DropCollection($this->getDatabaseName(), $this->getCollectionName());
-        $operation->execute($this->getPrimaryServer());
+        $this->dropCollection();
 
         $changeStream->next();
 


### PR DESCRIPTION
See: https://github.com/mongodb/mongo-php-library/issues/562

This is a regression test for [CDRIVER-2744](https://jira.mongodb.org/browse/CDRIVER-2744). It builds upon https://github.com/mongodb/mongo-php-library/pull/563 (for [PHPLIB-373](https://jira.mongodb.org/browse/PHPLIB-373)) and may be fixed by either:

 * [PHPLIB-375](https://jira.mongodb.org/browse/PHPLIB-375): omitting read preference option for commands and queries sent in non-sharded topologies
 * [PHPC-1236](https://jira.mongodb.org/browse/PHPC-1236): Bumping libmongoc to 1.11.1 (once released)

I don't think we should merge this while failing and would suggest leaving it open until one of the solutions can be implemented.