### PR TITLE
PHPLIB-362: Prefer class name constant over string literals

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -35,9 +35,9 @@ use MongoDB\Operation\Watch;
 class Client
 {
     private static $defaultTypeMap = [
-        'array' => 'MongoDB\Model\BSONArray',
-        'document' => 'MongoDB\Model\BSONDocument',
-        'root' => 'MongoDB\Model\BSONDocument',
+        'array' => \MongoDB\Model\BSONArray::class,
+        'document' => \MongoDB\Model\BSONDocument::class,
+        'root' => \MongoDB\Model\BSONDocument::class,
     ];
     private static $wireVersionForReadConcern = 4;
     private static $wireVersionForWritableCommandWriteConcern = 5;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -62,9 +62,9 @@ use Traversable;
 class Collection
 {
     private static $defaultTypeMap = [
-        'array' => 'MongoDB\Model\BSONArray',
-        'document' => 'MongoDB\Model\BSONDocument',
-        'root' => 'MongoDB\Model\BSONDocument',
+        'array' => \MongoDB\Model\BSONArray::class,
+        'document' => \MongoDB\Model\BSONDocument::class,
+        'root' => \MongoDB\Model\BSONDocument::class,
     ];
     private static $wireVersionForFindAndModifyWriteConcern = 4;
     private static $wireVersionForReadConcern = 4;
@@ -117,11 +117,11 @@ class Collection
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -129,7 +129,7 @@ class Collection
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         $this->manager = $manager;

--- a/src/Database.php
+++ b/src/Database.php
@@ -42,9 +42,9 @@ use Traversable;
 class Database
 {
     private static $defaultTypeMap = [
-        'array' => 'MongoDB\Model\BSONArray',
-        'document' => 'MongoDB\Model\BSONDocument',
-        'root' => 'MongoDB\Model\BSONDocument',
+        'array' => \MongoDB\Model\BSONArray::class,
+        'document' => \MongoDB\Model\BSONDocument::class,
+        'root' => \MongoDB\Model\BSONDocument::class,
     ];
     private static $wireVersionForReadConcern = 4;
     private static $wireVersionForWritableCommandWriteConcern = 5;
@@ -91,11 +91,11 @@ class Database
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -103,7 +103,7 @@ class Database
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         $this->manager = $manager;

--- a/src/Exception/ResumeTokenException.php
+++ b/src/Exception/ResumeTokenException.php
@@ -17,7 +17,7 @@
 
 namespace MongoDB\Exception;
 
-class ResumeTokenException extends \Exception
+class ResumeTokenException extends RuntimeException
 {
     /**
      * Thrown when a resume token has an invalid type.

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -42,9 +42,9 @@ class Bucket
     private static $defaultBucketName = 'fs';
     private static $defaultChunkSizeBytes = 261120;
     private static $defaultTypeMap = [
-        'array' => 'MongoDB\Model\BSONArray',
-        'document' => 'MongoDB\Model\BSONDocument',
-        'root' => 'MongoDB\Model\BSONDocument',
+        'array' => \MongoDB\Model\BSONArray::class,
+        'document' => \MongoDB\Model\BSONDocument::class,
+        'root' => \MongoDB\Model\BSONDocument::class,
     ];
     private static $streamWrapperProtocol = 'gridfs';
 
@@ -111,11 +111,11 @@ class Bucket
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -123,7 +123,7 @@ class Bucket
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         $this->manager = $manager;
@@ -639,7 +639,7 @@ class Bucket
         $metadata = stream_get_meta_data($stream);
 
         if ( ! isset ($metadata['wrapper_data']) || ! $metadata['wrapper_data'] instanceof StreamWrapper) {
-            throw InvalidArgumentException::invalidType('$stream wrapper data', isset($metadata['wrapper_data']) ? $metadata['wrapper_data'] : null, 'MongoDB\Driver\GridFS\StreamWrapper');
+            throw InvalidArgumentException::invalidType('$stream wrapper data', isset($metadata['wrapper_data']) ? $metadata['wrapper_data'] : null, StreamWrapper::class);
         }
 
         return $metadata['wrapper_data']->getFile();

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -182,15 +182,15 @@ class Aggregate implements Executable
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -202,7 +202,7 @@ class Aggregate implements Executable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['batchSize']) && ! $options['useCursor']) {

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -286,11 +286,11 @@ class BulkWrite implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -106,15 +106,15 @@ class Count implements Executable, Explainable
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['skip']) && ! is_integer($options['skip'])) {

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -106,15 +106,15 @@ class CountDocuments implements Executable
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['skip']) && ! is_integer($options['skip'])) {

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -139,7 +139,7 @@ class CreateCollection implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['size']) && ! is_integer($options['size'])) {
@@ -167,7 +167,7 @@ class CreateCollection implements Executable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -104,11 +104,11 @@ class CreateIndexes implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -66,11 +66,11 @@ class DatabaseCommand implements Executable
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -85,11 +85,11 @@ class Delete implements Executable, Explainable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -91,15 +91,15 @@ class Distinct implements Executable, Explainable
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['readConcern']) && $options['readConcern']->isDefault()) {

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -67,7 +67,7 @@ class DropCollection implements Executable
     public function __construct($databaseName, $collectionName, array $options = [])
     {
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -75,7 +75,7 @@ class DropCollection implements Executable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -64,7 +64,7 @@ class DropDatabase implements Executable
     public function __construct($databaseName, array $options = [])
     {
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -72,7 +72,7 @@ class DropDatabase implements Executable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -80,7 +80,7 @@ class DropIndexes implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -88,7 +88,7 @@ class DropIndexes implements Executable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -74,15 +74,15 @@ class EstimatedDocumentCount implements Executable, Explainable
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['readConcern']) && $options['readConcern']->isDefault()) {

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -67,11 +67,11 @@ class Explain implements Executable
     public function __construct($databaseName, Explainable $explainable, array $options = [])
     {
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -224,11 +224,11 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['returnKey']) && ! is_bool($options['returnKey'])) {
@@ -236,7 +236,7 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['showRecordId']) && ! is_bool($options['showRecordId'])) {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -150,7 +150,7 @@ class FindAndModify implements Executable, Explainable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['sort']) && ! is_array($options['sort']) && ! is_object($options['sort'])) {
@@ -166,7 +166,7 @@ class FindAndModify implements Executable, Explainable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if ( ! is_bool($options['upsert'])) {

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -100,11 +100,11 @@ class InsertMany implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -76,11 +76,11 @@ class InsertOne implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -67,7 +67,7 @@ class ListCollections implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         $this->databaseName = (string) $databaseName;

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -67,7 +67,7 @@ class ListDatabases implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         $this->options = $options;

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -68,7 +68,7 @@ class ListIndexes implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         $this->databaseName = (string) $databaseName;

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -157,7 +157,7 @@ class MapReduce implements Executable
         }
 
         if (isset($options['finalize']) && ! $options['finalize'] instanceof JavascriptInterface) {
-            throw InvalidArgumentException::invalidType('"finalize" option', $options['finalize'], 'MongoDB\Driver\Javascript');
+            throw InvalidArgumentException::invalidType('"finalize" option', $options['finalize'], Javascript::class);
         }
 
         if (isset($options['jsMode']) && ! is_bool($options['jsMode'])) {
@@ -177,11 +177,11 @@ class MapReduce implements Executable
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
-            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], 'MongoDB\Driver\ReadConcern');
+            throw InvalidArgumentException::invalidType('"readConcern" option', $options['readConcern'], ReadConcern::class);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
-            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], 'MongoDB\Driver\ReadPreference');
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['scope']) && ! is_array($options['scope']) && ! is_object($options['scope'])) {
@@ -189,7 +189,7 @@ class MapReduce implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['sort']) && ! is_array($options['sort']) && ! is_object($options['sort'])) {
@@ -205,7 +205,7 @@ class MapReduce implements Executable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['readConcern']) && $options['readConcern']->isDefault()) {

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -69,7 +69,7 @@ class ModifyCollection implements Executable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -77,7 +77,7 @@ class ModifyCollection implements Executable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -126,7 +126,7 @@ class Update implements Executable, Explainable
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
-            throw InvalidArgumentException::invalidType('"session" option', $options['session'], 'MongoDB\Driver\Session');
+            throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
         if ( ! is_bool($options['upsert'])) {
@@ -134,7 +134,7 @@ class Update implements Executable, Explainable
         }
 
         if (isset($options['writeConcern']) && ! $options['writeConcern'] instanceof WriteConcern) {
-            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], 'MongoDB\Driver\WriteConcern');
+            throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -24,7 +24,7 @@ class ClientFunctionalTest extends FunctionalTestCase
 
     public function testGetManager()
     {
-        $this->assertInstanceOf('MongoDB\Driver\Manager', $this->client->getManager());
+        $this->assertInstanceOf(\MongoDB\Driver\Manager::class, $this->client->getManager());
     }
 
     public function testDropDatabase()
@@ -50,10 +50,10 @@ class ClientFunctionalTest extends FunctionalTestCase
 
         $databases = $this->client->listDatabases();
 
-        $this->assertInstanceOf('MongoDB\Model\DatabaseInfoIterator', $databases);
+        $this->assertInstanceOf(\MongoDB\Model\DatabaseInfoIterator::class, $databases);
 
         foreach ($databases as $database) {
-            $this->assertInstanceOf('MongoDB\Model\DatabaseInfo', $database);
+            $this->assertInstanceOf(\MongoDB\Model\DatabaseInfo::class, $database);
         }
 
         $that = $this;
@@ -103,6 +103,6 @@ class ClientFunctionalTest extends FunctionalTestCase
         if (version_compare($this->getFeatureCompatibilityVersion(), '3.6', '<')) {
             $this->markTestSkipped('startSession() is only supported on FCV 3.6 or higher');
         }
-        $this->assertInstanceOf('MongoDB\Driver\Session', $this->client->startSession());
+        $this->assertInstanceOf(\MongoDB\Driver\Session::class, $this->client->startSession());
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -63,13 +63,13 @@ class ClientTest extends TestCase
         $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
         $debug = $collection->__debugInfo();
 
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -86,13 +86,13 @@ class ClientTest extends TestCase
         $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName(), $collectionOptions);
         $debug = $collection->__debugInfo();
 
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -105,7 +105,7 @@ class ClientTest extends TestCase
         $debug = $database->__debugInfo();
 
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -125,13 +125,13 @@ class ClientTest extends TestCase
         $database = $client->selectDatabase($this->getDatabaseName());
         $debug = $database->__debugInfo();
 
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -148,13 +148,13 @@ class ClientTest extends TestCase
         $database = $client->selectDatabase($this->getDatabaseName(), $databaseOptions);
         $debug = $database->__debugInfo();
 
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 }

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -258,13 +258,13 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame($this->getCollectionName(), $debug['collectionName']);
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -280,13 +280,13 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $clone = $this->collection->withOptions($collectionOptions);
         $debug = $clone->__debugInfo();
 
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -300,7 +300,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
         $result = $this->collection->mapReduce($map, $reduce, $out);
 
-        $this->assertInstanceOf('MongoDB\MapReduceResult', $result);
+        $this->assertInstanceOf(\MongoDB\MapReduceResult::class, $result);
         $expected = [
             [ '_id' => 1.0, 'value' => 66.0 ],
         ];

--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -299,7 +299,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
             case 'bulkWrite':
                 $this->assertInternalType('array', $expectedResult);
-                $this->assertInstanceOf('MongoDB\BulkWriteResult', $actualResult);
+                $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $actualResult);
 
                 if (isset($expectedResult['deletedCount'])) {
                     $this->assertSame($expectedResult['deletedCount'], $actualResult->getDeletedCount());
@@ -356,7 +356,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             case 'deleteMany':
             case 'deleteOne':
                 $this->assertInternalType('array', $expectedResult);
-                $this->assertInstanceOf('MongoDB\DeleteResult', $actualResult);
+                $this->assertInstanceOf(\MongoDB\DeleteResult::class, $actualResult);
 
                 if (isset($expectedResult['deletedCount'])) {
                     $this->assertSame($expectedResult['deletedCount'], $actualResult->getDeletedCount());
@@ -374,7 +374,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
             case 'insertMany':
                 $this->assertInternalType('array', $expectedResult);
-                $this->assertInstanceOf('MongoDB\InsertManyResult', $actualResult);
+                $this->assertInstanceOf(\MongoDB\InsertManyResult::class, $actualResult);
 
                 if (isset($expectedResult['insertedCount'])) {
                     $this->assertSame($expectedResult['insertedCount'], $actualResult->getInsertedCount());
@@ -390,7 +390,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
             case 'insertOne':
                 $this->assertInternalType('array', $expectedResult);
-                $this->assertInstanceOf('MongoDB\InsertOneResult', $actualResult);
+                $this->assertInstanceOf(\MongoDB\InsertOneResult::class, $actualResult);
 
                 if (isset($expectedResult['insertedCount'])) {
                     $this->assertSame($expectedResult['insertedCount'], $actualResult->getInsertedCount());
@@ -408,7 +408,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             case 'updateMany':
             case 'updateOne':
                 $this->assertInternalType('array', $expectedResult);
-                $this->assertInstanceOf('MongoDB\UpdateResult', $actualResult);
+                $this->assertInstanceOf(\MongoDB\UpdateResult::class, $actualResult);
 
                 if (isset($expectedResult['matchedCount'])) {
                     $this->assertSame($expectedResult['matchedCount'], $actualResult->getMatchedCount());

--- a/tests/Database/CollectionManagementFunctionalTest.php
+++ b/tests/Database/CollectionManagementFunctionalTest.php
@@ -57,10 +57,10 @@ class CollectionManagementFunctionalTest extends FunctionalTestCase
         $this->assertCommandSucceeded($commandResult);
 
         $collections = $this->database->listCollections();
-        $this->assertInstanceOf('MongoDB\Model\CollectionInfoIterator', $collections);
+        $this->assertInstanceOf(\MongoDB\Model\CollectionInfoIterator::class, $collections);
 
         foreach ($collections as $collection) {
-            $this->assertInstanceOf('MongoDB\Model\CollectionInfo', $collection);
+            $this->assertInstanceOf(\MongoDB\Model\CollectionInfo::class, $collection);
         }
     }
 
@@ -73,10 +73,10 @@ class CollectionManagementFunctionalTest extends FunctionalTestCase
         $options = ['filter' => ['name' => $collectionName]];
 
         $collections = $this->database->listCollections($options);
-        $this->assertInstanceOf('MongoDB\Model\CollectionInfoIterator', $collections);
+        $this->assertInstanceOf(\MongoDB\Model\CollectionInfoIterator::class, $collections);
 
         foreach ($collections as $collection) {
-            $this->assertInstanceOf('MongoDB\Model\CollectionInfo', $collection);
+            $this->assertInstanceOf(\MongoDB\Model\CollectionInfo::class, $collection);
             $this->assertEquals($collectionName, $collection->getName());
         }
     }

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -89,7 +89,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $cursor = $this->database->command($command, $options);
 
-        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
         $commandResult = current($cursor->toArray());
 
         $this->assertCommandSucceeded($commandResult);
@@ -107,7 +107,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $cursor = $this->database->command($command, $options);
 
-        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
         $commandResult = current($cursor->toArray());
 
         $this->assertCommandSucceeded($commandResult);
@@ -149,7 +149,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame($this->getCollectionName(), $debug['collectionName']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -203,13 +203,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame($this->getCollectionName(), $debug['collectionName']);
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -225,13 +225,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $collection = $this->database->selectCollection($this->getCollectionName(), $collectionOptions);
         $debug = $collection->__debugInfo();
 
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -251,11 +251,11 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame('fs', $debug['bucketName']);
         $this->assertSame(261120, $debug['chunkSizeBytes']);
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -276,11 +276,11 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame('custom_fs', $debug['bucketName']);
         $this->assertSame(8192, $debug['chunkSizeBytes']);
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -299,13 +299,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -321,13 +321,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $clone = $this->database->withOptions($databaseOptions);
         $debug = $clone->__debugInfo();
 
-        $this->assertInstanceOf('MongoDB\Driver\ReadConcern', $debug['readConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf('MongoDB\Driver\ReadPreference', $debug['readPreference']);
+        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertInternalType('array', $debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf('MongoDB\Driver\WriteConcern', $debug['writeConcern']);
+        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 }

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -51,7 +51,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // End Example 1
 
         $this->assertSame(1, $insertOneResult->getInsertedCount());
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $insertOneResult->getInsertedId());
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $insertOneResult->getInsertedId());
         $this->assertInventoryCount(1);
 
         // Start Example 2
@@ -90,7 +90,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(3, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf('MongoDB\BSON\ObjectId', $id);
+            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
         }
         $this->assertInventoryCount(3);
     }
@@ -136,7 +136,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf('MongoDB\BSON\ObjectId', $id);
+            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -239,7 +239,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf('MongoDB\BSON\ObjectId', $id);
+            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -319,7 +319,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf('MongoDB\BSON\ObjectId', $id);
+            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -429,7 +429,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf('MongoDB\BSON\ObjectId', $id);
+            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -570,7 +570,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf('MongoDB\BSON\ObjectId', $id);
+            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -786,7 +786,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(10, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf('MongoDB\BSON\ObjectId', $id);
+            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
         }
         $this->assertInventoryCount(10);
 
@@ -896,7 +896,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf('MongoDB\BSON\ObjectId', $id);
+            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -1033,7 +1033,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         ]);
         // End Aggregation Example 1
 
-        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
     }
 
     public function testAggregation_example_2()
@@ -1059,7 +1059,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         ]);
         // End Aggregation Example 2
 
-        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
     }
 
     public function testAggregation_example_3()
@@ -1093,7 +1093,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         ]);
         // End Aggregation Example 3
 
-        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
     }
 
     public function testAggregation_example_4()
@@ -1128,7 +1128,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         ]);
         // End Aggregation Example 4
 
-        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
     }
 
     public function testRunCommand_example_1()
@@ -1140,7 +1140,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $result = $cursor->toArray()[0];
         // End runCommand Example 1
 
-        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
     }
 
     public function testRunCommand_example_2()
@@ -1154,7 +1154,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $result = $cursor->toArray()[0];
         // End runCommand Example 2
 
-        $this->assertInstanceOf('MongoDB\Driver\Cursor', $cursor);
+        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
     }
 
     public function testIndex_example_1()

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -60,8 +60,8 @@ abstract class FunctionalTestCase extends TestCase
 
     protected function assertSameObjectId($expectedObjectId, $actualObjectId)
     {
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $expectedObjectId);
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $actualObjectId);
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $expectedObjectId);
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $actualObjectId);
         $this->assertEquals((string) $expectedObjectId, (string) $actualObjectId);
     }
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -48,9 +48,9 @@ class FunctionsTest extends TestCase
                     'z' => [1, 2, 3],
                 ],
                 [
-                    'root' => 'MongoDB\Model\BSONDocument',
-                    'document' => 'MongoDB\Model\BSONDocument',
-                    'array' => 'MongoDB\Model\BSONArray',
+                    'root' => BSONDocument::class,
+                    'document' => BSONDocument::class,
+                    'array' => BSONArray::class,
                 ],
                 new BSONDocument([
                     'x' => 1,

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -323,7 +323,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $cursor = $this->bucket->find();
         $fileDocument = current($cursor->toArray());
 
-        $this->assertInstanceOf('MongoDB\Model\BSONDocument', $fileDocument);
+        $this->assertInstanceOf(\MongoDB\Model\BSONDocument::class, $fileDocument);
     }
 
     public function testFindOne()
@@ -344,7 +344,7 @@ class BucketFunctionalTest extends FunctionalTestCase
             ]
         );
 
-        $this->assertInstanceOf('MongoDB\Model\BSONDocument', $fileDocument);
+        $this->assertInstanceOf(\MongoDB\Model\BSONDocument::class, $fileDocument);
         $this->assertSameDocument(['filename' => 'b', 'length' => 6], $fileDocument);
     }
 
@@ -364,7 +364,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     {
         $chunksCollection = $this->bucket->getChunksCollection();
 
-        $this->assertInstanceOf('MongoDB\Collection', $chunksCollection);
+        $this->assertInstanceOf(\MongoDB\Collection::class, $chunksCollection);
         $this->assertEquals('fs.chunks', $chunksCollection->getCollectionName());
     }
 
@@ -392,8 +392,8 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $fileDocument = $this->bucket->getFileDocumentForStream($stream);
 
-        $this->assertInstanceOf('MongoDB\Model\BSONDocument', $fileDocument);
-        $this->assertInstanceOf('MongoDB\Model\BSONDocument', $fileDocument['metadata']);
+        $this->assertInstanceOf(\MongoDB\Model\BSONDocument::class, $fileDocument);
+        $this->assertInstanceOf(\MongoDB\Model\BSONDocument::class, $fileDocument['metadata']);
         $this->assertSame(['foo' => 'bar'], $fileDocument['metadata']->getArrayCopy());
     }
 
@@ -443,7 +443,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $id = $this->bucket->getFileIdForStream($stream);
 
-        $this->assertInstanceOf('MongoDB\Model\BSONDocument', $id);
+        $this->assertInstanceOf(\MongoDB\Model\BSONDocument::class, $id);
         $this->assertSame(['x' => 1], $id->getArrayCopy());
     }
 
@@ -475,7 +475,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     {
         $filesCollection = $this->bucket->getFilesCollection();
 
-        $this->assertInstanceOf('MongoDB\Collection', $filesCollection);
+        $this->assertInstanceOf(\MongoDB\Collection::class, $filesCollection);
         $this->assertEquals('fs.files', $filesCollection->getCollectionName());
     }
 

--- a/tests/GridFS/SpecFunctionalTest.php
+++ b/tests/GridFS/SpecFunctionalTest.php
@@ -337,14 +337,14 @@ class SpecFunctionalTest extends FunctionalTestCase
         switch ($error) {
             case 'FileNotFound':
             case 'RevisionNotFound':
-                return 'MongoDB\GridFS\Exception\FileNotFoundException';
+                return \MongoDB\GridFS\Exception\FileNotFoundException::class;
 
             case 'ChunkIsMissing':
             case 'ChunkIsWrongSize':
                 /* Although ReadableStream throws a CorruptFileException, the
                  * stream wrapper will convert it to a PHP error of type
                  * E_USER_WARNING. */
-                return 'PHPUnit\Framework\Error\Warning';
+                return \PHPUnit\Framework\Error\Warning::class;
 
             default:
                 throw new LogicException('Unsupported error: ' . $error);

--- a/tests/Model/BSONArrayTest.php
+++ b/tests/Model/BSONArrayTest.php
@@ -103,7 +103,7 @@ class BSONArrayTest extends TestCase
         $data = ['foo', 'bar'];
 
         $array = BSONArray::__set_state($data);
-        $this->assertInstanceOf('MongoDB\Model\BSONArray', $array);
+        $this->assertInstanceOf(\MongoDB\Model\BSONArray::class, $array);
         $this->assertSame($data, $array->getArrayCopy());
     }
 }

--- a/tests/Model/BSONDocumentTest.php
+++ b/tests/Model/BSONDocumentTest.php
@@ -111,7 +111,7 @@ class BSONDocumentTest extends TestCase
         $data = ['foo' => 'bar'];
 
         $document = BSONDocument::__set_state($data);
-        $this->assertInstanceOf('MongoDB\Model\BSONDocument', $document);
+        $this->assertInstanceOf(\MongoDB\Model\BSONDocument::class, $document);
         $this->assertSame($data, $document->getArrayCopy());
     }
 }

