### PR TITLE
PHPLIB-582: Create JSON test result file for evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -253,13 +253,6 @@ functions:
             chmod +x $i
           done
 
-  "init test-results":
-    - command: shell.exec
-      params:
-        script: |
-          ${PREPARE_SHELL}
-          echo '{"results": [{ "status": "FAIL", "test_file": "Build", "log_raw": "No test-results.json found was created"  } ]}' > ${PROJECT_DIRECTORY}/test-results.json
-
   "install dependencies":
     - command: shell.exec
       params:
@@ -275,7 +268,6 @@ pre:
   - func: "prepare resources"
   - func: "windows fix"
   - func: "fix absolute paths"
-  - func: "init test-results"
   - func: "make files executable"
   - func: "install dependencies"
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -26,10 +26,10 @@ PATH=/opt/php/${PHP_VERSION}-64bit/bin:$OLD_PATH
 case "$TESTS" in
    atlas-data-lake*)
       MONGODB_URI="mongodb://mhuser:pencil@127.0.0.1:27017"
-      php vendor/bin/phpunit --testsuite "Atlas Data Lake Test Suite"
+      php vendor/bin/phpunit --configuration phpunit.evergreen.xml --testsuite "Atlas Data Lake Test Suite"
       ;;
 
    *)
-      php vendor/bin/phpunit
+      php vendor/bin/phpunit --configuration phpunit.evergreen.xml
       ;;
 esac

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "jean85/pretty-package-versions": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^8.3",
+        "phpunit/phpunit": "^6.4",
         "sebastian/comparator": "^2.0 || ^3.0",
         "squizlabs/php_codesniffer": "^3.5, <3.5.5",
         "symfony/phpunit-bridge": "^4.4@dev"

--- a/phpunit.evergreen.xml
+++ b/phpunit.evergreen.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.3/phpunit.xsd"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+         defaultTestSuite="Default Test Suite"
+>
+
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="MONGODB_URI" value="mongodb://127.0.0.1:27017/?serverSelectionTimeoutMS=100"/>
+        <env name="MONGODB_DATABASE" value="phplib_test"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Default Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+
+        <testsuite name="Atlas Data Lake Test Suite">
+            <file>tests/SpecTests/AtlasDataLakeSpecTest.php</file>
+        </testsuite>
+    </testsuites>
+
+    <listeners>
+        <listener class="MongoDB\Tests\EvergreenLogListener">
+            <arguments>
+                <string>test-results.json</string>
+            </arguments>
+        </listener>
+    </listeners>
+</phpunit>

