### PR TITLE
DOCSP-10188: fix yaml file preventing docs build

### DIFF
--- a/docs/includes/apiargs-MongoDBClient-method-listDatabases-option.yaml
+++ b/docs/includes/apiargs-MongoDBClient-method-listDatabases-option.yaml
@@ -9,6 +9,9 @@ description: |
   For servers < 4.0.5, this option is ignored.
 
   .. versionadded:: 1.7
+interface: phpmethod
+operation: ~
+optional: true
 ---
 arg_name: option
 name: filter


### PR DESCRIPTION
This yaml file entry needs to include the interface, operation, and optional keys for the documentation to build. Please review when you get the chance so that I can publish the docs, thanks!