### PR TITLE
PHPLIB-570: Consult NamespaceNotFound error code in DropCollection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,10 @@ jobs:
     # Test against lowest supported dependencies
     - stage: Test
       php: "7.0"
+      dist: trusty
       env:
+        - SERVER_DISTRO=enterprise-ubuntu1404
+        - SERVER_VERSION=3.0.15
         - COMPOSER_OPTIONS=--prefer-lowest
 
       # Test older standalone server versions (3.0-4.0)

--- a/tests/Operation/DropCollectionFunctionalTest.php
+++ b/tests/Operation/DropCollectionFunctionalTest.php
@@ -38,8 +38,9 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
         $this->assertEquals(1, $writeResult->getInsertedCount());
 
         $operation = new DropCollection($this->getDatabaseName(), $this->getCollectionName());
-        $operation->execute($server);
+        $commandResult = $operation->execute($server);
 
+        $this->assertCommandSucceeded($commandResult);
         $this->assertCollectionDoesNotExist($this->getCollectionName());
     }
 
@@ -51,7 +52,11 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
         $this->assertCollectionDoesNotExist($this->getCollectionName());
 
         $operation = new DropCollection($this->getDatabaseName(), $this->getCollectionName());
-        $operation->execute($this->getPrimaryServer());
+        $commandResult = $operation->execute($this->getPrimaryServer());
+
+        $this->assertIsObject($commandResult);
+        $this->assertObjectHasAttribute('ok', $commandResult);
+        $this->assertEquals(0, $commandResult->ok);
     }
 
     public function testSessionOption()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-570

Changes the try/catch to CommandException and allows the original command reply to be returned instead of a synthetic document (based on pre-3.2 server responses). Also uses MongoDB 3.0 for prefer-lowest CI environment.
