### PR TITLE
PHPLIB-414: Improve collection comparison in GridFS spec tests

### DIFF
--- a/tests/GridFS/SpecFunctionalTest.php
+++ b/tests/GridFS/SpecFunctionalTest.php
@@ -269,6 +269,10 @@ class SpecFunctionalTest extends FunctionalTestCase
      */
     private function executeDataModification(array $dataModification)
     {
+        if (empty($dataModification)) {
+            throw new LogicException('Command for data modification is empty');
+        }
+
         foreach ($dataModification as $type => $collectionName) {
             break;
         }

--- a/tests/GridFS/SpecFunctionalTest.php
+++ b/tests/GridFS/SpecFunctionalTest.php
@@ -90,7 +90,7 @@ class SpecFunctionalTest extends FunctionalTestCase
      */
     private function assertEquivalentCollections($expectedCollection, $actualCollection, $actualResult)
     {
-        $mi = new MultipleIterator;
+        $mi = new MultipleIterator(MultipleIterator::MIT_NEED_ANY);
         $mi->attachIterator(new IteratorIterator($expectedCollection->find()));
         $mi->attachIterator(new IteratorIterator($actualCollection->find()));
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-414

This ensures that we use `MultipleIterator::MIT_NEED_ANY` when iterating the subject-under-test and expected output collections so that comparison does not stop prematurely if one collection containers fewer (or no) documents. This is similar to changes done in #592 for the CRUD spec test runner.

When making that improvement, I realized that the GridFS spec tests assumes that drivers _do not_ clean up orphan chunks when deleting a non-existent file despite the fact that such behavior is permitted as a "MAY" (see: [File Deletion](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#file-deletion))