### PR TITLE
PHPLIB-386: Assert upsertedIds field in bulkWrite CRUD spec tests

### DIFF
--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -263,10 +263,10 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                     $this->assertSame($expectedResult['upsertedCount'], $actualResult->getUpsertedCount());
                 }
 
-                if (array_key_exists('upsertedId', $expectedResult)) {
+                if (isset($expectedResult['upsertedIds'])) {
                     $this->assertSameDocument(
-                        ['upsertedId' => $expectedResult['upsertedId']],
-                        ['upsertedId' => $actualResult->getUpsertedId()]
+                        ['upsertedIds' => $expectedResult['upsertedIds']],
+                        ['upsertedIds' => $actualResult->getUpsertedIds()]
                     );
                 }
                 break;


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-386

I noticed this while testing PHPLIB against the new CRUD spec tests added in https://github.com/mongodb/specifications/pull/396.