### PR TITLE
PHPLIB-566, PHPLIB-567: Treat CursorNotFound as a resumable change stream error and sync tests

### DIFF
--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -42,6 +42,9 @@ class ChangeStream implements Iterator
      */
     const CURSOR_NOT_FOUND = 43;
 
+    /** @var int */
+    private static $cursorNotFound = 43;
+
     /** @var int[] */
     private static $resumableErrorCodes = [
         6, // HostUnreachable
@@ -195,6 +198,10 @@ class ChangeStream implements Iterator
 
         if (! $exception instanceof ServerException) {
             return false;
+        }
+
+        if ($exception->getCode() === self::$cursorNotFound) {
+            return true;
         }
 
         if (server_supports_feature($this->iterator->getServer(), self::$wireVersionForResumableChangeStreamError)) {

--- a/tests/SpecTests/change-streams/change-streams-errors.json
+++ b/tests/SpecTests/change-streams/change-streams-errors.json
@@ -107,7 +107,7 @@
       }
     },
     {
-      "description": "change stream errors on MaxTimeMSExpired",
+      "description": "change stream errors on ElectionInProgress",
       "minServerVersion": "4.2",
       "failPoint": {
         "configureFailPoint": "failCommand",
@@ -118,7 +118,7 @@
           "failCommands": [
             "getMore"
           ],
-          "errorCode": 50,
+          "errorCode": 216,
           "closeConnection": false
         }
       },
@@ -127,13 +127,7 @@
         "replicaset",
         "sharded"
       ],
-      "changeStreamPipeline": [
-        {
-          "$project": {
-            "_id": 0
-          }
-        }
-      ],
+      "changeStreamPipeline": [],
       "changeStreamOptions": {},
       "operations": [
         {
@@ -149,7 +143,7 @@
       ],
       "result": {
         "error": {
-          "code": 50
+          "code": 216
         }
       }
     }

--- a/tests/SpecTests/change-streams/change-streams-resume-whitelist.json
+++ b/tests/SpecTests/change-streams/change-streams-resume-whitelist.json
@@ -1648,6 +1648,102 @@
           }
         ]
       }
+    },
+    {
+      "description": "change stream resumes after CursorNotFound",
+      "minServerVersion": "4.2",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "getMore"
+          ],
+          "errorCode": 43,
+          "closeConnection": false
+        }
+      },
+      "target": "collection",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ],
+      "changeStreamPipeline": [],
+      "changeStreamOptions": {},
+      "operations": [
+        {
+          "database": "change-stream-tests",
+          "collection": "test",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "cursor": {},
+              "pipeline": [
+                {
+                  "$changeStream": {}
+                }
+              ]
+            },
+            "command_name": "aggregate",
+            "database_name": "change-stream-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": 42,
+              "collection": "test"
+            },
+            "command_name": "getMore",
+            "database_name": "change-stream-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "cursor": {},
+              "pipeline": [
+                {
+                  "$changeStream": {}
+                }
+              ]
+            },
+            "command_name": "aggregate",
+            "database_name": "change-stream-tests"
+          }
+        }
+      ],
+      "result": {
+        "success": [
+          {
+            "_id": "42",
+            "documentKey": "42",
+            "operationType": "insert",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "fullDocument": {
+              "x": {
+                "$numberInt": "1"
+              }
+            }
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-566
https://jira.mongodb.org/browse/PHPLIB-567

POC of https://github.com/mongodb/specifications/pull/834 for [DRIVERS-1308](https://jira.mongodb.org/browse/DRIVERS-1308). Language ticket is pending.