### PR TITLE
Remove mention of Generator in CachingIterator comments

### DIFF
--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -52,10 +52,9 @@ class CachingIterator implements Countable, Iterator
 
     /**
      * Initialize the iterator and stores the first item in the cache. This
-     * effectively rewinds the Traversable and the wrapping Generator, which
-     * will execute up to its first yield statement. Additionally, this mimics
-     * behavior of the SPL iterators and allows users to omit an explicit call
-     * to rewind() before using the other methods.
+     * effectively rewinds the Traversable and the wrapping IteratorIterator.
+     *  Additionally, this mimics behavior of the SPL iterators and allows users
+     * to omit an explicit call * to rewind() before using the other methods.
      *
      * @param Traversable $traversable
      */


### PR DESCRIPTION
This was overlooked from 52df7a112e760b595a3485f50c23adf0591b95e8

Context: https://github.com/mongodb/mongo-php-library/pull/758#discussion_r449075127