### PR TITLE
PHPLIB-430: Add test environment with multiple mongos nodes

### DIFF
--- a/mongo-orchestration/sharded_clusters/cluster.json
+++ b/mongo-orchestration/sharded_clusters/cluster.json
@@ -74,6 +74,13 @@
             "logappend": true,
             "port": 4300,
             "bind_ip_all": true
+        },
+        {
+            "logpath": "/tmp/SHARDED/ROUTER/4301/mongod.log",
+            "ipv6": true,
+            "logappend": true,
+            "port": 4301,
+            "bind_ip_all": true
         }
     ]
 }

--- a/mongo-orchestration/sharded_clusters/cluster_replset.json
+++ b/mongo-orchestration/sharded_clusters/cluster_replset.json
@@ -98,6 +98,13 @@
             "logappend": true,
             "port": 4430,
             "bind_ip_all": true
+        },
+        {
+            "logpath": "/tmp/SHARDED-RS/ROUTER/4431/mongod.log",
+            "ipv6": true,
+            "logappend": true,
+            "port": 4431,
+            "bind_ip_all": true
         }
     ]
 }

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -55,14 +55,17 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->insertDocument(['x' => 2]);
 
         $changeStream->next();
+        $this->assertTrue($changeStream->valid());
         $this->assertSameDocument($changeStream->current()->_id, $changeStream->getResumeToken());
 
         $changeStream->next();
+        $this->assertTrue($changeStream->valid());
         $this->assertSameDocument($changeStream->current()->_id, $changeStream->getResumeToken());
 
         $this->insertDocument(['x' => 3]);
 
         $changeStream->next();
+        $this->assertTrue($changeStream->valid());
         $this->assertSameDocument($changeStream->current()->_id, $changeStream->getResumeToken());
     }
 
@@ -116,6 +119,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $postBatchResumeToken = $this->getPostBatchResumeTokenFromReply($events[0]['succeeded']->getReply());
 
         $changeStream->next();
+        $this->assertTrue($changeStream->valid());
         $this->assertSameDocument($changeStream->current()->_id, $changeStream->getResumeToken());
 
         $changeStream->next();

--- a/tests/SpecTests/RetryableWritesSpecTest.php
+++ b/tests/SpecTests/RetryableWritesSpecTest.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests\SpecTests;
 
 use LogicException;
+use MongoDB\Driver\Manager;
 use stdClass;
 
 /**
@@ -22,9 +23,8 @@ class RetryableWritesSpecTest extends FunctionalTestCase
      */
     public function testRetryableWrites(stdClass $test, array $runOn = null, array $data)
     {
-        // TODO: Revise this once a test environment with multiple mongos nodes is available (see: PHPLIB-430)
         if (isset($test->useMultipleMongoses) && $test->useMultipleMongoses && $this->isShardedCluster()) {
-            $this->markTestSkipped('"useMultipleMongoses" is not supported');
+            $this->manager = new Manager(static::getUri(true));
         }
 
         if (isset($runOn)) {

--- a/tests/SpecTests/RetryableWritesSpecTest.php
+++ b/tests/SpecTests/RetryableWritesSpecTest.php
@@ -23,6 +23,10 @@ class RetryableWritesSpecTest extends FunctionalTestCase
      */
     public function testRetryableWrites(stdClass $test, array $runOn = null, array $data)
     {
+        if ($this->isShardedCluster() && ! $this->isShardedClusterUsingReplicasets()) {
+            $this->markTestSkipped('Transaction numbers are only allowed on a replica set member or mongos (PHPC-1415)');
+        }
+
         if (isset($test->useMultipleMongoses) && $test->useMultipleMongoses && $this->isShardedCluster()) {
             $this->manager = new Manager(static::getUri(true));
         }

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -123,6 +123,10 @@ class TransactionsSpecTest extends FunctionalTestCase
             $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);
         }
 
+        if ($this->isShardedCluster()) {
+            $this->markTestSkipped('PHP MongoDB driver 1.6.0alpha2 does not support running multi-document transactions on sharded clusters');
+        }
+
         if (isset($test->useMultipleMongoses) && $test->useMultipleMongoses && $this->isShardedCluster()) {
             $this->manager = new Manager(static::getUri(true));
         }

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -123,9 +123,8 @@ class TransactionsSpecTest extends FunctionalTestCase
             $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);
         }
 
-        // TODO: Revise this once a test environment with multiple mongos nodes is available (see: PHPLIB-430)
         if (isset($test->useMultipleMongoses) && $test->useMultipleMongoses && $this->isShardedCluster()) {
-            $this->markTestIncomplete('"useMultipleMongoses" is not supported');
+            $this->manager = new Manager(static::getUri(true));
         }
 
         if (isset($runOn)) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-430

This PR changes the mongo-orchestration configs for sharded cluster to include a second mongos node for each. To ensure that we're not running into errors due to running subsequent commands on separate mongos instances, the tests modify the connection URI to only use a single mongos node, unless explicitly requested to use multiple nodes. This is currently only the case in select tests for the retryable-writes and transaction specs.

Note that some tests had to be disabled: 
* Transaction tests on these clusters fail due to an error thrown in the driver, see https://github.com/mongodb/mongo-php-driver/pull/984 for more details. Once this has been removed in the driver, we can then run these tests again.
* Retryable write tests are skipped on non-replica set sharded clusters due to [PHPC-1415](PHPC-1415). Once this has been fixed this can be re-enabled.
* As mentioned in #655, functional tests for the `Watch` operation are disabled on sharded clusters with replica sets because of an issue with `getMore` not returning information. I'm still investigating that issue and will fix it separately.