### PR TITLE
PHPLIB-501: Prevent memory leaks from generators

### DIFF
--- a/tests/Model/CachingIteratorTest.php
+++ b/tests/Model/CachingIteratorTest.php
@@ -53,7 +53,7 @@ class CachingIteratorTest extends TestCase
 
     public function testPartialIterationDoesNotExhaust()
     {
-        $traversable = $this->getTraversableThatThrows([1, 2, new Exception()]);
+        $traversable = $this->getTraversable([1, 2, new Exception()]);
         $iterator = new CachingIterator($traversable);
 
         $expectedKey = 0;
@@ -110,13 +110,6 @@ class CachingIteratorTest extends TestCase
     }
 
     private function getTraversable($items)
-    {
-        foreach ($items as $item) {
-            yield $item;
-        }
-    }
-
-    private function getTraversableThatThrows($items)
     {
         foreach ($items as $item) {
             if ($item instanceof Exception) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-501

This was discovered while investigating https://github.com/doctrine/mongodb-odm/issues/2092. The different behaviour can be seen in action here: https://3v4l.org/UIfIb. Note that when we don't specifically unset the generator, it stays around much longer even though the wrapping iterator has already been garbage collected.