### PR TITLE
Assert initial resume token in resumeAfter test

### DIFF
--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -980,6 +980,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $options = $this->defaultOptions + ['resumeAfter' => $resumeToken];
         $operation = new Watch($this->manager, $this->getDatabaseName(), $this->getCollectionName(), [], $options);
         $changeStream = $operation->execute($this->getPrimaryServer());
+        $this->assertSame($resumeToken, $changeStream->getResumeToken());
 
         $changeStream->rewind();
         $this->assertTrue($changeStream->valid());


### PR DESCRIPTION
ChangeStream::getResumeToken() did not exist at the time this test was written; however, we do this assertion in testStartAfterOption().

This was originally suggested in https://github.com/mongodb/mongo-php-library/pull/659, but fell out as a related change to `testStartAfterOption()` was no longer needed.