### PR TITLE
PHPLIB-499: Handle absence of 'ns' field in index specifications returned from listIndexes

### DIFF
--- a/src/Model/IndexInfoIteratorIterator.php
+++ b/src/Model/IndexInfoIteratorIterator.php
@@ -18,6 +18,8 @@
 namespace MongoDB\Model;
 
 use IteratorIterator;
+use Traversable;
+use function array_key_exists;
 
 /**
  * IndexInfoIterator for both listIndexes command and legacy query results.
@@ -34,6 +36,19 @@ use IteratorIterator;
  */
 class IndexInfoIteratorIterator extends IteratorIterator implements IndexInfoIterator
 {
+    /** @var string|null $ns */
+    private $ns;
+
+    /**
+     * @param string|null $ns
+     */
+    public function __construct(Traversable $iterator, $ns = null)
+    {
+        parent::__construct($iterator);
+
+        $this->ns = $ns;
+    }
+
     /**
      * Return the current element as an IndexInfo instance.
      *
@@ -43,6 +58,12 @@ class IndexInfoIteratorIterator extends IteratorIterator implements IndexInfoIte
      */
     public function current()
     {
-        return new IndexInfo(parent::current());
+        $info = parent::current();
+
+        if (! array_key_exists('ns', $info) && $this->ns !== null) {
+            $info['ns'] = $this->ns;
+        }
+
+        return new IndexInfo($info);
     }
 }

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -149,6 +149,6 @@ class ListIndexes implements Executable
 
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);
 
-        return new IndexInfoIteratorIterator(new CachingIterator($cursor));
+        return new IndexInfoIteratorIterator(new CachingIterator($cursor), $this->databaseName . '.' . $this->collectionName);
     }
 }

--- a/tests/Operation/ListIndexesFunctionalTest.php
+++ b/tests/Operation/ListIndexesFunctionalTest.php
@@ -31,6 +31,7 @@ class ListIndexesFunctionalTest extends FunctionalTestCase
         foreach ($indexes as $index) {
             $this->assertInstanceOf(IndexInfo::class, $index);
             $this->assertEquals(['_id' => 1], $index->getKey());
+            $this->assertSame($this->getNamespace(), $index->getNamespace());
         }
     }
 


### PR DESCRIPTION
This serves as POC for the change. When creating an `IndexInfoIterator`, we provide it with an optional namespace, which will be used for the `ns` field in the index information if it wasn't provided by the server (which will be the case for 4.4).

This PR also deprecates the `getNamespace` method for consistency with the server. We may want to keep the method, but considering that the namespace is no longer part of the index information returned by the server, we may opt to drop the method as well.