### PR TITLE
PHPLIB-522: Loosen index equality checks for GridFS

### DIFF
--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -17,14 +17,18 @@
 
 namespace MongoDB\GridFS;
 
+use ArrayIterator;
 use MongoDB\Collection;
 use MongoDB\Driver\Cursor;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\UpdateResult;
+use MultipleIterator;
 use stdClass;
 use function abs;
+use function count;
+use function is_numeric;
 use function sprintf;
 
 /**
@@ -289,13 +293,15 @@ class CollectionWrapper
      */
     private function ensureChunksIndex()
     {
+        $expectedIndex = ['files_id' => 1, 'n' => 1];
+
         foreach ($this->chunksCollection->listIndexes() as $index) {
-            if ($index->isUnique() && $index->getKey() === ['files_id' => 1, 'n' => 1]) {
+            if ($index->isUnique() && $this->indexKeysMatch($expectedIndex, $index->getKey())) {
                 return;
             }
         }
 
-        $this->chunksCollection->createIndex(['files_id' => 1, 'n' => 1], ['unique' => true]);
+        $this->chunksCollection->createIndex($expectedIndex, ['unique' => true]);
     }
 
     /**
@@ -303,13 +309,15 @@ class CollectionWrapper
      */
     private function ensureFilesIndex()
     {
+        $expectedIndex = ['filename' => 1, 'uploadDate' => 1];
+
         foreach ($this->filesCollection->listIndexes() as $index) {
-            if ($index->getKey() === ['filename' => 1, 'uploadDate' => 1]) {
+            if ($this->indexKeysMatch($expectedIndex, $index->getKey())) {
                 return;
             }
         }
 
-        $this->filesCollection->createIndex(['filename' => 1, 'uploadDate' => 1]);
+        $this->filesCollection->createIndex($expectedIndex);
     }
 
     /**
@@ -332,6 +340,36 @@ class CollectionWrapper
 
         $this->ensureFilesIndex();
         $this->ensureChunksIndex();
+    }
+
+    private function indexKeysMatch(array $expectedKeys, array $actualKeys) : bool
+    {
+        if (count($expectedKeys) !== count($actualKeys)) {
+            return false;
+        }
+
+        $iterator = new MultipleIterator(MultipleIterator::MIT_NEED_ANY);
+        $iterator->attachIterator(new ArrayIterator($expectedKeys));
+        $iterator->attachIterator(new ArrayIterator($actualKeys));
+
+        foreach ($iterator as $key => $value) {
+            list($expectedKey, $actualKey)     = $key;
+            list($expectedValue, $actualValue) = $value;
+
+            if ($expectedKey !== $actualKey) {
+                return false;
+            }
+
+            /* Since we don't expect special indexes (e.g. text), we mark any
+             * index with a non-numeric definition as unequal. All others are
+             * compared against their int value to avoid differences due to
+             * some drivers using float values in the key specification. */
+            if (! is_numeric($actualValue) || (int) $expectedValue !== (int) $actualValue) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-522

Instead of using a strict array comparison (which checks order of elements as well as type-safe value checks), we are now using a `MultipleIterator` to iterate over the expected and actual keys in order. Since we assume numeric values for index sort only, we check if the actual value is numeric, then cast to int to cover for some drivers (e.g. the shell) creating indexes with float values for sort.

For the chunks index, we attempt to create the index even if an index with the same keys but non-unique exists. This will cause an exception, but there is no other way to work around this issue. Other index options are not considered for either index.