--- a/tests/EvergreenLogListener.php
+++ b/tests/EvergreenLogListener.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace MongoDB\Tests;
+
+use Exception;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\SelfDescribing;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestFailure;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+use PHPUnit\Util\Filter;
+use PHPUnit\Util\Printer;
+use function get_class;
+use function json_encode;
+use function round;
+
+// phpcs:disable SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException
+class EvergreenLogListener extends Printer implements TestListener
+{
+    /** @var array[] */
+    private $tests = [];
+
+    /** @var array|null */
+    private $currentTestCase = null;
+
+    /**
+     * Flush buffer and close output.
+     */
+    public function flush()
+    {
+        $this->write($this->getJson());
+
+        parent::flush();
+    }
+
+    /**
+     * An error occurred.
+     *
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
+     */
+    public function addError(Test $test, Exception $e, $time)
+    {
+        $this->doAddFault($test, $e, 'fail');
+    }
+
+    /**
+     * A warning occurred.
+     *
+     * @param Test    $test
+     * @param Warning $e
+     * @param float   $time
+     */
+    public function addWarning(Test $test, Warning $e, $time)
+    {
+        // Do nothing for now
+    }
+
+    /**
+     * A failure occurred.
+     *
+     * @param Test                 $test
+     * @param AssertionFailedError $e
+     * @param float                $time
+     */
+    public function addFailure(Test $test, AssertionFailedError $e, $time)
+    {
+        $this->doAddFault($test, $e, 'fail');
+    }
+
+    /**
+     * Incomplete test.
+     *
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
+     */
+    public function addIncompleteTest(Test $test, Exception $e, $time)
+    {
+        $this->doAddSkipped($test);
+    }
+
+    /**
+     * Risky test.
+     *
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
+     */
+    public function addRiskyTest(Test $test, Exception $e, $time)
+    {
+        return;
+    }
+
+    /**
+     * Skipped test.
+     *
+     * @param Test      $test
+     * @param Exception $e
+     * @param float     $time
+     */
+    public function addSkippedTest(Test $test, Exception $e, $time)
+    {
+        $this->doAddSkipped($test);
+    }
+
+    /**
+     * A testsuite started.
+     *
+     * @param TestSuite $suite
+     */
+    public function startTestSuite(TestSuite $suite)
+    {
+    }
+
+    /**
+     * A testsuite ended.
+     *
+     * @param TestSuite $suite
+     */
+    public function endTestSuite(TestSuite $suite)
+    {
+    }
+
+    /**
+     * A test started.
+     *
+     * @param Test $test
+     */
+    public function startTest(Test $test)
+    {
+        $this->currentTestCase = [
+            'status' => 'pass',
+            'test_file' => get_class($test) . '::' . $test->getName(),
+        ];
+    }
+
+    /**
+     * A test ended.
+     *
+     * @param Test  $test
+     * @param float $time
+     */
+    public function endTest(Test $test, $time)
+    {
+        if (! $this->currentTestCase) {
+            return;
+        }
+
+        $this->currentTestCase['elapsed'] = round($time, 6);
+
+        $this->tests[] = $this->currentTestCase;
+
+        $this->currentTestCase = null;
+    }
+
+    /**
+     * Returns the XML as a string.
+     *
+     * @return string
+     */
+    public function getJson()
+    {
+        return json_encode(['results' => $this->tests]);
+    }
+
+    /**
+     * Method which generalizes addError() and addFailure()
+     *
+     * @param Test      $test
+     * @param Exception $e
+     * @param string    $type
+     */
+    private function doAddFault(Test $test, Exception $e, $type)
+    {
+        if ($this->currentTestCase === null) {
+            return;
+        }
+
+        if ($test instanceof SelfDescribing) {
+            $buffer = $test->toString() . "\n";
+        } else {
+            $buffer = '';
+        }
+
+        $buffer .= TestFailure::exceptionToString($e) . "\n" .
+            Filter::getFilteredStacktrace($e);
+
+        $this->currentTestCase['status'] = $type;
+        $this->currentTestCase['raw_log'] = $buffer;
+    }
+
+    private function doAddSkipped(Test $test)
+    {
+        if ($this->currentTestCase === null) {
+            return;
+        }
+
+        $this->currentTestCase['status'] = 'skip';
+    }
+}
+// phpcs:enable SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException


### PR DESCRIPTION
PHPLIB-582

This ticket unfortunately is incomplete due to a few issues with the build system.

Reporting test results using `attach.results` does not allow us to easily add logs (e.g. information about assertion failures, traces, test output, etc.) to the test results. This is possible using `attach.xunit_results`, but I could not get that command to read the results files written by PHPUnit. For one, PHPUnit reports nested test suites (a feature of JUnit), which the parser in evergreen does not understand. This should be fixed by [EVG-12951](https://jira.mongodb.org/browse/EVG-12951).

While I had a temporary listener that worked around this by flattening the file (and to report a single test suite containing all tests), this still didn't yield any results. This went as far as Evergreen happily accepting a non-existent or invalid xUnit result file. So, for the time being, we report test results using the JSON format. This will at least cause them to show up in a "Tests" tab under individual tasks, allowing us to see which test failed without consulting the log. Once the problems mentioned above have been solved, we can revisit this and add more detail to the test reporting.

Note that due to how PHPUnit approaches its PHP version support, we cannot support both PHPUnit 6 and PHPUnit 8 anymore. While we could add return type hints in any class implementing the listener interface, we can't do so until we drop PHP 7.0 as the listener interface requires a `void` return type which was only introduced in 7.1. The easiest way to fix this is to drop PHPUnit 8 and rely on 6 only, which will work up to PHP 7.4. We can then revisit this once we start removing our custom listeners, drop support for PHP 7.0, or add support for PHP 8.