--- a/tests/Model/CollectionInfoTest.php
+++ b/tests/Model/CollectionInfoTest.php
@@ -64,7 +64,7 @@ class CollectionInfoTest extends TestCase
     {
         $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576]]);
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('MongoDB\Model\CollectionInfo is immutable');
+        $this->expectExceptionMessage(CollectionInfo::class .' is immutable');
         $info['options'] = ['capped' => false];
     }
 
@@ -72,7 +72,7 @@ class CollectionInfoTest extends TestCase
     {
         $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576]]);
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('MongoDB\Model\CollectionInfo is immutable');
+        $this->expectExceptionMessage(CollectionInfo::class .' is immutable');
         unset($info['options']);
     }
 }

--- a/tests/Model/DatabaseInfoTest.php
+++ b/tests/Model/DatabaseInfoTest.php
@@ -53,7 +53,7 @@ class DatabaseInfoTest extends TestCase
     {
         $info = new DatabaseInfo(['name' => 'foo', 'sizeOnDisk' => 1048576, 'empty' => false]);
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('MongoDB\Model\DatabaseInfo is immutable');
+        $this->expectExceptionMessage(DatabaseInfo::class .' is immutable');
         $info['empty'] = true;
     }
 
@@ -61,7 +61,7 @@ class DatabaseInfoTest extends TestCase
     {
         $info = new DatabaseInfo(['name' => 'foo', 'sizeOnDisk' => 1048576, 'empty' => false]);
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('MongoDB\Model\DatabaseInfo is immutable');
+        $this->expectExceptionMessage(DatabaseInfo::class .' is immutable');
         unset($info['empty']);
     }
 }

