### PR TITLE
PHPLIB-462: ensure compatibility with PHP 7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor/
 # PHPUnit
 phpunit.phar
 phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ env:
     - COMPOSER_OPTIONS=
 
 jobs:
-  allow_failures:
-    - php: "7.4snapshot"
-
   include:
 
     - stage: Smoke Testing

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "ext-mongodb": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27 || ^6.4 || ^8.3"
+        "phpunit/phpunit": "^5.7.27 || ^6.4 || ^8.3",
+        "symfony/phpunit-bridge": "^4.4@dev"
     },
     "autoload": {
         "psr-4": { "MongoDB\\": "src/" },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-mongodb": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27 || ^6.4"
+        "phpunit/phpunit": "^5.7.27 || ^6.4 || ^8.3"
     },
     "autoload": {
         "psr-4": { "MongoDB\\": "src/" },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,15 +2,10 @@
 
 <phpunit
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.3/phpunit.xsd"
-         backupGlobals="false"
-         backupStaticAttributes="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.3/phpunit.xsd"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="tests/bootstrap.php"
 >
 

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -6,15 +6,18 @@ use MongoDB\Client;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\Command;
 use MongoDB\Model\DatabaseInfo;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Functional tests for the Client class.
  */
 class ClientFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $client;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -67,7 +67,7 @@ class ClientTest extends TestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
@@ -90,7 +90,7 @@ class ClientTest extends TestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
@@ -129,7 +129,7 @@ class ClientTest extends TestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
@@ -152,7 +152,7 @@ class ClientTest extends TestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -262,7 +262,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
@@ -284,7 +284,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());

--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -300,7 +300,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 break;
 
             case 'bulkWrite':
