### PR TITLE
PHPLIB-608 Fix wrong validity check in CachingIterator

### DIFF
--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -157,8 +157,6 @@ class CachingIterator implements Countable, Iterator
             return;
         }
 
-        $key = $this->iterator->key();
-
-        $this->items[$key] = $this->iterator->current();
+        $this->items[$this->iterator->key()] = $this->iterator->current();
     }
 }

--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -153,11 +153,11 @@ class CachingIterator implements Countable, Iterator
      */
     private function storeCurrentItem()
     {
-        $key = $this->iterator->key();
-
-        if ($key === null) {
+        if (! $this->iterator->valid()) {
             return;
         }
+
+        $key = $this->iterator->key();
 
         $this->items[$key] = $this->iterator->current();
     }


### PR DESCRIPTION
PHPLIB-608

Note that this does not affect 1.8, as `CachingIterator` always wraps the given traversable in an `IteratorIterator`, which corrects this wrong behaviour in underlying iterators. In the upcoming 1.9 release, this is no longer the case for any traversable that implements the `Iterator` interface, so this wrong behaviour can lead to extra elements given (hence the test failures).