### PR TITLE
PHPLIB-412: Use virtualized Xenial image in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
-dist: trusty
-sudo: false
+dist: xenial
 
 addons:
   apt:
@@ -23,6 +22,7 @@ matrix:
   fast_finish: true
   include:
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
     - php: 7.1


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-412

Use a Trusty image for PHP 5.5, since it is not available on Xenial.

Based on https://github.com/mongodb/mongo-php-driver/pull/956