-                $this->assertInternalType('array', $expectedResult);
+                $this->assertIsArray($expectedResult);
                 $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $actualResult);
 
                 if (isset($expectedResult['deletedCount'])) {
@@ -357,7 +357,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
             case 'deleteMany':
             case 'deleteOne':
-                $this->assertInternalType('array', $expectedResult);
+                $this->assertIsArray($expectedResult);
                 $this->assertInstanceOf(\MongoDB\DeleteResult::class, $actualResult);
 
                 if (isset($expectedResult['deletedCount'])) {
@@ -375,7 +375,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 break;
 
             case 'insertMany':
-                $this->assertInternalType('array', $expectedResult);
+                $this->assertIsArray($expectedResult);
                 $this->assertInstanceOf(\MongoDB\InsertManyResult::class, $actualResult);
 
                 if (isset($expectedResult['insertedCount'])) {
@@ -391,7 +391,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 break;
 
             case 'insertOne':
-                $this->assertInternalType('array', $expectedResult);
+                $this->assertIsArray($expectedResult);
                 $this->assertInstanceOf(\MongoDB\InsertOneResult::class, $actualResult);
 
                 if (isset($expectedResult['insertedCount'])) {
@@ -409,7 +409,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             case 'replaceOne':
             case 'updateMany':
             case 'updateOne':
-                $this->assertInternalType('array', $expectedResult);
+                $this->assertIsArray($expectedResult);
                 $this->assertInstanceOf(\MongoDB\UpdateResult::class, $actualResult);
 
                 if (isset($expectedResult['matchedCount'])) {

--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -11,6 +11,7 @@ use MongoDB\Operation\FindOneAndReplace;
 use IteratorIterator;
 use LogicException;
 use MultipleIterator;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * CRUD spec functional tests.
@@ -19,9 +20,11 @@ use MultipleIterator;
  */
 class CrudSpecFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $expectedCollection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/Collection/FunctionalTestCase.php
+++ b/tests/Collection/FunctionalTestCase.php
@@ -5,15 +5,18 @@ namespace MongoDB\Tests\Collection;
 use MongoDB\Collection;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Base class for Collection functional tests.
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     protected $collection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -22,7 +25,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         $this->dropCollection();
     }
 
-    public function tearDown()
+    private function doTearDown()
     {
         if ($this->hasFailed()) {
             return;

--- a/tests/Compat/PolyfillAssertTrait.php
+++ b/tests/Compat/PolyfillAssertTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MongoDB\Tests\Compat;
+
+use PHPUnit\Framework\Assert;
+use ReflectionClass;
+use Symfony\Bridge\PhpUnit\Legacy\PolyfillAssertTrait as SymfonyPolyfillAssertTrait;
+
+$r = new ReflectionClass(Assert::class);
+if (! $r->hasMethod('assertEqualsWithDelta')) {
+    /**
+     * @internal
+     */
+    trait PolyfillAssertTrait
+    {
+        use SymfonyPolyfillAssertTrait;
+    }
+} else {
+    /**
+     * @internal
+     */
+    trait PolyfillAssertTrait
+    {
+    }
+}

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -111,7 +111,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $commandResult = current($cursor->toArray());
 
         $this->assertCommandSucceeded($commandResult);
-        $this->assertInternalType('array', $commandResult);
+        $this->assertIsArray($commandResult);
         $this->assertArrayHasKey('ismaster', $commandResult);
         $this->assertTrue($commandResult['ismaster']);
     }
@@ -207,7 +207,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
@@ -229,7 +229,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
@@ -303,7 +303,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
@@ -325,7 +325,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInternalType('array', $debug['typeMap']);
+        $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
         $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());

--- a/tests/Database/FunctionalTestCase.php
+++ b/tests/Database/FunctionalTestCase.php
@@ -4,15 +4,18 @@ namespace MongoDB\Tests\Database;
 
 use MongoDB\Database;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Base class for Database functional tests.
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     protected $database;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -498,7 +498,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(2, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInternalType('int', $id);
+            $this->assertIsInt($id);
         }
         $this->assertInventoryCount(2);
 

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -11,6 +11,7 @@ use MongoDB\Driver\Server;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Driver\Exception\ConnectionTimeoutException;
 use MongoDB\Operation\DropCollection;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Documentation examples to be parsed for inclusion in the MongoDB manual.
@@ -21,14 +22,16 @@ use MongoDB\Operation\DropCollection;
  */
 class DocumentationExamplesTest extends FunctionalTestCase
 {
-    public function setUp()
+    use SetUpTearDownTrait;
+
+    private function doSetUp()
     {
         parent::setUp();
 
         $this->dropCollection();
     }
 
-    public function tearDown()
+    private function doTearDown()
     {
         if ($this->hasFailed()) {
             return;

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -15,15 +15,18 @@ use MongoDB\Operation\DatabaseCommand;
 use MongoDB\Operation\DropCollection;
 use InvalidArgumentException;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use UnexpectedValueException;
 
 abstract class FunctionalTestCase extends TestCase
 {
+    use SetUpTearDownTrait;
+
     protected $manager;
 
     private $configuredFailPoints = [];
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -31,7 +34,7 @@ abstract class FunctionalTestCase extends TestCase
         $this->configuredFailPoints = [];
     }
 
-    public function tearDown()
+    private function doTearDown()
     {
         $this->disableFailPoints();
 

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -502,7 +502,7 @@ class BucketFunctionalTest extends FunctionalTestCase
             $expectedReadLength = min(4096, strlen($input) - strlen($buffer));
             $buffer .= $read = fread($stream, 4096);
 
-            $this->assertInternalType('string', $read);
+            $this->assertIsString($read);
             $this->assertEquals($expectedReadLength, strlen($read));
         }
 

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -5,17 +5,20 @@ namespace MongoDB\Tests\GridFS;
 use MongoDB\Collection;
 use MongoDB\GridFS\Bucket;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Base class for GridFS functional tests.
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     protected $bucket;
     protected $chunksCollection;
     protected $filesCollection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -39,7 +39,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
      */
     protected function assertStreamContents($expectedContents, $stream)
     {
-        $this->assertInternalType('resource', $stream);
+        $this->assertIsResource($stream);
         $this->assertSame('stream', get_resource_type($stream));
         $this->assertEquals($expectedContents, stream_get_contents($stream, -1, 0));
     }

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -9,15 +9,18 @@ use MongoDB\GridFS\ReadableStream;
 use MongoDB\GridFS\Exception\CorruptFileException;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Functional tests for the internal ReadableStream class.
  */
 class ReadableStreamFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collectionWrapper;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/GridFS/SpecFunctionalTest.php
+++ b/tests/GridFS/SpecFunctionalTest.php
@@ -13,6 +13,7 @@ use Exception;
 use IteratorIterator;
 use LogicException;
 use MultipleIterator;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * GridFS spec functional tests.
@@ -21,10 +22,12 @@ use MultipleIterator;
  */
 class SpecFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $expectedChunksCollection;
     private $expectedFilesCollection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -4,13 +4,16 @@ namespace MongoDB\Tests\GridFS;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\UTCDateTime;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Functional tests for the internal StreamWrapper class.
  */
 class StreamWrapperFunctionalTest extends FunctionalTestCase
 {
-    public function setUp()
+    use SetUpTearDownTrait;
+
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -5,15 +5,18 @@ namespace MongoDB\Tests\GridFS;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\CollectionWrapper;
 use MongoDB\GridFS\WritableStream;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Functional tests for the internal WritableStream class.
  */
 class WritableStreamFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collectionWrapper;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -11,12 +11,15 @@ use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\DropCollection;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\FunctionalTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class ChangeStreamIteratorTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -4,12 +4,15 @@ namespace MongoDB\Tests\Model;
 
 use MongoDB\Collection;
 use MongoDB\Tests\FunctionalTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class IndexInfoFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
@@ -17,7 +20,7 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
         $this->collection->drop();
     }
 
-    public function tearDown()
+    private function doTearDown()
     {
         if ($this->hasFailed()) {
             return;

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -12,12 +12,15 @@ use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\BulkWrite;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class BulkWriteFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -10,12 +10,15 @@ use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Operation\Delete;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class DeleteFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/Operation/FunctionalTestCase.php
+++ b/tests/Operation/FunctionalTestCase.php
@@ -8,20 +8,23 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Operation\DropCollection;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Base class for Operation functional tests.
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    public function setUp()
+    use SetUpTearDownTrait;
+
+    private function doSetUp()
     {
         parent::setUp();
 
         $this->dropCollection();
     }
 
-    public function tearDown()
+    private function doTearDown()
     {
         if ($this->hasFailed()) {
             return;

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -10,12 +10,15 @@ use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class InsertManyFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -10,12 +10,15 @@ use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class InsertOneFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -10,12 +10,15 @@ use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Operation\Update;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class UpdateFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private $collection;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -277,7 +277,7 @@ class WatchFunctionalTest extends FunctionalTestCase
     private function assertResumeAfter($expectedResumeToken, stdClass $command)
     {
         $this->assertObjectHasAttribute('pipeline', $command);
-        $this->assertInternalType('array', $command->pipeline);
+        $this->assertIsArray($command->pipeline);
         $this->assertArrayHasKey(0, $command->pipeline);
         $this->assertObjectHasAttribute('$changeStream', $command->pipeline[0]);
         $this->assertObjectHasAttribute('resumeAfter', $command->pipeline[0]->{'$changeStream'});
@@ -354,7 +354,7 @@ class WatchFunctionalTest extends FunctionalTestCase
     private function assertStartAtOperationTime(TimestampInterface $expectedOperationTime, stdClass $command)
     {
         $this->assertObjectHasAttribute('pipeline', $command);
-        $this->assertInternalType('array', $command->pipeline);
+        $this->assertIsArray($command->pipeline);
         $this->assertArrayHasKey(0, $command->pipeline);
         $this->assertObjectHasAttribute('$changeStream', $command->pipeline[0]);
         $this->assertObjectHasAttribute('startAtOperationTime', $command->pipeline[0]->{'$changeStream'});
@@ -1183,7 +1183,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $rp = $rc->getProperty('resumeCallable');
         $rp->setAccessible(true);
 
-        $this->assertInternalType('callable', $rp->getValue($changeStream));
+        $this->assertIsCallable($rp->getValue($changeStream));
 
         // Invalidate the cursor to verify that resumeCallable is unset when the cursor is exhausted.
         $this->dropCollection();
@@ -1210,9 +1210,9 @@ class WatchFunctionalTest extends FunctionalTestCase
     private function getPostBatchResumeTokenFromReply(stdClass $reply)
     {
         $this->assertObjectHasAttribute('cursor', $reply);
-        $this->assertInternalType('object', $reply->cursor);
+        $this->assertIsObject($reply->cursor);
         $this->assertObjectHasAttribute('postBatchResumeToken', $reply->cursor);
-        $this->assertInternalType('object', $reply->cursor->postBatchResumeToken);
+        $this->assertIsObject($reply->cursor->postBatchResumeToken);
 
         return $reply->cursor->postBatchResumeToken;
     }

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -19,14 +19,17 @@ use MongoDB\Operation\Watch;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
 use ReflectionClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 class WatchFunctionalTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     private static $wireVersionForStartAtOperationTime = 7;
 
     private $defaultOptions = ['maxAwaitTimeMS' => 500];
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 

--- a/tests/SpecTests/CommandMonitoringSpecTest.php
+++ b/tests/SpecTests/CommandMonitoringSpecTest.php
@@ -32,7 +32,7 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
 
         if (isset($expected->killCursors) && isset($expected->cursors) && is_array($expected->cursors)) {
             static::assertObjectHasAttribute('cursors', $actual);
-            static::assertInternalType('array', $actual->cursors);
+            static::assertIsArray($actual->cursors);
 
             foreach ($expected->cursors as $i => $cursorId) {
                 static::assertArrayHasKey($i, $actual->cursors);
@@ -63,7 +63,7 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
     {
         if (isset($expected->cursor->id) && $expected->cursor->id === 42) {
             static::assertObjectHasAttribute('cursor', $actual);
-            static::assertInternalType('object', $actual->cursor);
+            static::assertIsObject($actual->cursor);
             static::assertObjectHasAttribute('id', $actual->cursor);
             static::assertThat($actual->cursor->id, static::logicalOr(
                 static::isInstanceOf(Int64::class),
@@ -74,7 +74,7 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
 
         if (isset($expected->cursorsUnknown) && is_array($expected->cursorsUnknown)) {
             static::assertObjectHasAttribute('cursorsUnknown', $actual);
-            static::assertInternalType('array', $actual->cursorsUnknown);
+            static::assertIsArray($actual->cursorsUnknown);
 
             foreach ($expected->cursorsUnknown as $i => $cursorId) {
                 static::assertArrayHasKey($i, $actual->cursorsUnknown);
@@ -92,14 +92,14 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
 
         if (isset($expected->ok) && is_numeric($expected->ok)) {
             static::assertObjectHasAttribute('ok', $actual);
-            static::assertInternalType('numeric', $actual->ok);
+            static::assertIsNumeric($actual->ok);
             static::assertEquals($expected->ok, $actual->ok);
             unset($expected->ok);
         }
 
         if (isset($expected->writeErrors) && is_array($expected->writeErrors)) {
             static::assertObjectHasAttribute('writeErrors', $actual);
-            static::assertInternalType('array', $actual->writeErrors);
+            static::assertIsArray($actual->writeErrors);
 
             foreach ($expected->writeErrors as $i => $expectedWriteError) {
                 static::assertArrayHasKey($i, $actual->writeErrors);
@@ -116,7 +116,7 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
 
                 if (isset($expectedWriteError->errmsg) && $expectedWriteError->errmsg === '') {
                     static::assertObjectHasAttribute('errmsg', $actualWriteError);
-                    static::assertInternalType('string', $actualWriteError->errmsg);
+                    static::assertIsString($actualWriteError->errmsg);
                     static::assertNotEmpty($actualWriteError->errmsg);
                     unset($expected->writeErrors[$i]->errmsg);
                 }

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -17,6 +17,7 @@ use IteratorIterator;
 use LogicException;
 use MultipleIterator;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use UnexpectedValueException;
 
 /**
@@ -26,20 +27,22 @@ use UnexpectedValueException;
  */
 class FunctionalTestCase extends BaseFunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     const TOPOLOGY_SINGLE = 'single';
     const TOPOLOGY_REPLICASET = 'replicaset';
     const TOPOLOGY_SHARDED = 'sharded';
 
     private $context;
 
-    public function setUp()
+    private function doSetUp()
     {
         parent::setUp();
 
         $this->context = null;
     }
 
-    public function tearDown()
+    private function doTearDown()
     {
         $this->context = null;
 

--- a/tests/SpecTests/ResultExpectation.php
+++ b/tests/SpecTests/ResultExpectation.php
@@ -216,7 +216,7 @@ final class ResultExpectation
                 break;
 
             case self::ASSERT_MATCHES_DOCUMENT:
-                $test->assertInternalType('object', $expected);
+                $test->assertIsObject($expected);
                 $test->assertThat($actual, $test->logicalOr(
                     $test->isType('array'),
                     $test->isType('object')
@@ -236,7 +236,7 @@ final class ResultExpectation
                 break;
 
             case self::ASSERT_SAME_DOCUMENT:
-                $test->assertInternalType('object', $expected);
+                $test->assertIsObject($expected);
                 $test->assertThat($actual, $test->logicalOr(
                     $test->isType('array'),
                     $test->isType('object')

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -78,13 +78,13 @@ class TransactionsSpecTest extends FunctionalTestCase
 
         if (isset($expected->recoveryToken) && $expected->recoveryToken === 42) {
             static::assertObjectHasAttribute('recoveryToken', $actual);
-            static::assertInternalType('object', $actual->recoveryToken);
+            static::assertIsObject($actual->recoveryToken);
             unset($expected->recoveryToken);
         }
 
         if (isset($expected->readConcern->afterClusterTime) && $expected->readConcern->afterClusterTime === 42) {
             static::assertObjectHasAttribute('readConcern', $actual);
-            static::assertInternalType('object', $actual->readConcern);
+            static::assertIsObject($actual->readConcern);
             static::assertObjectHasAttribute('afterClusterTime', $actual->readConcern);
             static::assertInstanceOf(Timestamp::class, $actual->readConcern->afterClusterTime);
             unset($expected->readConcern->afterClusterTime);

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -12,6 +12,7 @@ use MongoDB\Driver\Server;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Driver\Exception\ServerException;
 use stdClass;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Transactions spec tests.
@@ -20,6 +21,8 @@ use stdClass;
  */
 class TransactionsSpecTest extends FunctionalTestCase
 {
+    use SetUpTearDownTrait;
+
     const INTERRUPTED = 11601;
 
     /* In addition to the useMultipleMongoses tests, these should all pass
@@ -38,14 +41,14 @@ class TransactionsSpecTest extends FunctionalTestCase
         'transaction-options: readConcern snapshot in startTransaction options' => 'PHPLIB does not properly inherit readConcern for transactions',
     ];
 
-    public static function setUpBeforeClass()
+    private static function doSetUpBeforeClass()
     {
         parent::setUpBeforeClass();
 
         static::killAllSessions();
     }
 
-    public function tearDown()
+    private function doTearDown()
     {
         if ($this->hasFailed()) {
             static::killAllSessions();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
+use MongoDB\Tests\Compat\PolyfillAssertTrait;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use InvalidArgumentException;
 use ReflectionClass;
@@ -15,6 +16,8 @@ use Traversable;
 
 abstract class TestCase extends BaseTestCase
 {
+    use PolyfillAssertTrait;
+
     /**
      * Return the connection URI.
      *


### PR DESCRIPTION
While we're not going to be running any PHP 7.4 features for a while, we at least want to make sure that we test the library on PHP 7.4. This requires upgrading to newer PHPUnit releases to avoid errors due to the deprecation of the `__toString` methods in reflection classes.

Upgrading to PHPUnit 7 or newer is non-trivial, as support for PHP 5 was dropped and PHPUnit introduces type hints. To cope with that, we use `symfony/phpunit-bridge` to provide compatibility layers for the `TestCase` class. Once https://github.com/symfony/symfony/pull/33078 is merged, we can also drop the constraint traits from this packages. However, since the traits are marked as `@internal` we don't need to wait for a merge of that pull request and can drop them once they're available in `symfony/phpunit-bridge`.