### PR TITLE
PHPLIB-591: CreateIndexes should not specify "ns" for index specifications

### DIFF
--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -62,14 +62,6 @@ class IndexInput implements Serializable
             }
         }
 
-        if (! isset($index['ns'])) {
-            throw new InvalidArgumentException('Required "ns" option is missing from index specification');
-        }
-
-        if (! is_string($index['ns'])) {
-            throw InvalidArgumentException::invalidType('"ns" option', $index['ns'], 'string');
-        }
-
         if (! isset($index['name'])) {
             $index['name'] = generate_index_name($index['key']);
         }

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -110,10 +110,6 @@ class CreateIndexes implements Executable
                 throw InvalidArgumentException::invalidType(sprintf('$index[%d]', $i), $index, 'array');
             }
 
-            if (! isset($index['ns'])) {
-                $index['ns'] = $databaseName . '.' . $collectionName;
-            }
-
             if (isset($index['collation'])) {
                 $this->isCollationUsed = true;
             }

--- a/tests/Model/IndexInputTest.php
+++ b/tests/Model/IndexInputTest.php
@@ -36,22 +36,10 @@ class IndexInputTest extends TestCase
         return $this->wrapValuesForDataProvider([true, [], new stdClass()]);
     }
 
-    public function testConstructorShouldRequireNamespace()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new IndexInput(['key' => ['x' => 1]]);
-    }
-
-    public function testConstructorShouldRequireNamespaceToBeString()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new IndexInput(['key' => ['x' => 1], 'ns' => 1]);
-    }
-
     public function testConstructorShouldRequireNameToBeString()
     {
         $this->expectException(InvalidArgumentException::class);
-        new IndexInput(['key' => ['x' => 1], 'ns' => 'foo.bar', 'name' => 1]);
+        new IndexInput(['key' => ['x' => 1], 'name' => 1]);
     }
 
     /**
@@ -59,7 +47,7 @@ class IndexInputTest extends TestCase
      */
     public function testNameGeneration($expectedName, array $key)
     {
-        $this->assertSame($expectedName, (string) new IndexInput(['key' => $key, 'ns' => 'foo.bar']));
+        $this->assertSame($expectedName, (string) new IndexInput(['key' => $key]));
     }
 
     public function provideExpectedNameAndKey()
@@ -77,16 +65,16 @@ class IndexInputTest extends TestCase
     {
         $expected = [
             'key' => ['x' => 1],
-            'ns' => 'foo.bar',
+            'unique' => true,
             'name' => 'x_1',
         ];
 
         $indexInput = new IndexInput([
             'key' => ['x' => 1],
-            'ns' => 'foo.bar',
+            'unique' => true,
         ]);
 
         $this->assertInstanceOf(Serializable::class, $indexInput);
-        $this->assertEquals($expected, $indexInput->bsonSerialize());
+        $this->assertSame($expected, $indexInput->bsonSerialize());
     }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-591

Also adds an extra option to the BSON serialization test.