### PR TITLE
PHPLIB-477: Deprecate CodeWScope for use within the mapReduce command

### DIFF
--- a/docs/includes/apiargs-MongoDBCollection-method-mapReduce-option.yaml
+++ b/docs/includes/apiargs-MongoDBCollection-method-mapReduce-option.yaml
@@ -13,6 +13,11 @@ name: finalize
 type: :php:`MongoDB\\BSON\\Javascript <class.mongodb-bson-javascript>`
 description: |
   Follows the reduce method and modifies the output.
+
+  .. note::
+
+     Passing a Javascript instance with a scope is deprecated. Put all scope
+     variables in the ``scope`` option of the MapReduce operation.
 interface: phpmethod
 operation: ~
 optional: true

--- a/docs/includes/apiargs-MongoDBCollection-method-mapReduce-param.yaml
+++ b/docs/includes/apiargs-MongoDBCollection-method-mapReduce-param.yaml
@@ -4,6 +4,11 @@ type: :php:`MongoDB\\BSON\\Javascript <mongodb-bson-javascript>`
 description: |
   A JavaScript function that associates or "maps" a value with a key and emits
   the key and value pair.
+
+  .. note::
+
+     Passing a Javascript instance with a scope is deprecated. Put all scope
+     variables in the ``scope`` option of the MapReduce operation.
 interface: phpmethod
 operation: ~
 optional: false
@@ -14,6 +19,11 @@ type: :php:`MongoDB\\BSON\\Javascript <class.mongodb-bson-javascript>`
 description: |
   A JavaScript function that "reduces" to a single object all the values
   associated with a particular key.
+
+  .. note::
+
+     Passing a Javascript instance with a scope is deprecated. Put all scope
+     variables in the ``scope`` option of the MapReduce operation.
 interface: phpmethod
 operation: ~
 optional: false

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -40,6 +40,8 @@ use function is_string;
 use function MongoDB\create_field_path_type_map;
 use function MongoDB\is_mapreduce_output_inline;
 use function MongoDB\server_supports_feature;
+use function trigger_error;
+use const E_USER_DEPRECATED;
 
 /**
  * Operation for the mapReduce command.
@@ -88,8 +90,14 @@ class MapReduce implements Executable
      *  * map (MongoDB\BSON\Javascript): A JavaScript function that associates
      *    or "maps" a value with a key and emits the key and value pair.
      *
+     *    Passing a Javascript instance with a scope is deprecated. Put all
+     *    scope variables in the "scope" option of the MapReduce operation.
+     *
      *  * reduce (MongoDB\BSON\Javascript): A JavaScript function that "reduces"
      *    to a single object all the values associated with a particular key.
+     *
+     *    Passing a Javascript instance with a scope is deprecated. Put all
+     *    scope variables in the "scope" option of the MapReduce operation.
      *
      *  * out (string|document): Specifies where to output the result of the
      *    map-reduce operation. You can either output to a collection or return
@@ -113,6 +121,9 @@ class MapReduce implements Executable
      *
      *  * finalize (MongoDB\BSON\JavascriptInterface): Follows the reduce method
      *    and modifies the output.
+     *
+     *    Passing a Javascript instance with a scope is deprecated. Put all
+     *    scope variables in the "scope" option of the MapReduce operation.
      *
      *  * jsMode (boolean): Specifies whether to convert intermediate data into
      *    BSON format between the execution of the map and reduce functions.
@@ -240,6 +251,19 @@ class MapReduce implements Executable
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {
             unset($options['writeConcern']);
+        }
+
+        // Handle deprecation of CodeWScope
+        if ($map->getScope() !== null) {
+            @trigger_error('Use of Javascript with scope in "$map" argument for MapReduce is deprecated. Put all scope variables in the "scope" option of the MapReduce operation.', E_USER_DEPRECATED);
+        }
+
+        if ($reduce->getScope() !== null) {
+            @trigger_error('Use of Javascript with scope in "$reduce" argument for MapReduce is deprecated. Put all scope variables in the "scope" option of the MapReduce operation.', E_USER_DEPRECATED);
+        }
+
+        if (isset($options['finalize']) && $options['finalize']->getScope() !== null) {
+            @trigger_error('Use of Javascript with scope in "finalize" option for MapReduce is deprecated. Put all scope variables in the "scope" option of the MapReduce operation.', E_USER_DEPRECATED);
         }
 
         $this->databaseName = (string) $databaseName;


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-477

Contrary to the original wording suggestion, I replaced the usage of "CodeWScope" for "Javascript instance with a scope". I don't think users will be familiar with the internal nomenclature of BSON types, so this may be more understandable to the average user.

Apart from deprecating these in the documentation, we also emit an `E_USER_DEPRECATED` PHP error that can be logged with libraries like [symfony/phpunit-bridge](https://github.com/symfony/phpunit-bridge).