### PR TITLE
PHPLIB-402: Add aggregate helper to Database class

### DIFF
--- a/docs/includes/apiargs-MongoDBDatabase-method-aggregate-option.yaml
+++ b/docs/includes/apiargs-MongoDBDatabase-method-aggregate-option.yaml
@@ -13,31 +13,25 @@ source:
 source:
   file: apiargs-aggregate-option.yaml
   ref: comment
-post: |
-  .. versionadded:: 1.3
 ---
 source:
   file: apiargs-aggregate-option.yaml
   ref: explain
-post: |
-  .. versionadded:: 1.4
 ---
 source:
   file: apiargs-aggregate-option.yaml
   ref: hint
-post: |
-  .. versionadded:: 1.3
 ---
 source:
   file: apiargs-common-option.yaml
   ref: maxTimeMS
 ---
 source:
-  file: apiargs-MongoDBCollection-common-option.yaml
+  file: apiargs-MongoDBDatabase-common-option.yaml
   ref: readConcern
 ---
 source:
-  file: apiargs-MongoDBCollection-common-option.yaml
+  file: apiargs-MongoDBDatabase-common-option.yaml
   ref: readPreference
 post: |
   This option will be ignored when using the :ref:`$out <agg-out>` stage.
@@ -45,31 +39,13 @@ post: |
 source:
   file: apiargs-common-option.yaml
   ref: session
-post: |
-  .. versionadded:: 1.3
 ---
 source:
-  file: apiargs-MongoDBCollection-common-option.yaml
+  file: apiargs-MongoDBDatabase-common-option.yaml
   ref: typeMap
 ---
-arg_name: option
-name: useCursor
-type: boolean
-description: |
-  Indicates whether the command will request that the server provide results
-  using a cursor. The default is ``true``.
-
-  .. note::
-
-     MongoDB 3.6+ no longer supports returning results without a cursor (excluding
-     when the explain option is used) and specifying false for this option will
-     result in a server error.
-interface: phpmethod
-operation: ~
-optional: true
----
 source:
-  file: apiargs-MongoDBCollection-common-option.yaml
+  file: apiargs-MongoDBDatabase-common-option.yaml
   ref: writeConcern
 post: |
   This only applies when the :ref:`$out <agg-out>` stage is specified.

--- a/docs/includes/apiargs-MongoDBDatabase-method-aggregate-param.yaml
+++ b/docs/includes/apiargs-MongoDBDatabase-method-aggregate-param.yaml
@@ -1,0 +1,14 @@
+arg_name: param
+name: $pipeline
+type: array
+description: |
+  Specifies an :manual:`aggregation pipeline </core/aggregation-pipeline>`
+  operation.
+interface: phpmethod
+operation: ~
+optional: false
+---
+source:
+  file: apiargs-common-param.yaml
+  ref: $options
+...

--- a/docs/includes/apiargs-aggregate-option.yaml
+++ b/docs/includes/apiargs-aggregate-option.yaml
@@ -1,0 +1,62 @@
+arg_name: option
+name: allowDiskUse
+type: boolean
+description: |
+  Enables writing to temporary files. When set to ``true``, aggregation stages
+  can write data to the ``_tmp`` sub-directory in the ``dbPath`` directory. The
+  default is ``false``.
+interface: phpmethod
+operation: ~
+optional: true
+---
+arg_name: option
+name: batchSize
+type: integer
+description: |
+  Specifies the initial batch size for the cursor. A batchSize of ``0`` means an
+  empty first batch and is useful for quickly returning a cursor or failure
+  message without doing significant server-side work.
+interface: phpmethod
+operation: ~
+optional: true
+---
+source:
+  file: apiargs-MongoDBCollection-common-option.yaml
+  ref: bypassDocumentValidation
+post: |
+  This only applies when using the :ref:`$out <agg-out>` stage.
+
+  Document validation requires MongoDB 3.2 or later: if you are using an earlier
+  version of MongoDB, this option will be ignored.
+---
+arg_name: option
+name: comment
+type: string
+description: |
+  Users can specify an arbitrary string to help trace the operation through the
+  database profiler, currentOp, and logs.
+interface: phpmethod
+operation: ~
+optional: true
+---
+arg_name: option
+name: explain
+type: boolean
+description: |
+  Specifies whether or not to return the information on the processing of the
+  pipeline.
+interface: phpmethod
+operation: ~
+optional: true
+---
+arg_name: option
+name: hint
+type: string|array|object
+description: |
+  The index to use. Specify either the index name as a string or the index key
+  pattern as a document. If specified, then the query system will only consider
+  plans using the hinted index.
+interface: phpmethod
+operation: ~
+optional: true
+...

