### PR TITLE
PHPLIB-547: Fix links to new enumeration methods

### DIFF
--- a/docs/reference/class/MongoDBClient.txt
+++ b/docs/reference/class/MongoDBClient.txt
@@ -37,6 +37,7 @@ Methods
    /reference/method/MongoDBClient-getReadPreference
    /reference/method/MongoDBClient-getTypeMap
    /reference/method/MongoDBClient-getWriteConcern
+   /reference/method/MongoDBClient-listDatabaseNames
    /reference/method/MongoDBClient-listDatabases
    /reference/method/MongoDBClient-selectCollection
    /reference/method/MongoDBClient-selectDatabase

--- a/docs/reference/class/MongoDBDatabase.txt
+++ b/docs/reference/class/MongoDBDatabase.txt
@@ -56,6 +56,7 @@ Methods
    /reference/method/MongoDBDatabase-getReadPreference
    /reference/method/MongoDBDatabase-getTypeMap
    /reference/method/MongoDBDatabase-getWriteConcern
+   /reference/method/MongoDBDatabase-listCollectionNames
    /reference/method/MongoDBDatabase-listCollections
    /reference/method/MongoDBDatabase-modifyCollection
    /reference/method/MongoDBDatabase-selectCollection

--- a/docs/reference/method/MongoDBClient-listDatabaseNames.txt
+++ b/docs/reference/method/MongoDBClient-listDatabaseNames.txt
@@ -67,7 +67,7 @@ The output would then resemble::
 See Also
 --------
 
-- :phpmethod:`MongoDB\\Database::listDatabases()`
+- :phpmethod:`MongoDB\\Client::listDatabases()`
 - :manual:`listDatabases </reference/command/listDatabases>` command reference
   in the MongoDB manual
 - `Enumerating Databases

--- a/docs/reference/method/MongoDBClient-listDatabases.txt
+++ b/docs/reference/method/MongoDBClient-listDatabases.txt
@@ -80,7 +80,7 @@ The output would then resemble::
 See Also
 --------
 
-- :phpmethod:`MongoDB\\Database::listDatabaseNames()`
+- :phpmethod:`MongoDB\\Client::listDatabaseNames()`
 - :manual:`listDatabases </reference/command/listDatabases>` command reference
   in the MongoDB manual
 - `Enumerating Databases


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-547

Fixes a typo from https://github.com/mongodb/mongo-php-library/pull/758