--- a/tests/Model/IndexInfoTest.php
+++ b/tests/Model/IndexInfoTest.php
@@ -134,7 +134,7 @@ class IndexInfoTest extends TestCase
         ]);
 
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('MongoDB\Model\IndexInfo is immutable');
+        $this->expectExceptionMessage(IndexInfo::class .' is immutable');
         $info['v'] = 2;
     }
 
@@ -148,7 +148,7 @@ class IndexInfoTest extends TestCase
         ]);
 
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('MongoDB\Model\IndexInfo is immutable');
+        $this->expectExceptionMessage(IndexInfo::class .' is immutable');
         unset($info['v']);
     }
 

--- a/tests/Model/IndexInputTest.php
+++ b/tests/Model/IndexInputTest.php
@@ -85,7 +85,7 @@ class IndexInputTest extends TestCase
             'ns' => 'foo.bar',
         ]);
 
-        $this->assertInstanceOf('MongoDB\BSON\Serializable', $indexInput);
+        $this->assertInstanceOf(\MongoDB\BSON\Serializable::class, $indexInput);
         $this->assertEquals($expected, $indexInput->bsonSerialize());
     }
 }

--- a/tests/Model/TypeMapArrayIteratorTest.php
+++ b/tests/Model/TypeMapArrayIteratorTest.php
@@ -79,7 +79,7 @@ class TypeMapArrayIteratorTest extends TestCase
         $iterator->rewind();
 
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('MongoDB\Model\TypeMapArrayIterator is immutable');
+        $this->expectExceptionMessage(TypeMapArrayIterator::class . ' is immutable');
         call_user_func_array([$iterator, $method], $args);
     }
 

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -36,12 +36,12 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $operation = new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), $ops);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\BulkWriteResult', $result);
+        $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $result);
         $this->assertSame(4, $result->getInsertedCount());
 
         $insertedIds = $result->getInsertedIds();
         $this->assertSame(1, $insertedIds[0]);
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $insertedIds[1]);
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $insertedIds[1]);
         $this->assertSame('foo', $insertedIds[2]);
         $this->assertSame('bar', $insertedIds[3]);
 
