### PR TITLE
PHPLIB-330: Add property type hints

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,8 +19,6 @@
         <!-- Exclude sniffs that require newer PHP versions -->
         <!-- Available with PHP 7.0 -->
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes" />
-        <!-- In addition to requiring PHP 7.0, this sniff will cause a significant amount of BC breaks. Proceed with caution! -->
-        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration" />
         <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly" />
         <exclude name="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" />
 
@@ -61,7 +59,6 @@
 
         <!-- These sniffs cause a large diff, so enable them in separate steps -->
         <exclude name="SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectAnnotationsGroup" />
-        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment" />
         <exclude name="Squiz.Strings.DoubleQuoteUsage" />
 
         <!-- Sniff currently breaks, see https://github.com/slevomat/coding-standard/issues/727 -->
@@ -87,6 +84,24 @@
             <property phpcs-only="true" name="allowFullyQualifiedNameForCollidingConstants" value="false"/>
             <property phpcs-only="true" name="allowFullyQualifiedNameForCollidingFunctions" value="false"/>
             <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- Only enable some checks regarding type hints -->
+    <!-- In addition to requiring PHP 7.0, this sniff will cause a significant amount of BC breaks. Proceed with caution! -->
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+        <!-- Traversable type hints often end up as mixed[], so we skip them for now -->
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification" />
+
+        <!-- Will cause BC breaks to method signatures - disabled for now -->
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint" />
+
+        <properties>
+            <property name="enableObjectTypeHint" value="true" />
+            <property name="enableEachParameterAndReturnInspection" value="false" />
         </properties>
     </rule>
 

