### PR TITLE
PHPLIB-461: Fix functional tests for change streams on sharded clusters

### DIFF
--- a/mongo-orchestration/sharded_clusters/cluster_replset.json
+++ b/mongo-orchestration/sharded_clusters/cluster_replset.json
@@ -50,7 +50,11 @@
                         "journal": true,
                         "logappend": true,
                         "port": 4400,
-                        "bind_ip_all": true
+                        "bind_ip_all": true,
+                        "setParameter":  {
+                            "periodicNoopIntervalSecs":  1,
+                            "writePeriodicNoops":  true
+                        }
                     } },
                     { "procParams": {
                         "dbpath": "/tmp/SHARDED-RS/SHARD1/4401",
@@ -59,7 +63,11 @@
                         "journal": true,
                         "logappend": true,
                         "port": 4401,
-                        "bind_ip_all": true
+                        "bind_ip_all": true,
+                        "setParameter":  {
+                            "periodicNoopIntervalSecs":  1,
+                            "writePeriodicNoops":  true
+                        }
                     } }
                 ]
             }
@@ -76,7 +84,11 @@
                         "journal": true,
                         "logappend": true,
                         "port": 4410,
-                        "bind_ip_all": true
+                        "bind_ip_all": true,
+                        "setParameter":  {
+                            "periodicNoopIntervalSecs":  1,
+                            "writePeriodicNoops":  true
+                        }
                     } },
                     { "procParams": {
                         "dbpath": "/tmp/SHARDED-RS/SHARD2/4411",
@@ -85,7 +97,11 @@
                         "journal": true,
                         "logappend": true,
                         "port": 4411,
-                        "bind_ip_all": true
+                        "bind_ip_all": true,
+                        "setParameter":  {
+                            "periodicNoopIntervalSecs":  1,
+                            "writePeriodicNoops":  true
+                        }
                     } }
                 ]
             }

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -935,6 +935,10 @@ class DocumentationExamplesTest extends FunctionalTestCase
     {
         $this->skipIfChangeStreamIsNotSupported();
 
+        if ($this->isShardedCluster()) {
+            $this->markTestSkipped('Test does not apply on sharded clusters: need more than a single getMore call on the change stream.');
+        }
+
         $db = new Database($this->manager, $this->getDatabaseName());
         $db->dropCollection('inventory');
         $db->createCollection('inventory');

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -336,9 +336,6 @@ abstract class FunctionalTestCase extends TestCase
                 if (! $this->isShardedClusterUsingReplicasets()) {
                     $this->markTestSkipped('$changeStream is only supported with replicasets');
                 }
-
-                // Temporarily skip tests because of an issue with change streams in the driver
-                $this->markTestSkipped('$changeStreams currently don\'t on replica sets');
                 break;
 
             case Server::TYPE_RS_PRIMARY:


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-461

Due to the way `getMore` works on sharded clusters, we can't rely on the first `getMore` call after an insert to return the data we expect. I'll quote the response from the query team to my questions about why `getMore` behaves this way.

> First, it will be useful to understand the semantics of `getMore` on a tailable `awaitData` cursor such as that created by `$changeStream`:
> 1. If there are documents available when the `getMore` starts running, then `getMore` will read up to `batchSize` OR `EOF`, whichever comes first. It will then return immediately without waiting for any further results.
> 2. If there are no documents available when the `getMore` starts running, it will wait up to the specified `awaitData` timeout to see if any documents become available.
> 3. If documents become available while the `getMore` is waiting, it will adopt the behaviour outlined in (1). In other words: once the `getMore` has obtained at least one result, it cancels its `awaitData` timeout and does not wait again.
> 
> The second thing to understand is the behaviour of change streams in a sharded cluster. For reasons [outlined in this comment](https://jira.mongodb.org/browse/SERVER-36526?focusedCommentId=1972933&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1972933), change streams must open a cursor on every shard even when monitoring an unsharded collection. Because each change stream is globally-sorted, it cannot return result A from shard X until it has obtained at least one result from every other shard that sorts **later than** result A. In other words, it cannot return A to the client until every other shard has promised that they will never produce a result that sorts before A. To guard against the possibility that one or more shards never return any results, each shard has a no-op writer that updates its oplog every `periodicNoopIntervalSecs` seconds. This allows the shard to return a high-water-mark promising that it will never return a future result which sorts before that point, so we are guaranteed that the change stream will eventually be allowed to return result A to the client.

With an `maxAwaitTimeMS` of 500 ms we stay below the minimum `periodicNoopIntervalSecs` of 1 second, which can cause our `getMore` commands on shards without data to time out before a no-op is read from the oplog. One way to solve this would be to increase the `maxAwaitTimeMS` to a value above 1000 ms to ensure that `getMore` calls don't time out before another no-op is written, but this causes tests to be significantly slower. Furthermore, we should never make any assumptions as to what batch a change stream event is returned in, only that it will eventually be returned in the correct order. To ensure the tests don't unnecessarily fail on sharded clusters, they will now execute multiple `getMore` calls if necessary, only failing if a given number (currently 5) of `getMore` calls fails to return any data. This was also necessary since resume operations would still yield empty batches on the initial call to `aggregate`.

This PR also contains a workaround for [PHPC-1419](https://jira.mongodb.org/browse/PHPC-1419), where a `NonResumableChangeStreamError` error label is not applied to the `ServerException` create for a `ChangeStreamFatalError`. This causes the iterator to repeatedly retry resuming the change stream for an unresumable error. This workaround can be removed once the above issue was fixed.