### PR TITLE
 PHPLIB-442: Ensure change stream resume token is updated after resume

### DIFF
--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -102,22 +102,7 @@ class ChangeStream implements Iterator
     {
         try {
             $this->csIt->next();
-            if ($this->valid()) {
-                if ($this->hasAdvanced) {
-                    $this->key++;
-                }
-                $this->hasAdvanced = true;
-                $this->resumeToken = $this->extractResumeToken($this->csIt->current());
-            }
-            /* If the cursorId is 0, the server has invalidated the cursor so we
-             * will never perform another getMore. This means that we cannot
-             * resume and we can therefore unset the resumeCallable, which will
-             * free any reference to Watch. This will also free the only
-             * reference to an implicit session, since any such reference
-             * belongs to Watch. */
-            if ((string) $this->getCursorId() === '0') {
-                $this->resumeCallable = null;
-            }
+            $this->onIteration(true);
         } catch (RuntimeException $e) {
             if ($this->isResumableError($e)) {
                 $this->resume();
@@ -133,14 +118,7 @@ class ChangeStream implements Iterator
     {
         try {
             $this->csIt->rewind();
-            if ($this->valid()) {
-                $this->hasAdvanced = true;
-                $this->resumeToken = $this->extractResumeToken($this->csIt->current());
-            }
-            // As with next(), free the callable once we know it will never be used.
-            if ((string) $this->getCursorId() === '0') {
-                $this->resumeCallable = null;
-            }
+            $this->onIteration(false);
         } catch (RuntimeException $e) {
             if ($this->isResumableError($e)) {
                 $this->resume();
@@ -215,6 +193,38 @@ class ChangeStream implements Iterator
     }
 
     /**
+     * Perform housekeeping after an iteration event (i.e. next or rewind).
+     *
+     * @param boolean $isNext Whether the iteration event was a call to next()
+     * @throws ResumeTokenException
+     */
+    private function onIteration($isNext)
+    {
+        /* If the cursorId is 0, the server has invalidated the cursor and we
+         * will never perform another getMore nor need to resume since any
+         * remaining results (up to and including the invalidate event) will
+         * have been received in the last response. Therefore, we can unset the
+         * resumeCallable. This will free any reference to Watch as well as the
+         * only reference to any implicit session created therein. */
+        if ((string) $this->getCursorId() === '0') {
+            $this->resumeCallable = null;
+        }
+
+        if (!$this->valid()) {
+            return;
+        }
+
+        /* Increment the key if the iteration event was a call to next() and we
+         * have already advanced past the first result. */
+        if ($isNext && $this->hasAdvanced) {
+            $this->key++;
+        }
+
+        $this->hasAdvanced = true;
+        $this->resumeToken = $this->extractResumeToken($this->csIt->current());
+    }
+
+    /**
      * Creates a new changeStream after a resumable server error.
      *
      * @return void
@@ -224,5 +234,6 @@ class ChangeStream implements Iterator
         $newChangeStream = call_user_func($this->resumeCallable, $this->resumeToken);
         $this->csIt = $newChangeStream->csIt;
         $this->csIt->rewind();
+        $this->onIteration(false);
     }
 }

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -138,7 +138,7 @@ class ChangeStream implements Iterator
     /**
      * Extracts the resume token (i.e. "_id" field) from the change document.
      *
-     * @param array|document $document Change document
+     * @param array|object $document Change document
      * @return mixed
      * @throws InvalidArgumentException
      * @throws ResumeTokenException if the resume token is not found or invalid


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-442

This extracts common logic in next() and rewind() to a new method, which is now also called by resume() after it rewinds the internal iterator.