### PR TITLE
PHPLIB-570: Fix CI failures from previous PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ jobs:
       env:
         - SERVER_DISTRO=enterprise-ubuntu1404
         - SERVER_VERSION=3.0.15
+        - DEPLOYMENT=STANDALONE_OLD
         - COMPOSER_OPTIONS=--prefer-lowest
 
       # Test older standalone server versions (3.0-4.0)

--- a/tests/Operation/DropCollectionFunctionalTest.php
+++ b/tests/Operation/DropCollectionFunctionalTest.php
@@ -54,9 +54,9 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
         $operation = new DropCollection($this->getDatabaseName(), $this->getCollectionName());
         $commandResult = $operation->execute($this->getPrimaryServer());
 
+        /* Avoid inspecting the result document as mongos returns {ok:1.0},
+         * which is inconsistent from the expected mongod response of {ok:0}. */
         $this->assertIsObject($commandResult);
-        $this->assertObjectHasAttribute('ok', $commandResult);
-        $this->assertEquals(0, $commandResult->ok);
     }
 
     public function testSessionOption()


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-570

Fix CI failures from https://github.com/mongodb/mongo-php-library/pull/768

Will ensure I wait for CI results before merging this time :stuck_out_tongue: 