### PR TITLE
Add Options constant classes

### DIFF
--- a/src/Operation/Options/AggregateOptions.php
+++ b/src/Operation/Options/AggregateOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class AggregateOptions

--- a/src/Operation/Options/AggregateOptions.php
+++ b/src/Operation/Options/AggregateOptions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class AggregateOptions
+{
+    const ALLOW_DISK_USE = 'allowDiskUse';
+    const BATCH_SIZE = 'batchSize';
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const COMMENT = 'comment';
+    const EXPLAIN = 'explain';
+    const HINT = 'hint';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+    const USE_CURSOR = 'useCursor';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/BulkWriteOptions.php
+++ b/src/Operation/Options/BulkWriteOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class BulkWriteOptions

--- a/src/Operation/Options/BulkWriteOptions.php
+++ b/src/Operation/Options/BulkWriteOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class BulkWriteOptions
+{
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const ORDERED = 'ordered';
+    const SESSION = 'session';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/CountDocumentsOptions.php
+++ b/src/Operation/Options/CountDocumentsOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class CountDocumentsOptions

--- a/src/Operation/Options/CountDocumentsOptions.php
+++ b/src/Operation/Options/CountDocumentsOptions.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class CountDocumentsOptions
+{
+    const COLLATION = 'collation';
+    const HINT = 'hint';
+    const LIMIT = 'limit';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const SESSION = 'session';
+    const SKIP = 'skip';
+}

--- a/src/Operation/Options/CountOptions.php
+++ b/src/Operation/Options/CountOptions.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class CountOptions
+{
+    const COLLATION = 'collation';
+    const HINT = 'hint';
+    const LIMIT = 'limit';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const SESSION = 'session';
+    const SKIP = 'skip';
+}

--- a/src/Operation/Options/CountOptions.php
+++ b/src/Operation/Options/CountOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class CountOptions

--- a/src/Operation/Options/CreateCollectionOptions.php
+++ b/src/Operation/Options/CreateCollectionOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class CreateCollectionOptions

--- a/src/Operation/Options/CreateCollectionOptions.php
+++ b/src/Operation/Options/CreateCollectionOptions.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class CreateCollectionOptions
+{
+    const AUTO_INDEX_ID = 'autoIndexId';
+    const CAPPED = 'capped';
+    const COLLATION = 'collation';
+    const FLAGS = 'flags';
+    const INDEX_OPTION_DEFAULTS = 'indexOptionDefaults';
+    const MAX = 'max';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const SESSION = 'session';
+    const SIZE = 'size';
+    const STORAGE_ENGINE = 'storageEngine';
+    const TYPE_MAP = 'typeMap';
+    const VALIDATION_ACTION = 'validationAction';
+    const VALIDATION_LEVEL = 'validationLevel';
+    const VALIDATOR = 'validator';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/CreateIndexOptions.php
+++ b/src/Operation/Options/CreateIndexOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class CreateIndexOptions

--- a/src/Operation/Options/CreateIndexOptions.php
+++ b/src/Operation/Options/CreateIndexOptions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class CreateIndexOptions
+{
+    const BACKGROUND = 'background';
+    const COLLATION = 'collation';
+    const EXPIRE_AFTER_SECONDS = 'expireAfterSeconds';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const NAME = 'name';
+    const PARTIAL_FILTER_EXPRESSION = 'partialFilterExpression';
+    const SESSION = 'session';
+    const SPARSE = 'sparse';
+    const TWO_D_SPHERE_INDEX_VERSION = '2dsphereIndexVersion';
+    const UNIQUE = 'unique';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/CreateIndexesOptions.php
+++ b/src/Operation/Options/CreateIndexesOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class CreateIndexesOptions
+{
+    const MAX_TIME_MS = 'maxTimeMS';
+    const SESSION = 'session';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/CreateIndexesOptions.php
+++ b/src/Operation/Options/CreateIndexesOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class CreateIndexesOptions

--- a/src/Operation/Options/DeleteManyOptions.php
+++ b/src/Operation/Options/DeleteManyOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class DeleteManyOptions
+{
+    const COLLATION = 'collation';
+    const SESSION = 'session';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/DeleteManyOptions.php
+++ b/src/Operation/Options/DeleteManyOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class DeleteManyOptions

--- a/src/Operation/Options/DeleteOneOptions.php
+++ b/src/Operation/Options/DeleteOneOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class DeleteOneOptions

--- a/src/Operation/Options/DeleteOneOptions.php
+++ b/src/Operation/Options/DeleteOneOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class DeleteOneOptions
+{
+    const COLLATION = 'collation';
+    const SESSION = 'session';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/DistinctOptions.php
+++ b/src/Operation/Options/DistinctOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class DistinctOptions

--- a/src/Operation/Options/DistinctOptions.php
+++ b/src/Operation/Options/DistinctOptions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class DistinctOptions
+{
+    const COLLATION = 'collation';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+}

--- a/src/Operation/Options/DropCollectionOptions.php
+++ b/src/Operation/Options/DropCollectionOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class DropCollectionOptions

--- a/src/Operation/Options/DropCollectionOptions.php
+++ b/src/Operation/Options/DropCollectionOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class DropCollectionOptions
+{
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/DropDatabaseOptions.php
+++ b/src/Operation/Options/DropDatabaseOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class DropDatabaseOptions

--- a/src/Operation/Options/DropDatabaseOptions.php
+++ b/src/Operation/Options/DropDatabaseOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class DropDatabaseOptions
+{
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/DropIndexOptions.php
+++ b/src/Operation/Options/DropIndexOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class DropIndexOptions

--- a/src/Operation/Options/DropIndexOptions.php
+++ b/src/Operation/Options/DropIndexOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class DropIndexOptions
+{
+    const MAX_TIME_MS = 'maxTimeMS';
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/DropIndexesOptions.php
+++ b/src/Operation/Options/DropIndexesOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class DropIndexesOptions
+{
+    const MAX_TIME_MS = 'maxTimeMS';
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/DropIndexesOptions.php
+++ b/src/Operation/Options/DropIndexesOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class DropIndexesOptions

--- a/src/Operation/Options/DropOptions.php
+++ b/src/Operation/Options/DropOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class DropOptions
+{
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/DropOptions.php
+++ b/src/Operation/Options/DropOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class DropOptions

--- a/src/Operation/Options/EstimatedDocumentCountOptions.php
+++ b/src/Operation/Options/EstimatedDocumentCountOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class EstimatedDocumentCountOptions

--- a/src/Operation/Options/EstimatedDocumentCountOptions.php
+++ b/src/Operation/Options/EstimatedDocumentCountOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class EstimatedDocumentCountOptions
+{
+    const MAX_TIME_MS = 'maxTimeMS';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const SESSION = 'session';
+}

--- a/src/Operation/Options/ExplainOptions.php
+++ b/src/Operation/Options/ExplainOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class ExplainOptions

--- a/src/Operation/Options/ExplainOptions.php
+++ b/src/Operation/Options/ExplainOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class ExplainOptions
+{
+    const READ_PREFERENCE = 'readPreference';
+    const TYPE_MAP = 'typeMap';
+    const VERBOSITY = 'verbosity';
+}

--- a/src/Operation/Options/FindOneAndDeleteOptions.php
+++ b/src/Operation/Options/FindOneAndDeleteOptions.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class FindOneAndDeleteOptions
+{
+    const COLLATION = 'collation';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const PROJECTION = 'projection';
+    const SESSION = 'session';
+    const SORT = 'sort';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/FindOneAndDeleteOptions.php
+++ b/src/Operation/Options/FindOneAndDeleteOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class FindOneAndDeleteOptions

--- a/src/Operation/Options/FindOneAndReplaceOptions.php
+++ b/src/Operation/Options/FindOneAndReplaceOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class FindOneAndReplaceOptions

--- a/src/Operation/Options/FindOneAndReplaceOptions.php
+++ b/src/Operation/Options/FindOneAndReplaceOptions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class FindOneAndReplaceOptions
+{
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const COLLATION = 'collation';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const PROJECTION = 'projection';
+    const RETURN_DOCUMENT = 'returnDocument';
+    const SESSION = 'session';
+    const SORT = 'sort';
+    const TYPE_MAP = 'typeMap';
+    const UPSERT = 'upsert';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/FindOneAndUpdateOptions.php
+++ b/src/Operation/Options/FindOneAndUpdateOptions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class FindOneAndUpdateOptions
+{
+    const ARRAY_FILTERS = 'arrayFilters';
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const COLLATION = 'collation';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const PROJECTION = 'projection';
+    const RETURN_DOCUMENT = 'returnDocument';
+    const SESSION = 'session';
+    const SORT = 'sort';
+    const TYPE_MAP = 'typeMap';
+    const UPSERT = 'upsert';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/FindOneAndUpdateOptions.php
+++ b/src/Operation/Options/FindOneAndUpdateOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class FindOneAndUpdateOptions

--- a/src/Operation/Options/FindOneOptions.php
+++ b/src/Operation/Options/FindOneOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class FindOneOptions

--- a/src/Operation/Options/FindOneOptions.php
+++ b/src/Operation/Options/FindOneOptions.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class FindOneOptions
+{
+    const COLLATION = 'collation';
+    const COMMENT = 'comment';
+    const HINT = 'hint';
+    const MAX = 'max';
+    const MAX_SCAN = 'maxScan';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const MIN = 'min';
+    const MODIFIERS = 'modifiers';
+    const PROJECTION = 'projection';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const RETURN_KEY = 'returnKey';
+    const SESSION = 'session';
+    const SHOW_RECORD_ID = 'showRecordId';
+    const SKIP = 'skip';
+    const SORT = 'sort';
+    const TYPE_MAP = 'typeMap';
+}

--- a/src/Operation/Options/FindOptions.php
+++ b/src/Operation/Options/FindOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class FindOptions

--- a/src/Operation/Options/FindOptions.php
+++ b/src/Operation/Options/FindOptions.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class FindOptions
+{
+    const ALLOW_PARTIAL_RESULTS = 'allowPartialResults';
+    const BATCH_SIZE = 'batchSize';
+    const COLLATION = 'collation';
+    const COMMENT = 'comment';
+    const CURSOR_TYPE = 'cursorType';
+    const HINT = 'hint';
+    const LIMIT = 'limit';
+    const MAX = 'max';
+    const MAX_AWAIT_TIME_MS = 'maxAwaitTimeMS';
+    const MAX_SCAN = 'maxScan';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const MIN = 'min';
+    const MODIFIERS = 'modifiers';
+    const NO_CURSOR_TIMEOUT = 'noCursorTimeout';
+    const OPLOG_REPLAY = 'oplogReplay';
+    const PROJECTION = 'projection';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const RETURN_KEY = 'returnKey';
+    const SESSION = 'session';
+    const SHOW_RECORD_ID = 'showRecordId';
+    const SKIP = 'skip';
+    const SNAPSHOT = 'snapshot';
+    const SORT = 'sort';
+    const TYPE_MAP = 'typeMap';
+}

--- a/src/Operation/Options/InsertManyOptions.php
+++ b/src/Operation/Options/InsertManyOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class InsertManyOptions

--- a/src/Operation/Options/InsertManyOptions.php
+++ b/src/Operation/Options/InsertManyOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class InsertManyOptions
+{
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const ORDERED = 'ordered';
+    const SESSION = 'session';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/InsertOneOptions.php
+++ b/src/Operation/Options/InsertOneOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class InsertOneOptions

--- a/src/Operation/Options/InsertOneOptions.php
+++ b/src/Operation/Options/InsertOneOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class InsertOneOptions
+{
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const SESSION = 'session';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/ListCollectionsOptions.php
+++ b/src/Operation/Options/ListCollectionsOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class ListCollectionsOptions
+{
+    const FILTER = 'filter';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const SESSION = 'session';
+}

--- a/src/Operation/Options/ListCollectionsOptions.php
+++ b/src/Operation/Options/ListCollectionsOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class ListCollectionsOptions

--- a/src/Operation/Options/ListDatabasesOptions.php
+++ b/src/Operation/Options/ListDatabasesOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class ListDatabasesOptions
+{
+    const FILTER = 'filter';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const SESSION = 'session';
+}

--- a/src/Operation/Options/ListDatabasesOptions.php
+++ b/src/Operation/Options/ListDatabasesOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class ListDatabasesOptions

--- a/src/Operation/Options/ListIndexesOptions.php
+++ b/src/Operation/Options/ListIndexesOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class ListIndexesOptions

--- a/src/Operation/Options/ListIndexesOptions.php
+++ b/src/Operation/Options/ListIndexesOptions.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class ListIndexesOptions
+{
+    const MAX_TIME_MS = 'maxTimeMS';
+    const SESSION = 'session';
+}

--- a/src/Operation/Options/MapReduceOptions.php
+++ b/src/Operation/Options/MapReduceOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class MapReduceOptions

--- a/src/Operation/Options/MapReduceOptions.php
+++ b/src/Operation/Options/MapReduceOptions.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class MapReduceOptions
+{
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const COLLATION = 'collation';
+    const FINALIZE = 'finalize';
+    const JS_MODE = 'jsMode';
+    const LIMIT = 'limit';
+    const MAX_TIME_MS = 'maxTimeMS';
+    const QUERY = 'query';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const SCOPE = 'scope';
+    const SESSION = 'session';
+    const SORT = 'sort';
+    const TYPE_MAP = 'typeMap';
+    const VERBOSE = 'verbose';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/ModifyCollectionOptions.php
+++ b/src/Operation/Options/ModifyCollectionOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class ModifyCollectionOptions
+{
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/ModifyCollectionOptions.php
+++ b/src/Operation/Options/ModifyCollectionOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class ModifyCollectionOptions

--- a/src/Operation/Options/ReplaceOneOptions.php
+++ b/src/Operation/Options/ReplaceOneOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class ReplaceOneOptions

--- a/src/Operation/Options/ReplaceOneOptions.php
+++ b/src/Operation/Options/ReplaceOneOptions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class ReplaceOneOptions
+{
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const COLLATION = 'collation';
+    const SESSION = 'session';
+    const UPSERT = 'upsert';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/SelectCollectionOptions.php
+++ b/src/Operation/Options/SelectCollectionOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class SelectCollectionOptions

--- a/src/Operation/Options/SelectCollectionOptions.php
+++ b/src/Operation/Options/SelectCollectionOptions.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class SelectCollectionOptions
+{
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const SESSION = 'session';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/SelectDatabaseOptions.php
+++ b/src/Operation/Options/SelectDatabaseOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class SelectDatabaseOptions

--- a/src/Operation/Options/SelectDatabaseOptions.php
+++ b/src/Operation/Options/SelectDatabaseOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class SelectDatabaseOptions
+{
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/SelectGridFSBucketOptions.php
+++ b/src/Operation/Options/SelectGridFSBucketOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class SelectGridFSBucketOptions

--- a/src/Operation/Options/SelectGridFSBucketOptions.php
+++ b/src/Operation/Options/SelectGridFSBucketOptions.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class SelectGridFSBucketOptions
+{
+    const BUCKET_NAME = 'bucketName';
+    const CHUNK_SIZE_BYTES = 'chunkSizeBytes';
+    const DISABLE_MD5 = 'disableMD5';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/SessionOptions.php
+++ b/src/Operation/Options/SessionOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class SessionOptions

--- a/src/Operation/Options/SessionOptions.php
+++ b/src/Operation/Options/SessionOptions.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class SessionOptions
+{
+    const CAUSAL_CONSISTENCY = 'causalConsistency';
+    const DEFAULT_TRANSACTION_OPTIONS = 'defaultTransactionOptions';
+}

--- a/src/Operation/Options/SessionTransactionOptions.php
+++ b/src/Operation/Options/SessionTransactionOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class SessionTransactionOptions

--- a/src/Operation/Options/SessionTransactionOptions.php
+++ b/src/Operation/Options/SessionTransactionOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class SessionTransactionOptions
+{
+    const MAX_COMMIT_TIME_MS = 'maxCommitTimeMS';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/StartSessionOptions.php
+++ b/src/Operation/Options/StartSessionOptions.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class StartSessionOptions
+{
+    const CAUSAL_CONSISTENCY = 'causalConsistency';
+    const DEFAULT_TRANSACTION_OPTIONS = 'defaultTransactionOptions';
+}

--- a/src/Operation/Options/StartSessionOptions.php
+++ b/src/Operation/Options/StartSessionOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class StartSessionOptions

--- a/src/Operation/Options/UpdateManyOptions.php
+++ b/src/Operation/Options/UpdateManyOptions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class UpdateManyOptions
+{
+    const ARRAY_FILTERS = 'arrayFilters';
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const COLLATION = 'collation';
+    const SESSION = 'session';
+    const UPSERT = 'upsert';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/UpdateManyOptions.php
+++ b/src/Operation/Options/UpdateManyOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class UpdateManyOptions

--- a/src/Operation/Options/UpdateOneOptions.php
+++ b/src/Operation/Options/UpdateOneOptions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class UpdateOneOptions
+{
+    const ARRAY_FILTERS = 'arrayFilters';
+    const BYPASS_DOCUMENT_VALIDATION = 'bypassDocumentValidation';
+    const COLLATION = 'collation';
+    const SESSION = 'session';
+    const UPSERT = 'upsert';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Operation/Options/UpdateOneOptions.php
+++ b/src/Operation/Options/UpdateOneOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class UpdateOneOptions

--- a/src/Operation/Options/ValidationAction.php
+++ b/src/Operation/Options/ValidationAction.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class ValidationAction
+{
+    const ERROR = 'error';
+    const WARN = 'warn';
+}

--- a/src/Operation/Options/ValidationAction.php
+++ b/src/Operation/Options/ValidationAction.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class ValidationAction

--- a/src/Operation/Options/ValidationLevel.php
+++ b/src/Operation/Options/ValidationLevel.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class ValidationLevel

--- a/src/Operation/Options/ValidationLevel.php
+++ b/src/Operation/Options/ValidationLevel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class ValidationLevel
+{
+    const MODERATE = 'moderate';
+    const OFF = 'off';
+    const STRICT = 'strict';
+}

--- a/src/Operation/Options/WatchOptions.php
+++ b/src/Operation/Options/WatchOptions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MongoDB\Operation\Options;
+
+final class WatchOptions
+{
+    const BATCH_SIZE = 'batchSize';
+    const COLLATION = 'collation';
+    const FULL_DOCUMENT = 'fullDocument';
+    const MAX_AWAIT_TIME_MS = 'maxAwaitTimeMS';
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const RESUME_AFTER = 'resumeAfter';
+    const SESSION = 'session';
+    const START_AFTER = 'startAfter';
+    const START_AT_OPERATION_TIME = 'startAtOperationTime';
+    const TYPE_MAP = 'typeMap';
+}

--- a/src/Operation/Options/WatchOptions.php
+++ b/src/Operation/Options/WatchOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Operation\Options;
 
 final class WatchOptions

--- a/src/Options/ClientOptions.php
+++ b/src/Options/ClientOptions.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace MongoDB\Options;
+
+final class ClientOptions
+{
+    const ALLOW_INVALID_HOSTNAME = 'allow_invalid_hostname';
+    const CERTIFICATE_AUTHORITY_DIR = 'ca_dir';
+    const CERTIFICATE_AUTHORITY_FILE = 'ca_file';
+    const CONTEXT = 'context';
+    const CERTIFICATE_REVOCATION_LIST_FILE = 'crl_file';
+    const PEM_FILE = 'pem_file';
+    const PEM_PASSPHRASE = 'pem_pwd';
+    const TYPE_MAP = 'typeMap';
+    const WEAK_CERT_VALIDATION = 'weak_cert_validation';
+}

--- a/src/Options/ClientOptions.php
+++ b/src/Options/ClientOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Options;
 
 final class ClientOptions

--- a/src/Options/CollectionOptions.php
+++ b/src/Options/CollectionOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Options;
 
 final class CollectionOptions

--- a/src/Options/CollectionOptions.php
+++ b/src/Options/CollectionOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Options;
+
+final class CollectionOptions
+{
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Options/DatabaseOptions.php
+++ b/src/Options/DatabaseOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Options;
 
 final class DatabaseOptions

--- a/src/Options/DatabaseOptions.php
+++ b/src/Options/DatabaseOptions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MongoDB\Options;
+
+final class DatabaseOptions
+{
+    const READ_CONCERN = 'readConcern';
+    const READ_PREFERENCE = 'readPreference';
+    const TYPE_MAP = 'typeMap';
+    const WRITE_CONCERN = 'writeConcern';
+}

--- a/src/Options/DriverOptions.php
+++ b/src/Options/DriverOptions.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MongoDB\Options;
+
+final class DriverOptions
+{
+    const ALLOW_INVALID_HOSTNAME = 'allow_invalid_hostname';
+    const CERTIFICATE_AUTHORITY_DIR = 'ca_dir';
+    const CERTIFICATE_AUTHORITY_FILE = 'ca_file';
+    const CONTEXT = 'context';
+    const CERTIFICATE_REVOCATION_LIST_FILE = 'crl_file';
+    const PEM_FILE = 'pem_file';
+    const PEM_PASSPHRASE = 'pem_pwd';
+    const WEAK_CERT_VALIDATION = 'weak_cert_validation';
+}

--- a/src/Options/DriverOptions.php
+++ b/src/Options/DriverOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Options;
 
 final class DriverOptions

--- a/src/Options/UriOptions.php
+++ b/src/Options/UriOptions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MongoDB\Options;
+
+final class UriOptions
+{
+    const APP_NAME = 'appname';
+    const AUTH_MECHANISM = 'authMechanism';
+    const AUTH_MECHANISM_PROPERTIES = 'authMechanismProperties';
+    const AUTH_SOURCE = 'authSource';
+    const CANONICALIZE_HOSTNAME = 'canonicalizeHostname';
+    const COMPRESSORS = 'compressors';
+    const CONNECT_TIMEOUT_MS = 'connectTimeoutMS';
+    const GSSAPI_SERVICE_NAME = 'gssapiServiceName';
+    const HEARTBEAT_FREQUENCY_MS = 'heartbeatFrequencyMS';
+    const JOURNAL = 'journal';
+    const LOCAL_THRESHOLD_MS = 'localThresholdMS';
+    const MAX_STALENESS_SECONDS = 'maxStalenessSeconds';
+    const PASSWORD = 'password';
+    const READ_CONCERN_LEVEL = 'readConcernLevel';
+    const READ_PREFERENCE = 'readPreference';
+    const READ_PREFERENCE_TAGS = 'readPreferenceTags';
+    const REPLICA_SET = 'replicaSet';
+    const RETRY_READS = 'retryReads';
+    const RETRY_WRITES = 'retryWrites';
+    const SAFE = 'safe';
+    const SERVER_SELECTION_TIMEOUT_MS = 'serverSelectionTimeoutMS';
+    const SERVER_SELECTION_TRY_ONCE = 'serverSelectionTryOnce';
+    const SLAVE_OK = 'slaveOk';
+    const SOCKET_CHECK_INTERVAL_MS = 'socketCheckIntervalMS';
+    const SOCKET_TIMEOUT_MS = 'socketTimeoutMS';
+    const SSL = 'ssl';
+    const TLS = 'tls';
+    const TLS_ALLOW_INVALID_CERTIFICATES = 'tlsAllowInvalidCertificates';
+    const TLS_ALLOW_INVALID_HOSTNAMES = 'tlsAllowInvalidHostnames';
+    const TLS_CAFILE = 'tlsCAFile';
+    const TLS_CERTIFICATE_KEY_FILE = 'tlsCertificateKeyFile';
+    const TLS_CERTIFICATE_KEY_FILE_PASSWORD = 'tlsCertificateKeyFilePassword';
+    const TLS_INSECURE = 'tlsInsecure';
+    const USERNAME = 'username';
+    const WRITE_CONCERN = 'w';
+    const WRITE_CONCERN_TIMEOUT_MS = 'wTimeoutMS';
+    const ZLIB_COMPRESSION_LEVEL = 'zlibCompressionLevel';
+}

--- a/src/Options/UriOptions.php
+++ b/src/Options/UriOptions.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace MongoDB\Options;
 
 final class UriOptions


### PR DESCRIPTION
This pull request adds final classes containing constants for various option keys. Often i cannot remember the proper label or casing for various options. These constants will help developers avoid spelling errors and would immediately know what options are available for which operation.

Example usages would be
```php
use MongoDB\Client;
use MongoDB\Driver\ReadPreference;
use MongoDB\Operation\Options\FindOptions;
use MongoDB\Options\ClientOptions;
use MongoDB\Options\DriverOptions;
use MongoDB\Options\UriOptions;

$uri = 'mongodb://127.0.0.1';
$username = getenv('MONGO_USERNAME');
$password = getenv('MONGO_PASSWORD');

$uriOptions = [
    UriOptions::READ_PREFERENCE => ReadPreference::RP_SECONDARY_PREFERRED,
    UriOptions::WRITE_CONCERN => 1,
    UriOptions::USERNAME => $username,
    UriOptions::PASSWORD => $password,
];

$driverOptions = [
    DriverOptions::ALLOW_INVALID_HOSTNAME => false,
];

$client new Client($uri, $uriOptions, $driverOptions);
$collection = $client->selectDatabase('myDatabase')->selectCollection('myCollection');

$options = [
    FindOptions::LIMIT => 100,
    FindOptions::SKIP => 10,
    FindOptions::SORT => ['key1' => -1],
];

$collection->find([], $options);
```
  
