### PR TITLE
PHPLIB-330: Implement checks for coding standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ vendor/
 phpunit.phar
 phpunit.xml
 .phpunit.result.cache
+
+# phpcs
+.phpcs-cache
+phpcs.xml

--- a/.phpcs/autoload.php
+++ b/.phpcs/autoload.php
@@ -1,0 +1,15 @@
+<?php
+
+// Since doctrine/coding-standard requires PHP 7, we can't add it as a dependency
+// yet. This autoload file adds more information to the phpcs error message,
+// telling the user how they can fix the error presented to them by phpcs.
+if (! file_exists(__DIR__ . '/../vendor/doctrine/coding-standard')) {
+    echo <<<ERRORMESSAGE
+==============================================================================
+ERROR: Doctrine coding standard is not installed. To rectify this, please run:
+composer require --dev doctrine/coding-standard=^6.0
+==============================================================================
+
+
+ERRORMESSAGE;
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,20 @@ jobs:
 
     - stage: Smoke Testing
       php: "7.3"
+      env:
+        - CHECKS=phpunit
+    - stage: Smoke Testing
+      php: "7.1"
+      before_install: []
+      before_script:
+        - pecl install -f mongodb-${DRIVER_VERSION}
+        - composer require --no-update doctrine/coding-standard=^6.0
+        - composer install --no-interaction --no-progress --no-suggest ${COMPOSER_OPTIONS}
+      script: vendor/bin/phpcs
+      after_script: []
+      after_failure: []
+      env:
+        - CHECKS=phpcs
 
     # Test remaining supported PHP versions
     - stage: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,31 @@ test suite. In addition to various PHPUnit options, it defines required
 this configuration by creating your own `phpunit.xml` file based on the
 `phpunit.xml.dist` file we provide.
 
+## Checking coding standards
+
+The library's code is checked using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer),
+which is installed as a development dependency by Composer. Due to the PHP
+requirement, the base version of the coding standard is not installed and needs
+to be added manually if you plan to contributing code:
+
+```
+$ composer require --dev doctrine/coding-standard=^6.0
+```
+
+Once the coding standard has been installed, you can check the code for style
+errors:
+
+
+```
+$ vendor/bin/phpcs
+```
+
+To automatically fix all fixable errors, use the `phpcbf` binary:
+
+```
+$ vendor/bin/phpcbf
+```
+
 ## Documentation
 
 Documentation for the library lives in the `docs/` directory and is built with

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7.27 || ^6.4 || ^8.3",
         "sebastian/comparator": "^1.0 || ^2.0 || ^3.0",
+        "squizlabs/php_codesniffer": "^3.4",
         "symfony/phpunit-bridge": "^4.4@dev"
     },
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,101 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors" />
+
+    <!-- Ignore warnings, show progress of the run, and show sniff names -->
+    <arg value="nps"/>
+
+    <autoload>.phpcs/autoload.php</autoload>
+
+    <file>.phpcs</file>
+    <file>src</file>
+    <file>tests</file>
+
+    <rule ref="Doctrine">
+        <!-- Exclude sniffs that require newer PHP versions -->
+        <!-- Available with PHP 7.0 -->
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes" />
+        <!-- In addition to requiring PHP 7.0, this sniff will cause a significant amount of BC breaks. Proceed with caution! -->
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration" />
+        <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" />
+
+        <!-- Available with PHP 7.1 -->
+        <exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
+        <exclude name="SlevomatCodingStandard.PHP.ShortList.LongListUsed" />
+        <exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
+
+        <!-- No statement alignment so far -->
+        <exclude name="Generic.Formatting.MultipleStatementAlignment" />
+
+        <!-- Class naming sniffs are excluded to preserve BC -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming" />
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousTraitNaming" />
+
+        <!-- Forbid useless annotations - Git and LICENCE file provide more accurate information -->
+        <!-- Disable forbidden annotation sniff as excluding @api from the list doesn't work -->
+        <exclude name="SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden" />
+
+        <!-- Keep long typehints (for now) -->
+        <exclude name="SlevomatCodingStandard.PHP.TypeCast.InvalidCastUsed" />
+        <exclude name="SlevomatCodingStandard.TypeHints.LongTypeHints" />
+
+        <!-- Don't require a full stop after @throws tags -->
+        <exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
+
+        <!-- Disable some sniffs as they can cause functional changes. These will be enabled later -->
+        <exclude name="Generic.PHP.ForbiddenFunctions.FoundWithAlternative" />
+        <exclude name="SlevomatCodingStandard.Classes.UnusedPrivateElements" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit" />
+        <exclude name="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn" />
+        <exclude name="SlevomatCodingStandard.Functions.StaticClosure" />
+        <exclude name="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
+        <exclude name="SlevomatCodingStandard.Operators.DisallowEqualOperators" />
+
+        <!-- These sniffs cause a large diff, so enable them in separate steps -->
+        <exclude name="SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectAnnotationsGroup" />
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment" />
+        <exclude name="Squiz.Strings.DoubleQuoteUsage" />
+
+        <!-- Sniff currently breaks, see https://github.com/slevomat/coding-standard/issues/727 -->
+        <exclude name="SlevomatCodingStandard.Namespaces.NamespaceSpacing" />
+    </rule>
+
+    <!-- Change use statement sorting to be compatible with PSR-12 -->
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+        <properties>
+            <property name="psr12Compatible" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- Forbid fully qualified names even for colliding names -->
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFallbackGlobalConstants" value="false"/>
+            <property name="allowFallbackGlobalFunctions" value="false"/>
+            <property name="allowFullyQualifiedGlobalClasses" value="false"/>
+            <property name="allowFullyQualifiedGlobalConstants" value="false"/>
+            <property name="allowFullyQualifiedGlobalFunctions" value="false"/>
+            <property phpcs-only="true" name="allowFullyQualifiedNameForCollidingClasses" value="false"/>
+            <property phpcs-only="true" name="allowFullyQualifiedNameForCollidingConstants" value="false"/>
+            <property phpcs-only="true" name="allowFullyQualifiedNameForCollidingFunctions" value="false"/>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>/src/GridFS/StreamWrapper</exclude-pattern>
+        <exclude-pattern>/tests/DocumentationExamplesTest.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>/tests/Compat/PolyfillAssertTrait.php</exclude-pattern>
+    </rule>
+</ruleset>

--- a/src/BulkWriteResult.php
+++ b/src/BulkWriteResult.php
@@ -30,8 +30,6 @@ class BulkWriteResult
     private $isAcknowledged;
 
     /**
-     * Constructor.
-     *
      * @param WriteResult $writeResult
      * @param mixed[]     $insertedIds
      */

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -17,13 +17,15 @@
 
 namespace MongoDB;
 
+use Iterator;
 use MongoDB\Driver\CursorId;
 use MongoDB\Driver\Exception\ConnectionException;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Exception\ResumeTokenException;
 use MongoDB\Model\ChangeStreamIterator;
-use Iterator;
+use function call_user_func;
+use function in_array;
 
 /**
  * Iterator for a change stream.
@@ -57,8 +59,6 @@ class ChangeStream implements Iterator
     private $hasAdvanced = false;
 
     /**
-     * Constructor.
-     *
      * @internal
      * @param ChangeStreamIterator $iterator
      * @param callable             $resumeCallable
@@ -109,6 +109,7 @@ class ChangeStream implements Iterator
         if ($this->valid()) {
             return $this->key;
         }
+
         return null;
     }
 
@@ -167,7 +168,7 @@ class ChangeStream implements Iterator
             return true;
         }
 
-        if ( ! $exception instanceof ServerException) {
+        if (! $exception instanceof ServerException) {
             return false;
         }
 
@@ -202,7 +203,7 @@ class ChangeStream implements Iterator
 
         /* Return early if there is not a current result. Avoid any attempt to
          * increment the iterator's key. */
