### PR TITLE
Clear value for obsolete options field

### DIFF
--- a/docs/includes/apiargs-common-option.yaml
+++ b/docs/includes/apiargs-common-option.yaml
@@ -33,7 +33,7 @@ description: |
   The default read concern to use for {{resource}} operations. Defaults to the
   {{parent}}'s read concern.
 interface: phpmethod
-operation: selectCollection
+operation: ~
 optional: true
 replacement:
   resource: "collection"


### PR DESCRIPTION
The operation field isn't used for anything in our documentation. This was introduced in d5c501a2ae0ee3fa7295d653e7061cbe643df029 and it looks like we missed cleaning it up in later commits that changed every other operation field to null.