### PR TITLE
PHPLIB-460: Use travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - SERVER_DISTRO=ubuntu1604
     - SERVER_VERSION=4.0.10
     - DEPLOYMENT=STANDALONE
+    - COMPOSER_OPTIONS=
 
 jobs:
   allow_failures:
@@ -39,6 +40,12 @@ jobs:
       php: "7.2"
     - stage: Test
       php: "7.4snapshot"
+
+    # Test against lowest supported dependencies
+    - stage: Test
+      php: "5.6"
+      env:
+        - COMPOSER_OPTIONS=--prefer-lowest
 
       # Test older standalone server versions (3.0-3.6)
     - stage: Test
@@ -124,7 +131,7 @@ before_script:
   - .travis/setup_mo.sh
   - pecl install -f mongodb-${DRIVER_VERSION}
   - php --ri mongodb
-  - composer install --no-interaction --no-progress --no-suggest
+  - composer update --no-interaction --no-progress --no-suggest --prefer-dist --prefer-stable ${COMPOSER_OPTIONS}
   - ulimit -c
   - ulimit -c unlimited -S
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,51 +19,79 @@ env:
     - SERVER_VERSION=4.0.10
     - DEPLOYMENT=STANDALONE
 
-matrix:
-  fast_finish: true
+jobs:
+  allow_failures:
+    - php: "7.4snapshot"
+
   include:
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
-    - php: 7.0
+
+    - stage: Smoke Testing
+      php: "7.3"
+
+    # Test remaining supported PHP versions
+    - stage: Test
+      php: "5.6"
+    - stage: Test
+      php: "7.0"
+    - stage: Test
+      php: "7.1"
+    - stage: Test
+      php: "7.2"
+    - stage: Test
+      php: "7.4snapshot"
+
+      # Test older standalone server versions (3.0-3.6)
+    - stage: Test
+      php: "7.0"
       dist: trusty
       env:
         - SERVER_DISTRO=ubuntu1404
         - SERVER_VERSION=3.0.15
         - DEPLOYMENT=STANDALONE_OLD
-    - php: 7.0
+    - stage: Test
+      php: "7.0"
       env:
         - SERVER_VERSION=3.2.22
         - DEPLOYMENT=STANDALONE_OLD
-    - php: 7.0
+    - stage: Test
+      php: "7.0"
       env:
         - SERVER_VERSION=3.4.21
         - DEPLOYMENT=STANDALONE_OLD
-    - php: 7.0
+    - stage: Test
+      php: "7.0"
       env:
         - SERVER_VERSION=3.6.13
-    - php: 7.3
+
+    # Test other server configurations
+    - stage: Test
+      php: "7.3"
       env:
         - DEPLOYMENT=STANDALONE_AUTH
-    - php: 7.3
+    - stage: Test
+      php: "7.3"
       env:
         - DEPLOYMENT=STANDALONE_SSL
-    - php: 7.3
+    - stage: Test
+      php: "7.3"
       env:
         - SERVER_VERSION=3.6.13
         - DEPLOYMENT=REPLICASET
-    - php: 7.3
+    - stage: Test
+      php: "7.3"
       env:
         - DEPLOYMENT=REPLICASET
-    - php: 7.3
+    - stage: Test
+      php: "7.3"
+      env:
+        - DEPLOYMENT=SHARDED_CLUSTER
+
+    # Test upcoming server versions
+    - stage: Test
+      php: "7.3"
       env:
         - SERVER_VERSION=4.2.0-rc1
         - DEPLOYMENT=REPLICASET
-    - php: 7.3
-      env:
-        - DEPLOYMENT=SHARDED_CLUSTER
 
 before_install:
   - pip install "mongo-orchestration>=0.6.7,<1.0" --user `whoami`


### PR DESCRIPTION
http://jira.mongodb.org/browse/PHPLIB-460

With these changes, we're preparing the build file to do more than just running tests. To make feedback more immediate and to save resources, the build now runs a smoke screen testing step before running the full build pipeline. This should catch simple errors and will also do static analysis before running all tests. Once smoke screen testing has completed, the full build pipeline will be executed.

This PR also adds testing against PHP 7.4 with the build currently failing due to a deprecation:
```
Function ReflectionType::__toString() is deprecated
/home/travis/build/alcaeus/mongo-php-library/tests/Operation/ExplainTest.php:17
```

This will be fixed at a later step once I've figured out what's causing this.