### PR TITLE
PHPLIB-580: Correctly express lack of event assertions in change stream tests

### DIFF
--- a/tests/SpecTests/change-streams/change-streams-errors.json
+++ b/tests/SpecTests/change-streams/change-streams-errors.json
@@ -14,7 +14,7 @@
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
       "operations": [],
-      "expectations": [],
+      "expectations": null,
       "result": {
         "error": {
           "code": 40573

--- a/tests/SpecTests/change-streams/change-streams.json
+++ b/tests/SpecTests/change-streams/change-streams.json
@@ -82,7 +82,7 @@
           }
         }
       ],
-      "expectations": [],
+      "expectations": null,
       "result": {
         "success": [
           {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-580

Synced with mongodb/specifications@90d96dabac9c645f922f2fcad1940c5c9a83e2b7