### PR TITLE
PHPLIB-615 Matrix testing for 4.4 era drivers

### DIFF
--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -50,6 +50,7 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
     /**
      * @group matrix-testing-exclude-server-5.0-driver-4.0
      * @group matrix-testing-exclude-server-5.0-driver-4.2
+     * @group matrix-testing-exclude-server-5.0-driver-4.4
      */
     public function testIsGeoHaystack()
     {

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -751,11 +751,11 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $collection = $context->selectCollection('keyvault', 'datakeys', ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)] + $context->defaultWriteOptions);
         $collection->drop();
 
-        if (!empty($keyVaultData)) {
-            $collection->insertMany($keyVaultData);
+        if (empty($keyVaultData)) {
+            return;
         }
 
-        return;
+        $collection->insertMany($keyVaultData);
     }
 
     private function prepareCorpusData(stdClass $data, ClientEncryption $clientEncryption)

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -168,9 +168,12 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      */
     public function testDataKeyAndDoubleEncryption(Closure $test)
     {
-        $client = new Client(static::getUri());
+        $this->setContext(Context::fromClientSideEncryption((object) [], 'db', 'coll'));
+        $client = $this->getContext()->getClient();
 
-        $client->selectCollection('keyvault', 'datakeys')->drop();
+        // This empty call ensures that the key vault is dropped with a majority
+        // write concern
+        $this->insertKeyVaultData([]);
         $client->selectCollection('db', 'coll')->drop();
 
         $encryptionOpts = [
@@ -312,13 +315,17 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      */
     public function testExternalKeyVault($withExternalKeyVault)
     {
-        $client = new Client(static::getUri());
-
-        $client->selectCollection('keyvault', 'datakeys')->drop();
+        $this->setContext(Context::fromClientSideEncryption((object) [], 'db', 'coll'));
+        $client = $this->getContext()->getClient();
         $client->selectCollection('db', 'coll')->drop();
 
-        $keyId = $client
-            ->selectCollection('keyvault', 'datakeys')
+        $keyVaultCollection = $client->selectCollection(
+            'keyvault',
+            'datakeys',
+            ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)] + $this->getContext()->defaultWriteOptions
+        );
+        $keyVaultCollection->drop();
+        $keyId = $keyVaultCollection
             ->insertOne($this->decodeJson(file_get_contents(__DIR__ . '/client-side-encryption/external/external-key.json')))
             ->getInsertedId();
 
@@ -370,13 +377,15 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      */
     public function testBSONSizeLimitsAndBatchSplitting()
     {
-        $client = new Client(static::getUri());
+        $this->setContext(Context::fromClientSideEncryption((object) [], 'db', 'coll'));
+        $client = $this->getContext()->getClient();
 
-        $client->selectCollection('keyvault', 'datakeys')->drop();
         $client->selectCollection('db', 'coll')->drop();
-
         $client->selectDatabase('db')->createCollection('coll', ['validator' => ['$jsonSchema' => $this->decodeJson(file_get_contents(__DIR__ . '/client-side-encryption/limits/limits-schema.json'))]]);
-        $client->selectCollection('keyvault', 'datakeys')->insertOne($this->decodeJson(file_get_contents(__DIR__ . '/client-side-encryption/limits/limits-key.json')));
+
+        $this->insertKeyVaultData([
+            $this->decodeJson(file_get_contents(__DIR__ . '/client-side-encryption/limits/limits-key.json')),
+        ]);
 
         $autoEncryptionOpts = [
             'keyVaultNamespace' => 'keyvault.datakeys',
@@ -491,7 +500,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      */
     public function testCorpus($schemaMap = true)
     {
-        $client = new Client(static::getUri());
+        $this->setContext(Context::fromClientSideEncryption((object) [], 'db', 'coll'));
+        $client = $this->getContext()->getClient();
 
         $client->selectDatabase('db')->dropCollection('coll');
 
@@ -503,8 +513,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                 ->createCollection('coll', ['validator' => ['$jsonSchema' => $schema]]);
         }
 
-        $client->selectDatabase('keyvault')->dropCollection('datakeys');
-        $client->selectCollection('keyvault', 'datakeys')->insertMany([
+        $this->insertKeyVaultData([
             $this->decodeJson(file_get_contents(__DIR__ . '/client-side-encryption/corpus/corpus-key-local.json')),
             $this->decodeJson(file_get_contents(__DIR__ . '/client-side-encryption/corpus/corpus-key-aws.json')),
         ]);
@@ -738,14 +747,13 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
     private function insertKeyVaultData(array $keyVaultData = null)
     {
-        if (empty($keyVaultData)) {
-            return;
-        }
-
         $context = $this->getContext();
         $collection = $context->selectCollection('keyvault', 'datakeys', ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)] + $context->defaultWriteOptions);
         $collection->drop();
-        $collection->insertMany($keyVaultData);
+
+        if (!empty($keyVaultData)) {
+            $collection->insertMany($keyVaultData);
+        }
 
         return;
     }


### PR DESCRIPTION
PHPLIB-615

Patch build here: https://spruce.mongodb.com/version/6040d7ab5623437bced1668d/tasks

CSFLE tests needed a change as there were intermittent failures on replica sets. Using a majority write concern fixes this. This was done for some tests, but apparently I missed a few of them when I originally did this.

Once this PR is merged, I'll merge changes up to the current development branch and update the PR to drivers-matrix-testing to test against the actual compat versions instead of branches on my fork.