### PR TITLE
PHPLIB-387: Support errors and unordered writes in CRUD spec tests

### DIFF
--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -350,6 +350,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
             case 'deleteMany':
             case 'deleteOne':
+                $this->assertInternalType('array', $expectedResult);
                 $this->assertInstanceOf('MongoDB\DeleteResult', $actualResult);
 
                 if (isset($expectedResult['deletedCount'])) {
@@ -383,6 +384,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 break;
 
             case 'insertOne':
+                $this->assertInternalType('array', $expectedResult);
                 $this->assertInstanceOf('MongoDB\InsertOneResult', $actualResult);
 
                 if (isset($expectedResult['insertedCount'])) {
@@ -400,6 +402,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             case 'replaceOne':
             case 'updateMany':
             case 'updateOne':
+                $this->assertInternalType('array', $expectedResult);
                 $this->assertInstanceOf('MongoDB\UpdateResult', $actualResult);
 
                 if (isset($expectedResult['matchedCount'])) {
@@ -489,7 +492,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
      * @param array $arguments
      * @return array
      */
-    private function prepareFindAndModifyArguments($arguments)
+    private function prepareFindAndModifyArguments(array $arguments)
     {
         if (isset($arguments['returnDocument'])) {
             $arguments['returnDocument'] = ('after' === strtolower($arguments['returnDocument']))

--- a/tests/Collection/spec-tests/read/count-empty.json
+++ b/tests/Collection/spec-tests/read/count-empty.json
@@ -1,0 +1,39 @@
+{
+  "data": [],
+  "tests": [
+    {
+      "description": "Estimated document count with empty collection",
+      "operation": {
+        "name": "estimatedDocumentCount",
+        "arguments": {}
+      },
+      "outcome": {
+        "result": 0
+      }
+    },
+    {
+      "description": "Count documents with empty collection",
+      "operation": {
+        "name": "countDocuments",
+        "arguments": {
+          "filter": {}
+        }
+      },
+      "outcome": {
+        "result": 0
+      }
+    },
+    {
+      "description": "Deprecated count with empty collection",
+      "operation": {
+        "name": "count",
+        "arguments": {
+          "filter": {}
+        }
+      },
+      "outcome": {
+        "result": 0
+      }
+    }
+  ]
+}

--- a/tests/Collection/spec-tests/write/bulkWrite-collation.json
+++ b/tests/Collection/spec-tests/write/bulkWrite-collation.json
@@ -1,0 +1,217 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": "ping"
+    },
+    {
+      "_id": 3,
+      "x": "pINg"
+    },
+    {
+      "_id": 4,
+      "x": "pong"
+    },
+    {
+      "_id": 5,
+      "x": "pONg"
+    }
+  ],
+  "minServerVersion": "3.4",
+  "tests": [
+    {
+      "description": "BulkWrite with delete operations and collation",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "x": "PING"
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            },
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "x": "PING"
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            },
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": "PONG"
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 4,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with update operations and collation",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": "ping"
+                },
+                "update": {
+                  "$set": {
+                    "x": "PONG"
+                  }
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 3
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "x": "ping"
+                },
+                "update": {
+                  "$set": {
+                    "x": "PONG"
+                  }
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "x": "ping"
+                },
+                "replacement": {
+                  "_id": 6,
+                  "x": "ping"
+                },
+                "upsert": true,
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 3
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": "pong"
+                },
+                "update": {
+                  "$set": {
+                    "x": "PONG"
+                  }
+                },
+                "collation": {
+                  "locale": "en_US",
+                  "strength": 2
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 6,
+          "modifiedCount": 4,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "2": 6
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": "PONG"
+            },
+            {
+              "_id": 3,
+              "x": "PONG"
+            },
+            {
+              "_id": 4,
+              "x": "PONG"
+            },
+            {
+              "_id": 5,
+              "x": "PONG"
+            },
+            {
+              "_id": 6,
+              "x": "ping"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/Collection/spec-tests/write/bulkWrite.json
+++ b/tests/Collection/spec-tests/write/bulkWrite.json
@@ -1,0 +1,790 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "minServerVersion": "2.6",
+  "tests": [
+    {
+      "description": "BulkWrite with deleteOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                }
+              }
+            },
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with deleteMany operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lt": 11
+                  }
+                }
+              }
+            },
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 2,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with insertOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "insertedIds": {
+            "0": 3,
+            "1": 4
+          },
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with replaceOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "replacement": {
+                  "_id": 1,
+                  "x": 11
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "replacement": {
+                  "x": 12
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "x": 33
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 2,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with updateOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 0
+                },
+                "update": {
+                  "$set": {
+                    "x": 0
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "update": {
+                  "$set": {
+                    "x": 11
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "update": {
+                  "$set": {
+                    "x": 33
+                  }
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 2,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with updateMany operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lt": 11
+                  }
+                },
+                "update": {
+                  "$set": {
+                    "x": 0
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                },
+                "update": {
+                  "$unset": {
+                    "y": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "update": {
+                  "$set": {
+                    "x": 33
+                  }
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 4,
+          "modifiedCount": 2,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with mixed ordered operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            },
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$nin": [
+                      24,
+                      34
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 4
+                },
+                "replacement": {
+                  "_id": 4,
+                  "x": 44
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 2,
+          "insertedCount": 2,
+          "insertedIds": {
+            "0": 3,
+            "3": 4
+          },
+          "matchedCount": 3,
+          "modifiedCount": 3,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "5": 4
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 34
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with mixed unordered operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "_id": 3,
+                  "x": 33
+                },
+                "upsert": true
+              }
+            },
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "0": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite continue-on-error behavior with unordered (preexisting duplicate key)",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 2,
+                  "x": 22
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite continue-on-error behavior with unordered (duplicate key in requests)",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/Collection/spec-tests/write/insertMany.json
+++ b/tests/Collection/spec-tests/write/insertMany.json
@@ -20,7 +20,10 @@
               "_id": 3,
               "x": 33
             }
-          ]
+          ],
+          "options": {
+            "ordered": true
+          }
         }
       },
       "outcome": {
@@ -29,6 +32,110 @@
             "0": 2,
             "1": 3
           }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (preexisting duplicate key)",
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (duplicate key in requests)",
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
         },
         "collection": {
           "data": [

--- a/tests/Collection/spec-tests/write/updateMany-arrayFilters.json
+++ b/tests/Collection/spec-tests/write/updateMany-arrayFilters.json
@@ -98,7 +98,8 @@
       "outcome": {
         "result": {
           "matchedCount": 2,
-          "modifiedCount": 1
+          "modifiedCount": 1,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-387

These improvements complement test revisions in https://github.com/mongodb/specifications/pull/399.

We can wait until the new spec tests are merged so that they can be incorporated into this PR; however, the test runner changes can be reviewed immediately.