### PR TITLE
Use named datasets in spec tests

### DIFF
--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -34,8 +34,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
      */
     public function testSpecification(array $initialData, array $test, $minServerVersion, $maxServerVersion)
     {
-        $this->setName(str_replace(' ', '_', $test['description']));
-
         if (isset($minServerVersion) || isset($maxServerVersion)) {
             $this->checkServerVersion($minServerVersion, $maxServerVersion);
         }
@@ -71,7 +69,8 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             $maxServerVersion = isset($json['maxServerVersion']) ? $json['maxServerVersion'] : null;
 
             foreach ($json['tests'] as $test) {
-                $testArgs[] = [$json['data'], $test, $minServerVersion, $maxServerVersion];
+                $name = str_replace(' ', '_', $test['description']);
+                $testArgs[$name] = [$json['data'], $test, $minServerVersion, $maxServerVersion];
             }
         }
 

--- a/tests/GridFS/SpecFunctionalTest.php
+++ b/tests/GridFS/SpecFunctionalTest.php
@@ -40,7 +40,6 @@ class SpecFunctionalTest extends FunctionalTestCase
      */
     public function testSpecification(array $initialData, array $test)
     {
-        $this->setName(str_replace(' ', '_', $test['description']));
         $this->initializeData($initialData);
 
         if (isset($test['arrange'])) {
@@ -77,7 +76,8 @@ class SpecFunctionalTest extends FunctionalTestCase
             $json = json_decode(file_get_contents($filename), true);
 
             foreach ($json['tests'] as $test) {
-                $testArgs[] = [$json['data'], $test];
+                $name = str_replace(' ', '_', $test['description']);
+                $testArgs[$name] = [$json['data'], $test];
             }
         }
 

--- a/tests/SpecTests/ChangeStreamsSpecTest.php
+++ b/tests/SpecTests/ChangeStreamsSpecTest.php
@@ -58,17 +58,14 @@ class ChangeStreamsSpecTest extends FunctionalTestCase
      * Execute an individual test case from the specification.
      *
      * @dataProvider provideTests
-     * @param string    $name            Test name
-     * @param stdClass  $test            Individual "tests[]" document
-     * @param string    $databaseName    Name of database under test
-     * @param string    $collectionName  Name of collection under test
-     * @param string    $database2Name   Name of alternate database under test
-     * @param string    $collection2Name Name of alternate collection under test
+     * @param stdClass $test            Individual "tests[]" document
+     * @param string   $databaseName    Name of database under test
+     * @param string   $collectionName  Name of collection under test
+     * @param string   $database2Name   Name of alternate database under test
+     * @param string   $collection2Name Name of alternate collection under test
      */
-    public function testChangeStreams($name, stdClass $test, $databaseName = null, $collectionName = null, $database2Name = null, $collection2Name = null)
+    public function testChangeStreams(stdClass $test, $databaseName = null, $collectionName = null, $database2Name = null, $collection2Name = null)
     {
-        $this->setName($name);
-
         $this->checkServerRequirements($this->createRunOn($test));
 
         if (!isset($databaseName, $collectionName, $database2Name, $collection2Name)) {
@@ -151,7 +148,7 @@ class ChangeStreamsSpecTest extends FunctionalTestCase
 
             foreach ($json->tests as $test) {
                 $name = $group . ': ' . $test->description;
-                $testArgs[] = [$name, $test, $databaseName, $collectionName, $database2Name, $collection2Name];
+                $testArgs[$name] = [$test, $databaseName, $collectionName, $database2Name, $collection2Name];
             }
         }
 

--- a/tests/SpecTests/CommandMonitoringSpecTest.php
+++ b/tests/SpecTests/CommandMonitoringSpecTest.php
@@ -130,16 +130,13 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
      * Execute an individual test case from the specification.
      *
      * @dataProvider provideTests
-     * @param string    $name           Test name
      * @param stdClass  $test           Individual "tests[]" document
      * @param array     $data           Top-level "data" array to initialize collection
      * @param string    $databaseName   Name of database under test
      * @param string    $collectionName Name of collection under test
      */
-    public function testCommandMonitoring($name, stdClass $test, array $data, $databaseName = null, $collectionName = null)
+    public function testCommandMonitoring(stdClass $test, array $data, $databaseName = null, $collectionName = null)
     {
-        $this->setName($name);
-
         $this->checkServerRequirements($this->createRunOn($test));
 
         $databaseName = isset($databaseName) ? $databaseName : $this->getDatabaseName();
@@ -177,7 +174,7 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
 
             foreach ($json->tests as $test) {
                 $name = $group . ': ' . $test->description;
-                $testArgs[] = [$name, $test, $data, $databaseName, $collectionName];
+                $testArgs[$name] = [$test, $data, $databaseName, $collectionName];
             }
         }
 

--- a/tests/SpecTests/CrudSpecTest.php
+++ b/tests/SpecTests/CrudSpecTest.php
@@ -37,17 +37,16 @@ class CrudSpecTest extends FunctionalTestCase
      * Execute an individual test case from the specification.
      *
      * @dataProvider provideTests
-     * @param string   $name           Test name
      * @param stdClass $test           Individual "tests[]" document
      * @param array    $runOn          Top-level "runOn" array with server requirements
      * @param array    $data           Top-level "data" array to initialize collection
      * @param string   $databaseName   Name of database under test
      * @param string   $collectionName Name of collection under test
      */
-    public function testCrud($name, stdClass $test, array $runOn = null, array $data, $databaseName = null, $collectionName = null)
+    public function testCrud(stdClass $test, array $runOn = null, array $data, $databaseName = null, $collectionName = null)
     {
-        if (isset(self::$incompleteTests[$name])) {
-            $this->markTestIncomplete(self::$incompleteTests[$name]);
+        if (isset(self::$incompleteTests[$this->dataDescription()])) {
+            $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);
         }
 
         if (isset($runOn)) {
@@ -104,7 +103,7 @@ class CrudSpecTest extends FunctionalTestCase
 
             foreach ($json->tests as $test) {
                 $name = $group . ': ' . $test->description;
-                $testArgs[$name] = [$name, $test, $runOn, $data, $databaseName, $collectionName];
+                $testArgs[$name] = [$test, $runOn, $data, $databaseName, $collectionName];
             }
         }
 

--- a/tests/SpecTests/RetryableWritesSpecTest.php
+++ b/tests/SpecTests/RetryableWritesSpecTest.php
@@ -16,15 +16,12 @@ class RetryableWritesSpecTest extends FunctionalTestCase
      * Execute an individual test case from the specification.
      *
      * @dataProvider provideTests
-     * @param string   $name  Test name
      * @param stdClass $test  Individual "tests[]" document
      * @param array    $runOn Top-level "runOn" array with server requirements
      * @param array    $data  Top-level "data" array to initialize collection
      */
-    public function testRetryableWrites($name, stdClass $test, array $runOn = null, array $data)
+    public function testRetryableWrites(stdClass $test, array $runOn = null, array $data)
     {
-        $this->setName($name);
-
         // TODO: Revise this once a test environment with multiple mongos nodes is available (see: PHPLIB-430)
         if (isset($test->useMultipleMongoses) && $test->useMultipleMongoses && $this->isShardedCluster()) {
             $this->markTestSkipped('"useMultipleMongoses" is not supported');
@@ -63,7 +60,7 @@ class RetryableWritesSpecTest extends FunctionalTestCase
 
             foreach ($json->tests as $test) {
                 $name = $group . ': ' . $test->description;
-                $testArgs[] = [$name, $test, $runOn, $data];
+                $testArgs[$name] = [$test, $runOn, $data];
             }
         }
 

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -113,19 +113,16 @@ class TransactionsSpecTest extends FunctionalTestCase
      * Execute an individual test case from the specification.
      *
      * @dataProvider provideTests
-     * @param string    $name           Test name
-     * @param stdClass  $test           Individual "tests[]" document
-     * @param array     $runOn          Top-level "runOn" array with server requirements
-     * @param array     $data           Top-level "data" array to initialize collection
-     * @param string    $databaseName   Name of database under test
-     * @param string    $collectionName Name of collection under test
+     * @param stdClass $test           Individual "tests[]" document
+     * @param array    $runOn          Top-level "runOn" array with server requirements
+     * @param array    $data           Top-level "data" array to initialize collection
+     * @param string   $databaseName   Name of database under test
+     * @param string   $collectionName Name of collection under test
      */
-    public function testTransactions($name, stdClass $test, array $runOn = null, array $data, $databaseName = null, $collectionName = null)
+    public function testTransactions(stdClass $test, array $runOn = null, array $data, $databaseName = null, $collectionName = null)
     {
-        $this->setName($name);
-
-        if (isset(self::$incompleteTests[$name])) {
-            $this->markTestIncomplete(self::$incompleteTests[$name]);
+        if (isset(self::$incompleteTests[$this->dataDescription()])) {
+            $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);
         }
 
         // TODO: Revise this once a test environment with multiple mongos nodes is available (see: PHPLIB-430)
@@ -192,7 +189,7 @@ class TransactionsSpecTest extends FunctionalTestCase
 
             foreach ($json->tests as $test) {
                 $name = $group . ': ' . $test->description;
-                $testArgs[] = [$name, $test, $runOn, $data, $databaseName, $collectionName];
+                $testArgs[$name] = [$test, $runOn, $data, $databaseName, $collectionName];
             }
         }
 


### PR DESCRIPTION
This fixes issues in tools like PhpStorm that are not able to show test progress when the test name changes.