### PR TITLE
PHPLIB-502: Assert against transaction state

### DIFF
--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -568,8 +568,7 @@ final class Operation
                  * instead exposes a bool to let us know whether a transaction
                  * is currently in progress. This code may fail down the line
                  * and should be adjusted once PHPC-1438 is implemented. */
-                $expected = in_array($this->arguments['state'], ['in_progress', 'starting']);
-                $test->assertSame($expected, $args['session']->isInTransaction());
+                $test->assertSame($this->arguments['state'], $args['session']->getTransactionState());
 
                 return null;
             case 'assertSessionUnpinned':


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-502

This makes use of the new `getTransactionState` accessor introduced in https://github.com/mongodb/mongo-php-driver/pull/1061 to assert against the transaction state in spec tests.