@@ -70,14 +70,14 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $operation = new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), $ops);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\BulkWriteResult', $result);
+        $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $result);
         $this->assertSame(5, $result->getMatchedCount());
         $this->assertSame(5, $result->getModifiedCount());
         $this->assertSame(2, $result->getUpsertedCount());
 
         $upsertedIds = $result->getUpsertedIds();
         $this->assertSame(5, $upsertedIds[2]);
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $upsertedIds[3]);
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $upsertedIds[3]);
 
         $expected = [
             ['_id' => 1, 'x' => 11],
@@ -103,7 +103,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $operation = new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), $ops);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\BulkWriteResult', $result);
+        $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $result);
         $this->assertSame(3, $result->getDeletedCount());
 
         $expected = [
@@ -128,7 +128,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $operation = new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), $ops);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\BulkWriteResult', $result);
+        $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $result);
 
         $this->assertSame(1, $result->getInsertedCount());
         $this->assertSame([2 => 4], $result->getInsertedIds());

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -31,7 +31,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
         $operation = new Delete($this->getDatabaseName(), $this->getCollectionName(), $filter, 1);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\DeleteResult', $result);
+        $this->assertInstanceOf(\MongoDB\DeleteResult::class, $result);
         $this->assertSame(1, $result->getDeletedCount());
 
         $expected = [
@@ -51,7 +51,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
         $operation = new Delete($this->getDatabaseName(), $this->getCollectionName(), $filter, 0);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\DeleteResult', $result);
+        $this->assertInstanceOf(\MongoDB\DeleteResult::class, $result);
         $this->assertSame(2, $result->getDeletedCount());
 
         $expected = [

--- a/tests/Operation/ExplainTest.php
+++ b/tests/Operation/ExplainTest.php
@@ -6,6 +6,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Count;
 use MongoDB\Operation\Distinct;
 use MongoDB\Operation\Explain;
+use MongoDB\Operation\Explainable;
 
 class ExplainTest extends TestCase
 {
@@ -14,7 +15,7 @@ class ExplainTest extends TestCase
      */
     public function testConstructorOptionTypeChecks(array $options)
     {
-        $explainable = $this->getMockBuilder('MongoDB\Operation\Explainable')->getMock();
+        $explainable = $this->getMockBuilder(Explainable::class)->getMock();
         $this->expectException(InvalidArgumentException::class);
         new Explain($this->getDatabaseName(), $explainable, $options);
     }

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -161,7 +161,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 ['_id' => 1, 'x' => (object) ['foo' => 'bar']],
             ],
             [
-                ['root' => 'MongoDB\Model\BSONDocument', 'document' => 'object'],
+                ['root' => BSONDocument::class, 'document' => 'object'],
                 new BSONDocument(['_id' => 1, 'x' => (object) ['foo' => 'bar']]),
             ],
         ];

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -34,12 +34,12 @@ class InsertManyFunctionalTest extends FunctionalTestCase
         $operation = new InsertMany($this->getDatabaseName(), $this->getCollectionName(), $documents);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\InsertManyResult', $result);
+        $this->assertInstanceOf(\MongoDB\InsertManyResult::class, $result);
         $this->assertSame(4, $result->getInsertedCount());
 
         $insertedIds = $result->getInsertedIds();
         $this->assertSame('foo', $insertedIds[0]);
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $insertedIds[1]);
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $insertedIds[1]);
         $this->assertSame('bar', $insertedIds[2]);
         $this->assertSame('baz', $insertedIds[3]);
 