--- a/docs/reference/class/MongoDBDatabase.txt
+++ b/docs/reference/class/MongoDBDatabase.txt
@@ -45,6 +45,7 @@ Methods
 
    /reference/method/MongoDBDatabase__construct
    /reference/method/MongoDBDatabase__get
+   /reference/method/MongoDBDatabase-aggregate
    /reference/method/MongoDBDatabase-command
    /reference/method/MongoDBDatabase-createCollection
    /reference/method/MongoDBDatabase-drop

--- a/docs/reference/method/MongoDBDatabase-aggregate.txt
+++ b/docs/reference/method/MongoDBDatabase-aggregate.txt
@@ -1,6 +1,8 @@
-================================
-MongoDB\\Collection::aggregate()
-================================
+==============================
+MongoDB\\Database::aggregate()
+==============================
+
+.. versionadded:: 1.5
 
 .. default-domain:: mongodb
 
@@ -13,10 +15,12 @@ MongoDB\\Collection::aggregate()
 Definition
 ----------
 
-.. phpmethod:: MongoDB\\Collection::aggregate()
+.. phpmethod:: MongoDB\\Database::aggregate()
 
-   Executes an :manual:`aggregation framework pipeline
-   </core/aggregation-pipeline>` operation on the collection.
+   Runs a specified :manual:`admin/diagnostic pipeline
+   </reference/operator/aggregation-pipeline/#db-aggregate-stages>` which does
+   not require an underlying collection. For aggregations on collection data,
+   see :phpmethod:`MongoDB\\Collection::aggregate()`.
 
    .. code-block:: php
 
@@ -24,11 +28,11 @@ Definition
 
    This method has the following parameters:
 
-   .. include:: /includes/apiargs/MongoDBCollection-method-aggregate-param.rst
+   .. include:: /includes/apiargs/MongoDBDatabase-method-aggregate-param.rst
 
    The ``$options`` parameter supports the following options:
 
-   .. include:: /includes/apiargs/MongoDBCollection-method-aggregate-option.rst
+   .. include:: /includes/apiargs/MongoDBDatabase-method-aggregate-option.rst
 
 Return Values
 -------------
@@ -45,25 +49,14 @@ Errors/Exceptions
 .. include:: /includes/extracts/error-invalidargumentexception.rst
 .. include:: /includes/extracts/error-driver-runtimeexception.rst
 
-.. _php-coll-agg-method-behavior:
-
-Behavior
---------
-
-:phpmethod:`MongoDB\\Collection::aggregate()`'s return value depends on the
-MongoDB server version and whether the ``useCursor`` option is specified. If
-``useCursor`` is ``true``, a :php:`MongoDB\\Driver\\Cursor
-<class.mongodb-driver-cursor>` object is returned. If ``useCursor`` is
-``false``, an :php:`ArrayIterator <arrayiterator>` is returned that wraps the
-``result`` array from the command response document. In both cases, the return
-value will be :php:`Traversable <traversable>`.
+.. _php-db-agg-method-behavior:
 
 .. todo: add examples
 
 See Also
 --------
 
-- :phpmethod:`MongoDB\\Database::aggregate()`
+- :phpmethod:`MongoDB\\Collection::aggregate()`
 - :manual:`aggregate </reference/command/aggregate>` command reference in the
   MongoDB manual
 - :manual:`Aggregation Pipeline </core/aggregation-pipeline>` documentation in

