### PR TITLE
Update to latest ext-mongodb and MongoDB server versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 
 env:
   global:
-    - DRIVER_VERSION=1.6.0alpha2
+    - DRIVER_VERSION=1.6.0alpha3
     - SERVER_DISTRO=ubuntu1604
     - SERVER_VERSION=4.0.10
     - DEPLOYMENT=STANDALONE

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   global:
     - DRIVER_VERSION=1.6.0alpha3
     - SERVER_DISTRO=ubuntu1604
-    - SERVER_VERSION=4.0.10
+    - SERVER_VERSION=4.2.0
     - DEPLOYMENT=STANDALONE
     - COMPOSER_OPTIONS=
 
@@ -44,7 +44,7 @@ jobs:
       env:
         - COMPOSER_OPTIONS=--prefer-lowest
 
-      # Test older standalone server versions (3.0-3.6)
+      # Test older standalone server versions (3.0-4.0)
     - stage: Test
       php: "7.0"
       dist: trusty
@@ -66,6 +66,10 @@ jobs:
       php: "7.0"
       env:
         - SERVER_VERSION=3.6.13
+    - stage: Test
+      php: "7.3"
+      env:
+        - SERVER_VERSION=4.0.12
 
     # Test other server configurations
     - stage: Test
@@ -93,13 +97,6 @@ jobs:
       php: "7.3"
       env:
         - DEPLOYMENT=SHARDED_CLUSTER_RS
-
-    # Test upcoming server versions
-    - stage: Test
-      php: "7.3"
-      env:
-        - SERVER_VERSION=4.2.0-rc1
-        - DEPLOYMENT=REPLICASET
 
 before_install:
   - pip install "mongo-orchestration>=0.6.7,<1.0" --user `whoami`

--- a/.travis/setup_mo.sh
+++ b/.travis/setup_mo.sh
@@ -9,7 +9,7 @@ fi
 case $DEPLOYMENT in
   SHARDED_CLUSTER)
     ${TRAVIS_BUILD_DIR}/.travis/mo.sh ${TRAVIS_BUILD_DIR}/mongo-orchestration/sharded_clusters/cluster.json start > /tmp/mo-result.json
-    cat /tmp/mo-result.json | tail -n 1 | php -r 'echo json_decode(file_get_contents("php://stdin"))->mongodb_uri;' > /tmp/uri.txt
+    cat /tmp/mo-result.json | tail -n 1 | php -r 'echo json_decode(file_get_contents("php://stdin"))->mongodb_uri, "/?retryWrites=false";' > /tmp/uri.txt
     ;;
   SHARDED_CLUSTER_RS)
     ${TRAVIS_BUILD_DIR}/.travis/mo.sh ${TRAVIS_BUILD_DIR}/mongo-orchestration/sharded_clusters/cluster_replset.json start > /tmp/mo-result.json

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -9,6 +9,7 @@ use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedException;
 use MongoDB\Operation\Count;
 use MongoDB\Operation\MapReduce;
 use MongoDB\Tests\CommandObserver;
