### PR TITLE
Allow PHP 8 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
     ],
     "require": {
-        "php": "^7.0",
+        "php": ">=7.0",
         "ext-hash": "*",
         "ext-json": "*",
         "ext-mongodb": "^1.8",


### PR DESCRIPTION
Allowing PHP 8 on master branch could allow people on dev channel to report issues on it.

What do you think about this ?

Actual problem accoding to alcaeus is that mongo-php-driver isn't ready yet. https://github.com/mongodb/mongo-php-driver/issues/1161