### PR TITLE
PHPLIB-558: Don't inherit read preference in Database::command

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -249,10 +249,6 @@ class Database
      */
     public function command($command, array $options = [])
     {
-        if (! isset($options['readPreference']) && ! is_in_transaction($options)) {
-            $options['readPreference'] = $this->readPreference;
-        }
-
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
         }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -301,6 +301,11 @@ abstract class FunctionalTestCase extends TestCase
         throw new UnexpectedValueException('Could not determine server storage engine');
     }
 
+    protected function isReplicaSet()
+    {
+        return $this->getPrimaryServer()->getType() !== Server::TYPE_RS_PRIMARY;
+    }
+
     protected function isShardedCluster()
     {
         if ($this->getPrimaryServer()->getType() == Server::TYPE_MONGOS) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-558

~Same as with https://github.com/mongodb/mongo-php-driver/pull/1144, I've targeted the upcoming minor release for this fix, but can back port to the current stable release for a July patch release.~