@@ -151,6 +151,6 @@ class InsertManyFunctionalTest extends FunctionalTestCase
      */
     public function testUnacknowledgedWriteConcernAccessesInsertedId(InsertManyResult $result)
     {
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $result->getInsertedIds()[0]);
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $result->getInsertedIds()[0]);
     }
 }

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -30,7 +30,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $operation = new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\InsertOneResult', $result);
+        $this->assertInstanceOf(\MongoDB\InsertOneResult::class, $result);
         $this->assertSame(1, $result->getInsertedCount());
         $this->assertSame('foo', $result->getInsertedId());
 
@@ -57,9 +57,9 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $operation = new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\InsertOneResult', $result);
+        $this->assertInstanceOf(\MongoDB\InsertOneResult::class, $result);
         $this->assertSame(1, $result->getInsertedCount());
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $result->getInsertedId());
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $result->getInsertedId());
 
         $expected = [
             ['_id' => $result->getInsertedId(), 'x' => 11],
@@ -166,6 +166,6 @@ class InsertOneFunctionalTest extends FunctionalTestCase
      */
     public function testUnacknowledgedWriteConcernAccessesInsertedId(InsertOneResult $result)
     {
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $result->getInsertedId());
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $result->getInsertedId());
     }
 }

--- a/tests/Operation/ListCollectionsFunctionalTest.php
+++ b/tests/Operation/ListCollectionsFunctionalTest.php
@@ -24,12 +24,12 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
         $operation = new ListCollections($this->getDatabaseName(), ['filter' => ['name' => $this->getCollectionName()]]);
         $collections = $operation->execute($server);
 
