### PR TITLE
Automatically skip tests if failCommand is not available

### DIFF
--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -689,10 +689,6 @@ class WatchFunctionalTest extends FunctionalTestCase
      */
     public function testNonResumableErrorCodes($errorCode)
     {
-        if (version_compare($this->getServerVersion(), '4.0.0', '<')) {
-            $this->markTestSkipped('failCommand is not supported');
-        }
-
         $this->configureFailPoint([
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],


### PR DESCRIPTION
Since failCommand is only available on newer server versions and need a special parameter to be enabled, the configureFailPoint helper now automatically skips a test if failCommand is not available, instead of failing the test with an error.