### PR TITLE
PHPLIB-368: Remove redundant check for RC within transaction

### DIFF
--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -213,11 +213,6 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      */
     public function execute(Server $server)
     {
-        $inTransaction = isset($this->options['session']) && $this->options['session']->isInTransaction();
-        if ($inTransaction && isset($this->options['readConcern'])) {
-            throw UnsupportedException::readConcernNotSupportedInTransaction();
-        }
-
         return new ChangeStream($this->executeAggregate($server), $this->resumeCallable);
     }
 

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -551,6 +551,17 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     );
                 }, 'w'
             ],
+
+            /* Disabled, as it's illegal to use change streams in transactions
+            [
+                function($collection, $session, $options = []) {
+                    $collection->watch(
+                        [],
+                        ['session' => $session] + $options
+                    );
+                }, 'r'
+            ],
+            */
         ];
     }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-368

Aggregate::execute() already checks for this. This also adds a note in CollectionFunctionalTest that watch() is prohibited within a transaction, as is done for other methods.