### PR TITLE
Consult $actualValue when setting $actualType

### DIFF
--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -315,7 +315,7 @@ class DocumentsMatchConstraint extends Constraint
             }
 
             $expectedType = is_object($expectedValue) ? get_class($expectedValue) : gettype($expectedValue);
-            $actualType = is_object($expectedValue) ? get_class($actualValue) : gettype($actualValue);
+            $actualType = is_object($actualValue) ? get_class($actualValue) : gettype($actualValue);
 
             // Workaround for ObjectComparator printing the whole actual object
             if ($expectedType !== $actualType) {


### PR DESCRIPTION
Fixes a typo from 0b923b08985fe369d50d071fefa31e03b221b6fd