-        $this->assertInstanceOf('MongoDB\Model\CollectionInfoIterator', $collections);
+        $this->assertInstanceOf(\MongoDB\Model\CollectionInfoIterator::class, $collections);
 
         $this->assertCount(1, $collections);
 
         foreach ($collections as $collection) {
-            $this->assertInstanceOf('MongoDB\Model\CollectionInfo', $collection);
+            $this->assertInstanceOf(\MongoDB\Model\CollectionInfo::class, $collection);
             $this->assertEquals($this->getCollectionName(), $collection->getName());
         }
     }
@@ -49,10 +49,10 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
         $operation = new ListCollections($this->getDatabaseName(), ['filter' => ['name' => $this->getCollectionName()]]);
         $collections = $operation->execute($server);
 
-        $this->assertInstanceOf('MongoDB\Model\CollectionInfoIterator', $collections);
+        $this->assertInstanceOf(\MongoDB\Model\CollectionInfoIterator::class, $collections);
 
         foreach ($collections as $collection) {
-            $this->assertInstanceOf('MongoDB\Model\CollectionInfo', $collection);
+            $this->assertInstanceOf(\MongoDB\Model\CollectionInfo::class, $collection);
             $this->assertArrayHasKey('readOnly', $collection['info']);
             $this->assertEquals(['v' => 2, 'key' => ['_id' => 1], 'name' => '_id_', 'ns' => $this->getNamespace()], $collection['idIndex']);
         }

