### PR TITLE
PHPLIB-559: Make aggregate command explainable

### DIFF
--- a/docs/reference/method/MongoDBCollection-explain.txt
+++ b/docs/reference/method/MongoDBCollection-explain.txt
@@ -50,6 +50,7 @@ Explainable Commands
 
 Explainable commands include, but are not limited to:
 
+   - :phpclass:`MongoDB\\Operation\\Aggregate`
    - :phpclass:`MongoDB\\Operation\\Count`
    - :phpclass:`MongoDB\\Operation\\DeleteMany`
    - :phpclass:`MongoDB\\Operation\\DeleteOne`

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -48,7 +48,7 @@ use function sprintf;
  * @see \MongoDB\Collection::aggregate()
  * @see http://docs.mongodb.org/manual/reference/command/aggregate/
  */
-class Aggregate implements Executable
+class Aggregate implements Executable, Explainable
 {
     /** @var integer */
     private static $wireVersionForCollation = 5;
@@ -285,9 +285,12 @@ class Aggregate implements Executable
         }
 
         $hasExplain = ! empty($this->options['explain']);
-        $hasWriteStage = is_last_pipeline_operator_write($this->pipeline);
+        $hasWriteStage = $this->hasWriteStage();
 
-        $command = $this->createCommand($server, $hasWriteStage);
+        $command = new Command(
+            $this->createCommandDocument($server, $hasWriteStage),
+            $this->createCommandOptions()
+        );
         $options = $this->createOptions($hasWriteStage, $hasExplain);
 
         $cursor = $hasWriteStage && ! $hasExplain
@@ -315,20 +318,17 @@ class Aggregate implements Executable
         return new ArrayIterator($result->result);
     }
 
-    /**
-     * Create the aggregate command.
-     *
-     * @param Server  $server
-     * @param boolean $hasWriteStage
-     * @return Command
-     */
-    private function createCommand(Server $server, $hasWriteStage)
+    public function getCommandDocument(Server $server)
+    {
+        return $this->createCommandDocument($server, $this->hasWriteStage());
+    }
+
+    private function createCommandDocument(Server $server, bool $hasWriteStage) : array
     {
         $cmd = [
             'aggregate' => $this->collectionName ?? 1,
             'pipeline' => $this->pipeline,
         ];
-        $cmdOptions = [];
 
         $cmd['allowDiskUse'] = $this->options['allowDiskUse'];
 
@@ -352,10 +352,6 @@ class Aggregate implements Executable
             $cmd['hint'] = is_array($this->options['hint']) ? (object) $this->options['hint'] : $this->options['hint'];
         }
 
-        if (isset($this->options['maxAwaitTimeMS'])) {
-            $cmdOptions['maxAwaitTimeMS'] = $this->options['maxAwaitTimeMS'];
-        }
-
         if ($this->options['useCursor']) {
             /* Ignore batchSize if pipeline includes an $out or $merge stage, as
              * no documents will be returned and sending a batchSize of zero
@@ -365,7 +361,18 @@ class Aggregate implements Executable
                 : new stdClass();
         }
 
-        return new Command($cmd, $cmdOptions);
+        return $cmd;
+    }
+
+    private function createCommandOptions() : array
+    {
+        $cmdOptions = [];
+
+        if (isset($this->options['maxAwaitTimeMS'])) {
+            $cmdOptions['maxAwaitTimeMS'] = $this->options['maxAwaitTimeMS'];
+        }
+
+        return $cmdOptions;
     }
 
     /**
@@ -398,5 +405,10 @@ class Aggregate implements Executable
         }
 
         return $options;
+    }
+
+    private function hasWriteStage() : bool
+    {
+        return is_last_pipeline_operator_write($this->pipeline);
     }
 }

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -42,6 +42,9 @@ class Explain implements Executable
     const VERBOSITY_QUERY = 'queryPlanner';
 
     /** @var integer */
+    private static $wireVersionForAggregate = 7;
+
+    /** @var integer */
     private static $wireVersionForDistinct = 4;
 
     /** @var integer */
@@ -105,6 +108,10 @@ class Explain implements Executable
         }
 
         if ($this->isFindAndModify($this->explainable) && ! server_supports_feature($server, self::$wireVersionForFindAndModify)) {
+            throw UnsupportedException::explainNotSupported();
+        }
+
+        if ($this->explainable instanceof Aggregate && ! server_supports_feature($server, self::$wireVersionForAggregate)) {
             throw UnsupportedException::explainNotSupported();
         }
 

--- a/src/Operation/Explainable.php
+++ b/src/Operation/Explainable.php
@@ -20,8 +20,8 @@ namespace MongoDB\Operation;
 use MongoDB\Driver\Server;
 
 /**
- * Explainable interface for explainable operations (count, distinct, find,
- * findAndModify, delete, and update).
+ * Explainable interface for explainable operations (aggregate, count, distinct,
+ * find, findAndModify, delete, and update).
  *
  * @internal
  */


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-559

To be consistent with other methods, passing an `Aggregate` instance to `explain` on servers < 4.0 will throw an exception, as these versions don't support passing an `aggregate` command to `explain`. Users that still use older MongoDB versions can continue to use the `explain` flag in `aggregate`, which remains unchanged in this PR.