### PR TITLE
PHPLIB-636: ListIndexes should use CommandException for catching missing namespace and database errors

### DIFF
--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -19,7 +19,7 @@ namespace MongoDB\Operation;
 
 use EmptyIterator;
 use MongoDB\Driver\Command;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Exception\InvalidArgumentException;
@@ -90,7 +90,7 @@ class ListIndexes implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return IndexInfoIterator
-     * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
+     * @throws CommandException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)
     {
@@ -123,7 +123,7 @@ class ListIndexes implements Executable
      *
      * @param Server $server
      * @return IndexInfoIteratorIterator
-     * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
+     * @throws CommandException for other driver errors (e.g. connection errors)
      */
     private function executeCommand(Server $server)
     {
@@ -135,7 +135,7 @@ class ListIndexes implements Executable
 
         try {
             $cursor = $server->executeReadCommand($this->databaseName, new Command($cmd), $this->createOptions());
-        } catch (DriverRuntimeException $e) {
+        } catch (CommandException $e) {
             /* The server may return an error if the collection does not exist.
              * Check for possible error codes (see: SERVER-20463) and return an
              * empty iterator instead of throwing.

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -19,8 +19,8 @@ namespace MongoDB\Operation;
 
 use EmptyIterator;
 use MongoDB\Driver\Command;
-use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Exception\CommandException;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Exception\InvalidArgumentException;

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -19,6 +19,7 @@ namespace MongoDB\Operation;
 
 use EmptyIterator;
 use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
@@ -90,7 +91,7 @@ class ListIndexes implements Executable
      * @see Executable::execute()
      * @param Server $server
      * @return IndexInfoIterator
-     * @throws CommandException for other driver errors (e.g. connection errors)
+     * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)
     {
@@ -123,7 +124,7 @@ class ListIndexes implements Executable
      *
      * @param Server $server
      * @return IndexInfoIteratorIterator
-     * @throws CommandException for other driver errors (e.g. connection errors)
+     * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     private function executeCommand(Server $server)
     {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-636