--- a/docs/tutorial/crud.txt
+++ b/docs/tutorial/crud.txt
@@ -401,7 +401,7 @@ The |php-library|\'s :phpmethod:`MongoDB\\Collection::aggregate()` method
 returns a :php:`Traversable <traversable>` object, which you can iterate upon to
 access the results of the aggregation operation. Refer to the
 :phpmethod:`MongoDB\\Collection::aggregate()` method's :ref:`behavior
-reference <php-agg-method-behavior>` for more about the method's output.
+reference <php-coll-agg-method-behavior>` for more about the method's output.
 
 The following example lists the 5 US states with the most zip codes associated
 with them:

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -209,7 +209,7 @@ class Collection
         if ( ! isset($options['readConcern']) &&
             ! ($hasOutStage && $this->readConcern->getLevel() === ReadConcern::MAJORITY) &&
             \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) &&
-            ! $this->isInTransaction($options)) {
+            ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -220,7 +220,7 @@ class Collection
         if ($hasOutStage &&
             ! isset($options['writeConcern']) &&
             \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) &&
-            ! $this->isInTransaction($options)) {
+            ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -242,7 +242,7 @@ class Collection
      */
     public function bulkWrite(array $operations, array $options = [])
     {
-        if ( ! isset($options['writeConcern']) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -274,7 +274,7 @@ class Collection
 
         $server = $this->manager->selectServer($options['readPreference']);
 
-        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -303,7 +303,7 @@ class Collection
 
         $server = $this->manager->selectServer($options['readPreference']);
 
-        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -365,7 +365,7 @@ class Collection
     {
         $server = $this->manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -388,7 +388,7 @@ class Collection
      */
     public function deleteMany($filter, array $options = [])
     {
-        if ( ! isset($options['writeConcern']) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -412,7 +412,7 @@ class Collection
      */
     public function deleteOne($filter, array $options = [])
     {
-        if ( ! isset($options['writeConcern']) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -443,7 +443,7 @@ class Collection
 
         $server = $this->manager->selectServer($options['readPreference']);
 
-        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -470,7 +470,7 @@ class Collection
 
         $server = $this->manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -504,7 +504,7 @@ class Collection
 
         $server = $this->manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -531,7 +531,7 @@ class Collection
 
         $server = $this->manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -559,7 +559,7 @@ class Collection
 
         $server = $this->manager->selectServer($options['readPreference']);
 
-        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -617,7 +617,7 @@ class Collection
 
         $server = $this->manager->selectServer($options['readPreference']);
 
-        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -650,7 +650,7 @@ class Collection
 
         $server = $this->manager->selectServer($options['readPreference']);
 
-        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -682,7 +682,7 @@ class Collection
     {
         $server = $this->manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForFindAndModifyWriteConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForFindAndModifyWriteConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -719,7 +719,7 @@ class Collection
     {
         $server = $this->manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForFindAndModifyWriteConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForFindAndModifyWriteConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -756,7 +756,7 @@ class Collection
     {
         $server = $this->manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForFindAndModifyWriteConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForFindAndModifyWriteConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -865,7 +865,7 @@ class Collection
      */
     public function insertMany(array $documents, array $options = [])
     {
-        if ( ! isset($options['writeConcern']) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -888,7 +888,7 @@ class Collection
      */
     public function insertOne($document, array $options = [])
     {
-        if ( ! isset($options['writeConcern']) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -950,7 +950,7 @@ class Collection
          *
          * A read concern is also not compatible with transactions.
          */
-        if ( ! isset($options['readConcern']) && ! ($hasOutputCollection && $this->readConcern->getLevel() === ReadConcern::MAJORITY) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['readConcern']) && ! ($hasOutputCollection && $this->readConcern->getLevel() === ReadConcern::MAJORITY) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -958,7 +958,7 @@ class Collection
             $options['typeMap'] = $this->typeMap;
         }
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -982,7 +982,7 @@ class Collection
      */
     public function replaceOne($filter, $replacement, array $options = [])
     {
-        if ( ! isset($options['writeConcern']) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -1007,7 +1007,7 @@ class Collection
      */
     public function updateMany($filter, $update, array $options = [])
     {
-        if ( ! isset($options['writeConcern']) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -1032,7 +1032,7 @@ class Collection
      */
     public function updateOne($filter, $update, array $options = [])
     {
-        if ( ! isset($options['writeConcern']) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['writeConcern']) && ! \MongoDB\is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -1066,7 +1066,7 @@ class Collection
          * related to change streams being unsupported instead of an
          * UnsupportedException regarding use of the "readConcern" option from
          * the Aggregate operation class. */
-        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! $this->isInTransaction($options)) {
+        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern) && ! \MongoDB\is_in_transaction($options)) {
             $options['readConcern'] = $this->readConcern;
         }
 
@@ -1097,19 +1097,5 @@ class Collection
         ];
 
         return new Collection($this->manager, $this->databaseName, $this->collectionName, $options);
-    }
-
-    /**
-     * Returns whether we are currently in a transaction
-     *
-     * @param array  $options  Command options
-     * @return bool
-     */
-    private function isInTransaction(array $options)
-    {
-        if (isset($options['session']) && $options['session'] instanceof \MongoDB\Driver\Session && $options['session']->isInTransaction()) {
-            return true;
-        }
-        return false;
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -111,6 +111,22 @@ function is_first_key_operator($document)
 }
 
 /**
+ * Returns whether we are currently in a transaction.
+ *
+ * @internal
+ * @param array $options Command options
+ * @return boolean
+ */
+function is_in_transaction(array $options)
+{
+    if (isset($options['session']) && $options['session'] instanceof \MongoDB\Driver\Session && $options['session']->isInTransaction()) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
  * Return whether the aggregation pipeline ends with an $out operator.
  *
  * This is used for determining whether the aggregation pipeline must be

--- a/tests/SpecTests/CommandExpectations.php
+++ b/tests/SpecTests/CommandExpectations.php
@@ -64,6 +64,16 @@ class CommandExpectations implements CommandSubscriber
         return new self($expectedEvents);
     }
 
+    public static function fromCrud(array $expectedEvents)
+    {
+        $o = new self($expectedEvents);
+
+        $o->ignoreCommandFailed = true;
+        $o->ignoreCommandSucceeded = true;
+
+        return $o;
+    }
+
     public static function fromTransactions(array $expectedEvents)
     {
         $o = new self($expectedEvents);

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -53,6 +53,17 @@ final class Context
         return $o;
     }
 
+    public static function fromCrud(stdClass $test, $databaseName, $collectionName)
+    {
+        $o = new self($databaseName, $collectionName);
+
+        $clientOptions = isset($test->clientOptions) ? (array) $test->clientOptions : [];
+
+        $o->client = new Client(FunctionalTestCase::getUri(), $clientOptions);
+
+        return $o;
+    }
+
     public static function fromRetryableWrites(stdClass $test, $databaseName, $collectionName)
     {
         $o = new self($databaseName, $collectionName);

--- a/tests/SpecTests/CrudSpecTest.php
+++ b/tests/SpecTests/CrudSpecTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace MongoDB\Tests\SpecTests;
+
+use stdClass;
+
+/**
+ * Crud spec tests.
+ *
+ * @see https://github.com/mongodb/specifications/tree/master/source/crud
+ */
+class CrudSpecTest extends FunctionalTestCase
+{
+    /* These should all pass before the driver can be considered compatible with
+     * MongoDB 4.2. */
+    private static $incompleteTests = [
+        'aggregate-merge: Aggregate with $merge' => 'PHPLIB-438',
+        'aggregate-merge: Aggregate with $merge and batch size of 0' => 'PHPLIB-438',
+        'aggregate-merge: Aggregate with $merge and majority readConcern' => 'PHPLIB-438',
+        'aggregate-merge: Aggregate with $merge and local readConcern' => 'PHPLIB-438',
+        'aggregate-merge: Aggregate with $merge and available readConcern' => 'PHPLIB-438',
+        'aggregate-out-readConcern: readConcern majority with out stage' => 'PHPLIB-431',
+        'aggregate-out-readConcern: readConcern local with out stage' => 'PHPLIB-431',
+        'aggregate-out-readConcern: readConcern available with out stage' => 'PHPLIB-431',
+        'aggregate-out-readConcern: readConcern linearizable with out stage' => 'PHPLIB-431',
+        'aggregate-out-readConcern: invalid readConcern with out stage' => 'PHPLIB-431',
+        'bulkWrite-arrayFilters: BulkWrite with arrayFilters' => 'Fails due to command assertions',
+        'updateWithPipelines: UpdateOne using pipelines' => 'PHPLIB-418',
+        'updateWithPipelines: UpdateMany using pipelines' => 'PHPLIB-418',
+        'updateWithPipelines: FindOneAndUpdate using pipelines' => 'PHPLIB-418',
+    ];
+
+    /**
+     * Assert that the expected and actual command documents match.
+     *
+     * Note: this method may modify the $expected object.
+     *
+     * @param stdClass $expected Expected command document
+     * @param stdClass $actual   Actual command document
+     */
+    public static function assertCommandMatches(stdClass $expected, stdClass $actual)
+    {
+        static::assertDocumentsMatch($expected, $actual);
+    }
+
+    /**
+     * Execute an individual test case from the specification.
+     *
+     * @dataProvider provideTests
+     * @param string   $name           Test name
+     * @param stdClass $test           Individual "tests[]" document
+     * @param array    $runOn          Top-level "runOn" array with server requirements
+     * @param array    $data           Top-level "data" array to initialize collection
+     * @param string   $databaseName   Name of database under test
+     * @param string   $collectionName Name of collection under test
+     */
+    public function testCrud($name, stdClass $test, array $runOn = null, array $data, $databaseName = null, $collectionName = null)
+    {
+        if (isset(self::$incompleteTests[$name])) {
+            $this->markTestIncomplete(self::$incompleteTests[$name]);
+        }
+
+        if (isset($runOn)) {
+            $this->checkServerRequirements($runOn);
+        }
+
+        if (isset($test->skipReason)) {
+            $this->markTestSkipped($test->skipReason);
+        }
+
+        $databaseName = isset($databaseName) ? $databaseName : $this->getDatabaseName();
+        $collectionName = isset($collectionName) ? $collectionName : $this->getCollectionName();
+
+        $context = Context::fromCrud($test, $databaseName, $collectionName);
+        $this->setContext($context);
+
+        $this->dropTestAndOutcomeCollections();
+        $this->insertDataFixtures($data);
+
+        if (isset($test->failPoint)) {
+            $this->configureFailPoint($test->failPoint);
+        }
+
+        if (isset($test->expectations)) {
+            $commandExpectations = CommandExpectations::fromCrud($test->expectations);
+            $commandExpectations->startMonitoring();
+        }
+
+        foreach ($test->operations as $operation) {
+            Operation::fromCrud($operation)->assert($this, $context);
+        }
+
+        if (isset($commandExpectations)) {
+            $commandExpectations->stopMonitoring();
+            $commandExpectations->assert($this, $context);
+        }
+
+        if (isset($test->outcome->collection->data)) {
+            $this->assertOutcomeCollectionData($test->outcome->collection->data);
+        }
+    }
+
+    public function provideTests()
+    {
+        $testArgs = [];
+
+        foreach (glob(__DIR__ . '/crud/*.json') as $filename) {
+            $json = $this->decodeJson(file_get_contents($filename));
+            $group = basename($filename, '.json');
+            $runOn = isset($json->runOn) ? $json->runOn : null;
+            $data = isset($json->data) ? $json->data : [];
+            $databaseName = isset($json->database_name) ? $json->database_name : null;
+            $collectionName = isset($json->collection_name) ? $json->collection_name : null;
+
+            foreach ($json->tests as $test) {
+                $name = $group . ': ' . $test->description;
+                $testArgs[$name] = [$name, $test, $runOn, $data, $databaseName, $collectionName];
+            }
+        }
+
+        return $testArgs;
+    }
+}

--- a/tests/SpecTests/ResultExpectation.php
+++ b/tests/SpecTests/ResultExpectation.php
@@ -72,6 +72,19 @@ final class ResultExpectation
         return $o;
     }
 
+    public static function fromCrud(stdClass $operation, $defaultAssertionType)
+    {
+        if (property_exists($operation, 'result') && !self::isErrorResult($operation->result)) {
+            $assertionType = $operation->result === null ? self::ASSERT_NULL : $defaultAssertionType;
+            $expectedValue = $operation->result;
+        } else {
+            $assertionType = self::ASSERT_NOTHING;
+            $expectedValue = null;
+        }
+
+        return new self($assertionType, $expectedValue);
+    }
+
     public static function fromRetryableWrites(stdClass $outcome, $defaultAssertionType)
     {
         if (property_exists($outcome, 'result')) {

--- a/tests/SpecTests/crud/aggregate-merge.json
+++ b/tests/SpecTests/crud/aggregate-merge.json
@@ -1,0 +1,415 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.11"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "test_aggregate_merge",
+  "tests": [
+    {
+      "description": "Aggregate with $merge",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Aggregate with $merge and batch size of 0",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ],
+            "batchSize": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ],
+              "cursor": {}
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Aggregate with $merge and majority readConcern",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ],
+              "readConcern": {
+                "level": "majority"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Aggregate with $merge and local readConcern",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "local"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ],
+              "readConcern": {
+                "level": "local"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Aggregate with $merge and available readConcern",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "available"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$merge": {
+                  "into": "other_test_collection"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_merge",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$merge": {
+                    "into": "other_test_collection"
+                  }
+                }
+              ],
+              "readConcern": {
+                "level": "available"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/SpecTests/crud/aggregate-out-readConcern.json
+++ b/tests/SpecTests/crud/aggregate-out-readConcern.json
@@ -1,0 +1,385 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.0",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "test_aggregate_out_readconcern",
+  "tests": [
+    {
+      "description": "readConcern majority with out stage",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "majority"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readConcern local with out stage",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "local"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "local"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readConcern available with out stage",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "available"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "available"
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readConcern linearizable with out stage",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "linearizable"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "linearizable"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "invalid readConcern with out stage",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "aggregate",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "!invalid123"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$out": "other_test_collection"
+              }
+            ]
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test_aggregate_out_readconcern",
+              "pipeline": [
+                {
+                  "$sort": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$match": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                {
+                  "$out": "other_test_collection"
+                }
+              ],
+              "readConcern": {
+                "level": "!invalid123"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/SpecTests/crud/bulkWrite-arrayFilters.json
+++ b/tests/SpecTests/crud/bulkWrite-arrayFilters.json
@@ -1,0 +1,160 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.5.6"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "y": [
+        {
+          "b": 3
+        },
+        {
+          "b": 1
+        }
+      ]
+    },
+    {
+      "_id": 2,
+      "y": [
+        {
+          "b": 0
+        },
+        {
+          "b": 1
+        }
+      ]
+    }
+  ],
+  "collection_name": "test",
+  "database_name": "crud-tests",
+  "tests": [
+    {
+      "description": "BulkWrite with arrayFilters",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {},
+                  "update": {
+                    "$set": {
+                      "y.$[i].b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 3
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {},
+                  "update": {
+                    "$set": {
+                      "y.$[i].b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 1
+                    }
+                  ]
+                }
+              }
+            ],
+            "options": {
+              "ordered": true
+            }
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {},
+            "matchedCount": 3,
+            "modifiedCount": 3,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {},
+                  "u": {
+                    "$set": {
+                      "y.$[i].b": 2
+                    }
+                  },
+                  "arrayFilters": [
+                    {
+                      "i.b": 3
+                    }
+                  ]
+                },
+                {
+                  "q": {},
+                  "u": {
+                    "$set": {
+                      "y.$[i].b": 2
+                    }
+                  },
+                  "multi": true,
+                  "arrayFilters": [
+                    {
+                      "i.b": 1
+                    }
+                  ]
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "update",
+            "database_name": "crud-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "y": [
+                {
+                  "b": 2
+                },
+                {
+                  "b": 2
+                }
+              ]
+            },
+            {
+              "_id": 2,
+              "y": [
+                {
+                  "b": 0
+                },
+                {
+                  "b": 2
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/SpecTests/crud/db-aggregate.json
+++ b/tests/SpecTests/crud/db-aggregate.json
@@ -1,0 +1,81 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "3.6.0"
+    }
+  ],
+  "database_name": "admin",
+  "tests": [
+    {
+      "description": "Aggregate with $listLocalSessions",
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "database",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "dummy": "dummy field"
+                }
+              },
+              {
+                "$project": {
+                  "_id": 0,
+                  "dummy": 1
+                }
+              }
+            ]
+          },
+          "result": [
+            {
+              "dummy": "dummy field"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with $listLocalSessions and allowDiskUse",
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "database",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              },
+              {
+                "$addFields": {
+                  "dummy": "dummy field"
+                }
+              },
+              {
+                "$project": {
+                  "_id": 0,
+                  "dummy": 1
+                }
+              }
+            ],
+            "allowDiskUse": true
+          },
+          "result": [
+            {
+              "dummy": "dummy field"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/SpecTests/crud/updateWithPipelines.json
+++ b/tests/SpecTests/crud/updateWithPipelines.json
@@ -1,0 +1,239 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 1,
+      "y": 1,
+      "t": {
+        "u": {
+          "v": 1
+        }
+      }
+    },
+    {
+      "_id": 2,
+      "x": 2,
+      "y": 1
+    }
+  ],
+  "minServerVersion": "4.1.11",
+  "collection_name": "test",
+  "database_name": "crud-tests",
+  "tests": [
+    {
+      "description": "UpdateOne using pipelines",
+      "operations": [
+        {
+          "name": "updateOne",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceRoot": {
+                  "newRoot": "$t"
+                }
+              },
+              {
+                "$addFields": {
+                  "foo": 1
+                }
+              }
+            ]
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": [
+                    {
+                      "$replaceRoot": {
+                        "newRoot": "$t"
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "command_name": "update",
+            "database_name": "crud-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "u": {
+                "v": 1
+              },
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "y": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateMany using pipelines",
+      "operations": [
+        {
+          "name": "updateMany",
+          "arguments": {
+            "filter": {},
+            "update": [
+              {
+                "$project": {
+                  "x": 1
+                }
+              },
+              {
+                "$addFields": {
+                  "foo": 1
+                }
+              }
+            ]
+          },
+          "result": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {},
+                  "u": [
+                    {
+                      "$project": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ],
+                  "multi": true
+                }
+              ]
+            },
+            "command_name": "update",
+            "database_name": "crud-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 1,
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "foo": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate using pipelines",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$project": {
+                  "x": 1
+                }
+              },
+              {
+                "$addFields": {
+                  "foo": 1
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "update": [
+                {
+                  "$project": {
+                    "x": 1
+                  }
+                },
+                {
+                  "$addFields": {
+                    "foo": 1
+                  }
+                }
+              ]
+            },
+            "command_name": "findAndModify",
+            "database_name": "crud-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 1,
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "y": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-402

I've extracted the `is_in_transaction` helper from `MongoDB\Collection` in a separate to functions since we need it more often. I've also decided to extract the options for the aggregate helper to a common file to avoid unnecessary duplication of option descriptions.