@@ -619,8 +620,6 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
     /**
      * @dataProvider collectionWriteMethodClosures
-     * @expectedException MongoDB\Exception\UnsupportedException
-     * @expectedExceptionMessage "writeConcern" option cannot be specified within a transaction
      */
     public function testMethodInTransactionWithWriteConcernOption($method)
     {
@@ -631,6 +630,9 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $session = $this->manager->startSession();
         $session->startTransaction();
 
+        $this->expectException(UnsupportedException::class);
+        $this->expectExceptionMessage('"writeConcern" option cannot be specified within a transaction');
+
         try {
             call_user_func($method, $this->collection, $session, ['writeConcern' => new WriteConcern(1)]);
         } finally {
@@ -640,8 +642,6 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
     /**
      * @dataProvider collectionReadMethodClosures
-     * @expectedException MongoDB\Exception\UnsupportedException
-     * @expectedExceptionMessage "readConcern" option cannot be specified within a transaction
      */
     public function testMethodInTransactionWithReadConcernOption($method)
     {
@@ -651,6 +651,9 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
         $session = $this->manager->startSession();
         $session->startTransaction();
+
+        $this->expectException(UnsupportedException::class);
+        $this->expectExceptionMessage('"readConcern" option cannot be specified within a transaction');
 
         try {
             call_user_func($method, $this->collection, $session, ['readConcern' => new ReadConcern(ReadConcern::LOCAL)]);

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -94,10 +94,10 @@ abstract class FunctionalTestCase extends TestCase
             $parts[] = $urlParts['path'];
         }
         if (isset($urlParts['query'])) {
-            $parts += [
+            $parts = array_merge($parts, [
                 '?',
-                $urlParts['path']
-            ];
+                $urlParts['query']
+            ]);
         }
 
         return implode('', $parts);

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -217,7 +217,17 @@ class AggregateFunctionalTest extends FunctionalTestCase
                 $results = iterator_to_array($operation->execute($this->getPrimaryServer()));
 
                 $this->assertCount(1, $results);
-                $this->assertObjectHasAttribute('stages', current($results));
+                $result = current($results);
+
+                if ($this->isShardedCluster()) {
+                    $this->assertObjectHasAttribute('shards', $result);
+
+                    foreach ($result->shards as $shard) {
+                        $this->assertObjectHasAttribute('stages', $shard);
+                    }
+                } else {
+                    $this->assertObjectHasAttribute('stages', $result);
+                }
             },
             function(array $event) {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -28,6 +28,7 @@ class WatchFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    const INTERRUPTED = 11601;
     const NOT_MASTER = 10107;
 
     private static $wireVersionForStartAtOperationTime = 7;
@@ -1295,7 +1296,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->configureFailPoint([
             'configureFailPoint' => 'failCommand',
             'mode' => ['times' => 1],
-            'data' => ['failCommands' => ['aggregate'], 'errorCode' => self::NOT_MASTER],
+            'data' => ['failCommands' => ['aggregate'], 'errorCode' => self::INTERRUPTED],
         ]);
 
         $this->expectException(CommandException::class);

--- a/tests/SpecTests/ChangeStreamsSpecTest.php
+++ b/tests/SpecTests/ChangeStreamsSpecTest.php
@@ -18,6 +18,10 @@ use stdClass;
  */
 class ChangeStreamsSpecTest extends FunctionalTestCase
 {
+    private static $incompleteTests = [
+        'change-streams-errors: Change Stream should error when _id is projected out' => 'PHPC-1419',
+    ];
+
     /**
      * Assert that the expected and actual command documents match.
      *
@@ -66,6 +70,10 @@ class ChangeStreamsSpecTest extends FunctionalTestCase
      */
     public function testChangeStreams(stdClass $test, $databaseName = null, $collectionName = null, $database2Name = null, $collection2Name = null)
     {
+        if (isset(self::$incompleteTests[$this->dataDescription()])) {
+            $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);
+        }
+
         $this->checkServerRequirements($this->createRunOn($test));
 
         if (!isset($databaseName, $collectionName, $database2Name, $collection2Name)) {

--- a/tests/SpecTests/ErrorExpectation.php
+++ b/tests/SpecTests/ErrorExpectation.php
@@ -132,7 +132,7 @@ final class ErrorExpectation
         $test->assertNotNull($actual);
 
         if (isset($this->messageContains)) {
-            $test->assertContains($this->messageContains, $actual->getMessage(), '', true /* case-insensitive */);
+            $test->assertStringContainsStringIgnoringCase($this->messageContains, $actual->getMessage());
         }
 
         if (isset($this->codeName)) {
@@ -178,7 +178,7 @@ final class ErrorExpectation
         $test->assertInstanceOf(CommandException::class, $actual);
         $result = $actual->getResultDocument();
         $test->assertObjectHasAttribute('codeName', $result);
-        $test->assertAttributeSame($this->codeName, 'codeName', $result);
+        $test->assertSame($this->codeName, $result->codeName);
     }
 
     private static function isArrayOfStrings($array)


### PR DESCRIPTION
This pulls in alpha3 of the driver for travis-ci builds and updates the build pipeline to test against MongoDB 4.2.0 by default. MongoDB 4.0.12 is still tested as part of the "older server versions" sections in travis-ci.

This PR also fixes some leftover warnings from the PHPUnit upgrade that was done in #665.