### PR TITLE
Fix flaky test failures due to timeouts on mongos

### DIFF
--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -154,7 +154,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 $this->collection->createIndex(
                     ['x' => 1],
                     [
-                        'maxTimeMS' => 1000,
+                        'maxTimeMS' => 10000,
                         'session' => $this->manager->startSession(),
                         'sparse' => true,
                         'unique' => true,

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -156,6 +156,8 @@ class WatchFunctionalTest extends FunctionalTestCase
 
     public function testNextResumesAfterConnectionException()
     {
+        $this->skipIfIsShardedCluster('initial aggregate command times out due to socketTimeoutMS');
+
         /* In order to trigger a dropped connection, we'll use a new client with
          * a socket timeout that is less than the change stream's maxAwaitTimeMS
          * option. */
@@ -1600,7 +1602,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         return server_supports_feature($this->getPrimaryServer(), self::$wireVersionForStartAtOperationTime);
     }
 
-    private function advanceCursorUntilValid(Iterator $iterator, $limitOnShardedClusters = 5)
+    private function advanceCursorUntilValid(Iterator $iterator, $limitOnShardedClusters = 10)
     {
         if (! $this->isShardedCluster()) {
             $iterator->next();


### PR DESCRIPTION
Related: https://jira.mongodb.org/browse/PHPLIB-461