--- a/tests/Operation/ListDatabasesFunctionalTest.php
+++ b/tests/Operation/ListDatabasesFunctionalTest.php
@@ -20,10 +20,10 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
         $operation = new ListDatabases();
         $databases = $operation->execute($server);
 
-        $this->assertInstanceOf('MongoDB\Model\DatabaseInfoIterator', $databases);
+        $this->assertInstanceOf(\MongoDB\Model\DatabaseInfoIterator::class, $databases);
 
         foreach ($databases as $database) {
-            $this->assertInstanceOf('MongoDB\Model\DatabaseInfo', $database);
+            $this->assertInstanceOf(\MongoDB\Model\DatabaseInfo::class, $database);
         }
     }
 
@@ -42,12 +42,12 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
         $operation = new ListDatabases(['filter' => ['name' => $this->getDatabaseName()]]);
         $databases = $operation->execute($server);
 
-        $this->assertInstanceOf('MongoDB\Model\DatabaseInfoIterator', $databases);
+        $this->assertInstanceOf(\MongoDB\Model\DatabaseInfoIterator::class, $databases);
 
         $this->assertCount(1, $databases);
 
         foreach ($databases as $database) {
-            $this->assertInstanceOf('MongoDB\Model\DatabaseInfo', $database);
+            $this->assertInstanceOf(\MongoDB\Model\DatabaseInfo::class, $database);
             $this->assertEquals($this->getDatabaseName(), $database->getName());
         }
     }

--- a/tests/Operation/ListIndexesFunctionalTest.php
+++ b/tests/Operation/ListIndexesFunctionalTest.php
@@ -22,12 +22,12 @@ class ListIndexesFunctionalTest extends FunctionalTestCase
         $operation = new ListIndexes($this->getDatabaseName(), $this->getCollectionName());
         $indexes = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\Model\IndexInfoIterator', $indexes);
+        $this->assertInstanceOf(\MongoDB\Model\IndexInfoIterator::class, $indexes);
 
         $this->assertCount(1, $indexes);
 
         foreach ($indexes as $index) {
-            $this->assertInstanceOf('MongoDB\Model\IndexInfo', $index);
+            $this->assertInstanceOf(\MongoDB\Model\IndexInfo::class, $index);
             $this->assertEquals(['_id' => 1], $index->getKey());
         }
     }

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -89,7 +89,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         $operation = new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\MapReduceResult', $result);
+        $this->assertInstanceOf(\MongoDB\MapReduceResult::class, $result);
         $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
         $this->assertNotEmpty($result->getCounts());
     }
@@ -105,7 +105,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         $operation = new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out, ['verbose' => true]);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\MapReduceResult', $result);
+        $this->assertInstanceOf(\MongoDB\MapReduceResult::class, $result);
         $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
         $this->assertNotEmpty($result->getCounts());
         $this->assertNotEmpty($result->getTiming());
