### PR TITLE
PHPLIB-563: Finalise PHP runtime axis

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -538,6 +538,11 @@ buildvariants:
 # Only tests against latest MongoDB and ext-mongodb versions
 - matrix_name: "test-php-versions"
   matrix_spec: {"os-php7": "*", "php-versions": "*", "edge-versions": "latest-stable", "driver-versions": "latest-stable" }
+  exclude_spec:
+    # rhel71-power8 fails due to not reaching pecl
+    - { "os-php7": "rhel71-power8", "php-versions": "*", edge-versions: "*", "driver-versions": "*" }
+    # rhel74-zseries doesn't start in a timely fashion - most likely missing executors
+    - { "os-php7": "rhel74-zseries", "php-versions": "*", edge-versions: "*", "driver-versions": "*" }
   display_name: "${os-php7}, PHP ${php-versions}, MongoDB ${edge-versions}, ext-mongodb ${driver-versions}"
   tasks:
     - name: "test-standalone"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -261,7 +261,7 @@ functions:
           ${PREPARE_SHELL}
           file="${PROJECT_DIRECTORY}/.evergreen/install-dependencies.sh"
           # Don't use ${file} syntax here because evergreen treats it as an empty expansion.
-          [ -f "$file" ] && PHP_VERSION=${PHP_VERSION} DRIVER_VERSION=${DRIVER_VERSION} DRIVER_REPO=${DRIVER_REPO} DRIVER_BRANCH=${DRIVER_BRANCH} sh $file || echo "$file not available, skipping"
+          [ -f "$file" ] && PHP_VERSION=${PHP_VERSION} DRIVER_VERSION=${DRIVER_VERSION} DRIVER_REPO=${DRIVER_REPO} DRIVER_BRANCH=${DRIVER_BRANCH} DEPENDENCIES=${DEPENDENCIES} sh $file || echo "$file not available, skipping"
 
 pre:
   - func: "fetch source"
@@ -434,6 +434,10 @@ axes:
   - id: driver-versions
     display_name: Driver Version
     values:
+      - id: "lowest-supported"
+        display_name: "1.8.0"
+        variables:
+          DRIVER_VERSION: "1.8.0"
       - id: "latest-stable"
         display_name: "1.8-stable"
       - id: "latest-minor-dev"
@@ -520,6 +524,13 @@ axes:
         variables:
            STORAGE_ENGINE: "inmemory"
 
+  - id: dependencies
+    display_name: Dependencies
+    values:
+      - id: lowest
+        display_name: Lowest
+        variables:
+          DEPENDENCIES: "lowest"
 
 buildvariants:
 
@@ -549,6 +560,16 @@ buildvariants:
 - matrix_name: "test-mongodb-versions"
   matrix_spec: {"os-php7": "rhel70-test", "php-edge-versions": "latest-stable", "versions": "*", "driver-versions": "latest-stable" }
   display_name: "MongoDB ${versions}, PHP ${php-edge-versions}, ${os-php7}, ext-mongodb ${driver-versions}"
+  tasks:
+    - name: "test-standalone"
+    - name: "test-replica_set"
+    - name: "test-sharded_cluster"
+
+# Tests oldest supported version
+# Enables --prefer-lowest for composer to test oldest dependencies against all server versions
+- matrix_name: "test-dependencies"
+  matrix_spec: { "dependencies": "lowest", "os-php7": "rhel70-test", "php-edge-versions": "oldest-supported", "versions": "*", "driver-versions": "lowest-supported" }
+  display_name: "Dependencies: ${dependencies}, MongoDB ${versions}, PHP ${php-edge-versions}, ${os-php7}, ext-mongodb ${driver-versions}"
   tasks:
     - name: "test-standalone"
     - name: "test-replica_set"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -459,7 +459,7 @@ axes:
         run_on: rhel71-power8-test
       - id: rhel74-zseries
         display_name: "RHEL 7.4 zSeries"
