### PR TITLE
PHPLIB-675 Add helpers to check collection types to CollectionInfo

### DIFF
--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -60,6 +60,8 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the maximum number of documents to keep in the capped collection.
      *
+     * @deprecated Deprecated in favor of using getOptions
+     *
      * @return integer|null
      */
     public function getCappedMax()
@@ -71,6 +73,8 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the maximum size (in bytes) of the capped collection.
      *
+     * @deprecated Deprecated in favor of using getOptions
+     *
      * @return integer|null
      */
     public function getCappedSize()
@@ -80,8 +84,30 @@ class CollectionInfo implements ArrayAccess
     }
 
     /**
+     * Return information about the _id index for the collection.
+     *
+     * @return array
+     */
+    public function getIdIndex(): array
+    {
+        return (array) ($this->info['idIndex'] ?? []);
+    }
+
+    /**
+     * Return the "info" property of the server response.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/listCollections/#output
+     * @return array
+     */
+    public function getInfo(): array
+    {
+        return (array) ($this->info['info'] ?? []);
+    }
+
+    /**
      * Return the collection name.
      *
+     * @see https://docs.mongodb.com/manual/reference/command/listCollections/#output
      * @return string
      */
     public function getName()
@@ -92,15 +118,29 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the collection options.
      *
+     * @see https://docs.mongodb.com/manual/reference/command/listCollections/#output
      * @return array
      */
     public function getOptions()
     {
-        return isset($this->info['options']) ? (array) $this->info['options'] : [];
+        return (array) ($this->info['options'] ?? []);
+    }
+
+    /**
+     * Return the collection type.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/listCollections/#output
+     * @return string
+     */
+    public function getType(): string
+    {
+        return (string) $this->info['type'];
     }
 
     /**
      * Return whether the collection is a capped collection.
+     *
+     * @deprecated Deprecated in favor of using getOptions
      *
      * @return boolean
      */

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -60,7 +60,7 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the maximum number of documents to keep in the capped collection.
      *
-     * @deprecated Deprecated in favor of using getOptions
+     * @deprecated 1.0 Deprecated in favor of using getOptions
      *
      * @return integer|null
      */
@@ -73,7 +73,7 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the maximum size (in bytes) of the capped collection.
      *
-     * @deprecated Deprecated in favor of using getOptions
+     * @deprecated 1.0 Deprecated in favor of using getOptions
      *
      * @return integer|null
      */
@@ -140,7 +140,7 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return whether the collection is a capped collection.
      *
-     * @deprecated Deprecated in favor of using getOptions
+     * @deprecated 1.0 Deprecated in favor of using getOptions
      *
      * @return boolean
      */

--- a/tests/Model/CollectionInfoTest.php
+++ b/tests/Model/CollectionInfoTest.php
@@ -42,13 +42,13 @@ class CollectionInfoTest extends TestCase
         ]);
 
         $this->assertSame([], $info->getOptions());
-        $this->assertFalse(isset($info['options']));
+        $this->assertArrayNotHasKey('options', $info);
 
         $this->assertSame([], $info->getInfo());
-        $this->assertFalse(isset($info['info']));
+        $this->assertArrayNotHasKey('info', $info);
 
         $this->assertSame([], $info->getIdIndex());
-        $this->assertFalse(isset($info['idIndex']));
+        $this->assertArrayNotHasKey('idIndex', $info);
     }
 
     public function testCappedCollectionMethods(): void

--- a/tests/Model/CollectionInfoTest.php
+++ b/tests/Model/CollectionInfoTest.php
@@ -8,19 +8,47 @@ use MongoDB\Tests\TestCase;
 
 class CollectionInfoTest extends TestCase
 {
-    public function testGetName(): void
+    public function testGetBasicInformation(): void
     {
-        $info = new CollectionInfo(['name' => 'foo']);
+        $info = new CollectionInfo([
+            'name' => 'foo',
+            'type' => 'view',
+            'options' => ['capped' => true, 'size' => 1048576],
+            'info' => ['readOnly' => true],
+            'idIndex' => ['idIndex' => true], // Dummy option
+        ]);
+
         $this->assertSame('foo', $info->getName());
+        $this->assertSame('foo', $info['name']);
+
+        $this->assertSame('view', $info->getType());
+        $this->assertSame('view', $info['type']);
+
+        $this->assertSame(['capped' => true, 'size' => 1048576], $info->getOptions());
+        $this->assertSame(['capped' => true, 'size' => 1048576], $info['options']);
+
+        $this->assertSame(['readOnly' => true], $info->getInfo());
+        $this->assertSame(['readOnly' => true], $info['info']);
+
+        $this->assertSame(['idIndex' => true], $info->getIdIndex());
+        $this->assertSame(['idIndex' => true], $info['idIndex']);
     }
 
-    public function testGetOptions(): void
+    public function testMissingFields(): void
     {
-        $info = new CollectionInfo(['name' => 'foo']);
-        $this->assertSame([], $info->getOptions());
+        $info = new CollectionInfo([
+            'name' => 'foo',
+            'type' => 'view',
+        ]);
 
-        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576]]);
-        $this->assertSame(['capped' => true, 'size' => 1048576], $info->getOptions());
+        $this->assertSame([], $info->getOptions());
+        $this->assertFalse(isset($info['options']));
+
+        $this->assertSame([], $info->getInfo());
+        $this->assertFalse(isset($info['info']));
+
+        $this->assertSame([], $info->getIdIndex());
+        $this->assertFalse(isset($info['idIndex']));
     }
 
     public function testCappedCollectionMethods(): void


### PR DESCRIPTION
PHPLIB-675

This adds `isCollection`, `isTimeSeries`, and `isView` helpers to `CollectionInfo` to complement `isCapped`.