### PR TITLE
PHPLIB-425: GridFS methods should throw if stream copying fails

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -109,6 +109,7 @@
     <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
         <exclude-pattern>/src/GridFS/StreamWrapper</exclude-pattern>
         <exclude-pattern>/tests/DocumentationExamplesTest.php</exclude-pattern>
+        <exclude-pattern>/tests/GridFS/UnusableStream.php</exclude-pattern>
     </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -249,7 +249,7 @@ class Bucket
         }
 
         if (@stream_copy_to_stream($this->openDownloadStream($id), $destination) === false) {
-            throw StreamException::downloadFailed();
+            throw StreamException::downloadFromIdFailed($id, $destination);
         }
     }
 
@@ -287,7 +287,7 @@ class Bucket
         }
 
         if (@stream_copy_to_stream($this->openDownloadStreamByName($filename, $options), $destination) === false) {
-            throw StreamException::downloadFailed();
+            throw StreamException::downloadFromFilenameFailed($filename, $destination);
         }
     }
 
@@ -625,7 +625,7 @@ class Bucket
 
         $destination = $this->openUploadStream($filename, $options);
         if (@stream_copy_to_stream($source, $destination) === false) {
-            throw StreamException::uploadFailed();
+            throw StreamException::uploadFailed($filename, $source);
         }
 
         return $this->getFileIdForStream($destination);

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -248,7 +248,7 @@ class Bucket
             throw InvalidArgumentException::invalidType('$destination', $destination, 'resource');
         }
 
-        if (stream_copy_to_stream($this->openDownloadStream($id), $destination) === false) {
+        if (@stream_copy_to_stream($this->openDownloadStream($id), $destination) === false) {
             throw StreamException::downloadFailed();
         }
     }
@@ -286,7 +286,7 @@ class Bucket
             throw InvalidArgumentException::invalidType('$destination', $destination, 'resource');
         }
 
-        if (stream_copy_to_stream($this->openDownloadStreamByName($filename, $options), $destination) === false) {
+        if (@stream_copy_to_stream($this->openDownloadStreamByName($filename, $options), $destination) === false) {
             throw StreamException::downloadFailed();
         }
     }
@@ -624,7 +624,7 @@ class Bucket
         }
 
         $destination = $this->openUploadStream($filename, $options);
-        if (stream_copy_to_stream($source, $destination) === false) {
+        if (@stream_copy_to_stream($source, $destination) === false) {
             throw StreamException::uploadFailed();
         }
 

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -248,8 +248,9 @@ class Bucket
             throw InvalidArgumentException::invalidType('$destination', $destination, 'resource');
         }
 
-        if (@stream_copy_to_stream($this->openDownloadStream($id), $destination) === false) {
-            throw StreamException::downloadFromIdFailed($id, $destination);
+        $source = $this->openDownloadStream($id);
+        if (@stream_copy_to_stream($source, $destination) === false) {
+            throw StreamException::downloadFromIdFailed($id, $source, $destination);
         }
     }
 
@@ -286,8 +287,9 @@ class Bucket
             throw InvalidArgumentException::invalidType('$destination', $destination, 'resource');
         }
 
-        if (@stream_copy_to_stream($this->openDownloadStreamByName($filename, $options), $destination) === false) {
-            throw StreamException::downloadFromFilenameFailed($filename, $destination);
+        $source = $this->openDownloadStreamByName($filename, $options);
+        if (@stream_copy_to_stream($source, $destination) === false) {
+            throw StreamException::downloadFromFilenameFailed($filename, $source, $destination);
         }
     }
 
@@ -624,8 +626,10 @@ class Bucket
         }
 
         $destination = $this->openUploadStream($filename, $options);
+
         if (@stream_copy_to_stream($source, $destination) === false) {
-            throw StreamException::uploadFailed($filename, $source);
+            $destinationUri = $this->createPathForFile($this->getRawFileDocumentForStream($destination));
+            throw StreamException::uploadFailed($filename, $source, $destinationUri);
         }
 
         return $this->getFileIdForStream($destination);