--- a/src/BulkWriteResult.php
+++ b/src/BulkWriteResult.php
@@ -25,8 +25,13 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class BulkWriteResult
 {
+    /** @var WriteResult */
     private $writeResult;
+
+    /** @var mixed[] */
     private $insertedIds;
+
+    /** @var boolean */
     private $isAcknowledged;
 
     /**

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -42,19 +42,27 @@ class ChangeStream implements Iterator
      */
     const CURSOR_NOT_FOUND = 43;
 
+    /** @var array */
     private static $nonResumableErrorCodes = [
         136, // CappedPositionLost
         237, // CursorKilled
         11601, // Interrupted
     ];
 
+    /** @var callable */
     private $resumeCallable;
+
+    /** @var ChangeStreamIterator */
     private $iterator;
+
+    /** @var integer */
     private $key = 0;
 
     /**
      * Whether the change stream has advanced to its first result. This is used
      * to determine whether $key should be incremented after an iteration event.
+     *
+     * @var boolean
      */
     private $hasAdvanced = false;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -37,19 +37,35 @@ use function is_array;
 
 class Client
 {
+    /** @var array */
     private static $defaultTypeMap = [
         'array' => BSONArray::class,
         'document' => BSONDocument::class,
         'root' => BSONDocument::class,
     ];
+
+    /** @var integer */
     private static $wireVersionForReadConcern = 4;
+
+    /** @var integer */
     private static $wireVersionForWritableCommandWriteConcern = 5;
 
+    /** @var Manager */
     private $manager;
+
+    /** @var ReadConcern */
     private $readConcern;
+
+    /** @var ReadPreference */
     private $readPreference;
+
+    /** @var string */
     private $uri;
+
+    /** @var array */
     private $typeMap;
+
+    /** @var WriteConcern */
     private $writeConcern;
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -66,22 +66,44 @@ use function strlen;
 
 class Collection
 {
+    /** @var array */
     private static $defaultTypeMap = [
         'array' => BSONArray::class,
         'document' => BSONDocument::class,
         'root' => BSONDocument::class,
     ];
+
+    /** @var integer */
     private static $wireVersionForFindAndModifyWriteConcern = 4;
+
+    /** @var integer */
     private static $wireVersionForReadConcern = 4;
+
+    /** @var integer */
     private static $wireVersionForWritableCommandWriteConcern = 5;
+
+    /** @var integer */
     private static $wireVersionForReadConcernWithWriteStage = 8;
 
+    /** @var string */
     private $collectionName;
+
+    /** @var string */
     private $databaseName;
+
+    /** @var Manager */
     private $manager;
+
+    /** @var ReadConcern */
     private $readConcern;
+
+    /** @var ReadPreference */
     private $readPreference;
+
+    /** @var array */
     private $typeMap;
+
+    /** @var WriteConcern */
     private $writeConcern;
 
     /**

--- a/src/Database.php
+++ b/src/Database.php
@@ -44,20 +44,38 @@ use function strlen;
 
 class Database
 {
+    /** @var array */
     private static $defaultTypeMap = [
         'array' => BSONArray::class,
         'document' => BSONDocument::class,
         'root' => BSONDocument::class,
     ];
+
+    /** @var integer */
     private static $wireVersionForReadConcern = 4;
+
+    /** @var integer */
     private static $wireVersionForWritableCommandWriteConcern = 5;
+
+    /** @var integer */
     private static $wireVersionForReadConcernWithWriteStage = 8;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var Manager */
     private $manager;
+
+    /** @var ReadConcern */
     private $readConcern;
+
+    /** @var ReadPreference */
     private $readPreference;
+
+    /** @var array */
     private $typeMap;
+
+    /** @var WriteConcern */
     private $writeConcern;
 
     /**

--- a/src/DeleteResult.php
+++ b/src/DeleteResult.php
@@ -25,12 +25,12 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class DeleteResult
 {
+    /** @var WriteResult */
     private $writeResult;
+
+    /** @var boolean */
     private $isAcknowledged;
 
-    /**
-     * @param WriteResult $writeResult
-     */
     public function __construct(WriteResult $writeResult)
     {
         $this->writeResult = $writeResult;

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -62,24 +62,50 @@ use function urlencode;
  */
 class Bucket
 {
+    /** @var string */
     private static $defaultBucketName = 'fs';
+
+    /** @var integer */
     private static $defaultChunkSizeBytes = 261120;
+
+    /** @var array */
     private static $defaultTypeMap = [
         'array' => BSONArray::class,
         'document' => BSONDocument::class,
         'root' => BSONDocument::class,
     ];
+
+    /** @var string */
     private static $streamWrapperProtocol = 'gridfs';
 
+    /** @var CollectionWrapper */
     private $collectionWrapper;
+
+    /** @var string */
     private $databaseName;
+
+    /** @var Manager */
     private $manager;
+
+    /** @var string */
     private $bucketName;
+
+    /** @var boolean */
     private $disableMD5;
+
+    /** @var integer */
     private $chunkSizeBytes;
+
+    /** @var ReadConcern */
     private $readConcern;
+
+    /** @var ReadPreference */
     private $readPreference;
+
+    /** @var array */
     private $typeMap;
+
+    /** @var WriteConcern */
     private $writeConcern;
 
     /**

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -34,10 +34,19 @@ use function sprintf;
  */
 class CollectionWrapper
 {
+    /** @var string */
     private $bucketName;
+
+    /** @var Collection */
     private $chunksCollection;
+
+    /** @var string */
     private $databaseName;
+
+    /** @var boolean */
     private $checkedIndexes = false;
+
+    /** @var Collection */
     private $filesCollection;
 
     /**

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -36,15 +36,34 @@ use function substr;
  */
 class ReadableStream
 {
+    /** @var string|null */
     private $buffer;
+
+    /** @var integer */
     private $bufferOffset = 0;
+
+    /** @var integer */
     private $chunkSize;
+
+    /** @var integer */
     private $chunkOffset = 0;
+
+    /** @var IteratorIterator|null */
     private $chunksIterator;
+
+    /** @var CollectionWrapper */
     private $collectionWrapper;
+
+    /** @var float|integer */
     private $expectedLastChunkSize = 0;
+
+    /** @var stdClass */
     private $file;
+
+    /** @var integer */
     private $length;
+
+    /** @var integer */
     private $numChunks = 0;
 
     /**

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -45,13 +45,16 @@ use const STREAM_IS_URL;
  */
 class StreamWrapper
 {
-    /**
-     * @var resource|null Stream context (set by PHP)
-     */
+    /** @var resource|null Stream context (set by PHP) */
     public $context;
 
+    /** @var string|null */
     private $mode;
+
+    /** @var string|null */
     private $protocol;
+
+    /** @var ReadableStream|WritableStream|null */
     private $stream;
 
     /**

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -44,16 +44,34 @@ use function substr;
  */
 class WritableStream
 {
+    /** @var integer */
     private static $defaultChunkSizeBytes = 261120;
 
+    /** @var string */
     private $buffer = '';
+
+    /** @var integer */
     private $chunkOffset = 0;
+
+    /** @var integer */
     private $chunkSize;
+
+    /** @var boolean */
     private $disableMD5;
+
+    /** @var CollectionWrapper */
     private $collectionWrapper;
+
+    /** @var array */
     private $file;
+
+    /** @var resource */
     private $hashCtx;
+
+    /** @var boolean */
     private $isClosed = false;
+
+    /** @var integer */
     private $length = 0;
 
     /**

--- a/src/InsertManyResult.php
+++ b/src/InsertManyResult.php
@@ -25,8 +25,13 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class InsertManyResult
 {
+    /** @var WriteResult */
     private $writeResult;
+
+    /** @var mixed[] */
     private $insertedIds;
+
+    /** @var boolean */
     private $isAcknowledged;
 
     /**

--- a/src/InsertOneResult.php
+++ b/src/InsertOneResult.php
@@ -25,8 +25,13 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class InsertOneResult
 {
+    /** @var WriteResult */
     private $writeResult;
+
+    /** @var mixed */
     private $insertedId;
+
+    /** @var boolean */
     private $isAcknowledged;
 
     /**

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -35,9 +35,16 @@ use function call_user_func;
  */
 class MapReduceResult implements IteratorAggregate
 {
+    /** @var callable */
     private $getIterator;
+
+    /** @var integer */
     private $executionTimeMS;
+
+    /** @var array */
     private $counts;
+
+    /** @var array */
     private $timing;
 
     /**

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -32,13 +32,25 @@ use function unpack;
  */
 class BSONIterator implements Iterator
 {
+    /** @var integer */
     private static $bsonSize = 4;
 
+    /** @var string */
     private $buffer;
+
+    /** @var integer */
     private $bufferLength;
+
+    /** @var mixed */
     private $current;
+
+    /** @var integer */
     private $key = 0;
+
+    /** @var integer */
     private $position = 0;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -38,9 +38,16 @@ use function reset;
  */
 class CachingIterator implements Countable, Iterator
 {
+    /** @var array */
     private $items = [];
+
+    /** @var Generator */
     private $iterator;
+
+    /** @var boolean */
     private $iteratorAdvanced = false;
+
+    /** @var boolean */
     private $iteratorExhausted = false;
 
     /**

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -45,10 +45,19 @@ use function MongoDB\Driver\Monitoring\removeSubscriber;
  */
 class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 {
+    /** @var integer */
     private $batchPosition = 0;
+
+    /** @var integer */
     private $batchSize;
+
+    /** @var boolean */
     private $isRewindNop;
+
+    /** @var object|null */
     private $postBatchResumeToken;
+
+    /** @var array|object|null */
     private $resumeToken;
 
     /**

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -34,6 +34,7 @@ use function array_key_exists;
  */
 class CollectionInfo implements ArrayAccess
 {
+    /** @var array */
     private $info;
 
     /**

--- a/src/Model/DatabaseInfo.php
+++ b/src/Model/DatabaseInfo.php
@@ -33,6 +33,7 @@ use function array_key_exists;
  */
 class DatabaseInfo implements ArrayAccess
 {
+    /** @var array */
     private $info;
 
     /**

--- a/src/Model/DatabaseInfoLegacyIterator.php
+++ b/src/Model/DatabaseInfoLegacyIterator.php
@@ -34,6 +34,7 @@ use function reset;
  */
 class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
 {
+    /** @var array */
     private $databases;
 
     /**

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -39,6 +39,7 @@ use function array_search;
  */
 class IndexInfo implements ArrayAccess
 {
+    /** @var array */
     private $info;
 
     /**

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -39,6 +39,7 @@ use function sprintf;
  */
 class IndexInput implements Serializable
 {
+    /** @var array */
     private $index;
 
     /**

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -50,14 +50,28 @@ use function sprintf;
  */
 class Aggregate implements Executable
 {
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForDocumentLevelValidation = 4;
+
+    /** @var integer */
     private static $wireVersionForReadConcern = 4;
+
+    /** @var integer */
     private static $wireVersionForWriteConcern = 5;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string|null */
     private $collectionName;
+
+    /** @var array */
     private $pipeline;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -51,15 +51,31 @@ class BulkWrite implements Executable
     const UPDATE_MANY = 'updateMany';
     const UPDATE_ONE  = 'updateOne';
 
+    /** @var integer */
     private static $wireVersionForArrayFilters = 6;
+
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForDocumentLevelValidation = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array[] */
     private $operations;
+
+    /** @var array */
     private $options;
+
+    /** @var boolean */
     private $isArrayFiltersUsed = false;
+
+    /** @var boolean */
     private $isCollationUsed = false;
 
     /**

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -43,12 +43,22 @@ use function MongoDB\server_supports_feature;
  */
 class Count implements Executable, Explainable
 {
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForReadConcern = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array|object */
     private $filter;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -39,11 +39,22 @@ use function is_object;
  */
 class CountDocuments implements Executable
 {
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array|object */
     private $filter;
+
+    /** @var array */
     private $aggregateOptions;
+
+    /** @var array */
     private $countOptions;
+
+    /** @var Aggregate */
     private $aggregate;
 
     /**

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -46,11 +46,19 @@ class CreateCollection implements Executable
     const USE_POWER_OF_2_SIZES = 1;
     const NO_PADDING = 2;
 
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForWriteConcern = 5;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array */
     private $options = [];
 
     /**

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -41,13 +41,25 @@ use function sprintf;
  */
 class CreateIndexes implements Executable
 {
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForWriteConcern = 5;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array */
     private $indexes = [];
+
+    /** @var boolean */
     private $isCollationUsed = false;
+
+    /** @var array */
     private $options = [];
 
     /**

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -34,8 +34,13 @@ use function is_object;
  */
 class DatabaseCommand implements Executable
 {
+    /** @var string */
     private $databaseName;
+
+    /** @var array|Command|object */
     private $command;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -40,12 +40,22 @@ use function MongoDB\server_supports_feature;
  */
 class Delete implements Executable, Explainable
 {
+    /** @var integer */
     private static $wireVersionForCollation = 5;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array|object */
     private $filter;
+
+    /** @var integer */
     private $limit;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/DeleteMany.php
+++ b/src/Operation/DeleteMany.php
@@ -32,6 +32,7 @@ use MongoDB\Exception\UnsupportedException;
  */
 class DeleteMany implements Executable, Explainable
 {
+    /** @var Delete */
     private $delete;
 
     /**

--- a/src/Operation/DeleteOne.php
+++ b/src/Operation/DeleteOne.php
@@ -32,6 +32,7 @@ use MongoDB\Exception\UnsupportedException;
  */
 class DeleteOne implements Executable, Explainable
 {
+    /** @var Delete */
     private $delete;
 
     /**

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -42,13 +42,25 @@ use function MongoDB\server_supports_feature;
  */
 class Distinct implements Executable, Explainable
 {
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForReadConcern = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var string */
     private $fieldName;
+
+    /** @var array|object */
     private $filter;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -38,11 +38,19 @@ use function MongoDB\server_supports_feature;
  */
 class DropCollection implements Executable
 {
+    /** @var string */
     private static $errorMessageNamespaceNotFound = 'ns not found';
+
+    /** @var integer */
     private static $wireVersionForWriteConcern = 5;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -38,9 +38,13 @@ use function MongoDB\server_supports_feature;
  */
 class DropDatabase implements Executable
 {
+    /** @var integer */
     private static $wireVersionForWriteConcern = 5;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -38,11 +38,19 @@ use function MongoDB\server_supports_feature;
  */
 class DropIndexes implements Executable
 {
+    /** @var integer */
     private static $wireVersionForWriteConcern = 5;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var string */
     private $indexName;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -33,9 +33,16 @@ use function array_intersect_key;
  */
 class EstimatedDocumentCount implements Executable, Explainable
 {
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array */
     private $options;
+
+    /** @var Count */
     private $count;
 
     /**

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -41,11 +41,19 @@ class Explain implements Executable
     const VERBOSITY_EXEC_STATS = 'executionStats';
     const VERBOSITY_QUERY = 'queryPlanner';
 
+    /** @var integer */
     private static $wireVersionForDistinct = 4;
+
+    /** @var integer */
     private static $wireVersionForFindAndModify = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var Explainable */
     private $explainable;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -49,12 +49,22 @@ class Find implements Executable, Explainable
     const TAILABLE = 2;
     const TAILABLE_AWAIT = 3;
 
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForReadConcern = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array|object */
     private $filter;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -45,13 +45,25 @@ use function MongoDB\server_supports_feature;
  */
 class FindAndModify implements Executable, Explainable
 {
+    /** @var integer */
     private static $wireVersionForArrayFilters = 6;
+
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForDocumentLevelValidation = 4;
+
+    /** @var integer */
     private static $wireVersionForWriteConcern = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -33,6 +33,7 @@ use function current;
  */
 class FindOne implements Executable, Explainable
 {
+    /** @var Find */
     private $find;
 
     /**

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -33,6 +33,7 @@ use function is_object;
  */
 class FindOneAndDelete implements Executable, Explainable
 {
+    /** @var FindAndModify */
     private $findAndModify;
 
     /**

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -38,6 +38,7 @@ class FindOneAndReplace implements Executable, Explainable
     const RETURN_DOCUMENT_BEFORE = 1;
     const RETURN_DOCUMENT_AFTER = 2;
 
+    /** @var FindAndModify */
     private $findAndModify;
 
     /**

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -39,6 +39,7 @@ class FindOneAndUpdate implements Executable, Explainable
     const RETURN_DOCUMENT_BEFORE = 1;
     const RETURN_DOCUMENT_AFTER = 2;
 
+    /** @var FindAndModify */
     private $findAndModify;
 
     /**

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -40,11 +40,19 @@ use function sprintf;
  */
 class InsertMany implements Executable
 {
+    /** @var integer */
     private static $wireVersionForDocumentLevelValidation = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var object[]|array[] */
     private $documents;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -39,11 +39,19 @@ use function MongoDB\server_supports_feature;
  */
 class InsertOne implements Executable
 {
+    /** @var integer */
     private static $wireVersionForDocumentLevelValidation = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array|object */
     private $document;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -38,7 +38,10 @@ use function is_object;
  */
 class ListCollections implements Executable
 {
+    /** @var string */
     private $databaseName;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -39,6 +39,7 @@ use function is_object;
  */
 class ListDatabases implements Executable
 {
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -37,11 +37,19 @@ use function is_integer;
  */
 class ListIndexes implements Executable
 {
+    /** @var integer */
     private static $errorCodeDatabaseNotFound = 60;
+
+    /** @var integer */
     private static $errorCodeNamespaceNotFound = 26;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -50,16 +50,34 @@ use function MongoDB\server_supports_feature;
  */
 class MapReduce implements Executable
 {
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForDocumentLevelValidation = 4;
+
+    /** @var integer */
     private static $wireVersionForReadConcern = 4;
+
+    /** @var integer */
     private static $wireVersionForWriteConcern = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var JavascriptInterface */
     private $map;
+
+    /** @var JavascriptInterface */
     private $reduce;
+
+    /** @var array|object|string */
     private $out;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -37,9 +37,16 @@ use function MongoDB\server_supports_feature;
  */
 class ModifyCollection implements Executable
 {
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array */
     private $collectionOptions;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -36,6 +36,7 @@ use function MongoDB\is_pipeline;
  */
 class ReplaceOne implements Executable
 {
+    /** @var Update */
     private $update;
 
     /**

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -43,14 +43,28 @@ use function MongoDB\server_supports_feature;
  */
 class Update implements Executable, Explainable
 {
+    /** @var integer */
     private static $wireVersionForArrayFilters = 6;
+
+    /** @var integer */
     private static $wireVersionForCollation = 5;
+
+    /** @var integer */
     private static $wireVersionForDocumentLevelValidation = 4;
 
+    /** @var string */
     private $databaseName;
+
+    /** @var string */
     private $collectionName;
+
+    /** @var array|object */
     private $filter;
+
+    /** @var array|object */
     private $update;
+
+    /** @var array */
     private $options;
 
     /**

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -36,6 +36,7 @@ use function MongoDB\is_pipeline;
  */
 class UpdateMany implements Executable, Explainable
 {
+    /** @var Update */
     private $update;
 
     /**

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -36,6 +36,7 @@ use function MongoDB\is_pipeline;
  */
 class UpdateOne implements Executable, Explainable
 {
+    /** @var Update */
     private $update;
 
     /**

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -54,21 +54,43 @@ use function MongoDB\server_supports_feature;
  */
 class Watch implements Executable, /* @internal */ CommandSubscriber
 {
-    private static $wireVersionForStartAtOperationTime = 7;
-
     const FULL_DOCUMENT_DEFAULT = 'default';
     const FULL_DOCUMENT_UPDATE_LOOKUP = 'updateLookup';
 
+    /** @var integer */
+    private static $wireVersionForStartAtOperationTime = 7;
+
+    /** @var Aggregate */
     private $aggregate;
+
+    /** @var array */
     private $aggregateOptions;
+
+    /** @var array */
     private $changeStreamOptions;
+
+    /** @var string|null */
     private $collectionName;
+
+    /** @var string */
     private $databaseName;
+
+    /** @var integer|null */
     private $firstBatchSize;
+
+    /** @var boolean */
     private $hasResumed = false;
+
+    /** @var Manager */
     private $manager;
+
+    /** @var TimestampInterface */
     private $operationTime;
+
+    /** @var array */
     private $pipeline;
+
+    /** @var object|null */
     private $postBatchResumeToken;
 
     /**

--- a/src/UpdateResult.php
+++ b/src/UpdateResult.php
@@ -25,12 +25,12 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class UpdateResult
 {
+    /** @var WriteResult */
     private $writeResult;
+
+    /** @var boolean */
     private $isAcknowledged;
 
-    /**
-     * @param WriteResult $writeResult
-     */
     public function __construct(WriteResult $writeResult)
     {
         $this->writeResult = $writeResult;

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -21,6 +21,7 @@ class ClientFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Client */
     private $client;
 
     private function doSetUp()

--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -37,6 +37,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $expectedCollection;
 
     private function doSetUp()

--- a/tests/Collection/FunctionalTestCase.php
+++ b/tests/Collection/FunctionalTestCase.php
@@ -13,6 +13,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     protected $collection;
 
     private function doSetUp()

--- a/tests/CommandObserver.php
+++ b/tests/CommandObserver.php
@@ -16,6 +16,7 @@ use function MongoDB\Driver\Monitoring\removeSubscriber;
  */
 class CommandObserver implements CommandSubscriber
 {
+    /** @var array */
     private $commands = [];
 
     public function observe(callable $execution, callable $commandCallback)

--- a/tests/Database/FunctionalTestCase.php
+++ b/tests/Database/FunctionalTestCase.php
@@ -13,6 +13,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Database */
     protected $database;
 
     private function doSetUp()

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -34,8 +34,10 @@ abstract class FunctionalTestCase extends TestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Manager */
     protected $manager;
 
+    /** @var array */
     private $configuredFailPoints = [];
 
     private function doSetUp()

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -19,8 +19,13 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Bucket */
     protected $bucket;
+
+    /** @var Collection */
     protected $chunksCollection;
+
+    /** @var Collection */
     protected $filesCollection;
 
     private function doSetUp()

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -18,6 +18,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var CollectionWrapper */
     private $collectionWrapper;
 
     private function doSetUp()

--- a/tests/GridFS/SpecFunctionalTest.php
+++ b/tests/GridFS/SpecFunctionalTest.php
@@ -38,7 +38,10 @@ class SpecFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $expectedChunksCollection;
+
+    /** @var Collection */
     private $expectedFilesCollection;
 
     private function doSetUp()

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -15,6 +15,7 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var CollectionWrapper */
     private $collectionWrapper;
 
     private function doSetUp()

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -19,6 +19,7 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $collection;
 
     private function doSetUp()

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -11,6 +11,7 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $collection;
 
     private function doSetUp()

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -19,6 +19,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $collection;
 
     private function doSetUp()

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -16,6 +16,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $collection;
 
     private function doSetUp()

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -17,6 +17,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $collection;
 
     private function doSetUp()

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -17,6 +17,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $collection;
 
     private function doSetUp()

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -17,6 +17,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
 {
     use SetUpTearDownTrait;
 
+    /** @var Collection */
     private $collection;
 
     private function doSetUp()

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -36,8 +36,10 @@ class WatchFunctionalTest extends FunctionalTestCase
     const INTERRUPTED = 11601;
     const NOT_MASTER = 10107;
 
+    /** @var integer */
     private static $wireVersionForStartAtOperationTime = 7;
 
+    /** @var array */
     private $defaultOptions = ['maxAwaitTimeMS' => 500];
 
     private function doSetUp()

--- a/tests/SpecTests/ChangeStreamsSpecTest.php
+++ b/tests/SpecTests/ChangeStreamsSpecTest.php
@@ -21,6 +21,7 @@ use function glob;
  */
 class ChangeStreamsSpecTest extends FunctionalTestCase
 {
+    /** @var array */
     private static $incompleteTests = ['change-streams-errors: Change Stream should error when _id is projected out' => 'PHPC-1419'];
 
     /**

--- a/tests/SpecTests/CommandExpectations.php
+++ b/tests/SpecTests/CommandExpectations.php
@@ -19,11 +19,22 @@ use function MongoDB\Driver\Monitoring\removeSubscriber;
  */
 class CommandExpectations implements CommandSubscriber
 {
+    /** @var array */
     private $actualEvents = [];
+
+    /** @var array */
     private $expectedEvents = [];
+
+    /** @var boolean */
     private $ignoreCommandFailed = false;
+
+    /** @var boolean */
     private $ignoreCommandStarted = false;
+
+    /** @var boolean */
     private $ignoreCommandSucceeded = false;
+
+    /** @var boolean */
     private $ignoreExtraEvents = false;
 
     private function __construct(array $events)

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -6,6 +6,7 @@ use LogicException;
 use MongoDB\Client;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use stdClass;
 use function array_diff_key;
@@ -21,18 +22,43 @@ use function mt_rand;
  */
 final class Context
 {
+    /** @var string|null */
     public $bucketName;
+
+    /** @var Client|null */
     public $client;
+
+    /** @var string */
     public $collectionName;
+
+    /** @var string */
     public $databaseName;
+
+    /** @var array */
     public $defaultWriteOptions = [];
+
+    /** @var array */
     public $outcomeFindOptions = [];
+
+    /** @var string */
     public $outcomeCollectionName;
+
+    /** @var Session|null */
     public $session0;
+
+    /** @var object */
     public $session0Lsid;
+
+    /** @var Session|null */
     public $session1;
+
+    /** @var object */
     public $session1Lsid;
 
+    /**
+     * @param string $databaseName
+     * @param string $collectionName
+     */
     private function __construct($databaseName, $collectionName)
     {
         $this->databaseName = $databaseName;

--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -29,15 +29,27 @@ class DocumentsMatchConstraint extends Constraint
 {
     use ConstraintTrait;
 
+    /** @var boolean */
     private $ignoreExtraKeysInRoot = false;
+
+    /** @var boolean */
     private $ignoreExtraKeysInEmbedded = false;
+
+    /** @var array */
     private $placeholders = [];
-    /* TODO: This is not currently used, but was preserved from the design of
+
+    /**
+     * TODO: This is not currently used, but was preserved from the design of
      * TestCase::assertMatchesDocument(), which would sort keys and then compare
      * documents as JSON strings. If the TODO item in matches() is implemented
      * to make document comparisons more efficient, we may consider supporting
-     * this option. */
+     * this option.
+     *
+     * @var boolean
+     */
     private $sortKeys = false;
+
+    /** @var BSONArray|BSONDocument */
     private $value;
 
     /** @var ComparisonFailure|null */

--- a/tests/SpecTests/ErrorExpectation.php
+++ b/tests/SpecTests/ErrorExpectation.php
@@ -21,6 +21,8 @@ final class ErrorExpectation
 {
     /**
      * @see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
+     *
+     * @var array
      */
     private static $codeNameMap = [
         'Interrupted' => 11601,
@@ -29,11 +31,22 @@ final class ErrorExpectation
         'OperationNotSupportedInTransaction' => 263,
     ];
 
+    /** @var integer */
     private $code;
+
+    /** @var string */
     private $codeName;
+
+    /** @var boolean */
     private $isExpected = false;
+
+    /** @var string[] */
     private $excludedLabels = [];
+
+    /** @var string[] */
     private $includedLabels = [];
+
+    /** @var string */
     private $messageContains;
 
     private function __construct()

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -33,6 +33,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     const TOPOLOGY_REPLICASET = 'replicaset';
     const TOPOLOGY_SHARDED = 'sharded';
 
+    /** @var Context|null */
     private $context;
 
     private function doSetUp()

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -37,14 +37,28 @@ final class Operation
     const OBJECT_SESSION0 = 'session0';
     const OBJECT_SESSION1 = 'session1';
 
+    /** @var ErrorExpectation|null */
     public $errorExpectation;
+
+    /** @var ResultExpectation|null */
     public $resultExpectation;
 
+    /** @var array */
     private $arguments = [];
+
+    /** @var string|null */
     private $collectionName;
+
+    /** @var array */
     private $collectionOptions = [];
+
+    /** @var string|null */
     private $databaseName;
+
+    /** @var string */
     private $name;
+
+    /** @var string */
     private $object = self::OBJECT_COLLECTION;
 
     private function __construct(stdClass $operation)

--- a/tests/SpecTests/ResultExpectation.php
+++ b/tests/SpecTests/ResultExpectation.php
@@ -35,10 +35,19 @@ final class ResultExpectation
     const ASSERT_NULL = 10;
     const ASSERT_CALLABLE = 11;
 
+    /** @var integer */
     private $assertionType = self::ASSERT_NOTHING;
+
+    /** @var mixed */
     private $expectedValue;
+
+    /** @var callable */
     private $assertionCallable;
 
+    /**
+     * @param integer $assertionType
+     * @param mixed   $expectedValue
+     */
     private function __construct($assertionType, $expectedValue)
     {
         switch ($assertionType) {

--- a/tests/SpecTests/RetryableReadsSpecTest.php
+++ b/tests/SpecTests/RetryableReadsSpecTest.php
@@ -16,6 +16,7 @@ use function strpos;
  */
 class RetryableReadsSpecTest extends FunctionalTestCase
 {
+    /** @var array */
     private static $skippedOperations = [
         'listCollectionNames' => 'Not implemented',
         'listCollectionObjects' => 'Not implemented',

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -27,8 +27,12 @@ class TransactionsSpecTest extends FunctionalTestCase
 
     const INTERRUPTED = 11601;
 
-    /* In addition to the useMultipleMongoses tests, these should all pass
-     * before the driver can be considered compatible with MongoDB 4.2. */
+    /**
+     * In addition to the useMultipleMongoses tests, these should all pass
+     * before the driver can be considered compatible with MongoDB 4.2.
+     *
+     * @var array
+     */
     private static $incompleteTests = [
         'error-labels: add unknown commit label to MaxTimeMSExpired' => 'PHPC-1382',
         'error-labels: add unknown commit label to writeConcernError MaxTimeMSExpired' => 'PHPC-1382',


### PR DESCRIPTION
This is a follow-up to #668 that I extracted to keep the diff small. This PR adds `@var` annotations to all properties in classes and partially enables the `TypeHintSniff`, requiring such property types to be declared. Declaring these types throughout the code helps with code completion, which currently doesn't always work because of missing type information.