@@ -122,7 +122,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         $operation = new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out, ['verbose' => false]);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\MapReduceResult', $result);
+        $this->assertInstanceOf(\MongoDB\MapReduceResult::class, $result);
         $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
         $this->assertNotEmpty($result->getCounts());
         $this->assertEmpty($result->getTiming());

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -105,7 +105,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $operation = new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, $update);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\UpdateResult', $result);
+        $this->assertInstanceOf(\MongoDB\UpdateResult::class, $result);
         $this->assertSame(1, $result->getMatchedCount());
         $this->assertSame(1, $result->getModifiedCount());
         $this->assertSame(0, $result->getUpsertedCount());
@@ -131,7 +131,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $operation = new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, $update, $options);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\UpdateResult', $result);
+        $this->assertInstanceOf(\MongoDB\UpdateResult::class, $result);
         $this->assertSame(2, $result->getMatchedCount());
         $this->assertSame(2, $result->getModifiedCount());
         $this->assertSame(0, $result->getUpsertedCount());
@@ -157,7 +157,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $operation = new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, $update, $options);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\UpdateResult', $result);
+        $this->assertInstanceOf(\MongoDB\UpdateResult::class, $result);
         $this->assertSame(0, $result->getMatchedCount());
         $this->assertSame(0, $result->getModifiedCount());
         $this->assertSame(1, $result->getUpsertedCount());
@@ -184,11 +184,11 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $operation = new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, $update, $options);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf('MongoDB\UpdateResult', $result);
+        $this->assertInstanceOf(\MongoDB\UpdateResult::class, $result);
         $this->assertSame(0, $result->getMatchedCount());
         $this->assertSame(0, $result->getModifiedCount());
         $this->assertSame(1, $result->getUpsertedCount());
-        $this->assertInstanceOf('MongoDB\BSON\ObjectId', $result->getUpsertedId());
+        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $result->getUpsertedId());
 
         $expected = [
             ['_id' => 1, 'x' => 11],

--- a/tests/SpecTests/CommandExpectations.php
+++ b/tests/SpecTests/CommandExpectations.php
@@ -91,7 +91,7 @@ class CommandExpectations implements CommandSubscriber
      */
     public function commandFailed(CommandFailedEvent $event)
     {
-        if ($this->ignoreCommandFailed) {
+        if ($this->ignoreCommandFailed || ($this->ignoreExtraEvents && count($this->actualEvents) === count($this->expectedEvents))) {
             return;
         }
 
@@ -105,7 +105,7 @@ class CommandExpectations implements CommandSubscriber
      */
     public function commandStarted(CommandStartedEvent $event)
     {
-        if ($this->ignoreCommandStarted) {
+        if ($this->ignoreCommandStarted || ($this->ignoreExtraEvents && count($this->actualEvents) === count($this->expectedEvents))) {
             return;
         }
 
@@ -119,7 +119,7 @@ class CommandExpectations implements CommandSubscriber
      */
     public function commandSucceeded(CommandSucceededEvent $event)
     {
-        if ($this->ignoreCommandSucceeded) {
+        if ($this->ignoreCommandSucceeded || ($this->ignoreExtraEvents && count($this->actualEvents) === count($this->expectedEvents))) {
             return;
         }
 
@@ -150,15 +150,11 @@ class CommandExpectations implements CommandSubscriber
      */
     public function assert(FunctionalTestCase $test, Context $context)
     {
-        $actualEvents = $this->ignoreExtraEvents
-            ? array_slice($this->actualEvents, 0, count($this->expectedEvents))
-            : $this->actualEvents;
-
-        $test->assertCount(count($this->expectedEvents), $actualEvents);
+        $test->assertCount(count($this->expectedEvents), $this->actualEvents);
 
         $mi = new MultipleIterator(MultipleIterator::MIT_NEED_ANY);
         $mi->attachIterator(new ArrayIterator($this->expectedEvents));
-        $mi->attachIterator(new ArrayIterator($actualEvents));
+        $mi->attachIterator(new ArrayIterator($this->actualEvents));
 
         foreach ($mi as $events) {
             list($expectedEventAndClass, $actualEvent) = $events;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,10 +10,10 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     throw new Exception('Can\'t find autoload.php. Did you install dependencies with Composer?');
 }
 
-if ( ! class_exists('PHPUnit\Framework\Error\Warning')) {
-    class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
+if ( ! class_exists(PHPUnit\Framework\Error\Warning::class)) {
+    class_alias(PHPUnit_Framework_Error_Warning::class, PHPUnit\Framework\Error\Warning::class);
 }
 
-if ( ! class_exists('PHPUnit\Framework\Constraint\Constraint')) {
-    class_alias('PHPUnit_Framework_Constraint', 'PHPUnit\Framework\Constraint\Constraint');
+if ( ! class_exists(PHPUnit\Framework\Constraint\Constraint::class)) {
+    class_alias(PHPUnit_Framework_Constraint::class, PHPUnit\Framework\Constraint\Constraint::class);
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-362

Note that I haven't added any `use` statements for new classes. This will be done automatically when we add `phpcs` checks in [PHPLIB-330](https://jira.mongodb.org/browse/PHPLIB-330).