### PR TITLE
PHPLIB-530: Test against MongoDB 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,12 @@ jobs:
       env:
         - SERVER_VERSION=4.0.12
 
+    # Test upcoming server version
+    - stage: Test
+      php: "7.3"
+      env:
+        - SERVER_VERSION=4.3.3
+
     # Test other server configurations
     - stage: Test
       php: "7.3"

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -55,8 +55,8 @@ class MapReduceResult implements IteratorAggregate
     public function __construct(callable $getIterator, stdClass $result)
     {
         $this->getIterator = $getIterator;
-        $this->executionTimeMS = (integer) $result->timeMillis;
-        $this->counts = (array) $result->counts;
+        $this->executionTimeMS = isset($result->timeMillis) ? (integer) $result->timeMillis : 0;
+        $this->counts = isset($result->counts) ? (array) $result->counts : [];
         $this->timing = isset($result->timing) ? (array) $result->timing : [];
     }
 

--- a/src/Model/CollectionInfoCommandIterator.php
+++ b/src/Model/CollectionInfoCommandIterator.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Model;
 
 use IteratorIterator;
+use Traversable;
 
 /**
  * CollectionInfoIterator for listCollections command results.
@@ -32,6 +33,19 @@ use IteratorIterator;
  */
 class CollectionInfoCommandIterator extends IteratorIterator implements CollectionInfoIterator
 {
+    /** @var string|null */
+    private $databaseName;
+
+    /**
+     * @param string|null $databaseName
+     */
+    public function __construct(Traversable $iterator, $databaseName = null)
+    {
+        parent::__construct($iterator);
+
+        $this->databaseName = $databaseName;
+    }
+
     /**
      * Return the current element as a CollectionInfo instance.
      *
@@ -41,6 +55,12 @@ class CollectionInfoCommandIterator extends IteratorIterator implements Collecti
      */
     public function current()
     {
-        return new CollectionInfo(parent::current());
+        $info = parent::current();
+
+        if ($this->databaseName !== null && isset($info['idIndex']) && ! isset($info['idIndex']['ns'])) {
+            $info['idIndex']['ns'] = $this->databaseName . '.' . $info['name'];
+        }
+
+        return new CollectionInfo($info);
     }
 }

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -136,6 +136,6 @@ class ListCollections implements Executable
         $cursor = $server->executeReadCommand($this->databaseName, new Command($cmd), $this->createOptions());
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);
 
-        return new CollectionInfoCommandIterator(new CachingIterator($cursor));
+        return new CollectionInfoCommandIterator(new CachingIterator($cursor), $this->databaseName);
     }
 }

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -396,8 +396,10 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
         $this->assertSameDocuments($expected, $result);
 
-        $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
-        $this->assertNotEmpty($result->getCounts());
+        if (version_compare($this->getServerVersion(), '4.3.0', '<')) {
+            $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
+            $this->assertNotEmpty($result->getCounts());
+        }
     }
 
     public function collectionMethodClosures()

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -92,12 +92,19 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         $result = $operation->execute($this->getPrimaryServer());
 
         $this->assertInstanceOf(MapReduceResult::class, $result);
-        $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
-        $this->assertNotEmpty($result->getCounts());
+
+        if (version_compare($this->getServerVersion(), '4.3.0', '<')) {
+            $this->assertGreaterThanOrEqual(0, $result->getExecutionTimeMS());
+            $this->assertNotEmpty($result->getCounts());
+        }
     }
 
     public function testResultIncludesTimingWithVerboseOption()
     {
+        if (version_compare($this->getServerVersion(), '4.3.0', '>=')) {
+            $this->markTestSkipped('mapReduce statistics are no longer exposed');
+        }
+
         $this->createFixtures(3);
 
         $map = new Javascript('function() { emit(this.x, this.y); }');
@@ -115,6 +122,10 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
     public function testResultDoesNotIncludeTimingWithoutVerboseOption()
     {
+        if (version_compare($this->getServerVersion(), '4.3.0', '>=')) {
+            $this->markTestSkipped('mapReduce statistics are no longer exposed');
+        }
+
         $this->createFixtures(3);
 
         $map = new Javascript('function() { emit(this.x, this.y); }');

--- a/tests/SpecTests/CrudSpecTest.php
+++ b/tests/SpecTests/CrudSpecTest.php
@@ -14,6 +14,13 @@ use function glob;
  */
 class CrudSpecTest extends FunctionalTestCase
 {
+    /** @var array */
+    private static $incompleteTests = [
+        'find-allowdiskuse: Find does not send allowDiskuse when value is not specified' => 'PHPLIB-500',
+        'find-allowdiskuse: Find sends allowDiskuse false when false is specified' => 'PHPLIB-500',
+        'find-allowdiskuse: Find sends allowDiskUse true when true is specified' => 'PHPLIB-500',
+    ];
+
     /**
      * Assert that the expected and actual command documents match.
      *
@@ -37,6 +44,10 @@ class CrudSpecTest extends FunctionalTestCase
      */
     public function testCrud(stdClass $test, array $runOn = null, array $data, $databaseName = null, $collectionName = null)
     {
+        if (isset(self::$incompleteTests[$this->dataDescription()])) {
+            $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);
+        }
+
         if (isset($runOn)) {
             $this->checkServerRequirements($runOn);
         }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-530, https://jira.mongodb.org/browse/PHPLIB-515

While working on #721, I noticed that we don't test against MongoDB 4.3. This PR adds 4.3 to the build pipeline and fixes test failures that come from this. Also removes execution stats from MapReduce (PHPLIB-515).