### PR TITLE
Update build pipeline

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -440,12 +440,18 @@ axes:
           DRIVER_VERSION: "1.8.1"
       - id: "latest-stable"
         display_name: "1.8-stable"
-      - id: "latest-minor-dev"
+        variables:
+          DRIVER_VERSION: "stable"
+      - id: "1.8-dev"
         display_name: "1.8-dev"
         variables:
           DRIVER_BRANCH: "v1.8"
+      - id: "1.9-dev"
+        display_name: "1.9-dev"
+        variables:
+          DRIVER_BRANCH: "v1.9"
       - id: "latest-dev"
-        display_name: "1.9-dev (master)"
+        display_name: "1.10-dev (master)"
         variables:
           DRIVER_BRANCH: "master"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
 
 env:
   global:
-    - DRIVER_VERSION=1.8.1
+    - DRIVER_VERSION=stable
     - SERVER_DISTRO=enterprise-ubuntu1604
     - SERVER_VERSION=4.4.0
     - DEPLOYMENT=STANDALONE
@@ -48,105 +48,20 @@ jobs:
       env:
         - CHECKS=phpcs
 
-    # Test remaining supported PHP versions
-    - stage: Test
-      php: "7.0"
-    - stage: Test
-      php: "7.1"
-    - stage: Test
-      php: "7.2"
-    - stage: Test
-      php: "7.3"
-
-    # Test against lowest supported dependencies
-    - stage: Test
-      php: "7.0"
-      dist: trusty
-      env:
-        - SERVER_DISTRO=enterprise-ubuntu1404
-        - SERVER_VERSION=3.0.15
-        - DEPLOYMENT=STANDALONE_OLD
-        - COMPOSER_OPTIONS=--prefer-lowest
-
-      # Test older standalone server versions (3.0-4.0)
-    - stage: Test
-      php: "7.0"
-      dist: trusty
-      env:
-        - SERVER_DISTRO=enterprise-ubuntu1404
-        - SERVER_VERSION=3.0.15
-        - DEPLOYMENT=STANDALONE_OLD
-    - stage: Test
-      php: "7.0"
-      env:
-        - SERVER_VERSION=3.2.22
-        - DEPLOYMENT=STANDALONE_OLD
-    - stage: Test
-      php: "7.0"
-      env:
-        - SERVER_VERSION=3.4.24
-        - DEPLOYMENT=STANDALONE_OLD
-    - stage: Test
-      php: "7.0"
-      env:
-        - SERVER_VERSION=3.6.19
-    - stage: Test
-      env:
-        - SERVER_VERSION=4.0.19
-    - stage: Test
-      env:
-        - SERVER_VERSION=4.2.8
-
-    # Test upcoming server version
-    #- stage: Test
-    #  env:
-    #    - SERVER_VERSION=4.5.0
-
-    # Test other server configurations
-    - stage: Test
-      env:
-        - DEPLOYMENT=STANDALONE_AUTH
-    - stage: Test
-      env:
-        - DEPLOYMENT=STANDALONE_SSL
-    - stage: Test
-      env:
-        - SERVER_VERSION=3.6.13
-        - DEPLOYMENT=REPLICASET
-    - stage: Test
-      env:
-        - DEPLOYMENT=REPLICASET
-    - stage: Test
-      env:
-        - DEPLOYMENT=SHARDED_CLUSTER
-    - stage: Test
-      env:
-        - DEPLOYMENT=SHARDED_CLUSTER_RS
-
-    # Test next patch release for driver
-    - stage: Test
-      env:
-        - DRIVER_BRANCH="v1.8"
-
-    # Test next minor release for driver
-    - stage: Test
-      env:
-        - DRIVER_BRANCH="master"
-
-    # Test upcoming PHP version
+    # Test against PHP 8
     - stage: Test
       php: "nightly"
       env:
-        - DRIVER_BRANCH="master"
+        - DRIVER_VERSION="1.9.0RC1"
     - stage: Test
       php: "nightly"
       env:
-        - DRIVER_BRANCH="master"
+        - DRIVER_VERSION="1.9.0RC1"
         - DEPLOYMENT=REPLICASET
     - stage: Test
       php: "nightly"
       env:
-        - DRIVER_BRANCH="master"
+        - DRIVER_VERSION="1.9.0RC1"
         - DEPLOYMENT=SHARDED_CLUSTER_RS
 
 before_install:


### PR DESCRIPTION
With travis-ci experiencing long queues, it makes sense to reduce the size of the build pipeline and exclude all variants that are being tested on evergreen. We now run a set of smokescreen tests on PHP 7.4, `phpcs` checks on PHP 7.1 (lowest version supported by doctrine/coding-standard) and PHP 8 builds for each topologies (as PHP 8 is not supported on Evergreen yet).