-        run_on: rhel72-zseries-test
+        run_on: rhel74-zseries-test
       - id: ubuntu1804-arm64-test
         display_name: "Ubuntu 18.04 ARM64"
         run_on: ubuntu1804-arm64-test
@@ -526,10 +526,8 @@ buildvariants:
 # Tests all PHP versions on all operating systems.
 # Only tests against latest MongoDB and ext-mongodb versions
 - matrix_name: "test-php-versions"
-  matrix_spec: {"os-php7": ["debian92-test", "ubuntu1804-arm64-test", "rhel70-test"], "php-versions": "*", "edge-versions": "latest-stable", "driver-versions": "latest-stable" }
-  exclude_spec:
-    - { "os-php7": ["debian92-test", "rhel70-test"], "php-versions": "7.0", edge-versions: "*", "driver-versions": "*" }
-  display_name: "PHP ${php-versions}, ${os-php7}, MongoDB ${edge-versions}, ext-mongodb ${driver-versions}"
+  matrix_spec: {"os-php7": "*", "php-versions": "*", "edge-versions": "latest-stable", "driver-versions": "latest-stable" }
+  display_name: "${os-php7}, PHP ${php-versions}, MongoDB ${edge-versions}, ext-mongodb ${driver-versions}"
   tasks:
     - name: "test-standalone"
     - name: "test-replica_set"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -543,7 +543,7 @@ buildvariants:
     - { "os-php7": "rhel71-power8", "php-versions": "*", edge-versions: "*", "driver-versions": "*" }
     # rhel74-zseries doesn't start in a timely fashion - most likely missing executors
     - { "os-php7": "rhel74-zseries", "php-versions": "*", edge-versions: "*", "driver-versions": "*" }
-  display_name: "${os-php7}, PHP ${php-versions}, MongoDB ${edge-versions}, ext-mongodb ${driver-versions}"
+  display_name: "* ${os-php7}, PHP ${php-versions}, MongoDB ${edge-versions}, ext-mongodb ${driver-versions}"
   tasks:
     - name: "test-standalone"
     - name: "test-replica_set"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -72,6 +72,15 @@ case "$DISTRO" in
       ;;
 esac
 
+case "$DEPENDENCIES" in
+   lowest*)
+      COMPOSER_FLAGS="${COMPOSER_FLAGS} --prefer-lowest"
+      ;;
+
+   *)
+      ;;
+esac
+
 PHP_PATH=/opt/php/${PHP_VERSION}-64bit
 OLD_PATH=$PATH
 PATH=$PHP_PATH/bin:$OLD_PATH

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -4,6 +4,10 @@ set -o errexit  # Exit the script with error if any of the commands fail
 
 install_extension ()
 {
+   # Workaround to get PECL running on PHP 7.0
+   export PHP_PEAR_PHP_BIN=${PHP_PATH}/bin/php
+   export PHP_PEAR_INSTALL_DIR=${PHP_PATH}/lib/php
+
    rm -f ${PHP_PATH}/lib/php.ini
 
    if [ "x${DRIVER_BRANCH}" != "x" ] || [ "x${DRIVER_REPO}" != "x" ]; then


### PR DESCRIPTION
PHPLIB-563

This PR makes a few last changes to the pipeline:
- Exclude rhel74-zseries and rhel71-power8 because they don't pass or don't even start. Since this also affects PHPC, I'd take care of this in the PHPC follow-up epic.
- Add tests against lowest supported versions. We test the base driver release and oldest composer dependencies against all server versions.
- PHP 7.0 now also works on Debian 9.2 an RHEL 7.0. I was able to work around the pecl errors that prevented running on those platforms

Pull requests currently test the "test-php-versions" pipeline, which tests the driver on all PHP versions and several operating systems against the latest server. I'm open to adding additional variants/tasks to the mix, but thought that those were a good starting point.