### PR TITLE
Rely on Collection to apply read/write opts for old servers

### DIFF
--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -38,7 +38,7 @@ final class Context
     public $defaultWriteOptions = [];
 
     /** @var array */
-    public $outcomeFindOptions = [];
+    public $outcomeReadOptions = [];
 
     /** @var string */
     public $outcomeCollectionName;
@@ -98,7 +98,7 @@ final class Context
             'writeConcern' => new WriteConcern(WriteConcern::MAJORITY),
         ];
 
-        $o->outcomeFindOptions = [
+        $o->outcomeReadOptions = [
             'readConcern' => new ReadConcern('local'),
             'readPreference' => new ReadPreference('primary'),
         ];
@@ -147,7 +147,7 @@ final class Context
             'writeConcern' => new WriteConcern(WriteConcern::MAJORITY),
         ];
 
-        $o->outcomeFindOptions = [
+        $o->outcomeReadOptions = [
             'readConcern' => new ReadConcern('local'),
             'readPreference' => new ReadPreference('primary'),
         ];

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -101,12 +101,11 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      */
     protected function assertOutcomeCollectionData(array $expectedDocuments)
     {
-        $outcomeCollection = $this->getOutcomeCollection();
-        $findOptions = $this->getContext()->outcomeFindOptions;
+        $outcomeCollection = $this->getOutcomeCollection($this->getContext()->outcomeReadOptions);
 
         $mi = new MultipleIterator(MultipleIterator::MIT_NEED_ANY);
         $mi->attachIterator(new ArrayIterator($expectedDocuments));
-        $mi->attachIterator(new IteratorIterator($outcomeCollection->find([], $findOptions)));
+        $mi->attachIterator(new IteratorIterator($outcomeCollection->find()));
 
         foreach ($mi as $documents) {
             list($expectedDocument, $actualDocument) = $documents;
@@ -193,16 +192,16 @@ class FunctionalTestCase extends BaseFunctionalTestCase
 
         $collection = null;
         if ($context->collectionName !== null) {
-            $collection = $context->getCollection();
-            $collection->drop($context->defaultWriteOptions);
+            $collection = $context->getCollection($context->defaultWriteOptions);
+            $collection->drop();
         }
 
         if ($context->outcomeCollectionName !== null) {
-            $outcomeCollection = $this->getOutcomeCollection();
+            $outcomeCollection = $this->getOutcomeCollection($context->defaultWriteOptions);
 
             // Avoid redundant drop if the test and outcome collections are the same
             if ($collection === null || $outcomeCollection->getNamespace() !== $collection->getNamespace()) {
-                $outcomeCollection->drop($context->defaultWriteOptions);
+                $outcomeCollection->drop();
             }
         }
     }
@@ -226,12 +225,12 @@ class FunctionalTestCase extends BaseFunctionalTestCase
         return;
     }
 
-    private function getOutcomeCollection()
+    private function getOutcomeCollection(array $collectionOptions = [])
     {
         $context = $this->getContext();
 
         // Outcome collection need not use the client under test
-        return new Collection($this->manager, $context->databaseName, $context->outcomeCollectionName);
+        return new Collection($this->manager, $context->databaseName, $context->outcomeCollectionName, $collectionOptions);
     }
 
     /**


### PR DESCRIPTION
Server versions < 3.4 do not support write concerns for drop commands. Rather than pass the context's write options directly to drop(), filter them through the Collection class so it can decide to inherit them based on the server's wire version.

Likewise for executing find() on the output collection.

Cherry-picked from https://github.com/mongodb/mongo-php-library/pull/711. This didn't come up sooner because all existing CRUD and transaction tests have `minServerVersion` requirements > 3.4.