### PR TITLE
PHPLIB-519: Allow testing against development driver versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,18 @@ jobs:
       env:
         - DEPLOYMENT=SHARDED_CLUSTER_RS
 
+    # Test next patch release for driver
+    - stage: Test
+      php: "7.3"
+      env:
+        - DRIVER_BRANCH="v1.6"
+
+    # Test next minor release for driver
+    - stage: Test
+      php: "7.3"
+      env:
+        - DRIVER_BRANCH="master"
+
 before_install:
   - pip install "mongo-orchestration>=0.6.7,<1.0" --user `whoami`
   - export SERVER_FILENAME=mongodb-linux-x86_64-${SERVER_DISTRO}-${SERVER_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       php: "7.1"
       before_install: []
       before_script:
-        - pecl install -f mongodb-${DRIVER_VERSION}
+        - .travis/install-extension.sh
         - composer require --no-update doctrine/coding-standard=^6.0
         - composer install --no-interaction --no-progress --no-suggest ${COMPOSER_OPTIONS}
       script: vendor/bin/phpcs
@@ -120,28 +120,11 @@ before_install:
   - mongod --version
   - mongo-orchestration --version
   - export MO_PATH=`python -c 'import mongo_orchestration; from os import path; print(path.dirname(mongo_orchestration.__file__));'`
-  - |
-    INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    # tpecl is a helper to compile and cache php extensions
-      tpecl () {
-          local ext_name=$1
-          local ext_so=$2
-          local ext_dir=$(php -r "echo ini_get('extension_dir');")
-          local ext_cache=~/php-ext/$(basename $ext_dir)/$ext_name
-          if [[ -e $ext_cache/$ext_so ]]; then
-              echo extension = $ext_cache/$ext_so >> $INI
-          else
-              mkdir -p $ext_cache
-              echo yes | pecl install -f $ext_name &&
-              cp $ext_dir/$ext_so $ext_cache
-          fi
-      }
-      export -f tpecl
 
 before_script:
   - mongo-orchestration start
   - .travis/setup_mo.sh
-  - pecl install -f mongodb-${DRIVER_VERSION}
+  - .travis/install-extension.sh
   - php --ri mongodb
   - composer update --no-interaction --no-progress --no-suggest --prefer-dist --prefer-stable ${COMPOSER_OPTIONS}
   - ulimit -c

--- a/.travis/install-extension.sh
+++ b/.travis/install-extension.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+# tpecl is a helper to compile and cache php extensions
+tpecl () {
+    local ext_name=$1
+    local ext_so=$2
+    local ext_dir=$(php -r "echo ini_get('extension_dir');")
+    local ext_cache=~/php-ext/$(basename $ext_dir)/$ext_name
+    if [[ -e $ext_cache/$ext_so ]]; then
+        echo extension = $ext_cache/$ext_so >> $INI
+    else
+        mkdir -p $ext_cache
+        echo yes | pecl install -f $ext_name &&
+        cp $ext_dir/$ext_so $ext_cache
+    fi
+}
+
+if [ "x${DRIVER_VERSION}" != "x" ]; then
+  echo "Installing driver version ${DRIVER_VERSION} from PECL"
+  tpecl mongodb-${DRIVER_VERSION} mongodb.so
+fi

--- a/.travis/install-extension.sh
+++ b/.travis/install-extension.sh
@@ -16,7 +16,22 @@ tpecl () {
     fi
 }
 
-if [ "x${DRIVER_VERSION}" != "x" ]; then
+if [ "x${DRIVER_BRANCH}" != "x" ]; then
+  echo "Compiling driver branch ${DRIVER_BRANCH}"
+
+  mkdir -p /tmp/compile
+  git clone https://github.com/mongodb/mongo-php-driver /tmp/compile/mongo-php-driver
+  cd /tmp/compile/mongo-php-driver
+
+  git checkout ${DRIVER_BRANCH}
+  git submodule update --init
+  phpize
+  ./configure --enable-mongodb-developer-flags
+  make all -j20 > /dev/null
+  make install
+
+  echo "extension=mongodb.so" >> `php --ini | grep "Scan for additional .ini files in" | sed -e "s|.*:\s*||"`/mongodb.ini
+elif [ "x${DRIVER_VERSION}" != "x" ]; then
   echo "Installing driver version ${DRIVER_VERSION} from PECL"
   tpecl mongodb-${DRIVER_VERSION} mongodb.so
 fi


### PR DESCRIPTION
This allows us to later switch to always test against dev driver versions until the RC phase of the extension, saving us the trouble of releasing alpha builds of the driver for internal testing purposes.