### PR TITLE
PHPLIB-589 Drop support for PHP 7.0

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -400,10 +400,6 @@ axes:
         display_name: "7.1"
         variables:
           PHP_VERSION: "7.1.31"
-      - id: "7.0"
-        display_name: "7.0"
-        variables:
-          PHP_VERSION: "7.0.32"
 
   - id: php-edge-versions
     display_name: PHP Version
@@ -413,9 +409,9 @@ axes:
         variables:
           PHP_VERSION: "7.4.7"
       - id: "oldest-supported"
-        display_name: "7.0"
+        display_name: "7.1"
         variables:
-          PHP_VERSION: "7.0.32"
+          PHP_VERSION: "7.1.31"
 
   - id: versions
     display_name: MongoDB Version

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -29,10 +29,6 @@ set_php_version ()
 
 install_extension ()
 {
-   # Workaround to get PECL running on PHP 7.0
-   export PHP_PEAR_PHP_BIN=${PHP_PATH}/bin/php
-   export PHP_PEAR_INSTALL_DIR=${PHP_PATH}/lib/php
-
    rm -f ${PHP_PATH}/lib/php.ini
 
    if [ "x${EXTENSION_BRANCH}" != "x" ] || [ "x${EXTENSION_REPO}" != "x" ]; then

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
     ],
     "require": {
-        "php": "^7.0 || ^8.0",
+        "php": "^7.1 || ^8.0",
         "ext-hash": "*",
         "ext-json": "*",
         "ext-mongodb": "^1.10.0",

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -8,7 +8,6 @@ use MongoDB\Driver\Manager;
 use MongoDB\Driver\Session;
 use MongoDB\Model\DatabaseInfo;
 use MongoDB\Model\DatabaseInfoIterator;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function call_user_func;
 use function is_callable;
 use function sprintf;
@@ -19,12 +18,10 @@ use function version_compare;
  */
 class ClientFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Client */
     private $client;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -14,7 +14,6 @@ use MongoDB\Operation\FindOneAndReplace;
 use MongoDB\UpdateResult;
 use MultipleIterator;
 use PHPUnit_Framework_SkippedTestError;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function array_diff_key;
 use function array_key_exists;
 use function array_map;
@@ -36,12 +35,10 @@ use function version_compare;
  */
 class CrudSpecFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     private $expectedCollection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Collection/FunctionalTestCase.php
+++ b/tests/Collection/FunctionalTestCase.php
@@ -4,19 +4,16 @@ namespace MongoDB\Tests\Collection;
 
 use MongoDB\Collection;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Base class for Collection functional tests.
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     protected $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -25,7 +22,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         $this->dropCollection();
     }
 
