### PR TITLE
Allow PrettyVersion 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ext-hash": "*",
         "ext-json": "*",
         "ext-mongodb": "^1.9.0",
-        "jean85/pretty-package-versions": "^1.2",
+        "jean85/pretty-package-versions": "^1.2 || ^2.0.1",
         "symfony/polyfill-php80": "^1.19"
     },
     "require-dev": {


### PR DESCRIPTION
This simple bump allows for the 2.0 version of this lib, which leverages Composer 2 APIs and drops any sub dependency.

There are basically no BC; for more details, see the [the changelog](https://github.com/Jean85/pretty-package-versions/blob/2.x/CHANGELOG.md).