-        if (!$this->valid()) {
+        if (! $this->valid()) {
             return;
         }
 
@@ -236,6 +237,7 @@ class ChangeStream implements Iterator
     {
         if ($this->isResumableError($exception)) {
             $this->resume();
+
             return;
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,27 +17,30 @@
 
 namespace MongoDB;
 
+use MongoDB\Driver\Exception\InvalidArgumentException as DriverInvalidArgumentException;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
-use MongoDB\Driver\Exception\InvalidArgumentException as DriverInvalidArgumentException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Model\DatabaseInfoIterator;
 use MongoDB\Operation\DropDatabase;
 use MongoDB\Operation\ListDatabases;
 use MongoDB\Operation\Watch;
+use function is_array;
 
 class Client
 {
     private static $defaultTypeMap = [
-        'array' => \MongoDB\Model\BSONArray::class,
-        'document' => \MongoDB\Model\BSONDocument::class,
-        'root' => \MongoDB\Model\BSONDocument::class,
+        'array' => BSONArray::class,
+        'document' => BSONDocument::class,
+        'root' => BSONDocument::class,
     ];
     private static $wireVersionForReadConcern = 4;
     private static $wireVersionForWritableCommandWriteConcern = 5;
@@ -147,13 +150,13 @@ class Client
      */
     public function dropDatabase($databaseName, array $options = [])
     {
-        if ( ! isset($options['typeMap'])) {
+        if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
         }
 
         $server = $this->manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        if ( ! isset($options['writeConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern)) {
+        if (! isset($options['writeConcern']) && server_supports_feature($server, self::$wireVersionForWritableCommandWriteConcern)) {
             $options['writeConcern'] = $this->writeConcern;
         }
 
@@ -269,7 +272,7 @@ class Client
      * Start a new client session.
      *
      * @see http://php.net/manual/en/mongodb-driver-manager.startsession.php
-     * @param array  $options      Session options
+     * @param array $options Session options
      * @return Session
      */
     public function startSession(array $options = [])
@@ -288,17 +291,17 @@ class Client
      */
     public function watch(array $pipeline = [], array $options = [])
     {
-        if ( ! isset($options['readPreference'])) {
+        if (! isset($options['readPreference'])) {
             $options['readPreference'] = $this->readPreference;
         }
 
         $server = $this->manager->selectServer($options['readPreference']);
 
-        if ( ! isset($options['readConcern']) && \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern)) {
+        if (! isset($options['readConcern']) && server_supports_feature($server, self::$wireVersionForReadConcern)) {
             $options['readConcern'] = $this->readConcern;
         }
 
-        if ( ! isset($options['typeMap'])) {
+        if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
         }
 

--- a/src/DeleteResult.php
+++ b/src/DeleteResult.php
@@ -29,8 +29,6 @@ class DeleteResult
     private $isAcknowledged;
 
     /**
-     * Constructor.
-     *
      * @param WriteResult $writeResult
      */
     public function __construct(WriteResult $writeResult)

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -17,7 +17,9 @@
 
 namespace MongoDB\Exception;
 
-class BadMethodCallException extends \BadMethodCallException implements Exception
+use BadMethodCallException as BaseBadMethodCallException;
+
+class BadMethodCallException extends BaseBadMethodCallException implements Exception
 {
     /**
      * Thrown when a mutable method is invoked on an immutable object.

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Exception;
 
 use BadMethodCallException as BaseBadMethodCallException;
+use function sprintf;
 
 class BadMethodCallException extends BaseBadMethodCallException implements Exception
 {

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -17,6 +17,8 @@
 
 namespace MongoDB\Exception;
 
-interface Exception extends \MongoDB\Driver\Exception\Exception
+use MongoDB\Driver\Exception\Exception as DriverException;
+
+interface Exception extends DriverException
 {
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -17,7 +17,9 @@
 
 namespace MongoDB\Exception;
 
-class InvalidArgumentException extends \MongoDB\Driver\Exception\InvalidArgumentException implements Exception
+use MongoDB\Driver\Exception\InvalidArgumentException as DriverInvalidArgumentException;
+
+class InvalidArgumentException extends DriverInvalidArgumentException implements Exception
 {
     /**
      * Thrown when an argument or option has an invalid type.

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -18,6 +18,10 @@
 namespace MongoDB\Exception;
 
 use MongoDB\Driver\Exception\InvalidArgumentException as DriverInvalidArgumentException;
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 class InvalidArgumentException extends DriverInvalidArgumentException implements Exception
 {

--- a/src/Exception/ResumeTokenException.php
+++ b/src/Exception/ResumeTokenException.php
@@ -17,6 +17,9 @@
 
 namespace MongoDB\Exception;
 
+use function gettype;
+use function sprintf;
+
 class ResumeTokenException extends RuntimeException
 {
     /**

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -17,6 +17,8 @@
 
 namespace MongoDB\Exception;
 
-class RuntimeException extends \MongoDB\Driver\Exception\RuntimeException implements Exception
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+
+class RuntimeException extends DriverRuntimeException implements Exception
 {
 }

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -17,6 +17,8 @@
 
 namespace MongoDB\Exception;
 
-class UnexpectedValueException extends \MongoDB\Driver\Exception\UnexpectedValueException implements Exception
+use MongoDB\Driver\Exception\UnexpectedValueException as DriverUnexpectedValueException;
+
+class UnexpectedValueException extends DriverUnexpectedValueException implements Exception
 {
 }

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -18,12 +18,14 @@
 namespace MongoDB\GridFS;
 
 use MongoDB\Collection;
-use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\UpdateResult;
 use MongoDB\Driver\Cursor;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadPreference;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\UpdateResult;
 use stdClass;
+use function abs;
+use function sprintf;
 
 /**
  * CollectionWrapper abstracts the GridFS files and chunks collections.
@@ -122,7 +124,7 @@ class CollectionWrapper
      *
      * @see Bucket::downloadToStreamByName()
      * @see Bucket::openDownloadStreamByName()
-     * @param string $filename
+     * @param string  $filename
      * @param integer $revision
      * @return stdClass|null
      */
@@ -235,7 +237,7 @@ class CollectionWrapper
      */
     public function insertChunk($chunk)
     {
-        if ( ! $this->checkedIndexes) {
+        if (! $this->checkedIndexes) {
             $this->ensureIndexes();
         }
 
@@ -251,7 +253,7 @@ class CollectionWrapper
      */
     public function insertFile($file)
     {
-        if ( ! $this->checkedIndexes) {
+        if (! $this->checkedIndexes) {
             $this->ensureIndexes();
         }
 
@@ -262,7 +264,7 @@ class CollectionWrapper
      * Updates the filename field in the file document for a given ID.
      *
      * @param mixed  $id
-     * @param string $filename 
+     * @param string $filename
      * @return UpdateResult
      */
     public function updateFilenameForId($id, $filename)
@@ -315,7 +317,7 @@ class CollectionWrapper
 
         $this->checkedIndexes = true;
 
-        if ( ! $this->isFilesCollectionEmpty()) {
+        if (! $this->isFilesCollectionEmpty()) {
             return;
         }
 

--- a/src/GridFS/Exception/CorruptFileException.php
+++ b/src/GridFS/Exception/CorruptFileException.php
@@ -18,6 +18,7 @@
 namespace MongoDB\GridFS\Exception;
 
 use MongoDB\Exception\RuntimeException;
+use function sprintf;
 
 class CorruptFileException extends RuntimeException
 {

--- a/src/GridFS/Exception/FileNotFoundException.php
+++ b/src/GridFS/Exception/FileNotFoundException.php
@@ -18,6 +18,9 @@
 namespace MongoDB\GridFS\Exception;
 
 use MongoDB\Exception\RuntimeException;
+use function MongoDB\BSON\fromPHP;
+use function MongoDB\BSON\toJSON;
+use function sprintf;
 
 class FileNotFoundException extends RuntimeException
 {
@@ -43,7 +46,7 @@ class FileNotFoundException extends RuntimeException
      */
     public static function byId($id, $namespace)
     {
-        $json = \MongoDB\BSON\toJSON(\MongoDB\BSON\fromPHP(['_id' => $id]));
+        $json = toJSON(fromPHP(['_id' => $id]));
 
         return new static(sprintf('File "%s" not found in "%s"', $json, $namespace));
     }

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -17,10 +17,17 @@
 
 namespace MongoDB\GridFS;
 
+use IteratorIterator;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\Exception\CorruptFileException;
-use IteratorIterator;
 use stdClass;
+use function ceil;
+use function floor;
+use function is_integer;
+use function property_exists;
+use function sprintf;
+use function strlen;
+use function substr;
 
 /**
  * ReadableStream abstracts the process of reading a GridFS file.
@@ -49,15 +56,15 @@ class ReadableStream
      */
     public function __construct(CollectionWrapper $collectionWrapper, stdClass $file)
     {
-        if ( ! isset($file->chunkSize) || ! is_integer($file->chunkSize) || $file->chunkSize < 1) {
+        if (! isset($file->chunkSize) || ! is_integer($file->chunkSize) || $file->chunkSize < 1) {
             throw new CorruptFileException('file.chunkSize is not an integer >= 1');
         }
 
-        if ( ! isset($file->length) || ! is_integer($file->length) || $file->length < 0) {
+        if (! isset($file->length) || ! is_integer($file->length) || $file->length < 0) {
             throw new CorruptFileException('file.length is not an integer > 0');
         }
 
-        if ( ! isset($file->_id) && ! property_exists($file, '_id')) {
+        if (! isset($file->_id) && ! property_exists($file, '_id')) {
             throw new CorruptFileException('file._id does not exist');
         }
 
@@ -202,6 +209,7 @@ class ReadableStream
          */
         if ($lastChunkOffset > $this->chunkOffset) {
             $this->chunksIterator = null;
+
             return;
         }
 
@@ -239,7 +247,7 @@ class ReadableStream
             return false;
         }
 
-        if ( ! $this->chunksIterator->valid()) {
+        if (! $this->chunksIterator->valid()) {
             throw CorruptFileException::missingChunk($this->chunkOffset);
         }
 
@@ -253,7 +261,7 @@ class ReadableStream
 
         $actualChunkSize = strlen($this->buffer);
 
-        $expectedChunkSize = ($this->chunkOffset === $this->numChunks - 1)
+        $expectedChunkSize = $this->chunkOffset === $this->numChunks - 1
             ? $this->expectedLastChunkSize
             : $this->chunkSize;
 

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -242,6 +242,7 @@ class StreamWrapper
     private function getStatTemplate()
     {
         return [
+            // phpcs:disable Squiz.Arrays.ArrayDeclaration.IndexNoNewline
             0  => 0,  'dev'     => 0,
             1  => 0,  'ino'     => 0,
             2  => 0,  'mode'    => 0,
@@ -255,6 +256,7 @@ class StreamWrapper
             10 => 0,  'ctime'   => 0,
             11 => -1, 'blksize' => -1,
             12 => -1, 'blocks'  => -1,
+            // phpcs:enable
         ];
     }
 

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -17,9 +17,24 @@
 
 namespace MongoDB\GridFS;
 
-use MongoDB\BSON\UTCDateTime;
 use Exception;
+use MongoDB\BSON\UTCDateTime;
 use stdClass;
+use function explode;
+use function get_class;
+use function in_array;
+use function is_integer;
+use function sprintf;
+use function stream_context_get_options;
+use function stream_get_wrappers;
+use function stream_wrapper_register;
+use function stream_wrapper_unregister;
+use function trigger_error;
+use const E_USER_WARNING;
+use const SEEK_CUR;
+use const SEEK_END;
+use const SEEK_SET;
+use const STREAM_IS_URL;
 
 /**
  * Stream wrapper for reading and writing a GridFS file.
@@ -60,7 +75,7 @@ class StreamWrapper
             stream_wrapper_unregister($protocol);
         }
 
-        stream_wrapper_register($protocol, get_called_class(), \STREAM_IS_URL);
+        stream_wrapper_register($protocol, static::class, STREAM_IS_URL);
     }
 
     /**
@@ -81,7 +96,7 @@ class StreamWrapper
      */
     public function stream_eof()
     {
-        if ( ! $this->stream instanceof ReadableStream) {
+        if (! $this->stream instanceof ReadableStream) {
             return false;
         }
 
@@ -126,14 +141,15 @@ class StreamWrapper
      */
     public function stream_read($length)
     {
-        if ( ! $this->stream instanceof ReadableStream) {
+        if (! $this->stream instanceof ReadableStream) {
             return '';
         }
 
         try {
             return $this->stream->readBytes($length);
         } catch (Exception $e) {
-            trigger_error(sprintf('%s: %s', get_class($e), $e->getMessage()), \E_USER_WARNING);
+            trigger_error(sprintf('%s: %s', get_class($e), $e->getMessage()), E_USER_WARNING);
+
             return false;
         }
     }
@@ -146,15 +162,15 @@ class StreamWrapper
      * @param integer $whence One of SEEK_SET, SEEK_CUR, or SEEK_END
      * @return boolean True if the position was updated and false otherwise
      */
-    public function stream_seek($offset, $whence = \SEEK_SET)
+    public function stream_seek($offset, $whence = SEEK_SET)
     {
         $size = $this->stream->getSize();
 
-        if ($whence === \SEEK_CUR) {
+        if ($whence === SEEK_CUR) {
             $offset += $this->stream->tell();
         }
 
-        if ($whence === \SEEK_END) {
+        if ($whence === SEEK_END) {
             $offset += $size;
         }
 
@@ -222,14 +238,15 @@ class StreamWrapper
      */
     public function stream_write($data)
     {
-        if ( ! $this->stream instanceof WritableStream) {
+        if (! $this->stream instanceof WritableStream) {
             return 0;
         }
 
         try {
             return $this->stream->writeBytes($data);
         } catch (Exception $e) {
-            trigger_error(sprintf('%s: %s', get_class($e), $e->getMessage()), \E_USER_WARNING);
+            trigger_error(sprintf('%s: %s', get_class($e), $e->getMessage()), E_USER_WARNING);
+
             return false;
         }
     }

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -23,6 +23,19 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
+use function array_intersect_key;
+use function hash_final;
+use function hash_init;
+use function hash_update;
+use function is_array;
+use function is_bool;
+use function is_integer;
+use function is_object;
+use function is_string;
+use function MongoDB\is_string_array;
+use function sprintf;
+use function strlen;
+use function substr;
 
 /**
  * WritableStream abstracts the process of writing a GridFS file.
@@ -74,12 +87,12 @@ class WritableStream
     public function __construct(CollectionWrapper $collectionWrapper, $filename, array $options = [])
     {
         $options += [
-            '_id' => new ObjectId,
+            '_id' => new ObjectId(),
             'chunkSizeBytes' => self::$defaultChunkSizeBytes,
             'disableMD5' => false,
         ];
 
-        if (isset($options['aliases']) && ! \MongoDB\is_string_array($options['aliases'])) {
+        if (isset($options['aliases']) && ! is_string_array($options['aliases'])) {
             throw InvalidArgumentException::invalidType('"aliases" option', $options['aliases'], 'array of strings');
         }
 
@@ -107,7 +120,7 @@ class WritableStream
         $this->collectionWrapper = $collectionWrapper;
         $this->disableMD5 = $options['disableMD5'];
 
-        if ( ! $this->disableMD5) {
+        if (! $this->disableMD5) {
             $this->hashCtx = hash_init('md5');
         }
 
@@ -233,9 +246,9 @@ class WritableStream
     private function fileCollectionInsert()
     {
         $this->file['length'] = $this->length;
-        $this->file['uploadDate'] = new UTCDateTime;
+        $this->file['uploadDate'] = new UTCDateTime();
 
-        if ( ! $this->disableMD5) {
+        if (! $this->disableMD5) {
             $this->file['md5'] = hash_final($this->hashCtx);
         }
 
@@ -265,7 +278,7 @@ class WritableStream
             'data' => new Binary($data, Binary::TYPE_GENERIC),
         ];
 
-        if ( ! $this->disableMD5) {
+        if (! $this->disableMD5) {
             hash_update($this->hashCtx, $data);
         }
 

--- a/src/InsertManyResult.php
+++ b/src/InsertManyResult.php
@@ -30,8 +30,6 @@ class InsertManyResult
     private $isAcknowledged;
 
     /**
-     * Constructor.
-     *
      * @param WriteResult $writeResult
      * @param mixed[]     $insertedIds
      */

--- a/src/InsertOneResult.php
+++ b/src/InsertOneResult.php
@@ -30,8 +30,6 @@ class InsertOneResult
     private $isAcknowledged;
 
     /**
-     * Constructor.
-     *
      * @param WriteResult $writeResult
      * @param mixed       $insertedId
      */

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -20,6 +20,7 @@ namespace MongoDB;
 use IteratorAggregate;
 use stdClass;
 use Traversable;
+use function call_user_func;
 
 /**
  * Result class for mapReduce command results.
@@ -40,8 +41,6 @@ class MapReduceResult implements IteratorAggregate
     private $timing;
 
     /**
-     * Constructor.
-     *
      * @internal
      * @param callable $getIterator Callback that returns a Traversable for mapReduce results
      * @param stdClass $result      Result document from the mapReduce command

--- a/src/Model/BSONArray.php
+++ b/src/Model/BSONArray.php
@@ -17,10 +17,12 @@
 
 namespace MongoDB\Model;
 
-use MongoDB\BSON\Serializable;
-use MongoDB\BSON\Unserializable;
 use ArrayObject;
 use JsonSerializable;
+use MongoDB\BSON\Serializable;
+use MongoDB\BSON\Unserializable;
+use function array_values;
+use function MongoDB\recursive_copy;
 
 /**
  * Model class for a BSON array.
@@ -38,7 +40,7 @@ class BSONArray extends ArrayObject implements JsonSerializable, Serializable, U
     public function __clone()
     {
         foreach ($this as $key => $value) {
-            $this[$key] = \MongoDB\recursive_copy($value);
+            $this[$key] = recursive_copy($value);
         }
     }
 
@@ -52,7 +54,7 @@ class BSONArray extends ArrayObject implements JsonSerializable, Serializable, U
      */
     public static function __set_state(array $properties)
     {
-        $array = new static;
+        $array = new static();
         $array->exchangeArray($properties);
 
         return $array;

--- a/src/Model/BSONDocument.php
+++ b/src/Model/BSONDocument.php
@@ -17,10 +17,11 @@
 
 namespace MongoDB\Model;
 
-use MongoDB\BSON\Serializable;
-use MongoDB\BSON\Unserializable;
 use ArrayObject;
 use JsonSerializable;
+use MongoDB\BSON\Serializable;
+use MongoDB\BSON\Unserializable;
+use function MongoDB\recursive_copy;
 
 /**
  * Model class for a BSON document.
@@ -38,13 +39,11 @@ class BSONDocument extends ArrayObject implements JsonSerializable, Serializable
     public function __clone()
     {
         foreach ($this as $key => $value) {
-            $this[$key] = \MongoDB\recursive_copy($value);
+            $this[$key] = recursive_copy($value);
         }
     }
 
     /**
-     * Constructor.
-     *
      * This overrides the parent constructor to allow property access of entries
      * by default.
      *
@@ -68,7 +67,7 @@ class BSONDocument extends ArrayObject implements JsonSerializable, Serializable
      */
     public static function __set_state(array $properties)
     {
-        $document = new static;
+        $document = new static();
         $document->exchangeArray($properties);
 
         return $document;

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -17,10 +17,15 @@
 
 namespace MongoDB\Model;
 
+use Iterator;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
-use MongoDB\Model\BSONDocument;
-use Iterator;
+use function is_array;
+use function MongoDB\BSON\toPHP;
+use function sprintf;
+use function strlen;
+use function substr;
+use function unpack;
 
 /**
  * Iterator for BSON documents.
@@ -55,7 +60,7 @@ class BSONIterator implements Iterator
             throw InvalidArgumentException::invalidType('"typeMap" option', $options['typeMap'], 'array');
         }
 
-        if ( ! isset($options['typeMap'])) {
+        if (! isset($options['typeMap'])) {
             $options['typeMap'] = [];
         }
 
@@ -130,7 +135,7 @@ class BSONIterator implements Iterator
             throw new UnexpectedValueException(sprintf('Expected %d bytes; %d remaining', $documentLength, $this->bufferLength - $this->position));
         }
 
-        $this->current = \MongoDB\BSON\toPHP(substr($this->buffer, $this->position, $documentLength), $this->options['typeMap']);
+        $this->current = toPHP(substr($this->buffer, $this->position, $documentLength), $this->options['typeMap']);
         $this->position += $documentLength;
     }
 }

--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -21,6 +21,11 @@ use Countable;
 use Generator;
 use Iterator;
 use Traversable;
+use function count;
+use function current;
+use function key;
+use function next;
+use function reset;
 
 /**
  * Iterator for wrapping a Traversable and caching its results.
@@ -39,8 +44,6 @@ class CachingIterator implements Countable, Iterator
     private $iteratorExhausted = false;
 
     /**
-     * Constructor.
-     *
      * Initialize the iterator and stores the first item in the cache. This
      * effectively rewinds the Traversable and the wrapping Generator, which
      * will execute up to its first yield statement. Additionally, this mimics
@@ -90,7 +93,7 @@ class CachingIterator implements Countable, Iterator
      */
     public function next()
     {
-        if ( ! $this->iteratorExhausted) {
+        if (! $this->iteratorExhausted) {
             $this->iterator->next();
             $this->storeCurrentItem();
         }
@@ -128,7 +131,7 @@ class CachingIterator implements Countable, Iterator
      */
     private function exhaustIterator()
     {
-        while ( ! $this->iteratorExhausted) {
+        while (! $this->iteratorExhausted) {
             $this->next();
         }
     }

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -17,8 +17,9 @@
 
 namespace MongoDB\Model;
 
-use MongoDB\Exception\BadMethodCallException;
 use ArrayAccess;
+use MongoDB\Exception\BadMethodCallException;
+use function array_key_exists;
 
 /**
  * Collection information model class.
@@ -36,8 +37,6 @@ class CollectionInfo implements ArrayAccess
     private $info;
 
     /**
-     * Constructor.
-     *
      * @param array $info Collection info
      */
     public function __construct(array $info)
@@ -142,7 +141,7 @@ class CollectionInfo implements ArrayAccess
      */
     public function offsetSet($key, $value)
     {
-        throw BadMethodCallException::classIsImmutable(__CLASS__);
+        throw BadMethodCallException::classIsImmutable(self::class);
     }
 
     /**
@@ -154,6 +153,6 @@ class CollectionInfo implements ArrayAccess
      */
     public function offsetUnset($key)
     {
-        throw BadMethodCallException::classIsImmutable(__CLASS__);
+        throw BadMethodCallException::classIsImmutable(self::class);
     }
 }

--- a/src/Model/DatabaseInfo.php
+++ b/src/Model/DatabaseInfo.php
@@ -17,8 +17,10 @@
 
 namespace MongoDB\Model;
 
-use MongoDB\Exception\BadMethodCallException;
 use ArrayAccess;
+use MongoDB\Exception\BadMethodCallException;
+use function array_key_exists;
+
 /**
  * Database information model class.
  *
@@ -34,8 +36,6 @@ class DatabaseInfo implements ArrayAccess
     private $info;
 
     /**
-     * Constructor.
-     *
      * @param array $info Database info
      */
     public function __construct(array $info)
@@ -119,7 +119,7 @@ class DatabaseInfo implements ArrayAccess
      */
     public function offsetSet($key, $value)
     {
-        throw BadMethodCallException::classIsImmutable(__CLASS__);
+        throw BadMethodCallException::classIsImmutable(self::class);
     }
 
     /**
@@ -131,6 +131,6 @@ class DatabaseInfo implements ArrayAccess
      */
     public function offsetUnset($key)
     {
-        throw BadMethodCallException::classIsImmutable(__CLASS__);
+        throw BadMethodCallException::classIsImmutable(self::class);
     }
 }

--- a/src/Model/DatabaseInfoLegacyIterator.php
+++ b/src/Model/DatabaseInfoLegacyIterator.php
@@ -17,6 +17,11 @@
 
 namespace MongoDB\Model;
 
+use function current;
+use function key;
+use function next;
+use function reset;
+
 /**
  * DatabaseInfoIterator for inline listDatabases command results.
  *
@@ -32,8 +37,6 @@ class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
     private $databases;
 
     /**
-     * Constructor.
-     *
      * @param array $databases
      */
     public function __construct(array $databases)

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -17,8 +17,10 @@
 
 namespace MongoDB\Model;
 
-use MongoDB\Exception\BadMethodCallException;
 use ArrayAccess;
+use MongoDB\Exception\BadMethodCallException;
+use function array_key_exists;
+use function array_search;
 
 /**
  * Index information model class.
@@ -40,8 +42,6 @@ class IndexInfo implements ArrayAccess
     private $info;
 
     /**
-     * Constructor.
-     *
      * @param array $info Index info
      */
     public function __construct(array $info)
@@ -212,7 +212,7 @@ class IndexInfo implements ArrayAccess
      */
     public function offsetSet($key, $value)
     {
-        throw BadMethodCallException::classIsImmutable(__CLASS__);
+        throw BadMethodCallException::classIsImmutable(self::class);
     }
 
     /**
@@ -224,6 +224,6 @@ class IndexInfo implements ArrayAccess
      */
     public function offsetUnset($key)
     {
-        throw BadMethodCallException::classIsImmutable(__CLASS__);
+        throw BadMethodCallException::classIsImmutable(self::class);
     }
 }

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -19,6 +19,13 @@ namespace MongoDB\Model;
 
 use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+use function MongoDB\generate_index_name;
+use function sprintf;
 
 /**
  * Index input model class.
@@ -35,40 +42,38 @@ class IndexInput implements Serializable
     private $index;
 
     /**
-     * Constructor.
-     *
      * @param array $index Index specification
      * @throws InvalidArgumentException
      */
     public function __construct(array $index)
     {
-        if ( ! isset($index['key'])) {
+        if (! isset($index['key'])) {
             throw new InvalidArgumentException('Required "key" document is missing from index specification');
         }
 
-        if ( ! is_array($index['key']) && ! is_object($index['key'])) {
+        if (! is_array($index['key']) && ! is_object($index['key'])) {
             throw InvalidArgumentException::invalidType('"key" option', $index['key'], 'array or object');
         }
 
         foreach ($index['key'] as $fieldName => $order) {
-            if ( ! is_int($order) && ! is_float($order) && ! is_string($order)) {
+            if (! is_int($order) && ! is_float($order) && ! is_string($order)) {
                 throw InvalidArgumentException::invalidType(sprintf('order value for "%s" field within "key" option', $fieldName), $order, 'numeric or string');
             }
         }
 
-        if ( ! isset($index['ns'])) {
+        if (! isset($index['ns'])) {
             throw new InvalidArgumentException('Required "ns" option is missing from index specification');
         }
 
-        if ( ! is_string($index['ns'])) {
+        if (! is_string($index['ns'])) {
             throw InvalidArgumentException::invalidType('"ns" option', $index['ns'], 'string');
         }
 
-        if ( ! isset($index['name'])) {
-            $index['name'] = \MongoDB\generate_index_name($index['key']);
+        if (! isset($index['name'])) {
+            $index['name'] = generate_index_name($index['key']);
         }
 
-        if ( ! is_string($index['name'])) {
+        if (! is_string($index['name'])) {
             throw InvalidArgumentException::invalidType('"name" option', $index['name'], 'string');
         }
 

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -17,11 +17,18 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\Exception\UnsupportedException;
+use function array_intersect_key;
+use function count;
+use function current;
+use function is_array;
+use function is_float;
+use function is_integer;
+use function is_object;
 
 /**
  * Operation for obtaining an exact count of documents in a collection
@@ -80,7 +87,7 @@ class CountDocuments implements Executable
      */
     public function __construct($databaseName, $collectionName, $filter, array $options = [])
     {
-        if ( ! is_array($filter) && ! is_object($filter)) {
+        if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
         }
 
@@ -124,7 +131,7 @@ class CountDocuments implements Executable
         }
 
         $result = current($allResults);
-        if ( ! isset($result->n) || ! (is_integer($result->n) || is_float($result->n))) {
+        if (! isset($result->n) || ! (is_integer($result->n) || is_float($result->n))) {
             throw new UnexpectedValueException('count command did not return a numeric "n" value');
         }
 
@@ -137,7 +144,7 @@ class CountDocuments implements Executable
     private function createAggregate()
     {
         $pipeline = [
-            ['$match' => (object) $this->filter]
+            ['$match' => (object) $this->filter],
         ];
 
         if (isset($this->countOptions['skip'])) {

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -18,12 +18,21 @@
 namespace MongoDB\Operation;
 
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function current;
+use function is_array;
+use function is_bool;
+use function is_integer;
+use function is_object;
+use function is_string;
+use function MongoDB\server_supports_feature;
+use function trigger_error;
+use const E_USER_DEPRECATED;
 
 /**
  * Operation for the create command.
@@ -194,11 +203,11 @@ class CreateCollection implements Executable
      */
     public function execute(Server $server)
     {
-        if (isset($this->options['collation']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForCollation)) {
+        if (isset($this->options['collation']) && ! server_supports_feature($server, self::$wireVersionForCollation)) {
             throw UnsupportedException::collationNotSupported();
         }
 
-        if (isset($this->options['writeConcern']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForWriteConcern)) {
+        if (isset($this->options['writeConcern']) && ! server_supports_feature($server, self::$wireVersionForWriteConcern)) {
             throw UnsupportedException::writeConcernNotSupported();
         }
 

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -23,6 +23,8 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Exception\InvalidArgumentException;
+use function is_array;
+use function is_object;
 
 /**
  * Operation for executing a database command.
@@ -54,14 +56,14 @@ class DatabaseCommand implements Executable
      *  * typeMap (array): Type map for BSON deserialization. This will be
      *    applied to the returned Cursor (it is not sent to the server).
      *
-     * @param string       $databaseName   Database name
-     * @param array|object $command        Command document
-     * @param array        $options        Options for command execution
+     * @param string       $databaseName Database name
+     * @param array|object $command      Command document
+     * @param array        $options      Options for command execution
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct($databaseName, $command, array $options = [])
     {
-        if ( ! is_array($command) && ! is_object($command)) {
+        if (! is_array($command) && ! is_object($command)) {
             throw InvalidArgumentException::invalidType('$command', $command, 'array or object');
         }
 
@@ -78,7 +80,7 @@ class DatabaseCommand implements Executable
         }
 
         $this->databaseName = (string) $databaseName;
-        $this->command = ($command instanceof Command) ? $command : new Command($command);
+        $this->command = $command instanceof Command ? $command : new Command($command);
         $this->options = $options;
     }
 

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -19,12 +19,15 @@ namespace MongoDB\Operation;
 
 use MongoDB\DeleteResult;
 use MongoDB\Driver\BulkWrite as Bulk;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function is_array;
+use function is_object;
+use function MongoDB\server_supports_feature;
 
 /**
  * Operation for the delete command.
@@ -72,7 +75,7 @@ class Delete implements Executable, Explainable
      */
     public function __construct($databaseName, $collectionName, $filter, $limit, array $options = [])
     {
-        if ( ! is_array($filter) && ! is_object($filter)) {
+        if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
         }
 
@@ -113,7 +116,7 @@ class Delete implements Executable, Explainable
      */
     public function execute(Server $server)
     {
-        if (isset($this->options['collation']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForCollation)) {
+        if (isset($this->options['collation']) && ! server_supports_feature($server, self::$wireVersionForCollation)) {
             throw UnsupportedException::collationNotSupported();
         }
 

--- a/src/Operation/DeleteMany.php
+++ b/src/Operation/DeleteMany.php
@@ -18,8 +18,8 @@
 namespace MongoDB\Operation;
 
 use MongoDB\DeleteResult;
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 

--- a/src/Operation/DeleteOne.php
+++ b/src/Operation/DeleteOne.php
@@ -18,8 +18,8 @@
 namespace MongoDB\Operation;
 
 use MongoDB\DeleteResult;
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -18,12 +18,15 @@
 namespace MongoDB\Operation;
 
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function current;
+use function is_array;
+use function MongoDB\server_supports_feature;
 
 /**
  * Operation for the drop command.
@@ -98,7 +101,7 @@ class DropCollection implements Executable
      */
     public function execute(Server $server)
     {
-        if (isset($this->options['writeConcern']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForWriteConcern)) {
+        if (isset($this->options['writeConcern']) && ! server_supports_feature($server, self::$wireVersionForWriteConcern)) {
             throw UnsupportedException::writeConcernNotSupported();
         }
 

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -18,12 +18,15 @@
 namespace MongoDB\Operation;
 
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function current;
+use function is_array;
+use function MongoDB\server_supports_feature;
 
 /**
  * Operation for the dropDatabase command.
@@ -94,7 +97,7 @@ class DropDatabase implements Executable
      */
     public function execute(Server $server)
     {
-        if (isset($this->options['writeConcern']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForWriteConcern)) {
+        if (isset($this->options['writeConcern']) && ! server_supports_feature($server, self::$wireVersionForWriteConcern)) {
             throw UnsupportedException::writeConcernNotSupported();
         }
 

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -18,12 +18,16 @@
 namespace MongoDB\Operation;
 
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function current;
+use function is_array;
+use function is_integer;
+use function MongoDB\server_supports_feature;
 
 /**
  * Operation for the dropIndexes command.
@@ -112,7 +116,7 @@ class DropIndexes implements Executable
      */
     public function execute(Server $server)
     {
-        if (isset($this->options['writeConcern']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForWriteConcern)) {
+        if (isset($this->options['writeConcern']) && ! server_supports_feature($server, self::$wireVersionForWriteConcern)) {
             throw UnsupportedException::writeConcernNotSupported();
         }
 

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -17,11 +17,12 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\Exception\UnsupportedException;
+use function array_intersect_key;
 
 /**
  * Operation for obtaining an estimated count of documents in a collection
@@ -56,9 +57,9 @@ class EstimatedDocumentCount implements Executable, Explainable
      *
      *    Sessions are not supported for server versions < 3.6.
      *
-     * @param string       $databaseName   Database name
-     * @param string       $collectionName Collection name
-     * @param array        $options        Command options
+     * @param string $databaseName   Database name
+     * @param string $collectionName Collection name
+     * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct($databaseName, $collectionName, array $options = [])

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -21,9 +21,12 @@ use MongoDB\Driver\Command;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
-use MongoDB\Exception\UnsupportedException;
 use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\Model\BSONDocument;
+use MongoDB\Exception\UnsupportedException;
+use function current;
+use function is_array;
+use function is_string;
+use function MongoDB\server_supports_feature;
 
 /**
  * Operation for the explain command.
@@ -59,9 +62,9 @@ class Explain implements Executable
      *
      *  * verbosity (string): The mode in which the explain command will be run.
      *
-     * @param string $databaseName      Database name
+     * @param string      $databaseName Database name
      * @param Explainable $explainable  Operation to explain
-     * @param array  $options           Command options
+     * @param array       $options      Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct($databaseName, Explainable $explainable, array $options = [])
@@ -89,11 +92,11 @@ class Explain implements Executable
 
     public function execute(Server $server)
     {
-        if ($this->explainable instanceof Distinct && ! \MongoDB\server_supports_feature($server, self::$wireVersionForDistinct)) {
+        if ($this->explainable instanceof Distinct && ! server_supports_feature($server, self::$wireVersionForDistinct)) {
             throw UnsupportedException::explainNotSupported();
         }
 
-        if ($this->isFindAndModify($this->explainable) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForFindAndModify)) {
+        if ($this->isFindAndModify($this->explainable) && ! server_supports_feature($server, self::$wireVersionForFindAndModify)) {
             throw UnsupportedException::explainNotSupported();
         }
 
@@ -138,6 +141,7 @@ class Explain implements Executable
         if ($explainable instanceof FindAndModify || $explainable instanceof FindOneAndDelete || $explainable instanceof FindOneAndReplace || $explainable instanceof FindOneAndUpdate) {
             return true;
         }
+
         return false;
     }
 }

--- a/src/Operation/Explainable.php
+++ b/src/Operation/Explainable.php
@@ -27,5 +27,5 @@ use MongoDB\Driver\Server;
  */
 interface Explainable extends Executable
 {
-    function getCommandDocument(Server $server);
+    public function getCommandDocument(Server $server);
 }

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -18,15 +18,23 @@
 namespace MongoDB\Operation;
 
 use MongoDB\Driver\Cursor;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Query;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
-use MongoDB\Model\BSONDocument;
+use function is_array;
+use function is_bool;
+use function is_integer;
+use function is_object;
+use function is_string;
+use function MongoDB\server_supports_feature;
+use function trigger_error;
+use const E_USER_DEPRECATED;
+
 /**
  * Operation for the find command.
  *
@@ -147,7 +155,7 @@ class Find implements Executable, Explainable
      */
     public function __construct($databaseName, $collectionName, $filter, array $options = [])
     {
-        if ( ! is_array($filter) && ! is_object($filter)) {
+        if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
         }
 
@@ -168,7 +176,7 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['cursorType'])) {
-            if ( ! is_integer($options['cursorType'])) {
+            if (! is_integer($options['cursorType'])) {
                 throw InvalidArgumentException::invalidType('"cursorType" option', $options['cursorType'], 'integer');
             }
 
@@ -288,11 +296,11 @@ class Find implements Executable, Explainable
      */
     public function execute(Server $server)
     {
-        if (isset($this->options['collation']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForCollation)) {
+        if (isset($this->options['collation']) && ! server_supports_feature($server, self::$wireVersionForCollation)) {
             throw UnsupportedException::collationNotSupported();
         }
 
-        if (isset($this->options['readConcern']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForReadConcern)) {
+        if (isset($this->options['readConcern']) && ! server_supports_feature($server, self::$wireVersionForReadConcern)) {
             throw UnsupportedException::readConcernNotSupported();
         }
 
@@ -346,7 +354,7 @@ class Find implements Executable, Explainable
         ];
 
         foreach ($modifierFallback as $modifier) {
-            if ( ! isset($options[$modifier[0]]) && isset($options['modifiers'][$modifier[1]])) {
+            if (! isset($options[$modifier[0]]) && isset($options['modifiers'][$modifier[1]])) {
                 $options[$modifier[0]] = $options['modifiers'][$modifier[1]];
             }
         }
@@ -412,7 +420,7 @@ class Find implements Executable, Explainable
 
         $modifiers = empty($this->options['modifiers']) ? [] : (array) $this->options['modifiers'];
 
-        if ( ! empty($modifiers)) {
+        if (! empty($modifiers)) {
             $options['modifiers'] = $modifiers;
         }
 

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -17,10 +17,11 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function current;
 
 /**
  * Operation for finding a single document with the find command.
@@ -126,7 +127,7 @@ class FindOne implements Executable, Explainable
         $cursor = $this->find->execute($server);
         $document = current($cursor->toArray());
 
-        return ($document === false) ? null : $document;
+        return $document === false ? null : $document;
     }
 
     public function getCommandDocument(Server $server)

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -17,10 +17,12 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function is_array;
+use function is_object;
 
 /**
  * Operation for deleting a document with the findAndModify command.
@@ -71,7 +73,7 @@ class FindOneAndDelete implements Executable, Explainable
      */
     public function __construct($databaseName, $collectionName, $filter, array $options = [])
     {
-        if ( ! is_array($filter) && ! is_object($filter)) {
+        if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
         }
 

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -17,10 +17,14 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function is_array;
+use function is_integer;
+use function is_object;
+use function MongoDB\is_first_key_operator;
 
 /**
  * Operation for replacing a document with the findAndModify command.
@@ -90,15 +94,15 @@ class FindOneAndReplace implements Executable, Explainable
      */
     public function __construct($databaseName, $collectionName, $filter, $replacement, array $options = [])
     {
-        if ( ! is_array($filter) && ! is_object($filter)) {
+        if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
         }
 
-        if ( ! is_array($replacement) && ! is_object($replacement)) {
+        if (! is_array($replacement) && ! is_object($replacement)) {
             throw InvalidArgumentException::invalidType('$replacement', $replacement, 'array or object');
         }
 
-        if (\MongoDB\is_first_key_operator($replacement)) {
+        if (is_first_key_operator($replacement)) {
             throw new InvalidArgumentException('First key in $replacement argument is an update operator');
         }
 
@@ -111,7 +115,7 @@ class FindOneAndReplace implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'array or object');
         }
 
-        if ( ! is_integer($options['returnDocument'])) {
+        if (! is_integer($options['returnDocument'])) {
             throw InvalidArgumentException::invalidType('"returnDocument" option', $options['returnDocument'], 'integer');
         }
 

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -17,10 +17,14 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function is_array;
+use function is_integer;
+use function is_object;
+use function MongoDB\is_first_key_operator;
 
 /**
  * Operation for updating a document with the findAndModify command.
@@ -93,15 +97,15 @@ class FindOneAndUpdate implements Executable, Explainable
      */
     public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
     {
-        if ( ! is_array($filter) && ! is_object($filter)) {
+        if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
         }
 
-        if ( ! is_array($update) && ! is_object($update)) {
+        if (! is_array($update) && ! is_object($update)) {
             throw InvalidArgumentException::invalidType('$update', $update, 'array or object');
         }
 
-        if ( ! \MongoDB\is_first_key_operator($update)) {
+        if (! is_first_key_operator($update)) {
             throw new InvalidArgumentException('First key in $update argument is not an update operator');
         }
 
@@ -114,7 +118,7 @@ class FindOneAndUpdate implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'array or object');
         }
 
-        if ( ! is_integer($options['returnDocument'])) {
+        if (! is_integer($options['returnDocument'])) {
             throw InvalidArgumentException::invalidType('"returnDocument" option', $options['returnDocument'], 'integer');
         }
 

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -17,14 +17,19 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\InsertManyResult;
 use MongoDB\Driver\BulkWrite as Bulk;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\InsertManyResult;
+use function is_array;
+use function is_bool;
+use function is_object;
+use function MongoDB\server_supports_feature;
+use function sprintf;
 
 /**
  * Operation for inserting multiple documents with the insert command.
@@ -82,7 +87,7 @@ class InsertMany implements Executable
                 throw new InvalidArgumentException(sprintf('$documents is not a list (unexpected index: "%s")', $i));
             }
 
-            if ( ! is_array($document) && ! is_object($document)) {
+            if (! is_array($document) && ! is_object($document)) {
                 throw InvalidArgumentException::invalidType(sprintf('$documents[%d]', $i), $document, 'array or object');
             }
 
@@ -95,7 +100,7 @@ class InsertMany implements Executable
             throw InvalidArgumentException::invalidType('"bypassDocumentValidation" option', $options['bypassDocumentValidation'], 'boolean');
         }
 
-        if ( ! is_bool($options['ordered'])) {
+        if (! is_bool($options['ordered'])) {
             throw InvalidArgumentException::invalidType('"ordered" option', $options['ordered'], 'boolean');
         }
 
@@ -134,9 +139,8 @@ class InsertMany implements Executable
 
         $options = ['ordered' => $this->options['ordered']];
 
-        if (
-            ! empty($this->options['bypassDocumentValidation']) &&
-            \MongoDB\server_supports_feature($server, self::$wireVersionForDocumentLevelValidation)
+        if (! empty($this->options['bypassDocumentValidation']) &&
+            server_supports_feature($server, self::$wireVersionForDocumentLevelValidation)
         ) {
             $options['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
         }

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -17,14 +17,18 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\InsertOneResult;
 use MongoDB\Driver\BulkWrite as Bulk;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\InsertOneResult;
+use function is_array;
+use function is_bool;
+use function is_object;
+use function MongoDB\server_supports_feature;
 
 /**
  * Operation for inserting a single document with the insert command.
@@ -67,7 +71,7 @@ class InsertOne implements Executable
      */
     public function __construct($databaseName, $collectionName, $document, array $options = [])
     {
-        if ( ! is_array($document) && ! is_object($document)) {
+        if (! is_array($document) && ! is_object($document)) {
             throw InvalidArgumentException::invalidType('$document', $document, 'array or object');
         }
 
@@ -110,9 +114,8 @@ class InsertOne implements Executable
             throw UnsupportedException::writeConcernNotSupportedInTransaction();
         }
 
-        if (
-            ! empty($this->options['bypassDocumentValidation']) &&
-            \MongoDB\server_supports_feature($server, self::$wireVersionForDocumentLevelValidation)
+        if (! empty($this->options['bypassDocumentValidation']) &&
+            server_supports_feature($server, self::$wireVersionForDocumentLevelValidation)
         ) {
             $options['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
         }

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -18,13 +18,16 @@
 namespace MongoDB\Operation;
 
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\CachingIterator;
 use MongoDB\Model\CollectionInfoCommandIterator;
 use MongoDB\Model\CollectionInfoIterator;
+use function is_array;
+use function is_integer;
+use function is_object;
 
 /**
  * Operation for the listCollections command.
@@ -119,7 +122,7 @@ class ListCollections implements Executable
     {
         $cmd = ['listCollections' => 1];
 
-        if ( ! empty($this->options['filter'])) {
+        if (! empty($this->options['filter'])) {
             $cmd['filter'] = (object) $this->options['filter'];
         }
 

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -18,13 +18,17 @@
 namespace MongoDB\Operation;
 
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\Model\DatabaseInfoIterator;
 use MongoDB\Model\DatabaseInfoLegacyIterator;
+use function current;
+use function is_array;
+use function is_integer;
+use function is_object;
 
 /**
  * Operation for the ListDatabases command.
@@ -86,7 +90,7 @@ class ListDatabases implements Executable
     {
         $cmd = ['listDatabases' => 1];
 
-        if ( ! empty($this->options['filter'])) {
+        if (! empty($this->options['filter'])) {
             $cmd['filter'] = (object) $this->options['filter'];
         }
 
@@ -98,7 +102,7 @@ class ListDatabases implements Executable
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);
         $result = current($cursor->toArray());
 
-        if ( ! isset($result['databases']) || ! is_array($result['databases'])) {
+        if (! isset($result['databases']) || ! is_array($result['databases'])) {
             throw new UnexpectedValueException('listDatabases command did not return a "databases" array');
         }
 

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -17,16 +17,16 @@
 
 namespace MongoDB\Operation;
 
+use EmptyIterator;
 use MongoDB\Driver\Command;
-use MongoDB\Driver\Query;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\CachingIterator;
 use MongoDB\Model\IndexInfoIterator;
 use MongoDB\Model\IndexInfoIteratorIterator;
-use EmptyIterator;
+use function is_integer;
 
 /**
  * Operation for the listIndexes command.
@@ -133,7 +133,7 @@ class ListIndexes implements Executable
              * empty iterator instead of throwing.
              */
             if ($e->getCode() === self::$errorCodeNamespaceNotFound || $e->getCode() === self::$errorCodeDatabaseNotFound) {
-                return new IndexInfoIteratorIterator(new EmptyIterator);
+                return new IndexInfoIteratorIterator(new EmptyIterator());
             }
 
             throw $e;

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -156,7 +156,7 @@ class MapReduce implements Executable
         }
 
         if (isset($options['finalize']) && ! $options['finalize'] instanceof JavascriptInterface) {
-            throw InvalidArgumentException::invalidType('"finalize" option', $options['finalize'], Javascript::class);
+            throw InvalidArgumentException::invalidType('"finalize" option', $options['finalize'], JavascriptInterface::class);
         }
 
         if (isset($options['jsMode']) && ! is_bool($options['jsMode'])) {

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -18,12 +18,15 @@
 namespace MongoDB\Operation;
 
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use function current;
+use function is_array;
+use function MongoDB\server_supports_feature;
 
 /**
  * Operation for the collMod command.
@@ -56,10 +59,10 @@ class ModifyCollection implements Executable
      *    This is not supported for server versions < 3.2 and will result in an
      *    exception at execution time if used.
      *
-     * @param string       $databaseName      Database name
-     * @param string       $collectionName    Collection or view to modify
-     * @param array        $collectionOptions Collection or view options to assign
-     * @param array        $options           Command options
+     * @param string $databaseName      Database name
+     * @param string $collectionName    Collection or view to modify
+     * @param array  $collectionOptions Collection or view options to assign
+     * @param array  $options           Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct($databaseName, $collectionName, array $collectionOptions, array $options = [])
@@ -100,7 +103,7 @@ class ModifyCollection implements Executable
      */
     public function execute(Server $server)
     {
-        if (isset($this->options['writeConcern']) && ! \MongoDB\server_supports_feature($server, self::$wireVersionForWriteConcern)) {
+        if (isset($this->options['writeConcern']) && ! server_supports_feature($server, self::$wireVersionForWriteConcern)) {
             throw UnsupportedException::writeConcernNotSupported();
         }
 

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -17,11 +17,14 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\UpdateResult;
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\UpdateResult;
+use function is_array;
+use function is_object;
+use function MongoDB\is_first_key_operator;
 
 /**
  * Operation for replacing a single document with the update command.
@@ -68,11 +71,11 @@ class ReplaceOne implements Executable
      */
     public function __construct($databaseName, $collectionName, $filter, $replacement, array $options = [])
     {
-        if ( ! is_array($replacement) && ! is_object($replacement)) {
+        if (! is_array($replacement) && ! is_object($replacement)) {
             throw InvalidArgumentException::invalidType('$replacement', $replacement, 'array or object');
         }
 
-        if (\MongoDB\is_first_key_operator($replacement)) {
+        if (is_first_key_operator($replacement)) {
             throw new InvalidArgumentException('First key in $replacement argument is an update operator');
         }
 

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -17,11 +17,14 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\UpdateResult;
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\UpdateResult;
+use function is_array;
+use function is_object;
+use function MongoDB\is_first_key_operator;
 
 /**
  * Operation for updating multiple documents with the update command.
@@ -74,11 +77,11 @@ class UpdateMany implements Executable, Explainable
      */
     public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
     {
-        if ( ! is_array($update) && ! is_object($update)) {
+        if (! is_array($update) && ! is_object($update)) {
             throw InvalidArgumentException::invalidType('$update', $update, 'array or object');
         }
 
-        if ( ! \MongoDB\is_first_key_operator($update)) {
+        if (! is_first_key_operator($update)) {
             throw new InvalidArgumentException('First key in $update argument is not an update operator');
         }
 

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -17,11 +17,14 @@
 
 namespace MongoDB\Operation;
 
-use MongoDB\UpdateResult;
-use MongoDB\Driver\Server;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\UpdateResult;
+use function is_array;
+use function is_object;
+use function MongoDB\is_first_key_operator;
 
 /**
  * Operation for updating a single document with the update command.
@@ -74,11 +77,11 @@ class UpdateOne implements Executable, Explainable
      */
     public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
     {
-        if ( ! is_array($update) && ! is_object($update)) {
+        if (! is_array($update) && ! is_object($update)) {
             throw InvalidArgumentException::invalidType('$update', $update, 'array or object');
         }
 
-        if ( ! \MongoDB\is_first_key_operator($update)) {
+        if (! is_first_key_operator($update)) {
             throw new InvalidArgumentException('First key in $update argument is not an update operator');
         }
 

--- a/src/UpdateResult.php
+++ b/src/UpdateResult.php
@@ -29,8 +29,6 @@ class UpdateResult
     private $isAcknowledged;
 
     /**
-     * Constructor.
-     *
      * @param WriteResult $writeResult
      */
     public function __construct(WriteResult $writeResult)

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -4,9 +4,15 @@ namespace MongoDB\Tests;
 
 use MongoDB\Client;
 use MongoDB\Driver\BulkWrite;
-use MongoDB\Driver\Command;
+use MongoDB\Driver\Manager;
+use MongoDB\Driver\Session;
 use MongoDB\Model\DatabaseInfo;
+use MongoDB\Model\DatabaseInfoIterator;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function call_user_func;
+use function is_callable;
+use function sprintf;
+use function version_compare;
 
 /**
  * Functional tests for the Client class.
@@ -27,7 +33,7 @@ class ClientFunctionalTest extends FunctionalTestCase
 
     public function testGetManager()
     {
-        $this->assertInstanceOf(\MongoDB\Driver\Manager::class, $this->client->getManager());
+        $this->assertInstanceOf(Manager::class, $this->client->getManager());
     }
 
     public function testDropDatabase()
@@ -53,14 +59,14 @@ class ClientFunctionalTest extends FunctionalTestCase
 
         $databases = $this->client->listDatabases();
 
-        $this->assertInstanceOf(\MongoDB\Model\DatabaseInfoIterator::class, $databases);
+        $this->assertInstanceOf(DatabaseInfoIterator::class, $databases);
 
         foreach ($databases as $database) {
-            $this->assertInstanceOf(\MongoDB\Model\DatabaseInfo::class, $database);
+            $this->assertInstanceOf(DatabaseInfo::class, $database);
         }
 
         $that = $this;
-        $this->assertDatabaseExists($this->getDatabaseName(), function(DatabaseInfo $info) use ($that) {
+        $this->assertDatabaseExists($this->getDatabaseName(), function (DatabaseInfo $info) use ($that) {
             $that->assertFalse($info->isEmpty());
             $that->assertGreaterThan(0, $info->getSizeOnDisk());
         });
@@ -74,7 +80,7 @@ class ClientFunctionalTest extends FunctionalTestCase
      * the given name is found, it will be passed to the callback, which may
      * perform additional assertions.
      *
-     * @param string $databaseName
+     * @param string   $databaseName
      * @param callable $callback
      */
     private function assertDatabaseExists($databaseName, $callback = null)
@@ -106,6 +112,6 @@ class ClientFunctionalTest extends FunctionalTestCase
         if (version_compare($this->getFeatureCompatibilityVersion(), '3.6', '<')) {
             $this->markTestSkipped('startSession() is only supported on FCV 3.6 or higher');
         }
-        $this->assertInstanceOf(\MongoDB\Driver\Session::class, $this->client->startSession());
+        $this->assertInstanceOf(Session::class, $this->client->startSession());
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -63,13 +63,13 @@ class ClientTest extends TestCase
         $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
         $debug = $collection->__debugInfo();
 
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -86,13 +86,13 @@ class ClientTest extends TestCase
         $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName(), $collectionOptions);
         $debug = $collection->__debugInfo();
 
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -105,7 +105,7 @@ class ClientTest extends TestCase
         $debug = $database->__debugInfo();
 
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -125,13 +125,13 @@ class ClientTest extends TestCase
         $database = $client->selectDatabase($this->getDatabaseName());
         $debug = $database->__debugInfo();
 
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -148,13 +148,13 @@ class ClientTest extends TestCase
         $database = $client->selectDatabase($this->getDatabaseName(), $databaseOptions);
         $debug = $database->__debugInfo();
 
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 }

--- a/tests/Collection/FunctionalTestCase.php
+++ b/tests/Collection/FunctionalTestCase.php
@@ -3,7 +3,6 @@
 namespace MongoDB\Tests\Collection;
 
 use MongoDB\Collection;
-use MongoDB\Driver\WriteConcern;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 

--- a/tests/CommandObserver.php
+++ b/tests/CommandObserver.php
@@ -2,11 +2,14 @@
 
 namespace MongoDB\Tests;
 
+use Exception;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
-use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
-use Exception;
+use MongoDB\Driver\Monitoring\CommandSucceededEvent;
+use function call_user_func;
+use function MongoDB\Driver\Monitoring\addSubscriber;
+use function MongoDB\Driver\Monitoring\removeSubscriber;
 
 /**
  * Observes command documents using the driver's monitoring API.
@@ -19,13 +22,14 @@ class CommandObserver implements CommandSubscriber
     {
         $this->commands = [];
 
-        \MongoDB\Driver\Monitoring\addSubscriber($this);
+        addSubscriber($this);
 
         try {
             call_user_func($execution);
-        } catch (Exception $executionException) {}
+        } catch (Exception $executionException) {
+        }
 
-        \MongoDB\Driver\Monitoring\removeSubscriber($this);
+        removeSubscriber($this);
 
         foreach ($this->commands as $command) {
             call_user_func($commandCallback, $command);

--- a/tests/Database/CollectionManagementFunctionalTest.php
+++ b/tests/Database/CollectionManagementFunctionalTest.php
@@ -2,9 +2,13 @@
 
 namespace MongoDB\Tests\Database;
 
+use InvalidArgumentException;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Model\CollectionInfo;
-use InvalidArgumentException;
+use MongoDB\Model\CollectionInfoIterator;
+use function call_user_func;
+use function is_callable;
+use function sprintf;
 
 /**
  * Functional tests for collection management methods.
@@ -18,7 +22,7 @@ class CollectionManagementFunctionalTest extends FunctionalTestCase
 
         $commandResult = $this->database->createCollection($basicCollectionName);
         $this->assertCommandSucceeded($commandResult);
-        $this->assertCollectionExists($basicCollectionName, function(CollectionInfo $info) use ($that) {
+        $this->assertCollectionExists($basicCollectionName, function (CollectionInfo $info) use ($that) {
             $that->assertFalse($info->isCapped());
         });
 
@@ -31,7 +35,7 @@ class CollectionManagementFunctionalTest extends FunctionalTestCase
 
         $commandResult = $this->database->createCollection($cappedCollectionName, $cappedCollectionOptions);
         $this->assertCommandSucceeded($commandResult);
-        $this->assertCollectionExists($cappedCollectionName, function(CollectionInfo $info) use ($that) {
+        $this->assertCollectionExists($cappedCollectionName, function (CollectionInfo $info) use ($that) {
             $that->assertTrue($info->isCapped());
             $that->assertEquals(100, $info->getCappedMax());
             $that->assertEquals(1048576, $info->getCappedSize());
@@ -57,10 +61,10 @@ class CollectionManagementFunctionalTest extends FunctionalTestCase
         $this->assertCommandSucceeded($commandResult);
 
         $collections = $this->database->listCollections();
-        $this->assertInstanceOf(\MongoDB\Model\CollectionInfoIterator::class, $collections);
+        $this->assertInstanceOf(CollectionInfoIterator::class, $collections);
 
         foreach ($collections as $collection) {
-            $this->assertInstanceOf(\MongoDB\Model\CollectionInfo::class, $collection);
+            $this->assertInstanceOf(CollectionInfo::class, $collection);
         }
     }
 
@@ -73,10 +77,10 @@ class CollectionManagementFunctionalTest extends FunctionalTestCase
         $options = ['filter' => ['name' => $collectionName]];
 
         $collections = $this->database->listCollections($options);
-        $this->assertInstanceOf(\MongoDB\Model\CollectionInfoIterator::class, $collections);
+        $this->assertInstanceOf(CollectionInfoIterator::class, $collections);
 
         foreach ($collections as $collection) {
-            $this->assertInstanceOf(\MongoDB\Model\CollectionInfo::class, $collection);
+            $this->assertInstanceOf(CollectionInfo::class, $collection);
             $this->assertEquals($collectionName, $collection->getName());
         }
     }

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -4,11 +4,14 @@ namespace MongoDB\Tests\Database;
 
 use MongoDB\Database;
 use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\Cursor;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateIndexes;
+use function array_key_exists;
+use function current;
 
 /**
  * Functional tests for the Database class.
@@ -89,7 +92,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $cursor = $this->database->command($command, $options);
 
-        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
+        $this->assertInstanceOf(Cursor::class, $cursor);
         $commandResult = current($cursor->toArray());
 
         $this->assertCommandSucceeded($commandResult);
@@ -107,7 +110,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $cursor = $this->database->command($command, $options);
 
-        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
+        $this->assertInstanceOf(Cursor::class, $cursor);
         $commandResult = current($cursor->toArray());
 
         $this->assertCommandSucceeded($commandResult);
@@ -149,7 +152,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame($this->getCollectionName(), $debug['collectionName']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -186,7 +189,6 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         }
     }
 
-
     public function testSelectCollectionInheritsOptions()
     {
         $databaseOptions = [
@@ -203,13 +205,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame($this->getCollectionName(), $debug['collectionName']);
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -225,13 +227,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $collection = $this->database->selectCollection($this->getCollectionName(), $collectionOptions);
         $debug = $collection->__debugInfo();
 
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -251,11 +253,11 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame('fs', $debug['bucketName']);
         $this->assertSame(261120, $debug['chunkSizeBytes']);
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -276,11 +278,11 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame('custom_fs', $debug['bucketName']);
         $this->assertSame(8192, $debug['chunkSizeBytes']);
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -299,13 +301,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
@@ -321,13 +323,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $clone = $this->database->withOptions($databaseOptions);
         $debug = $clone->__debugInfo();
 
-        $this->assertInstanceOf(\MongoDB\Driver\ReadConcern::class, $debug['readConcern']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(\MongoDB\Driver\ReadPreference::class, $debug['readPreference']);
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
         $this->assertSame(ReadPreference::RP_SECONDARY_PREFERRED, $debug['readPreference']->getMode());
         $this->assertIsArray($debug['typeMap']);
         $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(\MongoDB\Driver\WriteConcern::class, $debug['writeConcern']);
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 }

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -2,16 +2,20 @@
 
 namespace MongoDB\Tests;
 
+use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Client;
 use MongoDB\Database;
 use MongoDB\Driver\Cursor;
-use MongoDB\Driver\ReadPreference;
-use MongoDB\Driver\Server;
-use MongoDB\Driver\WriteConcern;
 use MongoDB\Driver\Exception\ConnectionTimeoutException;
-use MongoDB\Operation\DropCollection;
+use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\WriteConcern;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function in_array;
+use function ob_end_clean;
+use function ob_start;
+use function var_dump;
+use function version_compare;
 
 /**
  * Documentation examples to be parsed for inclusion in the MongoDB manual.
@@ -54,7 +58,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // End Example 1
 
         $this->assertSame(1, $insertOneResult->getInsertedCount());
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $insertOneResult->getInsertedId());
+        $this->assertInstanceOf(ObjectId::class, $insertOneResult->getInsertedId());
         $this->assertInventoryCount(1);
 
         // Start Example 2
@@ -71,19 +75,19 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 3
         $insertManyResult = $db->inventory->insertMany([
             [
-                'item' => 'journal', 
+                'item' => 'journal',
                 'qty' => 25,
                 'tags' => ['blank', 'red'],
                 'size' => ['h' => 14, 'w' => 21, 'uom' => 'cm'],
             ],
             [
-                'item' => 'mat', 
+                'item' => 'mat',
                 'qty' => 85,
                 'tags' => ['gray'],
                 'size' => ['h' => 27.9, 'w' => 35.5, 'uom' => 'cm'],
             ],
             [
-                'item' => 'mousepad', 
+                'item' => 'mousepad',
                 'qty' => 25,
                 'tags' => ['gel', 'blue'],
                 'size' => ['h' => 19, 'w' => 22.85, 'uom' => 'cm'],
@@ -93,7 +97,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(3, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
+            $this->assertInstanceOf(ObjectId::class, $id);
         }
         $this->assertInventoryCount(3);
     }
@@ -105,31 +109,31 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 6
         $insertManyResult = $db->inventory->insertMany([
             [
-                'item' => 'journal', 
+                'item' => 'journal',
                 'qty' => 25,
                 'size' => ['h' => 14, 'w' => 21, 'uom' => 'cm'],
                 'status' => 'A',
             ],
             [
-                'item' => 'notebook', 
+                'item' => 'notebook',
                 'qty' => 50,
                 'size' => ['h' => 8.5, 'w' => 11, 'uom' => 'in'],
                 'status' => 'A',
             ],
             [
-                'item' => 'paper', 
+                'item' => 'paper',
                 'qty' => 100,
                 'size' => ['h' => 8.5, 'w' => 11, 'uom' => 'in'],
                 'status' => 'D',
             ],
             [
-                'item' => 'planner', 
+                'item' => 'planner',
                 'qty' => 75,
                 'size' => ['h' => 22.85, 'w' => 30, 'uom' => 'cm'],
                 'status' => 'D',
             ],
             [
-                'item' => 'postcard', 
+                'item' => 'postcard',
                 'qty' => 45,
                 'size' => ['h' => 10, 'w' => 15.25, 'uom' => 'cm'],
                 'status' => 'A',
@@ -139,7 +143,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
+            $this->assertInstanceOf(ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -208,31 +212,31 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 14
         $insertManyResult = $db->inventory->insertMany([
             [
-                'item' => 'journal', 
+                'item' => 'journal',
                 'qty' => 25,
                 'size' => ['h' => 14, 'w' => 21, 'uom' => 'cm'],
                 'status' => 'A',
             ],
             [
-                'item' => 'notebook', 
+                'item' => 'notebook',
                 'qty' => 50,
                 'size' => ['h' => 8.5, 'w' => 11, 'uom' => 'in'],
                 'status' => 'A',
             ],
             [
-                'item' => 'paper', 
+                'item' => 'paper',
                 'qty' => 100,
                 'size' => ['h' => 8.5, 'w' => 11, 'uom' => 'in'],
                 'status' => 'D',
             ],
             [
-                'item' => 'planner', 
+                'item' => 'planner',
                 'qty' => 75,
                 'size' => ['h' => 22.85, 'w' => 30, 'uom' => 'cm'],
                 'status' => 'D',
             ],
             [
-                'item' => 'postcard', 
+                'item' => 'postcard',
                 'qty' => 45,
                 'size' => ['h' => 10, 'w' => 15.25, 'uom' => 'cm'],
                 'status' => 'A',
@@ -242,7 +246,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
+            $this->assertInstanceOf(ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -288,31 +292,31 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 20
         $insertManyResult = $db->inventory->insertMany([
             [
-                'item' => 'journal', 
+                'item' => 'journal',
                 'qty' => 25,
                 'tags' => ['blank', 'red'],
                 'dim_cm' => [14, 21],
             ],
             [
-                'item' => 'notebook', 
+                'item' => 'notebook',
                 'qty' => 50,
                 'tags' => ['red', 'blank'],
                 'dim_cm' => [14, 21],
             ],
             [
-                'item' => 'paper', 
+                'item' => 'paper',
                 'qty' => 100,
                 'tags' => ['red', 'blank', 'plain'],
                 'dim_cm' => [14, 21],
             ],
             [
-                'item' => 'planner', 
+                'item' => 'planner',
                 'qty' => 75,
                 'tags' => ['blank', 'red'],
                 'dim_cm' => [22.85, 30],
             ],
             [
-                'item' => 'postcard', 
+                'item' => 'postcard',
                 'qty' => 45,
                 'tags' => ['blue'],
                 'dim_cm' => [10, 15.25],
@@ -322,7 +326,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
+            $this->assertInstanceOf(ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -394,34 +398,34 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 29
         $insertManyResult = $db->inventory->insertMany([
             [
-                'item' => 'journal', 
+                'item' => 'journal',
                 'instock' => [
                     ['warehouse' => 'A',  'qty' => 5],
                     ['warehouse' => 'C',  'qty' => 15],
                 ],
             ],
             [
-                'item' => 'notebook', 
+                'item' => 'notebook',
                 'instock' => [
                     ['warehouse' => 'C',  'qty' => 5],
                 ],
             ],
             [
-                'item' => 'paper', 
+                'item' => 'paper',
                 'instock' => [
                     ['warehouse' => 'A',  'qty' => 60],
                     ['warehouse' => 'B',  'qty' => 15],
                 ],
             ],
             [
-                'item' => 'planner', 
+                'item' => 'planner',
                 'instock' => [
                     ['warehouse' => 'A',  'qty' => 40],
                     ['warehouse' => 'B',  'qty' => 5],
                 ],
             ],
             [
-                'item' => 'postcard', 
+                'item' => 'postcard',
                 'instock' => [
                     ['warehouse' => 'B',  'qty' => 15],
                     ['warehouse' => 'C',  'qty' => 35],
@@ -432,7 +436,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
+            $this->assertInstanceOf(ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -573,7 +577,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
+            $this->assertInstanceOf(ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -789,7 +793,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(10, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
+            $this->assertInstanceOf(ObjectId::class, $id);
         }
         $this->assertInventoryCount(10);
 
@@ -899,7 +903,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertSame(5, $insertManyResult->getInsertedCount());
         foreach ($insertManyResult->getInsertedIds() as $id) {
-            $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $id);
+            $this->assertInstanceOf(ObjectId::class, $id);
         }
         $this->assertInventoryCount(5);
 
@@ -949,6 +953,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $this->assertNull($firstChange);
         $this->assertNull($secondChange);
 
+        // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
         // Start Changestream Example 2
         $changeStream = $db->inventory->watch([], ['fullDocument' => \MongoDB\Operation\Watch::FULL_DOCUMENT_UPDATE_LOOKUP]);
         $changeStream->rewind();
@@ -959,6 +964,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $secondChange = $changeStream->current();
         // End Changestream Example 2
+        // phpcs:enable
 
         $this->assertNull($firstChange);
         $this->assertNull($secondChange);
@@ -983,6 +989,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $this->assertMatchesDocument($expectedChange, $lastChange);
 
+        // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
         // Start Changestream Example 3
         $resumeToken = $changeStream->getResumeToken();
 
@@ -995,6 +1002,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $firstChange = $changeStream->current();
         // End Changestream Example 3
+        // phpcs:enable
 
         $expectedChange = [
             '_id' => $firstChange->_id,
@@ -1036,7 +1044,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         ]);
         // End Aggregation Example 1
 
-        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
+        $this->assertInstanceOf(Cursor::class, $cursor);
     }
 
     public function testAggregation_example_2()
@@ -1048,21 +1056,23 @@ class DocumentationExamplesTest extends FunctionalTestCase
             ['$unwind' => '$items'],
             ['$match' => ['items.fruit' => 'banana']],
             [
-                '$group' => ['_id' => ['day' => ['$dayOfWeek' => '$date']],
-                'count' => ['$sum' => '$items.quantity']],
+                '$group' => [
+                    '_id' => ['day' => ['$dayOfWeek' => '$date']],
+                    'count' => ['$sum' => '$items.quantity'],
+                ],
             ],
             [
                 '$project' => [
                     'dayOfWeek' => '$_id.day',
                     'numberSold' => '$count',
                     '_id' => 0,
-                ]
+                ],
             ],
             ['$sort' => ['numberSold' => 1]],
         ]);
         // End Aggregation Example 2
 
-        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
+        $this->assertInstanceOf(Cursor::class, $cursor);
     }
 
     public function testAggregation_example_3()
@@ -1072,31 +1082,35 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Aggregation Example 3
         $cursor = $db->sales->aggregate([
             ['$unwind' => '$items'],
-            ['$group' => [
-                '_id' => ['day' => ['$dayOfWeek' => '$date']],
-                'items_sold' => ['$sum' => '$items.quantity'],
-                'revenue' => [
-                    '$sum' => [
-                        '$multiply' => ['$items.quantity', '$items.price']
-                    ]
+            [
+                '$group' => [
+                    '_id' => ['day' => ['$dayOfWeek' => '$date']],
+                    'items_sold' => ['$sum' => '$items.quantity'],
+                    'revenue' => [
+                        '$sum' => [
+                            '$multiply' => ['$items.quantity', '$items.price'],
+                        ],
+                    ],
                 ],
-            ]],
-            ['$project' => [
-                'day' => '$_id.day',
-                'revenue' => 1,
-                'items_sold' => 1,
-                'discount' => [
-                    '$cond' => [
-                        'if' => ['$lte' => ['$revenue', 250]],
-                        'then' => 25,
-                        'else' => 0,
-                    ]
+            ],
+            [
+                '$project' => [
+                    'day' => '$_id.day',
+                    'revenue' => 1,
+                    'items_sold' => 1,
+                    'discount' => [
+                        '$cond' => [
+                            'if' => ['$lte' => ['$revenue', 250]],
+                            'then' => 25,
+                            'else' => 0,
+                        ],
+                    ],
                 ],
-            ]],
+            ],
         ]);
         // End Aggregation Example 3
 
-        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
+        $this->assertInstanceOf(Cursor::class, $cursor);
     }
 
     public function testAggregation_example_4()
@@ -1109,29 +1123,36 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         // Start Aggregation Example 4
         $cursor = $db->air_alliances->aggregate([
-            ['$lookup' => [
-                'from' => 'air_airlines',
-                'let' => ['constituents' => '$airlines'],
-                'pipeline' => [['$match' => [
-                        '$expr' => ['$in' => ['$name', '$constituents']]
-                ]]],
-                'as' => 'airlines',
-            ]],
-            ['$project' => [
-                '_id' => 0,
-                'name' => 1,
-                'airlines' => [
-                    '$filter' => [
-                        'input' => '$airlines',
-                        'as' => 'airline',
-                        'cond' => ['$eq' => ['$$airline.country', 'Canada']],
-                    ]
+            [
+                '$lookup' => [
+                    'from' => 'air_airlines',
+                    'let' => ['constituents' => '$airlines'],
+                    'pipeline' => [[
+                        '$match' => [
+                            '$expr' => ['$in' => ['$name', '$constituents']],
+                        ],
+                    ],
+                    ],
+                    'as' => 'airlines',
                 ],
-            ]],
+            ],
+            [
+                '$project' => [
+                    '_id' => 0,
+                    'name' => 1,
+                    'airlines' => [
+                        '$filter' => [
+                            'input' => '$airlines',
+                            'as' => 'airline',
+                            'cond' => ['$eq' => ['$$airline.country', 'Canada']],
+                        ],
+                    ],
+                ],
+            ],
         ]);
         // End Aggregation Example 4
 
-        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
+        $this->assertInstanceOf(Cursor::class, $cursor);
     }
 
     public function testRunCommand_example_1()
@@ -1143,7 +1164,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $result = $cursor->toArray()[0];
         // End runCommand Example 1
 
-        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
+        $this->assertInstanceOf(Cursor::class, $cursor);
     }
 
     public function testRunCommand_example_2()
@@ -1157,7 +1178,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $result = $cursor->toArray()[0];
         // End runCommand Example 2
 
-        $this->assertInstanceOf(\MongoDB\Driver\Cursor::class, $cursor);
+        $this->assertInstanceOf(Cursor::class, $cursor);
     }
 
     public function testIndex_example_1()
@@ -1185,12 +1206,15 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $this->assertEquals('cuisine_1_name_1', $indexName);
     }
 
+    // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
+    // phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
+    // phpcs:disable Squiz.WhiteSpace.FunctionSpacing.After
     // Start Transactions Intro Example 1
     private function updateEmployeeInfo1(\MongoDB\Client $client, \MongoDB\Driver\Session $session)
     {
         $session->startTransaction([
             'readConcern' => new \MongoDB\Driver\ReadConcern('snapshot'),
-            'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY)
+            'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY),
         ]);
 
         try {
@@ -1231,6 +1255,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         }
     }
     // End Transactions Intro Example 1
+    // phpcs:enable
 
     public function testTransactions_intro_example_1()
     {
@@ -1241,12 +1266,12 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $client = new Client(static::getUri());
 
         /* The WC is required: https://docs.mongodb.com/manual/core/transactions/#transactions-and-locks */
-        $client->hr->dropCollection('employees', ['writeConcern' => new \MongoDB\Driver\WriteConcern('majority')]);
-        $client->reporting->dropCollection('events', ['writeConcern' => new \MongoDB\Driver\WriteConcern('majority')]);
+        $client->hr->dropCollection('employees', ['writeConcern' => new WriteConcern('majority')]);
+        $client->reporting->dropCollection('events', ['writeConcern' => new WriteConcern('majority')]);
 
         /* Collections need to be created before a transaction starts */
-        $client->hr->createCollection('employees', ['writeConcern' => new \MongoDB\Driver\WriteConcern('majority')]);
-        $client->reporting->createCollection('events', ['writeConcern' => new \MongoDB\Driver\WriteConcern('majority')]);
+        $client->hr->createCollection('employees', ['writeConcern' => new WriteConcern('majority')]);
+        $client->reporting->createCollection('events', ['writeConcern' => new WriteConcern('majority')]);
 
         $session = $client->startSession();
 
@@ -1258,6 +1283,9 @@ class DocumentationExamplesTest extends FunctionalTestCase
         }
     }
 
+    // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
+    // phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
+    // phpcs:disable Squiz.WhiteSpace.FunctionSpacing.After
     // Start Transactions Retry Example 1
     private function runTransactionWithRetry1(callable $txnFunc, \MongoDB\Client $client, \MongoDB\Driver\Session $session)
     {
@@ -1282,7 +1310,11 @@ class DocumentationExamplesTest extends FunctionalTestCase
         }
     }
     // End Transactions Retry Example 1
+    // phpcs:enable
 
+    // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
+    // phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
+    // phpcs:disable Squiz.WhiteSpace.FunctionSpacing.After
     // Start Transactions Retry Example 2
     private function commitWithRetry2(\MongoDB\Driver\Session $session)
     {
@@ -1308,7 +1340,11 @@ class DocumentationExamplesTest extends FunctionalTestCase
         }
     }
     // End Transactions Retry Example 2
+    // phpcs:enable
 
+    // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
+    // phpcs:disable Squiz.Commenting.FunctionComment.WrongStyle
+    // phpcs:disable Squiz.WhiteSpace.FunctionSpacing.After
     // Start Transactions Retry Example 3
     private function runTransactionWithRetry3(callable $txnFunc, \MongoDB\Client $client, \MongoDB\Driver\Session $session)
     {
@@ -1394,6 +1430,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         }
     }
     // End Transactions Retry Example 3
+    // phpcs:enable
 
     public function testTransactions_retry_example_3()
     {
@@ -1404,12 +1441,12 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $client = new Client(static::getUri());
 
         /* The WC is required: https://docs.mongodb.com/manual/core/transactions/#transactions-and-locks */
-        $client->hr->dropCollection('employees', ['writeConcern' => new \MongoDB\Driver\WriteConcern('majority')]);
-        $client->reporting->dropCollection('events', ['writeConcern' => new \MongoDB\Driver\WriteConcern('majority')]);
+        $client->hr->dropCollection('employees', ['writeConcern' => new WriteConcern('majority')]);
+        $client->reporting->dropCollection('events', ['writeConcern' => new WriteConcern('majority')]);
 
         /* Collections need to be created before a transaction starts */
-        $client->hr->createCollection('employees', ['writeConcern' => new \MongoDB\Driver\WriteConcern('majority')]);
-        $client->reporting->createCollection('events', ['writeConcern' => new \MongoDB\Driver\WriteConcern('majority')]);
+        $client->hr->createCollection('employees', ['writeConcern' => new WriteConcern('majority')]);
+        $client->reporting->createCollection('events', ['writeConcern' => new WriteConcern('majority')]);
 
         ob_start();
         try {
@@ -1419,7 +1456,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         }
     }
 
-    function testCausalConsistency()
+    public function testCausalConsistency()
     {
         $this->skipIfCausalConsistencyIsNotSupported();
 
@@ -1443,6 +1480,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
             [ 'sku' => '111', 'name' => 'Peanuts', 'start' => new UTCDateTime() ]
         );
 
+        // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
         // Start Causal Consistency Example 1
         $items = $client->selectDatabase(
             'test',
@@ -1468,9 +1506,11 @@ class DocumentationExamplesTest extends FunctionalTestCase
             [ 'session' => $s1 ]
         );
         // End Causal Consistency Example 1
+        // phpcs:enable
 
         ob_start();
 
+        // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
         // Start Causal Consistency Example 2
         $s2 = $client->startSession(
             [ 'causalConsistency' => true ]
@@ -1483,7 +1523,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
             [
                 'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::RP_SECONDARY),
                 'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::MAJORITY),
-                'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY, 1000)
+                'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY, 1000),
             ]
         )->items;
 
@@ -1495,6 +1535,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
             var_dump($item);
         }
         // End Causal Consistency Example 2
+        // phpcs:enable
 
         ob_end_clean();
     }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -2,11 +2,14 @@
 
 namespace MongoDB\Tests;
 
+use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
-use MongoDB\Driver\ReadConcern;
-use MongoDB\Driver\WriteConcern;
-use MongoDB\Exception\InvalidArgumentException;
+use function MongoDB\apply_type_map_to_document;
+use function MongoDB\create_field_path_type_map;
+use function MongoDB\generate_index_name;
+use function MongoDB\is_first_key_operator;
+use function MongoDB\is_mapreduce_output_inline;
 
 /**
  * Unit tests for utility functions.
@@ -18,7 +21,7 @@ class FunctionsTest extends TestCase
      */
     public function testApplyTypeMapToDocument($document, array $typeMap, $expectedDocument)
     {
-        $this->assertEquals($expectedDocument, \MongoDB\apply_type_map_to_document($document, $typeMap));
+        $this->assertEquals($expectedDocument, apply_type_map_to_document($document, $typeMap));
     }
 
     public function provideDocumentAndTypeMap()
@@ -61,37 +64,27 @@ class FunctionsTest extends TestCase
             [
                 [
                     'x' => 1,
-                    'random' => [
-                        'foo' => 'bar',
-                    ],
+                    'random' => ['foo' => 'bar'],
                     'value' => [
                         'bar' => 'baz',
-                        'embedded' => [
-                            'foo' => 'bar',
-                        ],
+                        'embedded' => ['foo' => 'bar'],
                     ],
                 ],
                 [
                     'root' => 'array',
                     'document' => 'stdClass',
                     'array' => 'array',
-                    'fieldPaths' => [
-                        'value' => 'array',
-                    ],
+                    'fieldPaths' => ['value' => 'array'],
                 ],
                 [
                     'x' => 1,
-                    'random' => (object) [
-                        'foo' => 'bar',
-                    ],
+                    'random' => (object) ['foo' => 'bar'],
                     'value' => [
                         'bar' => 'baz',
-                        'embedded' => (object) [
-                            'foo' => 'bar',
-                        ],
+                        'embedded' => (object) ['foo' => 'bar'],
                     ],
                 ],
-            ]
+            ],
         ];
     }
 
@@ -100,7 +93,7 @@ class FunctionsTest extends TestCase
      */
     public function testGenerateIndexName($document, $expectedName)
     {
-        $this->assertSame($expectedName, \MongoDB\generate_index_name($document));
+        $this->assertSame($expectedName, generate_index_name($document));
     }
 
     public function provideIndexSpecificationDocumentsAndGeneratedNames()
@@ -120,7 +113,7 @@ class FunctionsTest extends TestCase
     public function testGenerateIndexNameArgumentTypeCheck($document)
     {
         $this->expectException(InvalidArgumentException::class);
-        \MongoDB\generate_index_name($document);
+        generate_index_name($document);
     }
 
     /**
@@ -128,7 +121,7 @@ class FunctionsTest extends TestCase
      */
     public function testIsFirstKeyOperator($document, $isFirstKeyOperator)
     {
-        $this->assertSame($isFirstKeyOperator, \MongoDB\is_first_key_operator($document));
+        $this->assertSame($isFirstKeyOperator, is_first_key_operator($document));
     }
 
     public function provideIsFirstKeyOperatorDocuments()
@@ -149,7 +142,7 @@ class FunctionsTest extends TestCase
     public function testIsFirstKeyOperatorArgumentTypeCheck($document)
     {
         $this->expectException(InvalidArgumentException::class);
-        \MongoDB\is_first_key_operator($document);
+        is_first_key_operator($document);
     }
 
     /**
@@ -157,7 +150,7 @@ class FunctionsTest extends TestCase
      */
     public function testIsMapReduceOutputInline($out, $isInline)
     {
-        $this->assertSame($isInline, \MongoDB\is_mapreduce_output_inline($out));
+        $this->assertSame($isInline, is_mapreduce_output_inline($out));
     }
 
     public function provideMapReduceOutValues()
@@ -175,7 +168,7 @@ class FunctionsTest extends TestCase
      */
     public function testCreateFieldPathTypeMap(array $expected, array $typeMap, $fieldPath = 'field')
     {
-        $this->assertEquals($expected, \MongoDB\create_field_path_type_map($typeMap, $fieldPath));
+        $this->assertEquals($expected, create_field_path_type_map($typeMap, $fieldPath));
     }
 
     public function provideTypeMapValues()
@@ -205,14 +198,12 @@ class FunctionsTest extends TestCase
                         'field' => 'array',
                         'field.$' => 'object',
                         'field.$.nested' => 'array',
-                    ]
+                    ],
                 ],
                 [
                     'root' => 'object',
                     'array' => 'MongoDB\Model\BSONArray',
-                    'fieldPaths' => [
-                        'nested' => 'array',
-                    ]
+                    'fieldPaths' => ['nested' => 'array'],
                 ],
                 'field.$',
             ],
@@ -223,13 +214,11 @@ class FunctionsTest extends TestCase
                     'fieldPaths' => [
                         'field' => 'array',
                         'field.$.nested' => 'array',
-                    ]
+                    ],
                 ],
                 [
                     'array' => 'MongoDB\Model\BSONArray',
-                    'fieldPaths' => [
-                        'nested' => 'array',
-                    ]
+                    'fieldPaths' => ['nested' => 'array'],
                 ],
                 'field.$',
             ],

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -6,6 +6,11 @@ use MongoDB\Collection;
 use MongoDB\GridFS\Bucket;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function fopen;
+use function fwrite;
+use function get_resource_type;
+use function rewind;
+use function stream_get_contents;
 
 /**
  * Base class for GridFS functional tests.

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -5,11 +5,11 @@ namespace MongoDB\Tests\GridFS;
 use MongoDB\BSON\Binary;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\CollectionWrapper;
-use MongoDB\GridFS\ReadableStream;
 use MongoDB\GridFS\Exception\CorruptFileException;
+use MongoDB\GridFS\ReadableStream;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function array_filter;
 
 /**
  * Functional tests for the internal ReadableStream class.
@@ -119,8 +119,9 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
 
     public function provideFilteredFileIdAndExpectedBytes()
     {
-        return array_filter($this->provideFileIdAndExpectedBytes(),
-            function(array $args) {
+        return array_filter(
+            $this->provideFileIdAndExpectedBytes(),
+            function (array $args) {
                 return $args[1] > 0;
             }
         );
@@ -219,12 +220,12 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
 
         $commands = [];
 
-        (new CommandObserver)->observe(
-            function() use ($stream, $offset, $length, $expectedBytes) {
+        (new CommandObserver())->observe(
+            function () use ($stream, $offset, $length, $expectedBytes) {
                 $stream->seek($offset);
                 $this->assertSame($expectedBytes, $stream->readBytes($length));
             },
-            function(array $event) use (&$commands) {
+            function (array $event) use (&$commands) {
                 $commands[] = $event['started']->getCommandName();
             }
         );
@@ -255,12 +256,12 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
 
         $commands = [];
 
-        (new CommandObserver)->observe(
-            function() use ($stream, $offset, $length, $expectedBytes) {
+        (new CommandObserver())->observe(
+            function () use ($stream, $offset, $length, $expectedBytes) {
                 $stream->seek($offset);
                 $this->assertSame($expectedBytes, $stream->readBytes($length));
             },
-            function(array $event) use (&$commands) {
+            function (array $event) use (&$commands) {
                 $commands[] = $event['started']->getCommandName();
             }
         );
@@ -289,12 +290,12 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
 
         $commands = [];
 
-        (new CommandObserver)->observe(
-            function() use ($stream, $offset, $length, $expectedBytes) {
+        (new CommandObserver())->observe(
+            function () use ($stream, $offset, $length, $expectedBytes) {
                 $stream->seek($offset);
                 $this->assertSame($expectedBytes, $stream->readBytes($length));
             },
-            function(array $event) use (&$commands) {
+            function (array $event) use (&$commands) {
                 $commands[] = $event['started']->getCommandName();
             }
         );

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -5,6 +5,15 @@ namespace MongoDB\Tests\GridFS;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\UTCDateTime;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function fclose;
+use function feof;
+use function fread;
+use function fseek;
+use function fstat;
+use function fwrite;
+use const SEEK_CUR;
+use const SEEK_END;
+use const SEEK_SET;
 
 /**
  * Functional tests for the internal StreamWrapper class.
@@ -57,26 +66,26 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
     {
         $stream = $this->bucket->openDownloadStream('length-10');
 
-        $this->assertSame(0, fseek($stream, 2, \SEEK_SET));
+        $this->assertSame(0, fseek($stream, 2, SEEK_SET));
         $this->assertSame('cde', fread($stream, 3));
-        $this->assertSame(0, fseek($stream, 10, \SEEK_SET));
+        $this->assertSame(0, fseek($stream, 10, SEEK_SET));
         $this->assertSame('', fread($stream, 3));
-        $this->assertSame(-1, fseek($stream, -1, \SEEK_SET));
-        $this->assertSame(-1, fseek($stream, 11, \SEEK_SET));
+        $this->assertSame(-1, fseek($stream, -1, SEEK_SET));
+        $this->assertSame(-1, fseek($stream, 11, SEEK_SET));
 
-        $this->assertSame(0, fseek($stream, -5, \SEEK_CUR));
+        $this->assertSame(0, fseek($stream, -5, SEEK_CUR));
         $this->assertSame('fgh', fread($stream, 3));
-        $this->assertSame(0, fseek($stream, 1, \SEEK_CUR));
+        $this->assertSame(0, fseek($stream, 1, SEEK_CUR));
         $this->assertSame('j', fread($stream, 3));
-        $this->assertSame(-1, fseek($stream, 1, \SEEK_CUR));
-        $this->assertSame(-1, fseek($stream, -11, \SEEK_CUR));
+        $this->assertSame(-1, fseek($stream, 1, SEEK_CUR));
+        $this->assertSame(-1, fseek($stream, -11, SEEK_CUR));
 
-        $this->assertSame(0, fseek($stream, 0, \SEEK_END));
+        $this->assertSame(0, fseek($stream, 0, SEEK_END));
         $this->assertSame('', fread($stream, 3));
-        $this->assertSame(0, fseek($stream, -8, \SEEK_END));
+        $this->assertSame(0, fseek($stream, -8, SEEK_END));
         $this->assertSame('cde', fread($stream, 3));
-        $this->assertSame(-1, fseek($stream, -11, \SEEK_END));
-        $this->assertSame(-1, fseek($stream, 1, \SEEK_END));
+        $this->assertSame(-1, fseek($stream, -11, SEEK_END));
+        $this->assertSame(-1, fseek($stream, 1, SEEK_END));
     }
 
     public function testReadableStreamStat()
@@ -137,17 +146,17 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
 
         $this->assertSame(6, fwrite($stream, 'foobar'));
 
-        $this->assertSame(-1, fseek($stream, 0, \SEEK_SET));
-        $this->assertSame(-1, fseek($stream, 7, \SEEK_SET));
-        $this->assertSame(0, fseek($stream, 6, \SEEK_SET));
+        $this->assertSame(-1, fseek($stream, 0, SEEK_SET));
+        $this->assertSame(-1, fseek($stream, 7, SEEK_SET));
+        $this->assertSame(0, fseek($stream, 6, SEEK_SET));
 
-        $this->assertSame(0, fseek($stream, 0, \SEEK_CUR));
-        $this->assertSame(-1, fseek($stream, -1, \SEEK_CUR));
-        $this->assertSame(-1, fseek($stream, 1, \SEEK_CUR));
+        $this->assertSame(0, fseek($stream, 0, SEEK_CUR));
+        $this->assertSame(-1, fseek($stream, -1, SEEK_CUR));
+        $this->assertSame(-1, fseek($stream, 1, SEEK_CUR));
 
-        $this->assertSame(0, fseek($stream, 0, \SEEK_END));
-        $this->assertSame(-1, fseek($stream, -1, \SEEK_END));
-        $this->assertSame(-1, fseek($stream, 1, \SEEK_END));
+        $this->assertSame(0, fseek($stream, 0, SEEK_END));
+        $this->assertSame(-1, fseek($stream, -1, SEEK_END));
+        $this->assertSame(-1, fseek($stream, 1, SEEK_END));
     }
 
     public function testWritableStreamStatBeforeSaving()
@@ -171,7 +180,7 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $stat = fstat($stream);
         $this->assertSame(6, $stat[7]);
         $this->assertSame(6, $stat['size']);
-  }
+    }
 
     public function testWritableStreamStatAfterSaving()
     {

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -6,6 +6,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\CollectionWrapper;
 use MongoDB\GridFS\WritableStream;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function str_repeat;
 
 /**
  * Functional tests for the internal WritableStream class.

--- a/tests/Model/BSONArrayTest.php
+++ b/tests/Model/BSONArrayTest.php
@@ -6,8 +6,9 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Tests\TestCase;
-use stdClass;
 use ReflectionClass;
+use stdClass;
+use function json_encode;
 
 class BSONArrayTest extends TestCase
 {
@@ -25,13 +26,13 @@ class BSONArrayTest extends TestCase
         $array = new BSONArray([
             [
                 'foo',
-                new stdClass,
-                ['bar', new stdClass],
+                new stdClass(),
+                ['bar', new stdClass()],
             ],
             new BSONArray([
                 'foo',
-                new stdClass,
-                ['bar', new stdClass],
+                new stdClass(),
+                ['bar', new stdClass()],
             ]),
         ]);
         $arrayClone = clone $array;
@@ -50,8 +51,8 @@ class BSONArrayTest extends TestCase
         $this->assertFalse((new ReflectionClass(UncloneableObject::class))->isCloneable());
 
         $array = new BSONArray([
-            [new UncloneableObject],
-            new BSONArray([new UncloneableObject]),
+            [new UncloneableObject()],
+            new BSONArray([new UncloneableObject()]),
         ]);
         $arrayClone = clone $array;
 
@@ -66,8 +67,8 @@ class BSONArrayTest extends TestCase
         /* Note: this test does not check that the BSON type itself is cloned,
          * as that is not yet supported in the driver (see: PHPC-1230). */
         $array = new BSONArray([
-            [new ObjectId],
-            new BSONArray([new ObjectId]),
+            [new ObjectId()],
+            new BSONArray([new ObjectId()]),
         ]);
         $arrayClone = clone $array;
 
@@ -81,7 +82,7 @@ class BSONArrayTest extends TestCase
             'foo',
             new BSONArray(['foo' => 1, 'bar' => 2, 'baz' => 3]),
             new BSONDocument(['foo' => 1, 'bar' => 2, 'baz' => 3]),
-            new BSONArray([new BSONArray([new BSONArray])]),
+            new BSONArray([new BSONArray([new BSONArray()])]),
         ]);
 
         $expectedJson = '["foo",[1,2,3],{"foo":1,"bar":2,"baz":3},[[[]]]]';
@@ -103,7 +104,7 @@ class BSONArrayTest extends TestCase
         $data = ['foo', 'bar'];
 
         $array = BSONArray::__set_state($data);
-        $this->assertInstanceOf(\MongoDB\Model\BSONArray::class, $array);
+        $this->assertInstanceOf(BSONArray::class, $array);
         $this->assertSame($data, $array->getArrayCopy());
     }
 }

--- a/tests/Model/BSONDocumentTest.php
+++ b/tests/Model/BSONDocumentTest.php
@@ -2,13 +2,14 @@
 
 namespace MongoDB\Tests\Model;
 
+use ArrayObject;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Tests\TestCase;
-use ArrayObject;
-use stdClass;
 use ReflectionClass;
+use stdClass;
+use function json_encode;
 
 class BSONDocumentTest extends TestCase
 {
@@ -33,13 +34,13 @@ class BSONDocumentTest extends TestCase
         $document = new BSONDocument([
             'a' => [
                 'a' => 'foo',
-                'b' => new stdClass,
-                'c' => ['bar', new stdClass],
+                'b' => new stdClass(),
+                'c' => ['bar', new stdClass()],
             ],
             'b' => new BSONDocument([
                 'a' => 'foo',
-                'b' => new stdClass,
-                'c' => ['bar', new stdClass],
+                'b' => new stdClass(),
+                'c' => ['bar', new stdClass()],
             ]),
         ]);
         $documentClone = clone $document;
@@ -58,8 +59,8 @@ class BSONDocumentTest extends TestCase
         $this->assertFalse((new ReflectionClass(UncloneableObject::class))->isCloneable());
 
         $document = new BSONDocument([
-            'a' => ['a' => new UncloneableObject],
-            'b' => new BSONDocument(['a' => new UncloneableObject]),
+            'a' => ['a' => new UncloneableObject()],
+            'b' => new BSONDocument(['a' => new UncloneableObject()]),
         ]);
         $documentClone = clone $document;
 
@@ -74,8 +75,8 @@ class BSONDocumentTest extends TestCase
         /* Note: this test does not check that the BSON type itself is cloned,
          * as that is not yet supported in the driver (see: PHPC-1230). */
         $document = new BSONDocument([
-            'a' => ['a' => new ObjectId],
-            'b' => new BSONDocument(['a' => new ObjectId]),
+            'a' => ['a' => new ObjectId()],
+            'b' => new BSONDocument(['a' => new ObjectId()]),
         ]);
         $documentClone = clone $document;
 
@@ -89,7 +90,7 @@ class BSONDocumentTest extends TestCase
             'foo' => 'bar',
             'array' => new BSONArray([1, 2, 3]),
             'object' => new BSONDocument([1, 2, 3]),
-            'nested' => new BSONDocument([new BSONDocument([new BSONDocument])]),
+            'nested' => new BSONDocument([new BSONDocument([new BSONDocument()])]),
         ]);
 
         $expectedJson = '{"foo":"bar","array":[1,2,3],"object":{"0":1,"1":2,"2":3},"nested":{"0":{"0":{}}}}';
@@ -111,7 +112,7 @@ class BSONDocumentTest extends TestCase
         $data = ['foo' => 'bar'];
 
         $document = BSONDocument::__set_state($data);
-        $this->assertInstanceOf(\MongoDB\Model\BSONDocument::class, $document);
+        $this->assertInstanceOf(BSONDocument::class, $document);
         $this->assertSame($data, $document->getArrayCopy());
     }
 }

--- a/tests/Model/BSONIteratorTest.php
+++ b/tests/Model/BSONIteratorTest.php
@@ -3,11 +3,13 @@
 namespace MongoDB\Tests\Model;
 
 use MongoDB\Exception\UnexpectedValueException;
-use MongoDB\Model\BSONArray;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Model\BSONIterator;
 use MongoDB\Tests\TestCase;
-use stdClass;
+use function array_map;
+use function implode;
+use function iterator_to_array;
+use function MongoDB\BSON\fromPHP;
+use function substr;
 
 class BSONIteratorTest extends TestCase
 {
@@ -38,7 +40,7 @@ class BSONIteratorTest extends TestCase
                 [
                     (object) ['_id' => 1, 'x' => (object) ['foo' => 'bar']],
                     (object) ['_id' => 3, 'x' => (object) ['foo' => 'bar']],
-                ]
+                ],
             ],
             [
                 ['root' => 'array', 'document' => 'array'],
@@ -52,7 +54,7 @@ class BSONIteratorTest extends TestCase
                 [
                     ['_id' => 1, 'x' => ['foo' => 'bar']],
                     ['_id' => 3, 'x' => ['foo' => 'bar']],
-                ]
+                ],
             ],
             [
                 ['root' => 'object', 'document' => 'array'],
@@ -66,7 +68,7 @@ class BSONIteratorTest extends TestCase
                 [
                     (object) ['_id' => 1, 'x' => ['foo' => 'bar']],
                     (object) ['_id' => 3, 'x' => ['foo' => 'bar']],
-                ]
+                ],
             ],
             [
                 ['root' => 'array', 'document' => 'stdClass'],
@@ -80,14 +82,14 @@ class BSONIteratorTest extends TestCase
                 [
                     ['_id' => 1, 'x' => (object) ['foo' => 'bar']],
                     ['_id' => 3, 'x' => (object) ['foo' => 'bar']],
-                ]
+                ],
             ],
         ];
     }
 
     public function testCannotReadLengthFromFirstDocument()
     {
-        $binaryString = substr(\MongoDB\BSON\fromPHP([]), 0, 3);
+        $binaryString = substr(fromPHP([]), 0, 3);
 
         $bsonIt = new BSONIterator($binaryString);
 
@@ -98,7 +100,7 @@ class BSONIteratorTest extends TestCase
 
     public function testCannotReadLengthFromSubsequentDocument()
     {
-        $binaryString = \MongoDB\BSON\fromPHP([]) . substr(\MongoDB\BSON\fromPHP([]), 0, 3);
+        $binaryString = fromPHP([]) . substr(fromPHP([]), 0, 3);
 
         $bsonIt = new BSONIterator($binaryString);
         $bsonIt->rewind();
@@ -110,7 +112,7 @@ class BSONIteratorTest extends TestCase
 
     public function testCannotReadFirstDocument()
     {
-        $binaryString = substr(\MongoDB\BSON\fromPHP([]), 0, 4);
+        $binaryString = substr(fromPHP([]), 0, 4);
 
         $bsonIt = new BSONIterator($binaryString);
 
@@ -121,7 +123,7 @@ class BSONIteratorTest extends TestCase
 
     public function testCannotReadSecondDocument()
     {
-        $binaryString = \MongoDB\BSON\fromPHP([]) . substr(\MongoDB\BSON\fromPHP([]), 0, 4);
+        $binaryString = fromPHP([]) . substr(fromPHP([]), 0, 4);
 
         $bsonIt = new BSONIterator($binaryString);
         $bsonIt->rewind();

--- a/tests/Model/CachingIteratorTest.php
+++ b/tests/Model/CachingIteratorTest.php
@@ -2,9 +2,10 @@
 
 namespace MongoDB\Tests\Model;
 
+use Exception;
 use MongoDB\Model\CachingIterator;
 use MongoDB\Tests\TestCase;
-use Exception;
+use function iterator_to_array;
 
 class CachingIteratorTest extends TestCase
 {
@@ -52,7 +53,7 @@ class CachingIteratorTest extends TestCase
 
     public function testPartialIterationDoesNotExhaust()
     {
-        $traversable = $this->getTraversableThatThrows([1, 2, new Exception]);
+        $traversable = $this->getTraversableThatThrows([1, 2, new Exception()]);
         $iterator = new CachingIterator($traversable);
 
         $expectedKey = 0;

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -6,12 +6,14 @@ use MongoDB\Collection;
 use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\ChangeStreamIterator;
-use MongoDB\Operation\Find;
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\DropCollection;
+use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\FunctionalTestCase;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function array_merge;
+use function sprintf;
 
 class ChangeStreamIteratorTest extends FunctionalTestCase
 {
@@ -90,7 +92,9 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
         $cursor = $this->collection->find([], ['cursorType' => Find::TAILABLE]);
         $iterator = new ChangeStreamIterator($cursor, 2, null, $postBatchResumeToken);
 
-        $this->assertNoCommandExecuted(function() use ($iterator) { $iterator->rewind(); });
+        $this->assertNoCommandExecuted(function () use ($iterator) {
+            $iterator->rewind();
+        });
         $this->assertTrue($iterator->valid());
         $this->assertSameDocument(['resumeToken' => 1], $iterator->getResumeToken());
         $this->assertSameDocument(['_id' => ['resumeToken' => 1], 'x' => 1], $iterator->current());
@@ -108,7 +112,9 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
         $cursor = $this->collection->find(['x' => ['$gt' => 1]], ['cursorType' => Find::TAILABLE]);
         $iterator = new ChangeStreamIterator($cursor, 0, null, null);
 
-        $this->assertNoCommandExecuted(function() use ($iterator) { $iterator->rewind(); });
+        $this->assertNoCommandExecuted(function () use ($iterator) {
+            $iterator->rewind();
+        });
         $this->assertFalse($iterator->valid());
 
         $this->collection->insertOne(['_id' => ['resumeToken' => 2], 'x' => 2]);
@@ -128,7 +134,9 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
         $cursor = $this->collection->find([], ['cursorType' => Find::TAILABLE]);
         $iterator = new ChangeStreamIterator($cursor, 1, null, null);
 
-        $this->assertNoCommandExecuted(function() use ($iterator) { $iterator->rewind(); });
+        $this->assertNoCommandExecuted(function () use ($iterator) {
+            $iterator->rewind();
+        });
         $this->assertTrue($iterator->valid());
         $this->assertSameDocument(['_id' => ['resumeToken' => 1], 'x' => 1], $iterator->current());
 
@@ -146,9 +154,9 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
     {
         $commands = [];
 
-        (new CommandObserver)->observe(
+        (new CommandObserver())->observe(
             $callable,
-            function(array $event) use (&$commands) {
+            function (array $event) use (&$commands) {
                 $this->fail(sprintf('"%s" command was executed', $event['started']->getCommandName()));
             }
         );

--- a/tests/Model/CollectionInfoTest.php
+++ b/tests/Model/CollectionInfoTest.php
@@ -64,7 +64,7 @@ class CollectionInfoTest extends TestCase
     {
         $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576]]);
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage(CollectionInfo::class .' is immutable');
+        $this->expectExceptionMessage(CollectionInfo::class . ' is immutable');
         $info['options'] = ['capped' => false];
     }
 
@@ -72,7 +72,7 @@ class CollectionInfoTest extends TestCase
     {
         $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576]]);
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage(CollectionInfo::class .' is immutable');
+        $this->expectExceptionMessage(CollectionInfo::class . ' is immutable');
         unset($info['options']);
     }
 }

--- a/tests/Model/DatabaseInfoTest.php
+++ b/tests/Model/DatabaseInfoTest.php
@@ -53,7 +53,7 @@ class DatabaseInfoTest extends TestCase
     {
         $info = new DatabaseInfo(['name' => 'foo', 'sizeOnDisk' => 1048576, 'empty' => false]);
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage(DatabaseInfo::class .' is immutable');
+        $this->expectExceptionMessage(DatabaseInfo::class . ' is immutable');
         $info['empty'] = true;
     }
 
@@ -61,7 +61,7 @@ class DatabaseInfoTest extends TestCase
     {
         $info = new DatabaseInfo(['name' => 'foo', 'sizeOnDisk' => 1048576, 'empty' => false]);
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage(DatabaseInfo::class .' is immutable');
+        $this->expectExceptionMessage(DatabaseInfo::class . ' is immutable');
         unset($info['empty']);
     }
 }

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -5,6 +5,7 @@ namespace MongoDB\Tests\Model;
 use MongoDB\Collection;
 use MongoDB\Tests\FunctionalTestCase;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function version_compare;
 
 class IndexInfoFunctionalTest extends FunctionalTestCase
 {

--- a/tests/Model/IndexInfoTest.php
+++ b/tests/Model/IndexInfoTest.php
@@ -134,7 +134,7 @@ class IndexInfoTest extends TestCase
         ]);
 
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage(IndexInfo::class .' is immutable');
+        $this->expectExceptionMessage(IndexInfo::class . ' is immutable');
         $info['v'] = 2;
     }
 
@@ -148,7 +148,7 @@ class IndexInfoTest extends TestCase
         ]);
 
         $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage(IndexInfo::class .' is immutable');
+        $this->expectExceptionMessage(IndexInfo::class . ' is immutable');
         unset($info['v']);
     }
 

--- a/tests/Model/IndexInputTest.php
+++ b/tests/Model/IndexInputTest.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Tests\Model;
 
+use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\IndexInput;
 use MongoDB\Tests\TestCase;
@@ -32,7 +33,7 @@ class IndexInputTest extends TestCase
 
     public function provideInvalidFieldOrderValues()
     {
-        return $this->wrapValuesForDataProvider([true, [], new stdClass]);
+        return $this->wrapValuesForDataProvider([true, [], new stdClass()]);
     }
 
     public function testConstructorShouldRequireNamespace()
@@ -85,7 +86,7 @@ class IndexInputTest extends TestCase
             'ns' => 'foo.bar',
         ]);
 
-        $this->assertInstanceOf(\MongoDB\BSON\Serializable::class, $indexInput);
+        $this->assertInstanceOf(Serializable::class, $indexInput);
         $this->assertEquals($expected, $indexInput->bsonSerialize());
     }
 }

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -2,23 +2,25 @@
 
 namespace MongoDB\Tests\Operation;
 
+use ArrayIterator;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Operation\Aggregate;
 use MongoDB\Tests\CommandObserver;
-use ArrayIterator;
-use Exception;
 use stdClass;
+use function current;
+use function iterator_to_array;
+use function version_compare;
 
 class AggregateFunctionalTest extends FunctionalTestCase
 {
     public function testBatchSizeIsIgnoredIfPipelineIncludesOutStage()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Aggregate(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -28,8 +30,8 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
-                $this->assertEquals(new stdClass, $event['started']->getCommand()->cursor);
+            function (array $event) {
+                $this->assertEquals(new stdClass(), $event['started']->getCommand()->cursor);
             }
         );
 
@@ -43,8 +45,8 @@ class AggregateFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('$currentOp is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Aggregate(
                     'admin',
                     null,
@@ -53,7 +55,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertSame(1, $event['started']->getCommand()->aggregate);
             }
         );
@@ -61,8 +63,8 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
     public function testDefaultReadConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Aggregate(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -72,7 +74,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
             }
         );
@@ -80,8 +82,8 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
     public function testDefaultWriteConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Aggregate(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -91,7 +93,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -129,8 +131,8 @@ class AggregateFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Aggregate(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -140,7 +142,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -203,15 +205,15 @@ class AggregateFunctionalTest extends FunctionalTestCase
     {
         if (version_compare($this->getServerVersion(), '3.4.0', '<')) {
             $this->markTestSkipped('The writeConcern option is not supported');
-       }
+        }
 
         $this->createFixtures(3);
 
         $pipeline = [['$match' => ['_id' => ['$ne' => 2]]], ['$out' => $this->getCollectionName() . '.output']];
         $options = ['explain' => true, 'writeConcern' => new WriteConcern(1)];
 
-        (new CommandObserver)->observe(
-            function() use ($pipeline, $options) {
+        (new CommandObserver())->observe(
+            function () use ($pipeline, $options) {
                 $operation = new Aggregate($this->getDatabaseName(), $this->getCollectionName(), $pipeline, $options);
 
                 $results = iterator_to_array($operation->execute($this->getPrimaryServer()));
@@ -229,7 +231,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
                     $this->assertObjectHasAttribute('stages', $result);
                 }
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -243,8 +245,8 @@ class AggregateFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Aggregate(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -254,7 +256,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
             }
@@ -267,8 +269,8 @@ class AggregateFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Aggregate(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -278,7 +280,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\ObjectId;
 use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite as Bulk;
@@ -11,8 +12,8 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\BulkWrite;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function version_compare;
 
 class BulkWriteFunctionalTest extends FunctionalTestCase
 {
@@ -39,12 +40,12 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $operation = new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), $ops);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $result);
+        $this->assertInstanceOf(BulkWriteResult::class, $result);
         $this->assertSame(4, $result->getInsertedCount());
 
         $insertedIds = $result->getInsertedIds();
         $this->assertSame(1, $insertedIds[0]);
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $insertedIds[1]);
+        $this->assertInstanceOf(ObjectId::class, $insertedIds[1]);
         $this->assertSame('foo', $insertedIds[2]);
         $this->assertSame('bar', $insertedIds[3]);
 
@@ -73,14 +74,14 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $operation = new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), $ops);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $result);
+        $this->assertInstanceOf(BulkWriteResult::class, $result);
         $this->assertSame(5, $result->getMatchedCount());
         $this->assertSame(5, $result->getModifiedCount());
         $this->assertSame(2, $result->getUpsertedCount());
 
         $upsertedIds = $result->getUpsertedIds();
         $this->assertSame(5, $upsertedIds[2]);
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $upsertedIds[3]);
+        $this->assertInstanceOf(ObjectId::class, $upsertedIds[3]);
 
         $expected = [
             ['_id' => 1, 'x' => 11],
@@ -106,7 +107,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $operation = new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), $ops);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $result);
+        $this->assertInstanceOf(BulkWriteResult::class, $result);
         $this->assertSame(3, $result->getDeletedCount());
 
         $expected = [
@@ -131,7 +132,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $operation = new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), $ops);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\BulkWriteResult::class, $result);
+        $this->assertInstanceOf(BulkWriteResult::class, $result);
 
         $this->assertSame(1, $result->getInsertedCount());
         $this->assertSame([2 => 4], $result->getInsertedIds());
@@ -291,8 +292,8 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new BulkWrite(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -302,7 +303,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -314,8 +315,8 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new BulkWrite(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -325,7 +326,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
             }
@@ -338,8 +339,8 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new BulkWrite(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -349,7 +350,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/CountDocumentsFunctionalTest.php
+++ b/tests/Operation/CountDocumentsFunctionalTest.php
@@ -4,7 +4,6 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Operation\CountDocuments;
 use MongoDB\Operation\InsertMany;
-use stdClass;
 
 class CountDocumentsFunctionalTest extends FunctionalTestCase
 {

--- a/tests/Operation/CountFunctionalTest.php
+++ b/tests/Operation/CountFunctionalTest.php
@@ -6,14 +6,14 @@ use MongoDB\Operation\Count;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function version_compare;
 
 class CountFunctionalTest extends FunctionalTestCase
 {
     public function testDefaultReadConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Count(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -23,7 +23,7 @@ class CountFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
             }
         );
@@ -76,8 +76,8 @@ class CountFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Count(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -87,7 +87,7 @@ class CountFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/CreateCollectionFunctionalTest.php
+++ b/tests/Operation/CreateCollectionFunctionalTest.php
@@ -4,14 +4,14 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function version_compare;
 
 class CreateCollectionFunctionalTest extends FunctionalTestCase
 {
     public function testDefaultWriteConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new CreateCollection(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -20,7 +20,7 @@ class CreateCollectionFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -32,8 +32,8 @@ class CreateCollectionFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new CreateCollection(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -42,7 +42,7 @@ class CreateCollectionFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/CreateCollectionTest.php
+++ b/tests/Operation/CreateCollectionTest.php
@@ -85,11 +85,11 @@ class CreateCollectionTest extends TestCase
 
     public function testAutoIndexIdOptionIsDeprecated()
     {
-        $this->assertDeprecated(function() {
+        $this->assertDeprecated(function () {
             new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), ['autoIndexId' => true]);
         });
 
-        $this->assertDeprecated(function() {
+        $this->assertDeprecated(function () {
             new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), ['autoIndexId' => false]);
         });
     }

--- a/tests/Operation/CreateIndexesFunctionalTest.php
+++ b/tests/Operation/CreateIndexesFunctionalTest.php
@@ -2,14 +2,16 @@
 
 namespace MongoDB\Tests\Operation;
 
+use InvalidArgumentException;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\CreateIndexes;
-use MongoDB\Operation\DropIndexes;
 use MongoDB\Operation\ListIndexes;
 use MongoDB\Tests\CommandObserver;
-use InvalidArgumentException;
-use stdClass;
+use function call_user_func;
+use function is_callable;
+use function sprintf;
+use function version_compare;
 
 class CreateIndexesFunctionalTest extends FunctionalTestCase
 {
@@ -21,7 +23,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
         $createdIndexNames = $operation->execute($this->getPrimaryServer());
 
         $this->assertSame('x_1', $createdIndexNames[0]);
-        $this->assertIndexExists('x_1', function(IndexInfo $info) {
+        $this->assertIndexExists('x_1', function (IndexInfo $info) {
             $this->assertTrue($info->isSparse());
             $this->assertTrue($info->isUnique());
             $this->assertFalse($info->isTtl());
@@ -36,7 +38,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
         $createdIndexNames = $operation->execute($this->getPrimaryServer());
 
         $this->assertSame('y_-1_z_1', $createdIndexNames[0]);
-        $this->assertIndexExists('y_-1_z_1', function(IndexInfo $info) {
+        $this->assertIndexExists('y_-1_z_1', function (IndexInfo $info) {
             $this->assertFalse($info->isSparse());
             $this->assertFalse($info->isUnique());
             $this->assertFalse($info->isTtl());
@@ -51,7 +53,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
         $createdIndexNames = $operation->execute($this->getPrimaryServer());
 
         $this->assertSame('g_2dsphere_z_1', $createdIndexNames[0]);
-        $this->assertIndexExists('g_2dsphere_z_1', function(IndexInfo $info) {
+        $this->assertIndexExists('g_2dsphere_z_1', function (IndexInfo $info) {
             $this->assertFalse($info->isSparse());
             $this->assertFalse($info->isUnique());
             $this->assertFalse($info->isTtl());
@@ -66,7 +68,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
         $createdIndexNames = $operation->execute($this->getPrimaryServer());
 
         $this->assertSame('my_ttl', $createdIndexNames[0]);
-        $this->assertIndexExists('my_ttl', function(IndexInfo $info) {
+        $this->assertIndexExists('my_ttl', function (IndexInfo $info) {
             $this->assertFalse($info->isSparse());
             $this->assertFalse($info->isUnique());
             $this->assertTrue($info->isTtl());
@@ -89,25 +91,25 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
 
         $this->assertSame($expectedNames, $createdIndexNames);
 
-        $this->assertIndexExists('x_1', function(IndexInfo $info) {
+        $this->assertIndexExists('x_1', function (IndexInfo $info) {
             $this->assertTrue($info->isSparse());
             $this->assertTrue($info->isUnique());
             $this->assertFalse($info->isTtl());
         });
 
-        $this->assertIndexExists('y_-1_z_1', function(IndexInfo $info) {
+        $this->assertIndexExists('y_-1_z_1', function (IndexInfo $info) {
             $this->assertFalse($info->isSparse());
             $this->assertFalse($info->isUnique());
             $this->assertFalse($info->isTtl());
         });
 
-        $this->assertIndexExists('g_2dsphere_z_1', function(IndexInfo $info) {
+        $this->assertIndexExists('g_2dsphere_z_1', function (IndexInfo $info) {
             $this->assertFalse($info->isSparse());
             $this->assertFalse($info->isUnique());
             $this->assertFalse($info->isTtl());
         });
 
-        $this->assertIndexExists('my_ttl', function(IndexInfo $info) {
+        $this->assertIndexExists('my_ttl', function (IndexInfo $info) {
             $this->assertFalse($info->isSparse());
             $this->assertFalse($info->isUnique());
             $this->assertTrue($info->isTtl());
@@ -129,8 +131,8 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
 
     public function testDefaultWriteConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new CreateIndexes(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -140,7 +142,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -152,8 +154,8 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new CreateIndexes(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -163,7 +165,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/DatabaseCommandFunctionalTest.php
+++ b/tests/Operation/DatabaseCommandFunctionalTest.php
@@ -4,7 +4,7 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Operation\DatabaseCommand;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function version_compare;
 
 class DatabaseCommandFunctionalTest extends FunctionalTestCase
 {
@@ -14,8 +14,8 @@ class DatabaseCommandFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new DatabaseCommand(
                     $this->getDatabaseName(),
                     ['ping' => 1],
@@ -24,7 +24,7 @@ class DatabaseCommandFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -2,15 +2,15 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\DeleteResult;
 use MongoDB\Collection;
+use MongoDB\DeleteResult;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Operation\Delete;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function version_compare;
 
 class DeleteFunctionalTest extends FunctionalTestCase
 {
@@ -34,7 +34,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
         $operation = new Delete($this->getDatabaseName(), $this->getCollectionName(), $filter, 1);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\DeleteResult::class, $result);
+        $this->assertInstanceOf(DeleteResult::class, $result);
         $this->assertSame(1, $result->getDeletedCount());
 
         $expected = [
@@ -54,7 +54,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
         $operation = new Delete($this->getDatabaseName(), $this->getCollectionName(), $filter, 0);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\DeleteResult::class, $result);
+        $this->assertInstanceOf(DeleteResult::class, $result);
         $this->assertSame(2, $result->getDeletedCount());
 
         $expected = [
@@ -70,8 +70,8 @@ class DeleteFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Delete(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -82,7 +82,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/DeleteTest.php
+++ b/tests/Operation/DeleteTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Delete;
+use function array_merge;
 
 class DeleteTest extends TestCase
 {

--- a/tests/Operation/DistinctFunctionalTest.php
+++ b/tests/Operation/DistinctFunctionalTest.php
@@ -5,14 +5,17 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Operation\Distinct;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function is_scalar;
+use function json_encode;
+use function usort;
+use function version_compare;
 
 class DistinctFunctionalTest extends FunctionalTestCase
 {
     public function testDefaultReadConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Distinct(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -23,7 +26,7 @@ class DistinctFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
             }
         );
@@ -35,8 +38,8 @@ class DistinctFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Distinct(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -47,7 +50,7 @@ class DistinctFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -62,9 +65,7 @@ class DistinctFunctionalTest extends FunctionalTestCase
         $bulkWrite->insert([
             'x' => (object) ['foo' => 'bar'],
         ]);
-        $bulkWrite->insert([
-            'x' => 4,
-        ]);
+        $bulkWrite->insert(['x' => 4]);
         $bulkWrite->insert([
             'x' => (object) ['foo' => ['foo' => 'bar']],
         ]);

--- a/tests/Operation/DropCollectionFunctionalTest.php
+++ b/tests/Operation/DropCollectionFunctionalTest.php
@@ -6,14 +6,15 @@ use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\ListCollections;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function sprintf;
+use function version_compare;
 
 class DropCollectionFunctionalTest extends FunctionalTestCase
 {
     public function testDefaultWriteConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new DropCollection(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -22,7 +23,7 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -59,8 +60,8 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new DropCollection(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -69,7 +70,7 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/DropDatabaseFunctionalTest.php
+++ b/tests/Operation/DropDatabaseFunctionalTest.php
@@ -7,14 +7,15 @@ use MongoDB\Operation\DropDatabase;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\ListDatabases;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function sprintf;
+use function version_compare;
 
 class DropDatabaseFunctionalTest extends FunctionalTestCase
 {
     public function testDefaultWriteConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new DropDatabase(
                     $this->getDatabaseName(),
                     ['writeConcern' => $this->createDefaultWriteConcern()]
@@ -22,7 +23,7 @@ class DropDatabaseFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -64,8 +65,8 @@ class DropDatabaseFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new DropDatabase(
                     $this->getDatabaseName(),
                     ['session' => $this->createSession()]
@@ -73,7 +74,7 @@ class DropDatabaseFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/DropIndexesFunctionalTest.php
+++ b/tests/Operation/DropIndexesFunctionalTest.php
@@ -2,13 +2,16 @@
 
 namespace MongoDB\Tests\Operation;
 
+use InvalidArgumentException;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\DropIndexes;
 use MongoDB\Operation\ListIndexes;
 use MongoDB\Tests\CommandObserver;
-use InvalidArgumentException;
-use stdClass;
+use function call_user_func;
+use function is_callable;
+use function sprintf;
+use function version_compare;
 
 class DropIndexesFunctionalTest extends FunctionalTestCase
 {
@@ -17,8 +20,8 @@ class DropIndexesFunctionalTest extends FunctionalTestCase
         $operation = new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => ['x' => 1]]]);
         $operation->execute($this->getPrimaryServer());
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new DropIndexes(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -28,7 +31,7 @@ class DropIndexesFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -126,8 +129,8 @@ class DropIndexesFunctionalTest extends FunctionalTestCase
         $operation = new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => ['x' => 1]]]);
         $operation->execute($this->getPrimaryServer());
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new DropIndexes(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -137,7 +140,7 @@ class DropIndexesFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/ExplainFunctionalTest.php
+++ b/tests/Operation/ExplainFunctionalTest.php
@@ -3,13 +3,12 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Driver\BulkWrite;
-use MongoDB\Collection;
 use MongoDB\Operation\Count;
 use MongoDB\Operation\CreateCollection;
-use MongoDB\Operation\Distinct;
 use MongoDB\Operation\Delete;
 use MongoDB\Operation\DeleteMany;
 use MongoDB\Operation\DeleteOne;
+use MongoDB\Operation\Distinct;
 use MongoDB\Operation\Explain;
 use MongoDB\Operation\Find;
 use MongoDB\Operation\FindAndModify;
@@ -21,7 +20,7 @@ use MongoDB\Operation\Update;
 use MongoDB\Operation\UpdateMany;
 use MongoDB\Operation\UpdateOne;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function version_compare;
 
 class ExplainFunctionalTest extends FunctionalTestCase
 {
@@ -151,7 +150,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         /* Calculate an approximate pivot to use for time assertions. We will
          * assert that the duration of blocking responses is greater than this
          * value, and vice versa. */
-        $pivot = ($maxAwaitTimeMS * 0.001) * 0.9;
+        $pivot = $maxAwaitTimeMS * 0.001 * 0.9;
 
         // Create a capped collection.
         $databaseName = $this->getDatabaseName();
@@ -169,12 +168,12 @@ class ExplainFunctionalTest extends FunctionalTestCase
 
         $operation = new Find($databaseName, $cappedCollectionName, [], ['cursorType' => Find::TAILABLE_AWAIT, 'maxAwaitTimeMS' => $maxAwaitTimeMS]);
 
-        (new CommandObserver)->observe(
-            function() use ($operation) {
+        (new CommandObserver())->observe(
+            function () use ($operation) {
                 $explainOperation = new Explain($this->getDatabaseName(), $operation, ['typeMap' => ['root' => 'array', 'document' => 'array']]);
                 $explainOperation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $command = $event['started']->getCommand();
                 $this->assertObjectNotHasAttribute('maxAwaitTimeMS', $command->explain);
                 $this->assertObjectHasAttribute('tailable', $command->explain);
@@ -194,19 +193,18 @@ class ExplainFunctionalTest extends FunctionalTestCase
             ['modifiers' => ['$orderby' => ['_id' => 1]]]
         );
 
-        (new CommandObserver)->observe(
-            function() use ($operation) {
+        (new CommandObserver())->observe(
+            function () use ($operation) {
                 $explainOperation = new Explain($this->getDatabaseName(), $operation, ['typeMap' => ['root' => 'array', 'document' => 'array']]);
                 $explainOperation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $command = $event['started']->getCommand();
                 $this->assertObjectHasAttribute('sort', $command->explain);
                 $this->assertObjectNotHasAttribute('modifiers', $command->explain);
             }
         );
     }
-
 
     /**
      * @dataProvider provideVerbosityInformation
@@ -300,8 +298,8 @@ class ExplainFunctionalTest extends FunctionalTestCase
 
         $this->createFixtures(3);
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Update(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -313,7 +311,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
                 $explainOperation = new Explain($this->getDatabaseName(), $operation);
                 $result = $explainOperation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute(
                     'bypassDocumentValidation',
                     $event['started']->getCommand()->explain
@@ -331,8 +329,8 @@ class ExplainFunctionalTest extends FunctionalTestCase
 
         $this->createFixtures(3);
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Update(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -344,7 +342,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
                 $explainOperation = new Explain($this->getDatabaseName(), $operation);
                 $result = $explainOperation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute(
                     'bypassDocumentValidation',
                     $event['started']->getCommand()->explain

--- a/tests/Operation/ExplainTest.php
+++ b/tests/Operation/ExplainTest.php
@@ -3,8 +3,6 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\Operation\Count;
-use MongoDB\Operation\Distinct;
 use MongoDB\Operation\Explain;
 use MongoDB\Operation\Explainable;
 

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -8,7 +8,7 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindAndModify;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function version_compare;
 
 class FindAndModifyFunctionalTest extends FunctionalTestCase
 {
@@ -20,8 +20,8 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         $manager = new Manager(static::getUri(), ['readConcernLevel' => 'majority']);
         $server = $manager->selectServer(new ReadPreference(ReadPreference::RP_PRIMARY));
 
-        (new CommandObserver)->observe(
-            function() use ($server) {
+        (new CommandObserver())->observe(
+            function () use ($server) {
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -30,7 +30,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($server);
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
             }
         );
@@ -38,8 +38,8 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
     public function testDefaultWriteConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -48,7 +48,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -60,8 +60,8 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -70,7 +70,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -82,8 +82,8 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -92,7 +92,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
             }
@@ -105,8 +105,8 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -115,7 +115,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -2,22 +2,22 @@
 
 namespace MongoDB\Tests\Operation;
 
+use IteratorIterator;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\ReadPreference;
-use MongoDB\Driver\WriteConcern;
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
-use Exception;
-use stdClass;
+use function microtime;
+use function version_compare;
 
 class FindFunctionalTest extends FunctionalTestCase
 {
     public function testDefaultReadConcernIsOmitted()
     {
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Find(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -27,7 +27,7 @@ class FindFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
             }
         );
@@ -35,7 +35,7 @@ class FindFunctionalTest extends FunctionalTestCase
 
     public function testHintOption()
     {
-        $bulkWrite = new BulkWrite;
+        $bulkWrite = new BulkWrite();
         $bulkWrite->insert(['_id' => 1, 'x' => 1]);
         $bulkWrite->insert(['_id' => 2, 'x' => 2]);
         $bulkWrite->insert(['_id' => 3, 'y' => 3]);
@@ -90,8 +90,8 @@ class FindFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Find(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -101,7 +101,7 @@ class FindFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -161,7 +161,7 @@ class FindFunctionalTest extends FunctionalTestCase
         /* Calculate an approximate pivot to use for time assertions. We will
          * assert that the duration of blocking responses is greater than this
          * value, and vice versa. */
-        $pivot = ($maxAwaitTimeMS * 0.001) * 0.9;
+        $pivot = $maxAwaitTimeMS * 0.001 * 0.9;
 
         // Create a capped collection.
         $databaseName = $this->getDatabaseName();
@@ -183,7 +183,7 @@ class FindFunctionalTest extends FunctionalTestCase
 
         $operation = new Find($databaseName, $cappedCollectionName, [], ['cursorType' => Find::TAILABLE_AWAIT, 'maxAwaitTimeMS' => $maxAwaitTimeMS]);
         $cursor = $operation->execute($this->getPrimaryServer());
-        $it = new \IteratorIterator($cursor);
+        $it = new IteratorIterator($cursor);
 
         /* The initial query includes the one and only document in its result
          * batch, so we should not expect a delay. */

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -130,18 +130,18 @@ class FindTest extends TestCase
 
     public function testSnapshotOptionIsDeprecated()
     {
-        $this->assertDeprecated(function() {
+        $this->assertDeprecated(function () {
             new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['snapshot' => true]);
         });
 
-        $this->assertDeprecated(function() {
+        $this->assertDeprecated(function () {
             new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['snapshot' => false]);
         });
     }
 
     public function testMaxScanOptionIsDeprecated()
     {
-        $this->assertDeprecated(function() {
+        $this->assertDeprecated(function () {
             new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['maxScan' => 1]);
         });
     }

--- a/tests/Operation/FunctionalTestCase.php
+++ b/tests/Operation/FunctionalTestCase.php
@@ -2,11 +2,8 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\Collection;
 use MongoDB\Driver\ReadConcern;
-use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Operation\DropCollection;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
@@ -35,7 +32,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
 
     protected function createDefaultReadConcern()
     {
-        return new ReadConcern;
+        return new ReadConcern();
     }
 
     protected function createDefaultWriteConcern()

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -2,15 +2,16 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
-use MongoDB\InsertManyResult;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
+use MongoDB\InsertManyResult;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function version_compare;
 
 class InsertManyFunctionalTest extends FunctionalTestCase
 {
@@ -37,12 +38,12 @@ class InsertManyFunctionalTest extends FunctionalTestCase
         $operation = new InsertMany($this->getDatabaseName(), $this->getCollectionName(), $documents);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\InsertManyResult::class, $result);
+        $this->assertInstanceOf(InsertManyResult::class, $result);
         $this->assertSame(4, $result->getInsertedCount());
 
         $insertedIds = $result->getInsertedIds();
         $this->assertSame('foo', $insertedIds[0]);
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $insertedIds[1]);
+        $this->assertInstanceOf(ObjectId::class, $insertedIds[1]);
         $this->assertSame('bar', $insertedIds[2]);
         $this->assertSame('baz', $insertedIds[3]);
 
@@ -62,8 +63,8 @@ class InsertManyFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new InsertMany(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -73,7 +74,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -85,8 +86,8 @@ class InsertManyFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new InsertMany(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -96,7 +97,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
             }
@@ -109,8 +110,8 @@ class InsertManyFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new InsertMany(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -120,7 +121,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
             }
         );
@@ -154,6 +155,6 @@ class InsertManyFunctionalTest extends FunctionalTestCase
      */
     public function testUnacknowledgedWriteConcernAccessesInsertedId(InsertManyResult $result)
     {
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $result->getInsertedIds()[0]);
+        $this->assertInstanceOf(ObjectId::class, $result->getInsertedIds()[0]);
     }
 }

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -2,15 +2,16 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
-use MongoDB\InsertOneResult;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
+use MongoDB\InsertOneResult;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function version_compare;
 
 class InsertOneFunctionalTest extends FunctionalTestCase
 {
@@ -33,7 +34,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $operation = new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\InsertOneResult::class, $result);
+        $this->assertInstanceOf(InsertOneResult::class, $result);
         $this->assertSame(1, $result->getInsertedCount());
         $this->assertSame('foo', $result->getInsertedId());
 
@@ -60,9 +61,9 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $operation = new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\InsertOneResult::class, $result);
+        $this->assertInstanceOf(InsertOneResult::class, $result);
         $this->assertSame(1, $result->getInsertedCount());
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $result->getInsertedId());
+        $this->assertInstanceOf(ObjectId::class, $result->getInsertedId());
 
         $expected = [
             ['_id' => $result->getInsertedId(), 'x' => 11],
@@ -77,8 +78,8 @@ class InsertOneFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new InsertOne(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -88,7 +89,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -100,8 +101,8 @@ class InsertOneFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new InsertOne(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -111,7 +112,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
             }
@@ -124,8 +125,8 @@ class InsertOneFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new InsertOne(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -135,7 +136,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
             }
         );
@@ -169,6 +170,6 @@ class InsertOneFunctionalTest extends FunctionalTestCase
      */
     public function testUnacknowledgedWriteConcernAccessesInsertedId(InsertOneResult $result)
     {
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $result->getInsertedId());
+        $this->assertInstanceOf(ObjectId::class, $result->getInsertedId());
     }
 }

--- a/tests/Operation/ListCollectionsFunctionalTest.php
+++ b/tests/Operation/ListCollectionsFunctionalTest.php
@@ -2,11 +2,13 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\Model\CollectionInfo;
+use MongoDB\Model\CollectionInfoIterator;
 use MongoDB\Operation\DropDatabase;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\ListCollections;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function version_compare;
 
 class ListCollectionsFunctionalTest extends FunctionalTestCase
 {
@@ -24,12 +26,12 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
         $operation = new ListCollections($this->getDatabaseName(), ['filter' => ['name' => $this->getCollectionName()]]);
         $collections = $operation->execute($server);
 
-        $this->assertInstanceOf(\MongoDB\Model\CollectionInfoIterator::class, $collections);
+        $this->assertInstanceOf(CollectionInfoIterator::class, $collections);
 
         $this->assertCount(1, $collections);
 
         foreach ($collections as $collection) {
-            $this->assertInstanceOf(\MongoDB\Model\CollectionInfo::class, $collection);
+            $this->assertInstanceOf(CollectionInfo::class, $collection);
             $this->assertEquals($this->getCollectionName(), $collection->getName());
         }
     }
@@ -49,10 +51,10 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
         $operation = new ListCollections($this->getDatabaseName(), ['filter' => ['name' => $this->getCollectionName()]]);
         $collections = $operation->execute($server);
 
-        $this->assertInstanceOf(\MongoDB\Model\CollectionInfoIterator::class, $collections);
+        $this->assertInstanceOf(CollectionInfoIterator::class, $collections);
 
         foreach ($collections as $collection) {
-            $this->assertInstanceOf(\MongoDB\Model\CollectionInfo::class, $collection);
+            $this->assertInstanceOf(CollectionInfo::class, $collection);
             $this->assertArrayHasKey('readOnly', $collection['info']);
             $this->assertEquals(['v' => 2, 'key' => ['_id' => 1], 'name' => '_id_', 'ns' => $this->getNamespace()], $collection['idIndex']);
         }
@@ -77,8 +79,8 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new ListCollections(
                     $this->getDatabaseName(),
                     ['session' => $this->createSession()]
@@ -86,7 +88,7 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/ListDatabasesFunctionalTest.php
+++ b/tests/Operation/ListDatabasesFunctionalTest.php
@@ -2,10 +2,12 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\Model\DatabaseInfo;
+use MongoDB\Model\DatabaseInfoIterator;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\ListDatabases;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function version_compare;
 
 class ListDatabasesFunctionalTest extends FunctionalTestCase
 {
@@ -20,10 +22,10 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
         $operation = new ListDatabases();
         $databases = $operation->execute($server);
 
-        $this->assertInstanceOf(\MongoDB\Model\DatabaseInfoIterator::class, $databases);
+        $this->assertInstanceOf(DatabaseInfoIterator::class, $databases);
 
         foreach ($databases as $database) {
-            $this->assertInstanceOf(\MongoDB\Model\DatabaseInfo::class, $database);
+            $this->assertInstanceOf(DatabaseInfo::class, $database);
         }
     }
 
@@ -42,12 +44,12 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
         $operation = new ListDatabases(['filter' => ['name' => $this->getDatabaseName()]]);
         $databases = $operation->execute($server);
 
-        $this->assertInstanceOf(\MongoDB\Model\DatabaseInfoIterator::class, $databases);
+        $this->assertInstanceOf(DatabaseInfoIterator::class, $databases);
 
         $this->assertCount(1, $databases);
 
         foreach ($databases as $database) {
-            $this->assertInstanceOf(\MongoDB\Model\DatabaseInfo::class, $database);
+            $this->assertInstanceOf(DatabaseInfo::class, $database);
             $this->assertEquals($this->getDatabaseName(), $database->getName());
         }
     }
@@ -58,15 +60,15 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new ListDatabases(
                     ['session' => $this->createSession()]
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/ListIndexesFunctionalTest.php
+++ b/tests/Operation/ListIndexesFunctionalTest.php
@@ -2,11 +2,13 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\Model\IndexInfo;
+use MongoDB\Model\IndexInfoIterator;
 use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\ListIndexes;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function version_compare;
 
 class ListIndexesFunctionalTest extends FunctionalTestCase
 {
@@ -22,12 +24,12 @@ class ListIndexesFunctionalTest extends FunctionalTestCase
         $operation = new ListIndexes($this->getDatabaseName(), $this->getCollectionName());
         $indexes = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\Model\IndexInfoIterator::class, $indexes);
+        $this->assertInstanceOf(IndexInfoIterator::class, $indexes);
 
         $this->assertCount(1, $indexes);
 
         foreach ($indexes as $index) {
-            $this->assertInstanceOf(\MongoDB\Model\IndexInfo::class, $index);
+            $this->assertInstanceOf(IndexInfo::class, $index);
             $this->assertEquals(['_id' => 1], $index->getKey());
         }
     }
@@ -49,8 +51,8 @@ class ListIndexesFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new ListIndexes(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -59,7 +61,7 @@ class ListIndexesFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -4,11 +4,13 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\BSON\Javascript;
 use MongoDB\Driver\BulkWrite;
+use MongoDB\MapReduceResult;
 use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\Find;
 use MongoDB\Operation\MapReduce;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use function iterator_to_array;
+use function version_compare;
 
 class MapReduceFunctionalTest extends FunctionalTestCase
 {
@@ -17,8 +19,8 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         // Collection must exist for mapReduce command
         $this->createCollection();
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new MapReduce(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -30,7 +32,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
             }
         );
@@ -41,8 +43,8 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         // Collection must exist for mapReduce command
         $this->createCollection();
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new MapReduce(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -54,7 +56,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
             }
         );
@@ -89,7 +91,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         $operation = new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\MapReduceResult::class, $result);
+        $this->assertInstanceOf(MapReduceResult::class, $result);
         $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
         $this->assertNotEmpty($result->getCounts());
     }
@@ -105,7 +107,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         $operation = new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out, ['verbose' => true]);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\MapReduceResult::class, $result);
+        $this->assertInstanceOf(MapReduceResult::class, $result);
         $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
         $this->assertNotEmpty($result->getCounts());
         $this->assertNotEmpty($result->getTiming());
@@ -122,7 +124,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         $operation = new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out, ['verbose' => false]);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\MapReduceResult::class, $result);
+        $this->assertInstanceOf(MapReduceResult::class, $result);
         $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
         $this->assertNotEmpty($result->getCounts());
         $this->assertEmpty($result->getTiming());
@@ -136,8 +138,8 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
         $this->createFixtures(3);
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new MapReduce(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -149,7 +151,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -163,8 +165,8 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
         $this->createFixtures(1);
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new MapReduce(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -176,7 +178,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
             }
@@ -191,8 +193,8 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
         $this->createFixtures(1);
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new MapReduce(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -204,7 +206,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
             }
         );

--- a/tests/Operation/MapReduceTest.php
+++ b/tests/Operation/MapReduceTest.php
@@ -109,6 +109,6 @@ class MapReduceTest extends TestCase
 
     private function getInvalidJavascriptValues()
     {
-        return [123, 3.14, 'foo', true, [], new stdClass, new ObjectId];
+        return [123, 3.14, 'foo', true, [], new stdClass(), new ObjectId()];
     }
 }

--- a/tests/Operation/ModifyCollectionFunctionalTest.php
+++ b/tests/Operation/ModifyCollectionFunctionalTest.php
@@ -2,8 +2,9 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\Operation\ModifyCollection;
 use MongoDB\Operation\CreateIndexes;
+use MongoDB\Operation\ModifyCollection;
+use function array_key_exists;
 
 class ModifyCollectionFunctionalTest extends FunctionalTestCase
 {

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -2,15 +2,16 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
-use MongoDB\UpdateResult;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Operation\Update;
 use MongoDB\Tests\CommandObserver;
-use stdClass;
+use MongoDB\UpdateResult;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use function version_compare;
 
 class UpdateFunctionalTest extends FunctionalTestCase
 {
@@ -31,8 +32,8 @@ class UpdateFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('Sessions are not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Update(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -43,7 +44,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
             }
         );
@@ -55,8 +56,8 @@ class UpdateFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Update(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -67,7 +68,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
             }
@@ -80,8 +81,8 @@ class UpdateFunctionalTest extends FunctionalTestCase
             $this->markTestSkipped('bypassDocumentValidation is not supported');
         }
 
-        (new CommandObserver)->observe(
-            function() {
+        (new CommandObserver())->observe(
+            function () {
                 $operation = new Update(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
@@ -92,7 +93,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
                 $operation->execute($this->getPrimaryServer());
             },
-            function(array $event) {
+            function (array $event) {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
             }
         );
@@ -108,7 +109,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $operation = new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, $update);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\UpdateResult::class, $result);
+        $this->assertInstanceOf(UpdateResult::class, $result);
         $this->assertSame(1, $result->getMatchedCount());
         $this->assertSame(1, $result->getModifiedCount());
         $this->assertSame(0, $result->getUpsertedCount());
@@ -134,7 +135,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $operation = new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, $update, $options);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\UpdateResult::class, $result);
+        $this->assertInstanceOf(UpdateResult::class, $result);
         $this->assertSame(2, $result->getMatchedCount());
         $this->assertSame(2, $result->getModifiedCount());
         $this->assertSame(0, $result->getUpsertedCount());
@@ -160,7 +161,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $operation = new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, $update, $options);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\UpdateResult::class, $result);
+        $this->assertInstanceOf(UpdateResult::class, $result);
         $this->assertSame(0, $result->getMatchedCount());
         $this->assertSame(0, $result->getModifiedCount());
         $this->assertSame(1, $result->getUpsertedCount());
@@ -187,11 +188,11 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $operation = new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, $update, $options);
         $result = $operation->execute($this->getPrimaryServer());
 
-        $this->assertInstanceOf(\MongoDB\UpdateResult::class, $result);
+        $this->assertInstanceOf(UpdateResult::class, $result);
         $this->assertSame(0, $result->getMatchedCount());
         $this->assertSame(0, $result->getModifiedCount());
         $this->assertSame(1, $result->getUpsertedCount());
-        $this->assertInstanceOf(\MongoDB\BSON\ObjectId::class, $result->getUpsertedId());
+        $this->assertInstanceOf(ObjectId::class, $result->getUpsertedId());
 
         $expected = [
             ['_id' => 1, 'x' => 11],

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -89,6 +89,6 @@ class WatchTest extends FunctionalTestCase
 
     private function getInvalidTimestampValues()
     {
-        return [123, 3.14, 'foo', true, [], new stdClass];
+        return [123, 3.14, 'foo', true, [], new stdClass()];
     }
 }

--- a/tests/PedantryTest.php
+++ b/tests/PedantryTest.php
@@ -7,6 +7,15 @@ use RecursiveIteratorIterator;
 use ReflectionClass;
 use ReflectionMethod;
 use RegexIterator;
+use function array_filter;
+use function array_map;
+use function realpath;
+use function str_replace;
+use function strcasecmp;
+use function strlen;
+use function substr;
+use function usort;
+use const DIRECTORY_SEPARATOR;
 
 /**
  * Pedantic tests that have nothing to do with functional correctness.
@@ -23,12 +32,12 @@ class PedantryTest extends TestCase
 
         $methods = array_filter(
             $methods,
-            function(ReflectionMethod $method) use ($class) {
+            function (ReflectionMethod $method) use ($class) {
                 return $method->getDeclaringClass() == $class;
             }
         );
 
-        $getSortValue = function(ReflectionMethod $method) {
+        $getSortValue = function (ReflectionMethod $method) {
             if ($method->getModifiers() & ReflectionMethod::IS_PRIVATE) {
                 return '2' . $method->getName();
             }
@@ -43,13 +52,17 @@ class PedantryTest extends TestCase
         $sortedMethods = $methods;
         usort(
             $sortedMethods,
-            function(ReflectionMethod $a, ReflectionMethod $b) use ($getSortValue) {
+            function (ReflectionMethod $a, ReflectionMethod $b) use ($getSortValue) {
                 return strcasecmp($getSortValue($a), $getSortValue($b));
             }
         );
 
-        $methods = array_map(function(ReflectionMethod $method) { return $method->getName(); }, $methods);
-        $sortedMethods = array_map(function(ReflectionMethod $method) { return $method->getName(); }, $sortedMethods);
+        $methods = array_map(function (ReflectionMethod $method) {
+            return $method->getName();
+        }, $methods);
+        $sortedMethods = array_map(function (ReflectionMethod $method) {
+            return $method->getName();
+        }, $sortedMethods);
 
         $this->assertEquals($sortedMethods, $methods);
     }

--- a/tests/SpecTests/ChangeStreamsSpecTest.php
+++ b/tests/SpecTests/ChangeStreamsSpecTest.php
@@ -2,14 +2,17 @@
 
 namespace MongoDB\Tests\SpecTests;
 
-use MongoDB\ChangeStream;
-use MongoDB\Client;
-use MongoDB\Driver\Exception\Exception;
-use MongoDB\Model\BSONDocument;
 use ArrayIterator;
 use LogicException;
+use MongoDB\ChangeStream;
+use MongoDB\Driver\Exception\Exception;
+use MongoDB\Model\BSONDocument;
 use MultipleIterator;
 use stdClass;
+use function basename;
+use function count;
+use function file_get_contents;
+use function glob;
 
 /**
  * Change Streams spec tests.
@@ -18,9 +21,7 @@ use stdClass;
  */
 class ChangeStreamsSpecTest extends FunctionalTestCase
 {
-    private static $incompleteTests = [
-        'change-streams-errors: Change Stream should error when _id is projected out' => 'PHPC-1419',
-    ];
+    private static $incompleteTests = ['change-streams-errors: Change Stream should error when _id is projected out' => 'PHPC-1419'];
 
     /**
      * Assert that the expected and actual command documents match.
@@ -76,7 +77,7 @@ class ChangeStreamsSpecTest extends FunctionalTestCase
 
         $this->checkServerRequirements($this->createRunOn($test));
 
-        if (!isset($databaseName, $collectionName, $database2Name, $collection2Name)) {
+        if (! isset($databaseName, $collectionName, $database2Name, $collection2Name)) {
             $this->fail('Required database and collection names are unset');
         }
 
@@ -179,13 +180,10 @@ class ChangeStreamsSpecTest extends FunctionalTestCase
         switch ($test->target) {
             case 'client':
                 return $context->client->watch($pipeline, $options);
-
             case 'database':
                 return $context->getDatabase()->watch($pipeline, $options);
-
             case 'collection':
                 return $context->getCollection()->watch($pipeline, $options);
-
             default:
                 throw new LogicException('Unsupported target: ' . $test->target);
         }
@@ -200,7 +198,7 @@ class ChangeStreamsSpecTest extends FunctionalTestCase
      */
     private function createRunOn(stdClass $test)
     {
-        $req = new stdClass;
+        $req = new stdClass();
 
         /* Append ".99" as patch version, since command monitoring tests expect
          * the minor version to be an inclusive upper bound. */
@@ -254,7 +252,7 @@ class ChangeStreamsSpecTest extends FunctionalTestCase
         $events = [];
 
         for ($i = 0, $changeStream->rewind(); $i < $maxIterations; $i++, $changeStream->next()) {
-            if ( ! $changeStream->valid()) {
+            if (! $changeStream->valid()) {
                 continue;
             }
 

--- a/tests/SpecTests/CommandExpectations.php
+++ b/tests/SpecTests/CommandExpectations.php
@@ -2,14 +2,17 @@
 
 namespace MongoDB\Tests\SpecTests;
 
-use MongoDB\Driver\Monitoring\CommandFailedEvent;
-use MongoDB\Driver\Monitoring\CommandStartedEvent;
-use MongoDB\Driver\Monitoring\CommandSucceededEvent;
-use MongoDB\Driver\Monitoring\CommandSubscriber;
 use ArrayIterator;
 use LogicException;
+use MongoDB\Driver\Monitoring\CommandFailedEvent;
+use MongoDB\Driver\Monitoring\CommandStartedEvent;
+use MongoDB\Driver\Monitoring\CommandSubscriber;
+use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 use MultipleIterator;
-use stdClass;
+use function count;
+use function key;
+use function MongoDB\Driver\Monitoring\addSubscriber;
+use function MongoDB\Driver\Monitoring\removeSubscriber;
 
 /**
  * Spec test CommandStartedEvent expectations.
@@ -131,7 +134,7 @@ class CommandExpectations implements CommandSubscriber
      */
     public function startMonitoring()
     {
-        \MongoDB\Driver\Monitoring\addSubscriber($this);
+        addSubscriber($this);
     }
 
     /**
@@ -139,7 +142,7 @@ class CommandExpectations implements CommandSubscriber
      */
     public function stopMonitoring()
     {
-        \MongoDB\Driver\Monitoring\removeSubscriber($this);
+        removeSubscriber($this);
     }
 
     /**

--- a/tests/SpecTests/CommandMonitoringSpecTest.php
+++ b/tests/SpecTests/CommandMonitoringSpecTest.php
@@ -3,6 +3,12 @@
 namespace MongoDB\Tests\SpecTests;
 
 use stdClass;
+use function array_diff;
+use function basename;
+use function file_get_contents;
+use function glob;
+use function is_array;
+use function is_numeric;
 
 /**
  * Command monitoring spec tests.
@@ -130,10 +136,10 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
      * Execute an individual test case from the specification.
      *
      * @dataProvider provideTests
-     * @param stdClass  $test           Individual "tests[]" document
-     * @param array     $data           Top-level "data" array to initialize collection
-     * @param string    $databaseName   Name of database under test
-     * @param string    $collectionName Name of collection under test
+     * @param stdClass $test           Individual "tests[]" document
+     * @param array    $data           Top-level "data" array to initialize collection
+     * @param string   $databaseName   Name of database under test
+     * @param string   $collectionName Name of collection under test
      */
     public function testCommandMonitoring(stdClass $test, array $data, $databaseName = null, $collectionName = null)
     {
@@ -190,12 +196,12 @@ class CommandMonitoringSpecTest extends FunctionalTestCase
      */
     private function createRunOn(stdClass $test)
     {
-        $req = new stdClass;
+        $req = new stdClass();
 
         $topologies = [
             self::TOPOLOGY_SINGLE,
             self::TOPOLOGY_REPLICASET,
-            self::TOPOLOGY_SHARDED
+            self::TOPOLOGY_SHARDED,
         ];
 
         /* Append ".99" as patch version, since command monitoring tests expect

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -2,12 +2,16 @@
 
 namespace MongoDB\Tests\SpecTests;
 
+use LogicException;
 use MongoDB\Client;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
-use LogicException;
 use stdClass;
+use function array_diff_key;
+use function array_keys;
+use function implode;
+use function mt_rand;
 
 /**
  * Execution context for spec tests.
@@ -153,22 +157,22 @@ final class Context
      */
     public function prepareOptions(array $options)
     {
-        if (isset($options['readConcern']) && !($options['readConcern'] instanceof ReadConcern)) {
+        if (isset($options['readConcern']) && ! ($options['readConcern'] instanceof ReadConcern)) {
             $readConcern = (array) $options['readConcern'];
             $diff = array_diff_key($readConcern, ['level' => 1]);
 
-            if (!empty($diff)) {
+            if (! empty($diff)) {
                 throw new LogicException('Unsupported readConcern args: ' . implode(',', array_keys($diff)));
             }
 
             $options['readConcern'] = new ReadConcern($readConcern['level']);
         }
 
-        if (isset($options['readPreference']) && !($options['readPreference'] instanceof ReadPreference)) {
+        if (isset($options['readPreference']) && ! ($options['readPreference'] instanceof ReadPreference)) {
             $readPreference = (array) $options['readPreference'];
             $diff = array_diff_key($readPreference, ['mode' => 1]);
 
-            if (!empty($diff)) {
+            if (! empty($diff)) {
                 throw new LogicException('Unsupported readPreference args: ' . implode(',', array_keys($diff)));
             }
 
@@ -179,7 +183,7 @@ final class Context
             $writeConcern = (array) $options['writeConcern'];
             $diff = array_diff_key($writeConcern, ['w' => 1, 'wtimeout' => 1, 'j' => 1]);
 
-            if (!empty($diff)) {
+            if (! empty($diff)) {
                 throw new LogicException('Unsupported writeConcern args: ' . implode(',', array_keys($diff)));
             }
 
@@ -205,7 +209,7 @@ final class Context
      */
     public function replaceArgumentSessionPlaceholder(array &$args)
     {
-        if (!isset($args['session'])) {
+        if (! isset($args['session'])) {
             return;
         }
 
@@ -233,7 +237,7 @@ final class Context
      */
     public function replaceCommandSessionPlaceholder(stdClass $command)
     {
-        if (!isset($command->lsid)) {
+        if (! isset($command->lsid)) {
             return;
         }
 

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -85,7 +85,7 @@ final class Context
 
         // TODO: Remove this once retryWrites=true by default (see: PHPC-1324)
         $clientOptions['retryWrites'] = true;
-        
+
         if (isset($test->outcome->collection->name)) {
             $o->outcomeCollectionName = $test->outcome->collection->name;
         }
@@ -175,7 +175,7 @@ final class Context
             $options['readPreference'] = new ReadPreference($readPreference['mode']);
         }
 
-        if (isset($options['writeConcern']) && !($options['writeConcern'] instanceof writeConcern)) {
+        if (isset($options['writeConcern']) && ! ($options['writeConcern'] instanceof WriteConcern)) {
             $writeConcern = (array) $options['writeConcern'];
             $diff = array_diff_key($writeConcern, ['w' => 1, 'wtimeout' => 1, 'j' => 1]);
 

--- a/tests/SpecTests/CrudSpecTest.php
+++ b/tests/SpecTests/CrudSpecTest.php
@@ -3,6 +3,9 @@
 namespace MongoDB\Tests\SpecTests;
 
 use stdClass;
+use function basename;
+use function file_get_contents;
+use function glob;
 
 /**
  * Crud spec tests.

--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -2,16 +2,23 @@
 
 namespace MongoDB\Tests\SpecTests;
 
+use ArrayObject;
+use InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use PHPUnit\Framework\Constraint\Constraint;
-use ArrayObject;
-use InvalidArgumentException;
 use RuntimeException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory;
 use stdClass;
 use Symfony\Bridge\PhpUnit\ConstraintTrait;
+use function array_values;
+use function get_class;
+use function in_array;
+use function is_array;
+use function is_object;
+use function is_scalar;
+use function sprintf;
 
 /**
  * Constraint that checks if one document matches another.
@@ -88,7 +95,7 @@ class DocumentsMatchConstraint extends Constraint
             return $success;
         }
 
-        if (!$success) {
+        if (! $success) {
             $this->fail($other, $description, $this->lastFailure);
         }
     }
@@ -115,7 +122,7 @@ class DocumentsMatchConstraint extends Constraint
         foreach ($expected as $key => $expectedValue) {
             $actualHasKey = $actual->offsetExists($key);
 
-            if (!$actualHasKey) {
+            if (! $actualHasKey) {
                 throw new RuntimeException(sprintf('$actual is missing key: "%s"', $keyPrefix . $key));
             }
 
@@ -154,7 +161,7 @@ class DocumentsMatchConstraint extends Constraint
                     '',
                     '',
                     false,
-                    \sprintf(
+                    sprintf(
                         'Field path "%s": %s is not instance of expected class "%s".',
                         $keyPrefix . $key,
                         $this->exporter()->shortenedExport($actualValue),
@@ -182,7 +189,7 @@ class DocumentsMatchConstraint extends Constraint
         }
 
         foreach ($actual as $key => $value) {
-            if (!$expected->offsetExists($key)) {
+            if (! $expected->offsetExists($key)) {
                 throw new RuntimeException(sprintf('$actual has extra key: "%s"', $keyPrefix . $key));
             }
         }
@@ -242,7 +249,7 @@ class DocumentsMatchConstraint extends Constraint
      */
     private function prepareBSON($bson, $isRoot, $sortKeys = false)
     {
-        if ( ! is_array($bson) && ! is_object($bson)) {
+        if (! is_array($bson) && ! is_object($bson)) {
             throw new InvalidArgumentException('$bson is not an array or object');
         }
 
@@ -251,11 +258,11 @@ class DocumentsMatchConstraint extends Constraint
         }
 
         if ($bson instanceof BSONArray || (is_array($bson) && $bson === array_values($bson))) {
-            if ( ! $bson instanceof BSONArray) {
+            if (! $bson instanceof BSONArray) {
                 $bson = new BSONArray($bson);
             }
         } else {
-            if ( ! $bson instanceof BSONDocument) {
+            if (! $bson instanceof BSONDocument) {
                 $bson = new BSONDocument((array) $bson);
             }
 

--- a/tests/SpecTests/DocumentsMatchConstraintTest.php
+++ b/tests/SpecTests/DocumentsMatchConstraintTest.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Tests\SpecTests;
 
-use ArrayObject;
 use MongoDB\Model\BSONArray;
 use MongoDB\Tests\TestCase;
 use PHPUnit\Framework\ExpectationFailedException;

--- a/tests/SpecTests/ErrorExpectation.php
+++ b/tests/SpecTests/ErrorExpectation.php
@@ -139,7 +139,7 @@ final class ErrorExpectation
             $this->assertCodeName($test, $actual);
         }
 
-        if (!empty($this->excludedLabels) or !empty($this->includedLabels)) {
+        if (! empty($this->excludedLabels) || ! empty($this->includedLabels)) {
             $test->assertInstanceOf(RuntimeException::class, $actual);
 
             foreach ($this->excludedLabels as $label) {

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -2,23 +2,23 @@
 
 namespace MongoDB\Tests\SpecTests;
 
-use MongoDB\Client;
-use MongoDB\Collection;
-use MongoDB\Driver\Server;
-use MongoDB\Driver\WriteConcern;
-use MongoDB\Driver\Exception\BulkWriteException;
-use MongoDB\Driver\Exception\RuntimeException;
-use MongoDB\Operation\FindOneAndReplace;
-use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
-use MongoDB\Tests\TestCase;
-use PHPUnit\Framework\SkippedTest;
 use ArrayIterator;
 use IteratorIterator;
 use LogicException;
+use MongoDB\Collection;
+use MongoDB\Driver\Server;
+use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
 use MultipleIterator;
+use PHPUnit\Framework\SkippedTest;
 use stdClass;
 use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use UnexpectedValueException;
+use function in_array;
+use function json_encode;
+use function MongoDB\BSON\fromJSON;
+use function MongoDB\BSON\toPHP;
+use function sprintf;
+use function version_compare;
 
 /**
  * Base class for spec test runners.
@@ -60,7 +60,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      */
     public static function assertCommandMatches(stdClass $expected, stdClass $actual)
     {
-        throw new LogicException(sprintf('%s does not assert CommandStartedEvents', get_called_class()));
+        throw new LogicException(sprintf('%s does not assert CommandStartedEvents', static::class));
     }
 
     /**
@@ -74,7 +74,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      */
     public static function assertCommandReplyMatches(stdClass $expected, stdClass $actual)
     {
-        throw new LogicException(sprintf('%s does not assert CommandSucceededEvents', get_called_class()));
+        throw new LogicException(sprintf('%s does not assert CommandSucceededEvents', static::class));
     }
 
     /**
@@ -150,7 +150,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      */
     protected function decodeJson($json)
     {
-        return \MongoDB\BSON\toPHP(\MongoDB\BSON\fromJSON($json));
+        return toPHP(fromJSON($json));
     }
 
     /**
@@ -161,7 +161,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      */
     protected function getContext()
     {
-        if (!$this->context instanceof Context) {
+        if (! $this->context instanceof Context) {
             throw new LogicException('Context has not been set');
         }
 

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -179,8 +179,7 @@ final class Operation
     /**
      * Executes the operation with a given context.
      *
-     * @param FunctionalTestCase $test    Test instance
-     * @param Context            $context Execution context
+     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the operation is unsupported
      */

--- a/tests/SpecTests/ResultExpectation.php
+++ b/tests/SpecTests/ResultExpectation.php
@@ -2,16 +2,20 @@
 
 namespace MongoDB\Tests\SpecTests;
 
+use LogicException;
 use MongoDB\BulkWriteResult;
 use MongoDB\DeleteResult;
-use MongoDB\InsertManyResult;
-use MongoDB\InsertOneResult;
-use MongoDB\UpdateResult;
 use MongoDB\Driver\WriteResult;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\InsertManyResult;
+use MongoDB\InsertOneResult;
 use MongoDB\Tests\TestCase;
-use LogicException;
+use MongoDB\UpdateResult;
 use stdClass;
+use function call_user_func;
+use function is_array;
+use function is_object;
+use function property_exists;
 
 /**
  * Spec test operation result expectation.
@@ -43,13 +47,13 @@ final class ResultExpectation
             case self::ASSERT_INSERTMANY:
             case self::ASSERT_INSERTONE:
             case self::ASSERT_UPDATE:
-                if (!is_object($expectedValue)) {
+                if (! is_object($expectedValue)) {
                     throw InvalidArgumentException::invalidType('$expectedValue', $expectedValue, 'object');
                 }
                 break;
 
             case self::ASSERT_SAME_DOCUMENTS:
-                if (!self::isArrayOfObjects($expectedValue)) {
+                if (! self::isArrayOfObjects($expectedValue)) {
                     throw InvalidArgumentException::invalidType('$expectedValue', $expectedValue, 'object[]');
                 }
                 break;
@@ -61,7 +65,7 @@ final class ResultExpectation
 
     public static function fromChangeStreams(stdClass $result, callable $assertionCallable)
     {
-        if (!property_exists($result, 'success')) {
+        if (! property_exists($result, 'success')) {
             return new self(self::ASSERT_NOTHING, null);
         }
 
@@ -74,7 +78,7 @@ final class ResultExpectation
 
     public static function fromCrud(stdClass $operation, $defaultAssertionType)
     {
-        if (property_exists($operation, 'result') && !self::isErrorResult($operation->result)) {
+        if (property_exists($operation, 'result') && ! self::isErrorResult($operation->result)) {
             $assertionType = $operation->result === null ? self::ASSERT_NULL : $defaultAssertionType;
             $expectedValue = $operation->result;
         } else {
@@ -100,7 +104,7 @@ final class ResultExpectation
 
     public static function fromTransactions(stdClass $operation, $defaultAssertionType)
     {
-        if (property_exists($operation, 'result') && !self::isErrorResult($operation->result)) {
+        if (property_exists($operation, 'result') && ! self::isErrorResult($operation->result)) {
             $assertionType = $operation->result === null ? self::ASSERT_NULL : $defaultAssertionType;
             $expectedValue = $operation->result;
         } else {
@@ -132,7 +136,7 @@ final class ResultExpectation
                     $test->isInstanceOf(WriteResult::class)
                 ));
 
-                if (!$actual->isAcknowledged()) {
+                if (! $actual->isAcknowledged()) {
                     break;
                 }
 
@@ -283,12 +287,12 @@ final class ResultExpectation
 
     private static function isArrayOfObjects($array)
     {
-        if (!is_array($array)) {
+        if (! is_array($array)) {
             return false;
         }
 
         foreach ($array as $object) {
-            if (!is_object($object)) {
+            if (! is_object($object)) {
                 return false;
             }
         }
@@ -305,7 +309,7 @@ final class ResultExpectation
      */
     private static function isErrorResult($result)
     {
-        if (!is_object($result)) {
+        if (! is_object($result)) {
             return false;
         }
 

--- a/tests/SpecTests/RetryableWritesSpecTest.php
+++ b/tests/SpecTests/RetryableWritesSpecTest.php
@@ -2,9 +2,11 @@
 
 namespace MongoDB\Tests\SpecTests;
 
-use LogicException;
 use MongoDB\Driver\Manager;
 use stdClass;
+use function basename;
+use function file_get_contents;
+use function glob;
 
 /**
  * Retryable writes spec tests.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,14 +10,14 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     throw new Exception('Can\'t find autoload.php. Did you install dependencies with Composer?');
 }
 
-if ( ! class_exists(PHPUnit\Framework\Error\Warning::class)) {
+if (! class_exists(PHPUnit\Framework\Error\Warning::class)) {
     class_alias(PHPUnit_Framework_Error_Warning::class, PHPUnit\Framework\Error\Warning::class);
 }
 
-if ( ! class_exists(PHPUnit\Framework\Constraint\Constraint::class)) {
+if (! class_exists(PHPUnit\Framework\Constraint\Constraint::class)) {
     class_alias(PHPUnit_Framework_Constraint::class, PHPUnit\Framework\Constraint\Constraint::class);
 }
 
-if ( ! class_exists(PHPUnit\Framework\ExpectationFailedException::class)) {
+if (! class_exists(PHPUnit\Framework\ExpectationFailedException::class)) {
     class_alias(PHPUnit_Framework_ExpectationFailedException::class, PHPUnit\Framework\ExpectationFailedException::class);
 }


### PR DESCRIPTION
This introduces a coding standard that is automatically checked during the build using phpcs. The coding standard itself is derived from doctrine/coding-standard. I've tried to keep :
* All sniffs that would produce code incompatible with PHP 5.6 are excluded (strict typing, null coalesce operator, class constant visibilities, and most notably type hints)
* All sniffs that cause BC breaks are excluded (again, mostly type hints as well as class naming sniffs)
* Sniffs that would cause functional changes are excluded, amongst other:
  * Using known aliases of common PHP functions (e.g. `sizeof` instead of `count`)
  * Unused private elements: side effects of this have to be carefully reviewed
  * Yoda comparisons
  * Reducing code nesting in favour of early exit
  * Useless if conditions instead of returning directly
  * Static closures
  * Unused variables in closures
  * Using the equal operator
* A follow-up pull request will add type hints to all properties in classes. This was extracted from this pull request to keep the diffs manageable.

This PR was designed to not really have to be reviewed. Most fixes were applied automatically (see last commit), with only some changes done manually.

Note: I've made a point of disabling some sniffs in `DocumentationExamplesTest`. This was done to keep the examples "portable" and allow people to simply copy/paste them to their code, e.g. by preserving fully qualified namespaces.