### PR TITLE
Update tested extension versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 
 env:
   global:
-    - DRIVER_VERSION=1.8.0
+    - DRIVER_VERSION=stable
     - SERVER_DISTRO=enterprise-ubuntu1604
     - SERVER_VERSION=4.4.0
     - DEPLOYMENT=STANDALONE
@@ -67,6 +67,7 @@ jobs:
         - SERVER_VERSION=3.0.15
         - DEPLOYMENT=STANDALONE_OLD
         - COMPOSER_OPTIONS=--prefer-lowest
+        - DRIVER_VERSION=1.8.0
 
       # Test older standalone server versions (3.0-4.0)
     - stage: Test

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,11 +133,15 @@ jobs:
       env:
         - DEPLOYMENT=SHARDED_CLUSTER_RS
 
-    # Test next patch release for driver
+    # Test next patch releases for driver
     - stage: Test
       php: "7.3"
       env:
         - DRIVER_BRANCH="v1.8"
+    - stage: Test
+      php: "7.3"
+      env:
+        - DRIVER_BRANCH="v1.9"
 
     # Test next minor release for driver
     - stage: Test

--- a/.travis/install-extension.sh
+++ b/.travis/install-extension.sh
@@ -37,4 +37,7 @@ if [ "x${DRIVER_BRANCH}" != "x" ] || [ "x${DRIVER_REPO}" != "x" ]; then
 elif [ "x${DRIVER_VERSION}" != "x" ]; then
   echo "Installing driver version ${DRIVER_VERSION} from PECL"
   tpecl mongodb-${DRIVER_VERSION} mongodb.so
+else
+  echo "Installing latest driver version"
+  tpecl mongodb mongodb.so
 fi


### PR DESCRIPTION
This changes the travis-ci tests to test against the latest stable extension version by default. It also adds the v1.9 branch to the tested extension versions as they are both supported.