--- a/src/GridFS/Exception/StreamException.php
+++ b/src/GridFS/Exception/StreamException.php
@@ -10,31 +10,37 @@ use function stream_get_meta_data;
 
 class StreamException extends RuntimeException
 {
-    /** @param resource $destination */
-    public static function downloadFromFilenameFailed(string $filename, $destination) : self
+    /**
+     * @param resource $source
+     * @param resource $destination
+     */
+    public static function downloadFromFilenameFailed(string $filename, $source, $destination) : self
     {
-        $metadata = stream_get_meta_data($destination);
+        $sourceMetadata = stream_get_meta_data($source);
+        $destinationMetadata = stream_get_meta_data($destination);
 
-        return new static(sprintf('Downloading GridFS file "%s" to resource "%s" failed: stream error.', $filename, $metadata['uri']));
+        return new static(sprintf('Downloading GridFS file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $filename));
     }
 
     /**
      * @param mixed    $id
+     * @param resource $source
      * @param resource $destination
      */
-    public static function downloadFromIdFailed($id, $destination) : self
+    public static function downloadFromIdFailed($id, $source, $destination) : self
     {
-        $stringId = toJSON(fromPHP(['_id' => $id]));
-        $metadata = stream_get_meta_data($destination);
+        $idString = toJSON(fromPHP(['_id' => $id]));
+        $sourceMetadata = stream_get_meta_data($source);
+        $destinationMetadata = stream_get_meta_data($destination);
 
-        return new static(sprintf('Downloading GridFS file with identifier "%s" to resource "%s" failed: stream error.', $stringId, $metadata['uri']));
+        return new static(sprintf('Downloading GridFS file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString));
     }
 
     /** @param resource $source */
-    public static function uploadFailed(string $filename, $source) : self
+    public static function uploadFailed(string $filename, $source, string $destinationUri) : self
     {
-        $metadata = stream_get_meta_data($source);
+        $sourceMetadata = stream_get_meta_data($source);
 
-        return new static(sprintf('Uploading file from resource "%s" to GridFS file "%s" failed: stream error.', $metadata['uri'], $filename));
+        return new static(sprintf('Uploading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationUri, $filename));
     }
 }

--- a/src/GridFS/Exception/StreamException.php
+++ b/src/GridFS/Exception/StreamException.php
@@ -19,7 +19,7 @@ class StreamException extends RuntimeException
         $sourceMetadata = stream_get_meta_data($source);
         $destinationMetadata = stream_get_meta_data($destination);
 
-        return new static(sprintf('Downloading GridFS file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $filename));
+        return new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $filename));
     }
 
     /**
@@ -33,7 +33,7 @@ class StreamException extends RuntimeException
         $sourceMetadata = stream_get_meta_data($source);
         $destinationMetadata = stream_get_meta_data($destination);
 
-        return new static(sprintf('Downloading GridFS file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString));
+        return new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString));
     }
 
     /** @param resource $source */

--- a/src/GridFS/Exception/StreamException.php
+++ b/src/GridFS/Exception/StreamException.php
@@ -3,16 +3,38 @@
 namespace MongoDB\GridFS\Exception;
 
 use MongoDB\Exception\RuntimeException;
+use function MongoDB\BSON\fromPHP;
+use function MongoDB\BSON\toJSON;
+use function sprintf;
+use function stream_get_meta_data;
 
 class StreamException extends RuntimeException
 {
-    public static function downloadFailed() : self
+    /** @param resource $destination */
+    public static function downloadFromFilenameFailed(string $filename, $destination) : self
     {
-        return new static('Downloading file from GridFS failed: stream error.');
+        $metadata = stream_get_meta_data($destination);
+
+        return new static(sprintf('Downloading GridFS file "%s" to resource "%s" failed: stream error.', $filename, $metadata['uri']));
     }
 
-    public static function uploadFailed() : self
+    /**
+     * @param mixed    $id
+     * @param resource $destination
+     */
+    public static function downloadFromIdFailed($id, $destination) : self
     {
-        return new static('Uploading file to GridFS failed: stream error.');
+        $stringId = toJSON(fromPHP(['_id' => $id]));
+        $metadata = stream_get_meta_data($destination);
+
+        return new static(sprintf('Downloading GridFS file with identifier "%s" to resource "%s" failed: stream error.', $stringId, $metadata['uri']));
+    }
+
+    /** @param resource $source */
+    public static function uploadFailed(string $filename, $source) : self
+    {
+        $metadata = stream_get_meta_data($source);
+
+        return new static(sprintf('Uploading file from resource "%s" to GridFS file "%s" failed: stream error.', $metadata['uri'], $filename));
     }
 }

--- a/src/GridFS/Exception/StreamException.php
+++ b/src/GridFS/Exception/StreamException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MongoDB\GridFS\Exception;
+
+use MongoDB\Exception\RuntimeException;
+
+class StreamException extends RuntimeException
+{
+    public static function downloadFailed() : self
+    {
+        return new static('Downloading file from GridFS failed: stream error.');
+    }
+
+    public static function uploadFailed() : self
+    {
+        return new static('Uploading file to GridFS failed: stream error.');
+    }
+}

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -31,6 +31,7 @@ use function str_repeat;
 use function stream_get_contents;
 use function strlen;
 use function substr;
+use const PHP_VERSION_ID;
 
 /**
  * Functional tests for the Bucket class.
@@ -730,6 +731,10 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testUploadFromStreamFails()
     {
+        if (PHP_VERSION_ID < 70400) {
+            $this->markTestSkipped('Test only works on PHP 7.4 and newer');
+        }
+
         UnusableStream::register();
         $source = fopen('unusable://temp', 'w');
 

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -715,7 +715,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->uploadFromStream('filename', $this->createStream('foo'), ['_id' => ['foo' => 'bar']]);
 
         $this->expectException(StreamException::class);
-        $this->expectExceptionMessageMatches('#^Downloading GridFS file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS identifier: "{ "_id" : { "foo" : "bar" } }$"#');
+        $this->expectExceptionMessageMatches('#^Downloading file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS identifier: "{ "_id" : { "foo" : "bar" } }"$#');
         $this->bucket->downloadToStream(['foo' => 'bar'], fopen('php://temp', 'r'));
     }
 
@@ -724,7 +724,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
 
         $this->expectException(StreamException::class);
-        $this->expectExceptionMessageMatches('#^Downloading GridFS file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS filename: "filename"$#');
+        $this->expectExceptionMessageMatches('#^Downloading file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS filename: "filename"$#');
         $this->bucket->downloadToStreamByName('filename', fopen('php://temp', 'r'));
     }
 

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -10,6 +10,7 @@ use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\Bucket;
 use MongoDB\GridFS\Exception\FileNotFoundException;
+use MongoDB\GridFS\Exception\StreamException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\ListCollections;
@@ -706,6 +707,34 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $this->assertIndexNotExists($this->filesCollection->getCollectionName(), 'filename_1_uploadDate_1');
         $this->assertIndexNotExists($this->chunksCollection->getCollectionName(), 'files_id_1_n_1');
+    }
+
+    public function testDownloadToStreamFails()
+    {
+        $this->bucket->uploadFromStream('filename', $this->createStream('foo'), ['_id' => ['foo' => 'bar']]);
+
+        $this->expectException(StreamException::class);
+        $this->expectExceptionMessageMatches('#^Downloading GridFS file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS identifier: "{ "_id" : { "foo" : "bar" } }$"#');
+        $this->bucket->downloadToStream(['foo' => 'bar'], fopen('php://temp', 'r'));
+    }
+
+    public function testDownloadToStreamByNameFails()
+    {
+        $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
+
+        $this->expectException(StreamException::class);
+        $this->expectExceptionMessageMatches('#^Downloading GridFS file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS filename: "filename"$#');
+        $this->bucket->downloadToStreamByName('filename', fopen('php://temp', 'r'));
+    }
+
+    public function testUploadFromStreamFails()
+    {
+        UnusableStream::register();
+        $source = fopen('unusable://temp', 'w');
+
+        $this->expectException(StreamException::class);
+        $this->expectExceptionMessageMatches('#^Uploading file from "unusable://temp" to "gridfs://.*/.*/.*" failed. GridFS filename: "filename"$#');
+        $this->bucket->uploadFromStream('filename', $source);
     }
 
     /**

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -716,7 +716,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->uploadFromStream('filename', $this->createStream('foo'), ['_id' => ['foo' => 'bar']]);
 
         $this->expectException(StreamException::class);
-        $this->expectExceptionMessageMatches('#^Downloading file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS identifier: "{ "_id" : { "foo" : "bar" } }"$#');
+        $this->expectExceptionMessageRegExp('#^Downloading file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS identifier: "{ "_id" : { "foo" : "bar" } }"$#');
         $this->bucket->downloadToStream(['foo' => 'bar'], fopen('php://temp', 'r'));
     }
 
@@ -725,7 +725,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
 
         $this->expectException(StreamException::class);
-        $this->expectExceptionMessageMatches('#^Downloading file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS filename: "filename"$#');
+        $this->expectExceptionMessageRegExp('#^Downloading file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS filename: "filename"$#');
         $this->bucket->downloadToStreamByName('filename', fopen('php://temp', 'r'));
     }
 
@@ -739,7 +739,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $source = fopen('unusable://temp', 'w');
 
         $this->expectException(StreamException::class);
-        $this->expectExceptionMessageMatches('#^Uploading file from "unusable://temp" to "gridfs://.*/.*/.*" failed. GridFS filename: "filename"$#');
+        $this->expectExceptionMessageRegExp('#^Uploading file from "unusable://temp" to "gridfs://.*/.*/.*" failed. GridFS filename: "filename"$#');
         $this->bucket->uploadFromStream('filename', $source);
     }
 

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -20,6 +20,7 @@ use function array_merge;
 use function call_user_func;
 use function current;
 use function fclose;
+use function fopen;
 use function fread;
 use function fwrite;
 use function hash_init;

--- a/tests/GridFS/UnusableStream.php
+++ b/tests/GridFS/UnusableStream.php
@@ -2,6 +2,13 @@
 
 namespace MongoDB\Tests\GridFS;
 
+use function in_array;
+use function stream_get_wrappers;
+use function stream_wrapper_register;
+use function stream_wrapper_unregister;
+use const SEEK_SET;
+use const STREAM_IS_URL;
+
 final class UnusableStream
 {
     public static function register($protocol = 'unusable')

--- a/tests/GridFS/UnusableStream.php
+++ b/tests/GridFS/UnusableStream.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace MongoDB\Tests\GridFS;
+
+final class UnusableStream
+{
+    public static function register($protocol = 'unusable')
+    {
+        if (in_array($protocol, stream_get_wrappers())) {
+            stream_wrapper_unregister($protocol);
+        }
+
+        stream_wrapper_register($protocol, static::class, STREAM_IS_URL);
+    }
+
+    public function stream_close()
+    {
+    }
+
+    public function stream_eof()
+    {
+        return true;
+    }
+
+    public function stream_open($path, $mode, $options, &$openedPath)
+    {
+        return true;
+    }
+
+    public function stream_read($length)
+    {
+        return false;
+    }
+
+    public function stream_seek($offset, $whence = SEEK_SET)
+    {
+        return true;
+    }
+
+    public function stream_stat()
+    {
+        return [];
+    }
+
+    public function stream_tell()
+    {
+        return 0;
+    }
+
+    public function stream_write($data)
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
PHPLIB-425

I'm not too happy with throwing a generic `StreamException`, but there really isn't more information we can reliably add to the error messages (except for mentioning whether it happened on up- or download). Targeting 1.8 for this change, since we're throwing new exceptions in three methods, which I don't want to add in a patch release. Happy to retarget the PR to 1.7 if we're not worried about the new exceptions.