### PR TITLE
PHPLIB-616 Continuous Matrix Testing for 4.2 era drivers

### DIFF
--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -381,7 +381,9 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
     /**
      * @group matrix-testing-server-4.4-driver-4.0
+     * @group matrix-testing-server-4.4-driver-4.2
      * @group matrix-testing-server-5.0-driver-4.0
+     * @group matrix-testing-server-5.0-driver-4.2
      */
     public function testMapReduce()
     {

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -47,7 +47,10 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
         $this->assertEquals($expectedVersion, $index['2dsphereIndexVersion']);
     }
 
-    /** @group matrix-testing-server-5.0-driver-4.0 */
+    /**
+     * @group matrix-testing-server-5.0-driver-4.0
+     * @group matrix-testing-server-5.0-driver-4.2
+     */
     public function testIsGeoHaystack()
     {
         $indexName = $this->collection->createIndex(['pos' => 'geoHaystack', 'x' => 1], ['bucketSize' => 5]);

--- a/tests/Operation/ListCollectionsFunctionalTest.php
+++ b/tests/Operation/ListCollectionsFunctionalTest.php
@@ -38,7 +38,9 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
 
     /**
      * @group matrix-testing-server-4.4-driver-4.0
+     * @group matrix-testing-server-4.4-driver-4.2
      * @group matrix-testing-server-5.0-driver-4.0
+     * @group matrix-testing-server-5.0-driver-4.2
      */
     public function testIdIndexAndInfo()
     {

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -14,7 +14,9 @@ use function version_compare;
 
 /**
  * @group matrix-testing-server-4.4-driver-4.0
+ * @group matrix-testing-server-4.4-driver-4.2
  * @group matrix-testing-server-5.0-driver-4.0
+ * @group matrix-testing-server-5.0-driver-4.2
  */
 class MapReduceFunctionalTest extends FunctionalTestCase
 {

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -186,6 +186,10 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     {
         $context = $this->getContext();
 
+        if ($context->databaseName === 'admin') {
+            return;
+        }
+
         if ($context->bucketName !== null) {
             $bucket = $context->getGridFSBucket($context->defaultWriteOptions);
             $bucket->drop();

--- a/tests/SpecTests/RetryableReadsSpecTest.php
+++ b/tests/SpecTests/RetryableReadsSpecTest.php
@@ -42,6 +42,9 @@ class RetryableReadsSpecTest extends FunctionalTestCase
      * Execute an individual test case from the specification.
      *
      * @dataProvider provideTests
+     * @group matrix-testing-server-4.4-driver-4.2
+     * @group matrix-testing-server-5.0-driver-4.2
+     *
      * @param stdClass     $test           Individual "tests[]" document
      * @param array        $runOn          Top-level "runOn" array with server requirements
      * @param array|object $data           Top-level "data" array to initialize collection


### PR DESCRIPTION
PHPLIB-616

This branch skips tests that fail when running the 4.2 driver against newer servers. The patch build has been updated to test 4.2 as well: https://spruce.mongodb.com/version/602f72fc9ccd4e172a60e6e8/tasks

The failing tests are tricky: these are single tests in some of the spec tests which we can't skip due to how data providers work. Skipping the entire test suite seems overkill, so I'll have to figure out another way to fix this.