### PR TITLE
PHPLIB-368: Require ext-mongodb ^1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.5",
         "ext-hash": "*",
         "ext-json": "*",
-        "ext-mongodb": "^1.5.2"
+        "ext-mongodb": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^6.4"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-368

#591 began using new transaction APIs, which first appeared in 1.6.0alpha1. This introduced some errors for those developing against the master branch, as reported in #597.

The following pastes confirm that 1.6.0alpha1 satisfies this requirement for Composer.

On PHP 7.2 with 1.5.3 installed:

```
$ composer check-platform-reqs
ext-dom        20031129                                               success  
ext-hash       1.0                                                    success  
ext-json       1.6.0                                                  success  
ext-libxml     7.2.11                                                 success  
ext-mbstring   7.2.11                                                 success  
ext-mongodb    1.5.3     mongodb/mongodb requires ext-mongodb (^1.6)  failed   
ext-Phar       2.0.2                                                  success  
ext-tokenizer  7.2.11                                                 success  
ext-xml        7.2.11                                                 success  
ext-xmlwriter  7.2.11                                                 success  
php            7.2.11                                                 success
```

On PHP 7.2, after installing 1.6.0alpha1:

```
$ composer check-platform-reqs
ext-dom        20031129       success  
ext-hash       1.0            success  
ext-json       1.6.0          success  
ext-libxml     7.2.11         success  
ext-mbstring   7.2.11         success  
ext-mongodb    1.6.0alpha1    success  
ext-Phar       2.0.2          success  
ext-tokenizer  7.2.11         success  
ext-xml        7.2.11         success  
ext-xmlwriter  7.2.11         success  
php            7.2.11         success 
```