### PR TITLE
PHPLIB-459: Support better failure descriptions in DocumentsMatchConstraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.27 || ^6.4 || ^8.3",
+        "sebastian/comparator": "^1.0 || ^2.0 || ^3.0",
         "symfony/phpunit-bridge": "^4.4@dev"
     },
     "autoload": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,3 +17,7 @@ if ( ! class_exists(PHPUnit\Framework\Error\Warning::class)) {
 if ( ! class_exists(PHPUnit\Framework\Constraint\Constraint::class)) {
     class_alias(PHPUnit_Framework_Constraint::class, PHPUnit\Framework\Constraint\Constraint::class);
 }
+
+if ( ! class_exists(PHPUnit\Framework\ExpectationFailedException::class)) {
+    class_alias(PHPUnit_Framework_ExpectationFailedException::class, PHPUnit\Framework\ExpectationFailedException::class);
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-459

This improves the error messages for the above constraint by no longer just printing the expected and actual object, but also by giving a reason for the failure and showing a diff. Comparison follows.

Instead of simply comparing values, this uses `sebastian/comparator` internally to compare object values and uses its exceptions to generate failure messages.

---

Here's an actual comparison failure before:
```
Failed asserting that stdClass Object &000000001f899da5000000004f623c22 (
    'update' => 'test'
    'ordered' => true
    '$db' => 'crud-tests'
    'lsid' => stdClass Object &000000001f899dc2000000004f623c22 (
        'id' => MongoDB\BSON\Binary Object &000000001f899daa000000004f623c22 (
            'data' => '(?z??A??-y{?T?C'
            'type' => 4
        )
    )
    'updates' => Array &0 (
        0 => stdClass Object &000000001f899da1000000004f623c22 (
            'q' => stdClass Object &000000001f899da9000000004f623c22 ()
            'u' => stdClass Object &000000001f899d9b000000004f623c22 (
                '$set' => stdClass Object &000000001f899dad000000004f623c22 (
                    'y.$[i].b' => 2
                )
            )
            'upsert' => false
            'multi' => false
            'arrayFilters' => stdClass Object &000000001f899db0000000004f623c22 (
                0 => stdClass Object &000000001f899db2000000004f623c22 (
                    'i.b' => 3
                )
            )
        )
        1 => stdClass Object &000000001f899db3000000004f623c22 (
            'q' => stdClass Object &000000001f899da3000000004f623c22 ()
            'u' => stdClass Object &000000001f899d95000000004f623c22 (
                '$set' => stdClass Object &000000001f899db7000000004f623c22 (
                    'y.$[i].b' => 2
                )
            )
            'upsert' => false
            'multi' => true
            'arrayFilters' => stdClass Object &000000001f899da7000000004f623c22 (
                0 => stdClass Object &000000001f899d9d000000004f623c22 (
                    'i.b' => 1
                )
            )
        )
    )
) matches {"update":"test","updates":[{"q":{},"u":{"$set":{"y.$[i].b":2}},"arrayFilters":[{"i.b":3}]},{"q":{},"u":{"$set":{"y.$[i].b":2}},"multi":true,"arrayFilters":[{"i.b":1}]}],"ordered":true}.
```

and the same failure after the change:
```
Failed asserting that two BSON objects are equal.
Field path "updates.0.arrayFilters": MongoDB\Model\BSONDocument Object (...) is not instance of expected class "MongoDB\Model\BSONArray".
--- Expected
+++ Actual
@@ @@
-MongoDB\Model\BSONDocument Object &0000000077a2cf6c00000000788c65fd (
+MongoDB\Model\BSONDocument Object &0000000077a2cf5d00000000788c65fd (
     'update' => 'test'
-    'updates' => MongoDB\Model\BSONArray Object &0000000077a2cf6d00000000788c65fd (
-        0 => MongoDB\Model\BSONDocument Object &0000000077a2cf5c00000000788c65fd (
-            'q' => MongoDB\Model\BSONDocument Object &0000000077a2cf6200000000788c65fd ()
-            'u' => MongoDB\Model\BSONDocument Object &0000000077a2cf6300000000788c65fd (
-                '$set' => MongoDB\Model\BSONDocument Object &0000000077a2cf6000000000788c65fd (
+    'ordered' => true
+    '$db' => 'crud-tests'
+    'lsid' => MongoDB\Model\BSONDocument Object &0000000077a2cf5200000000788c65fd (
+        'id' => MongoDB\BSON\Binary Object &0000000077a2cf5000000000788c65fd (
+            'data' => Binary String: 0xab912072076f4d8abf8eaf4988f954ea
+            'type' => 4
+        )
+    )
+    'updates' => MongoDB\Model\BSONArray Object &0000000077a2cf6500000000788c65fd (
+        0 => MongoDB\Model\BSONDocument Object &0000000077a2cf7c00000000788c65fd (
+            'q' => MongoDB\Model\BSONDocument Object &0000000077a2cf7700000000788c65fd ()
+            'u' => MongoDB\Model\BSONDocument Object &0000000077a2cf7500000000788c65fd (
+                '$set' => MongoDB\Model\BSONDocument Object &0000000077a2cf7300000000788c65fd (
                     'y.$[i].b' => 2
                 )
             )
-            'arrayFilters' => MongoDB\Model\BSONArray Object &0000000077a2cf6400000000788c65fd (
-                0 => MongoDB\Model\BSONDocument Object &0000000077a2cf6100000000788c65fd (
+            'upsert' => false
+            'multi' => false
+            'arrayFilters' => MongoDB\Model\BSONDocument Object &0000000077a2cf7200000000788c65fd (
+                0 => MongoDB\Model\BSONDocument Object &0000000077a2cf7000000000788c65fd (
                     'i.b' => 3
                 )
             )
         )
-        1 => MongoDB\Model\BSONDocument Object &0000000077a2cf6800000000788c65fd (
-            'q' => MongoDB\Model\BSONDocument Object &0000000077a2cf6900000000788c65fd ()
-            'u' => MongoDB\Model\BSONDocument Object &0000000077a2cf7f00000000788c65fd (
-                '$set' => MongoDB\Model\BSONDocument Object &0000000077a2cf7a00000000788c65fd (
+        1 => MongoDB\Model\BSONDocument Object &0000000077a2cf7900000000788c65fd (
+            'q' => MongoDB\Model\BSONDocument Object &0000000077a2cf7400000000788c65fd ()
+            'u' => MongoDB\Model\BSONDocument Object &0000000077a2cf8e00000000788c65fd (
+                '$set' => MongoDB\Model\BSONDocument Object &0000000077a2cf8d00000000788c65fd (
                     'y.$[i].b' => 2
                 )
             )
+            'upsert' => false
             'multi' => true
-            'arrayFilters' => MongoDB\Model\BSONArray Object &0000000077a2cf7d00000000788c65fd (
-                0 => MongoDB\Model\BSONDocument Object &0000000077a2cf7b00000000788c65fd (
+            'arrayFilters' => MongoDB\Model\BSONDocument Object &0000000077a2cf8c00000000788c65fd (
+                0 => MongoDB\Model\BSONDocument Object &0000000077a2cf8a00000000788c65fd (
                     'i.b' => 1
                 )
             )
         )
     )
-    'ordered' => true
```