### PR TITLE
PHPLIB-345: Fix PHP shutdown error with dangling writable streams

### DIFF
--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -57,6 +57,14 @@ class StreamWrapper
     /** @var ReadableStream|WritableStream|null */
     private $stream;
 
+    public function __destruct()
+    {
+        /* This destructor is a workaround for PHP trying to use the stream well
+         * after all objects have been destructed. This causes autoloading
+         * issues and possibly segmentation faults during PHP shutdown. */
+        $this->stream = null;
+    }
+
     /**
      * Return the stream's file document.
      *
@@ -88,6 +96,10 @@ class StreamWrapper
      */
     public function stream_close()
     {
+        if (! $this->stream) {
+            return;
+        }
+
         $this->stream->close();
     }
 

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -60,7 +60,7 @@ class StreamWrapper
     public function __destruct()
     {
         /* This destructor is a workaround for PHP trying to use the stream well
-         * after all objects have been destructed. This causes autoloading
+         * after all objects have been destructed. This can cause autoloading
          * issues and possibly segmentation faults during PHP shutdown. */
         $this->stream = null;
     }

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -720,10 +720,12 @@ class BucketFunctionalTest extends FunctionalTestCase
         }
 
         $path = __DIR__ . '/../../vendor/autoload.php';
-        @exec(
-            <<<CMD
+        $command = <<<CMD
 php -r "require '$path'; \\\$stream = (new MongoDB\Client)->test->selectGridFSBucket()->openUploadStream('filename', ['disableMD5' => true]);" 2>&1
-CMD,
+CMD;
+
+        @exec(
+            $command,
             $output,
             $return
         );


### PR DESCRIPTION
PHPLIB-345

This applies a suggestion by @sgolemon to avoid PHP trying to use previously destroyed stream objects. The behaviour can be shown by leaving a dangling writable stream, which causes errors on shutdown. The workaround ensures that the stream wrapper instance "forgets" that it owned a stream wrapper, as `StreamWrapper::stream_close` is called after `StreamWrapper::__destruct`.