### PR TITLE
PHPLIB-482: Add missing error expectation to crud tests

### DIFF
--- a/tests/SpecTests/ErrorExpectation.php
+++ b/tests/SpecTests/ErrorExpectation.php
@@ -75,6 +75,17 @@ final class ErrorExpectation
         return $o;
     }
 
+    public static function fromCrud(stdClass $result)
+    {
+        $o = new self();
+
+        if (isset($result->error)) {
+            $o->isExpected = $result->error;
+        }
+
+        return $o;
+    }
+
     public static function fromRetryableReads(stdClass $operation)
     {
         $o = new self();

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -158,6 +158,7 @@ final class Operation
     {
         $o = new self($operation);
 
+        $o->errorExpectation = ErrorExpectation::fromCrud($operation);
         $o->resultExpectation = ResultExpectation::fromCrud($operation, $o->getResultAssertionType());
 
         if (isset($operation->collectionOptions)) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-482

While looking at [PHPLIB-481](https://jira.mongodb.org/browse/PHPLIB-481), I realised that the crud spec tests don't check error expectations. While we're unlikely to miss any errors because of this (since the return value of the operation call is most likely not going to match the expectation), I still think it's sensible to add these to the 1.5 branch to ensure we're correctly running the spec tests.