### PR TITLE
PHPLIB-494: Fix validation of options with default values

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -95,7 +95,7 @@ class Client
     {
         $driverOptions += ['typeMap' => self::$defaultTypeMap];
 
-        if (isset($driverOptions['typeMap']) && ! is_array($driverOptions['typeMap'])) {
+        if (! is_array($driverOptions['typeMap'])) {
             throw InvalidArgumentException::invalidType('"typeMap" driver option', $driverOptions['typeMap'], 'array');
         }
 

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -143,19 +143,19 @@ class Bucket
             'disableMD5' => false,
         ];
 
-        if (isset($options['bucketName']) && ! is_string($options['bucketName'])) {
+        if (! is_string($options['bucketName'])) {
             throw InvalidArgumentException::invalidType('"bucketName" option', $options['bucketName'], 'string');
         }
 
-        if (isset($options['chunkSizeBytes']) && ! is_integer($options['chunkSizeBytes'])) {
+        if (! is_integer($options['chunkSizeBytes'])) {
             throw InvalidArgumentException::invalidType('"chunkSizeBytes" option', $options['chunkSizeBytes'], 'integer');
         }
 
-        if (isset($options['chunkSizeBytes']) && $options['chunkSizeBytes'] < 1) {
+        if ($options['chunkSizeBytes'] < 1) {
             throw new InvalidArgumentException(sprintf('Expected "chunkSizeBytes" option to be >= 1, %d given', $options['chunkSizeBytes']));
         }
 
-        if (isset($options['disableMD5']) && ! is_bool($options['disableMD5'])) {
+        if (! is_bool($options['disableMD5'])) {
             throw InvalidArgumentException::invalidType('"disableMD5" option', $options['disableMD5'], 'boolean');
         }
 

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -114,15 +114,15 @@ class WritableStream
             throw InvalidArgumentException::invalidType('"aliases" option', $options['aliases'], 'array of strings');
         }
 
-        if (isset($options['chunkSizeBytes']) && ! is_integer($options['chunkSizeBytes'])) {
+        if (! is_integer($options['chunkSizeBytes'])) {
             throw InvalidArgumentException::invalidType('"chunkSizeBytes" option', $options['chunkSizeBytes'], 'integer');
         }
 
-        if (isset($options['chunkSizeBytes']) && $options['chunkSizeBytes'] < 1) {
+        if ($options['chunkSizeBytes'] < 1) {
             throw new InvalidArgumentException(sprintf('Expected "chunkSizeBytes" option to be >= 1, %d given', $options['chunkSizeBytes']));
         }
 
-        if (isset($options['disableMD5']) && ! is_bool($options['disableMD5'])) {
+        if (! is_bool($options['disableMD5'])) {
             throw InvalidArgumentException::invalidType('"disableMD5" option', $options['disableMD5'], 'boolean');
         }
 

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -178,8 +178,12 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
             'readPreference' => new ReadPreference(ReadPreference::RP_PRIMARY),
         ];
 
-        if (isset($options['fullDocument']) && ! is_string($options['fullDocument'])) {
+        if (! is_string($options['fullDocument'])) {
             throw InvalidArgumentException::invalidType('"fullDocument" option', $options['fullDocument'], 'string');
+        }
+
+        if (! $options['readPreference'] instanceof ReadPreference) {
+            throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
         if (isset($options['resumeAfter']) && ! is_array($options['resumeAfter']) && ! is_object($options['resumeAfter'])) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -33,7 +33,7 @@ class ClientTest extends TestCase
     {
         $options = [];
 
-        foreach ($this->getInvalidArrayValues() as $value) {
+        foreach ($this->getInvalidArrayValues(true) as $value) {
             $options[][] = ['typeMap' => $value];
         }
 

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -62,15 +62,15 @@ class BucketFunctionalTest extends FunctionalTestCase
     {
         $options = [];
 
-        foreach ($this->getInvalidStringValues() as $value) {
+        foreach ($this->getInvalidStringValues(true) as $value) {
             $options[][] = ['bucketName' => $value];
         }
 
-        foreach ($this->getInvalidIntegerValues() as $value) {
+        foreach ($this->getInvalidIntegerValues(true) as $value) {
             $options[][] = ['chunkSizeBytes' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['disableMD5' => $value];
         }
 

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -50,11 +50,11 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
     {
         $options = [];
 
-        foreach ($this->getInvalidIntegerValues() as $value) {
+        foreach ($this->getInvalidIntegerValues(true) as $value) {
             $options[][] = ['chunkSizeBytes' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['disableMD5' => $value];
         }
 

--- a/tests/Operation/AggregateTest.php
+++ b/tests/Operation/AggregateTest.php
@@ -27,7 +27,7 @@ class AggregateTest extends TestCase
     {
         $options = [];
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['allowDiskUse' => $value];
         }
 
@@ -79,7 +79,7 @@ class AggregateTest extends TestCase
             $options[][] = ['typeMap' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['useCursor' => $value];
         }
 

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -412,7 +412,7 @@ class BulkWriteTest extends TestCase
             $options[][] = ['bypassDocumentValidation' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['ordered' => $value];
         }
 

--- a/tests/Operation/FindAndModifyTest.php
+++ b/tests/Operation/FindAndModifyTest.php
@@ -40,7 +40,7 @@ class FindAndModifyTest extends TestCase
             $options[][] = ['maxTimeMS' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['new' => $value];
         }
 
@@ -48,7 +48,7 @@ class FindAndModifyTest extends TestCase
             $options[][] = ['query' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['remove' => $value];
         }
 
@@ -68,7 +68,7 @@ class FindAndModifyTest extends TestCase
             $options[][] = ['update' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['upsert' => $value];
         }
 

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -49,7 +49,7 @@ class FindOneAndReplaceTest extends TestCase
             $options[][] = ['projection' => $value];
         }
 
-        foreach ($this->getInvalidIntegerValues() as $value) {
+        foreach ($this->getInvalidIntegerValues(true) as $value) {
             $options[][] = ['returnDocument' => $value];
         }
 

--- a/tests/Operation/FindOneAndUpdateTest.php
+++ b/tests/Operation/FindOneAndUpdateTest.php
@@ -49,7 +49,7 @@ class FindOneAndUpdateTest extends TestCase
             $options[][] = ['projection' => $value];
         }
 
-        foreach ($this->getInvalidIntegerValues() as $value) {
+        foreach ($this->getInvalidIntegerValues(true) as $value) {
             $options[][] = ['returnDocument' => $value];
         }
 

--- a/tests/Operation/InsertManyTest.php
+++ b/tests/Operation/InsertManyTest.php
@@ -48,7 +48,7 @@ class InsertManyTest extends TestCase
             $options[][] = ['bypassDocumentValidation' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['ordered' => $value];
         }
 

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -52,7 +52,7 @@ class UpdateTest extends TestCase
             $options[][] = ['collation' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['multi' => $value];
         }
 
@@ -60,7 +60,7 @@ class UpdateTest extends TestCase
             $options[][] = ['session' => $value];
         }
 
-        foreach ($this->getInvalidBooleanValues() as $value) {
+        foreach ($this->getInvalidBooleanValues(true) as $value) {
             $options[][] = ['upsert' => $value];
         }
 

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -52,7 +52,7 @@ class WatchTest extends FunctionalTestCase
             $options[][] = ['collation' => $value];
         }
 
-        foreach ($this->getInvalidStringValues() as $value) {
+        foreach ($this->getInvalidStringValues(true) as $value) {
             $options[][] = ['fullDocument' => $value];
         }
 
@@ -64,7 +64,7 @@ class WatchTest extends FunctionalTestCase
             $options[][] = ['readConcern' => $value];
         }
 
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
+        foreach ($this->getInvalidReadPreferenceValues(true) as $value) {
             $options[][] = ['readPreference' => $value];
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,6 +14,7 @@ use ReflectionClass;
 use stdClass;
 use Traversable;
 use function array_map;
+use function array_merge;
 use function array_values;
 use function call_user_func;
 use function getenv;
@@ -165,91 +166,109 @@ abstract class TestCase extends BaseTestCase
     /**
      * Return a list of invalid array values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidArrayValues()
+    protected function getInvalidArrayValues($includeNull = false)
     {
-        return [123, 3.14, 'foo', true, new stdClass()];
+        return array_merge([123, 3.14, 'foo', true, new stdClass()], $includeNull ? [null] : []);
     }
 
     /**
      * Return a list of invalid boolean values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidBooleanValues()
+    protected function getInvalidBooleanValues($includeNull = false)
     {
-        return [123, 3.14, 'foo', [], new stdClass()];
+        return array_merge([123, 3.14, 'foo', [], new stdClass()], $includeNull ? [null] : []);
     }
 
     /**
      * Return a list of invalid document values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidDocumentValues()
+    protected function getInvalidDocumentValues($includeNull = false)
     {
-        return [123, 3.14, 'foo', true];
+        return array_merge([123, 3.14, 'foo', true], $includeNull ? [null] : []);
     }
 
     /**
      * Return a list of invalid integer values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidIntegerValues()
+    protected function getInvalidIntegerValues($includeNull = false)
     {
-        return [3.14, 'foo', true, [], new stdClass()];
+        return array_merge([3.14, 'foo', true, [], new stdClass()], $includeNull ? [null] : []);
     }
 
     /**
      * Return a list of invalid ReadPreference values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidReadConcernValues()
+    protected function getInvalidReadConcernValues($includeNull = false)
     {
-        return [123, 3.14, 'foo', true, [], new stdClass(), new ReadPreference(ReadPreference::RP_PRIMARY), new WriteConcern(1)];
+        return array_merge([123, 3.14, 'foo', true, [], new stdClass(), new ReadPreference(ReadPreference::RP_PRIMARY), new WriteConcern(1)], $includeNull ? [null] : []);
     }
 
     /**
      * Return a list of invalid ReadPreference values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidReadPreferenceValues()
+    protected function getInvalidReadPreferenceValues($includeNull = false)
     {
-        return [123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new WriteConcern(1)];
+        return array_merge([123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new WriteConcern(1)], $includeNull ? [null] : []);
     }
 
     /**
      * Return a list of invalid Session values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidSessionValues()
+    protected function getInvalidSessionValues($includeNull = false)
     {
-        return [123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new ReadPreference(ReadPreference::RP_PRIMARY), new WriteConcern(1)];
+        return array_merge([123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new ReadPreference(ReadPreference::RP_PRIMARY), new WriteConcern(1)], $includeNull ? [null] : []);
     }
 
     /**
      * Return a list of invalid string values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidStringValues()
+    protected function getInvalidStringValues($includeNull = false)
     {
-        return [123, 3.14, true, [], new stdClass()];
+        return array_merge([123, 3.14, true, [], new stdClass()], $includeNull ? [null] : []);
     }
 
     /**
      * Return a list of invalid WriteConcern values.
      *
+     * @param boolean $includeNull
+     *
      * @return array
      */
-    protected function getInvalidWriteConcernValues()
+    protected function getInvalidWriteConcernValues($includeNull = false)
     {
-        return [123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new ReadPreference(ReadPreference::RP_PRIMARY)];
+        return array_merge([123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new ReadPreference(ReadPreference::RP_PRIMARY)], $includeNull ? [null] : []);
     }
 
     /**


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-494

This fixes a few validation errors where it is possible to use `null` as a valid value for an option, resulting in undefined behaviour. All other options that have a default value are directly checked for their type, without an `isset` check to guard against a missing option since it should always be present due to the array union.