-    private function doTearDown()
+    public function tearDown() : void
     {
         if ($this->hasFailed()) {
             return;

--- a/tests/Database/FunctionalTestCase.php
+++ b/tests/Database/FunctionalTestCase.php
@@ -4,19 +4,16 @@ namespace MongoDB\Tests\Database;
 
 use MongoDB\Database;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Base class for Database functional tests.
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Database */
     protected $database;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -9,7 +9,6 @@ use MongoDB\Driver\Cursor;
 use MongoDB\Driver\Exception\Exception;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function in_array;
 use function ob_end_clean;
 use function ob_start;
@@ -25,16 +24,14 @@ use function version_compare;
  */
 class DocumentationExamplesTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 
         $this->dropCollection();
     }
 
-    private function doTearDown()
+    public function tearDown() : void
     {
         if ($this->hasFailed()) {
             return;

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -17,7 +17,6 @@ use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\DatabaseCommand;
 use MongoDB\Operation\DropCollection;
 use stdClass;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use UnexpectedValueException;
 use function array_merge;
 use function count;
@@ -42,15 +41,13 @@ use const INFO_MODULES;
 
 abstract class FunctionalTestCase extends TestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Manager */
     protected $manager;
 
     /** @var array */
     private $configuredFailPoints = [];
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -58,7 +55,7 @@ abstract class FunctionalTestCase extends TestCase
         $this->configuredFailPoints = [];
     }
 
-    private function doTearDown()
+    public function tearDown() : void
     {
         $this->disableFailPoints();
 

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -5,7 +5,6 @@ namespace MongoDB\Tests\GridFS;
 use MongoDB\Collection;
 use MongoDB\GridFS\Bucket;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function fopen;
 use function fwrite;
 use function get_resource_type;
@@ -17,8 +16,6 @@ use function stream_get_contents;
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Bucket */
     protected $bucket;
 
@@ -28,7 +25,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
     /** @var Collection */
     protected $filesCollection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -8,7 +8,6 @@ use MongoDB\GridFS\CollectionWrapper;
 use MongoDB\GridFS\Exception\CorruptFileException;
 use MongoDB\GridFS\ReadableStream;
 use MongoDB\Tests\CommandObserver;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function array_filter;
 
 /**
@@ -16,12 +15,10 @@ use function array_filter;
  */
 class ReadableStreamFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var CollectionWrapper */
     private $collectionWrapper;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -4,7 +4,6 @@ namespace MongoDB\Tests\GridFS;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\UTCDateTime;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function fclose;
 use function feof;
 use function fread;
@@ -20,9 +19,7 @@ use const SEEK_SET;
  */
 class StreamWrapperFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -5,7 +5,6 @@ namespace MongoDB\Tests\GridFS;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\CollectionWrapper;
 use MongoDB\GridFS\WritableStream;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function str_repeat;
 
 /**
@@ -13,12 +12,10 @@ use function str_repeat;
  */
 class WritableStreamFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var CollectionWrapper */
     private $collectionWrapper;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -11,18 +11,15 @@ use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\FunctionalTestCase;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function array_merge;
 use function sprintf;
 
 class ChangeStreamIteratorTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     private $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -4,17 +4,14 @@ namespace MongoDB\Tests\Model;
 
 use MongoDB\Collection;
 use MongoDB\Tests\FunctionalTestCase;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function version_compare;
 
 class IndexInfoFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     private $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -22,7 +19,7 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
         $this->collection->drop();
     }
 
-    private function doTearDown()
+    public function tearDown() : void
     {
         if ($this->hasFailed()) {
             return;

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -11,17 +11,14 @@ use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\BulkWrite;
 use MongoDB\Tests\CommandObserver;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function version_compare;
 
 class BulkWriteFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     private $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -9,17 +9,14 @@ use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Operation\Delete;
 use MongoDB\Tests\CommandObserver;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function version_compare;
 
 class DeleteFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     private $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Operation/FunctionalTestCase.php
+++ b/tests/Operation/FunctionalTestCase.php
@@ -5,23 +5,20 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 
 /**
  * Base class for Operation functional tests.
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 
         $this->dropCollection();
     }
 
-    private function doTearDown()
+    public function tearDown() : void
     {
         if ($this->hasFailed()) {
             return;

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -10,17 +10,14 @@ use MongoDB\InsertManyResult;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function version_compare;
 
 class InsertManyFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     private $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -10,17 +10,14 @@ use MongoDB\InsertOneResult;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Tests\CommandObserver;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function version_compare;
 
 class InsertOneFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     private $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -10,17 +10,14 @@ use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Operation\Update;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\UpdateResult;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function version_compare;
 
 class UpdateFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var Collection */
     private $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -21,7 +21,6 @@ use MongoDB\Tests\CommandObserver;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionClass;
 use stdClass;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function array_diff_key;
 use function array_map;
 use function bin2hex;
@@ -37,8 +36,6 @@ use function version_compare;
  */
 class WatchFunctionalTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     const INTERRUPTED = 11601;
     const NOT_PRIMARY = 10107;
 
@@ -48,7 +45,7 @@ class WatchFunctionalTest extends FunctionalTestCase
     /** @var array */
     private $defaultOptions = ['maxAwaitTimeMS' => 500];
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/SpecTests/AtlasDataLakeSpecTest.php
+++ b/tests/SpecTests/AtlasDataLakeSpecTest.php
@@ -6,7 +6,6 @@ use MongoDB\Driver\Command;
 use MongoDB\Driver\Cursor;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function basename;
 use function current;
 use function explode;
@@ -21,9 +20,7 @@ use function parse_url;
  */
 class AtlasDataLakeSpecTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -18,7 +18,6 @@ use MongoDB\Operation\CreateCollection;
 use MongoDB\Tests\CommandObserver;
 use PHPUnit\Framework\SkippedTestError;
 use stdClass;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Throwable;
 use UnexpectedValueException;
 use function base64_decode;
@@ -40,11 +39,9 @@ use function unserialize;
  */
 class ClientSideEncryptionSpecTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     const LOCAL_MASTERKEY = 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk';
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -10,7 +10,6 @@ use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
 use MultipleIterator;
 use PHPUnit\Framework\SkippedTest;
 use stdClass;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use UnexpectedValueException;
 use function in_array;
 use function json_encode;
@@ -26,8 +25,6 @@ use function version_compare;
  */
 class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     const TOPOLOGY_SINGLE = 'single';
     const TOPOLOGY_REPLICASET = 'replicaset';
     const TOPOLOGY_SHARDED = 'sharded';
@@ -35,14 +32,14 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     /** @var Context|null */
     private $context;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 
         $this->context = null;
     }
 
-    private function doTearDown()
+    public function tearDown() : void
     {
         $this->context = null;
 

--- a/tests/SpecTests/PrimaryStepDownSpecTest.php
+++ b/tests/SpecTests/PrimaryStepDownSpecTest.php
@@ -12,7 +12,6 @@ use MongoDB\Driver\Server;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Operation\BulkWrite;
 use MongoDB\Tests\CommandObserver;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use UnexpectedValueException;
 use function current;
 use function sprintf;
@@ -22,8 +21,6 @@ use function sprintf;
  */
 class PrimaryStepDownSpecTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     const INTERRUPTED_AT_SHUTDOWN = 11600;
     const NOT_PRIMARY = 10107;
     const SHUTDOWN_IN_PROGRESS = 91;
@@ -34,7 +31,7 @@ class PrimaryStepDownSpecTest extends FunctionalTestCase
     /** @var Collection */
     private $collection;
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -9,7 +9,6 @@ use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 use stdClass;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function array_unique;
 use function basename;
 use function count;
@@ -25,8 +24,6 @@ use function glob;
  */
 class TransactionsSpecTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     const INTERRUPTED = 11601;
 
     /**
@@ -43,7 +40,7 @@ class TransactionsSpecTest extends FunctionalTestCase
         'transactions/errors-client: Client side error when transaction is in progress' => 'PHPLIB-665',
     ];
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -52,7 +49,7 @@ class TransactionsSpecTest extends FunctionalTestCase
         $this->skipIfTransactionsAreNotSupported();
     }
 
-    private function doTearDown()
+    public function tearDown() : void
     {
         if ($this->hasFailed()) {
             static::killAllSessions();

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -7,7 +7,6 @@ use Generator;
 use MongoDB\Tests\FunctionalTestCase;
 use PHPUnit\Framework\SkippedTest;
 use PHPUnit\Framework\Warning;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use function basename;
 use function dirname;
 use function glob;
@@ -19,8 +18,6 @@ use function glob;
  */
 class UnifiedSpecTest extends FunctionalTestCase
 {
-    use SetUpTearDownTrait;
-
     /** @var array */
     private static $incompleteTests = [
         // PHPLIB-573 and DRIVERS-1340
@@ -111,7 +108,7 @@ class UnifiedSpecTest extends FunctionalTestCase
     /** @var UnifiedTestRunner */
     private static $runner;
 
-    private static function doSetUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         parent::setUpBeforeClass();
 
@@ -120,7 +117,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner = new UnifiedTestRunner(static::getUri(true));
     }
 
-    private function doSetUp()
+    public function setUp() : void
     {
         parent::setUp();
 


### PR DESCRIPTION
PHPLIB-589

While we're only removing the (now deprecated) `SetUpTearDownTrait` at this time, more significant changes will happen once we drop PHP 7.1, as this allows us to start introducing argument types.