### PR TITLE
PHPLIB-675 Document new CollectionInfo methods

### DIFF
--- a/docs/reference/enumeration-classes.txt
+++ b/docs/reference/enumeration-classes.txt
@@ -43,8 +43,11 @@ Methods
 
    /reference/method/MongoDBModelCollectionInfo-getCappedMax
    /reference/method/MongoDBModelCollectionInfo-getCappedSize
+   /reference/method/MongoDBModelCollectionInfo-getIdIndex
+   /reference/method/MongoDBModelCollectionInfo-getInfo
    /reference/method/MongoDBModelCollectionInfo-getName
    /reference/method/MongoDBModelCollectionInfo-getOptions
+   /reference/method/MongoDBModelCollectionInfo-getType
    /reference/method/MongoDBModelCollectionInfo-isCapped
 
 ----

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
@@ -32,7 +32,7 @@ The document limit for the capped collection. If the collection is not capped,
 
 This method is deprecated in favor of using
 :phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()` and accessing the
-`max` key.
+``max`` key.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
@@ -2,6 +2,8 @@
 MongoDB\\Model\\CollectionInfo::getCappedMax()
 ==============================================
 
+.. deprecated:: 1.9
+
 .. default-domain:: mongodb
 
 .. contents:: On this page
@@ -27,6 +29,9 @@ Return Values
 
 The document limit for the capped collection. If the collection is not capped,
 ``null`` will be returned.
+
+This method is deprecated in favor of using
+:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()`.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
@@ -31,7 +31,8 @@ The document limit for the capped collection. If the collection is not capped,
 ``null`` will be returned.
 
 This method is deprecated in favor of using
-:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()`.
+:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()` and accessing the
+`max` key.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
@@ -32,7 +32,8 @@ The size limit for the capped collection in bytes. If the collection is not
 capped, ``null`` will be returned.
 
 This method is deprecated in favor of using
-:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()`.
+:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()` and accessing the
+`size` key.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
@@ -2,6 +2,8 @@
 MongoDB\\Model\\CollectionInfo::getCappedSize()
 ===============================================
 
+.. deprecated:: 1.9
+
 .. default-domain:: mongodb
 
 .. contents:: On this page
@@ -28,6 +30,9 @@ Return Values
 
 The size limit for the capped collection in bytes. If the collection is not
 capped, ``null`` will be returned.
+
+This method is deprecated in favor of using
+:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()`.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
@@ -33,7 +33,7 @@ capped, ``null`` will be returned.
 
 This method is deprecated in favor of using
 :phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()` and accessing the
-`size` key.
+``size`` key.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
@@ -2,6 +2,8 @@
 MongoDB\\Model\\CollectionInfo::getIdIndex()
 ============================================
 
+.. versionadded:: 1.9
+
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
@@ -1,0 +1,71 @@
+============================================
+MongoDB\\Model\\CollectionInfo::getIdIndex()
+============================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Model\\CollectionInfo::getIdIndex()
+
+   Returns information about the ``_id`` field index.
+
+   .. code-block:: php
+
+      function getIdIndex(): array
+
+Return Values
+-------------
+
+An array containing information on the ``_id`` index. This corresponds to the
+``idIndex`` field returned in the ``listCollections`` command reply.
+
+Examples
+--------
+
+.. code-block:: php
+
+   <?php
+
+   $info = new CollectionInfo([
+     'type' => 'view',
+     'name' => 'foo',
+     'idIndex' => [
+        'v' => 2,
+        'key' => ['_id' => 1],
+        'name' => '_id',
+        'ns' => 'test.foo',
+     ],
+   ]);
+
+   var_dump($info->getIdIndex());
+
+The output would then resemble::
+
+   array(4) {
+     ["v"]=>
+     int(2)
+     ["key"]=>
+     array(1) {
+       ["_id"]=>
+       int(1)
+     }
+     ["name"]=>
+     string(3) "_id"
+     ["ns"]=>
+     string(8) "test.foo"
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Database::createCollection()`
+- :manual:`listCollections </reference/command/listCollections>` command
+  reference in the MongoDB manual

--- a/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
@@ -2,6 +2,8 @@
 MongoDB\\Model\\CollectionInfo::getInfo()
 =========================================
 
+.. versionadded:: 1.9
+
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
@@ -1,0 +1,57 @@
+=========================================
+MongoDB\\Model\\CollectionInfo::getInfo()
+=========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Model\\CollectionInfo::getInfo()
+
+   Returns additional information about the collection.
+
+   .. code-block:: php
+
+      function getInfo(): array
+
+Return Values
+-------------
+
+An array containing extra information about the collection. This corresponds to
+the ``info`` field returned in the ``listCollections`` command reply.
+
+Examples
+--------
+
+.. code-block:: php
+
+   <?php
+
+   $info = new CollectionInfo([
+     'type' => 'view',
+     'name' => 'foo',
+     'info' => ['readOnly' => true]
+   ]);
+
+   var_dump($info->getInfo());
+
+The output would then resemble::
+
+   array(1) {
+     ["readOnly"]=>
+     bool(true)
+   }
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Database::createCollection()`
+- :manual:`listCollections </reference/command/listCollections>` command
+  reference in the MongoDB manual

--- a/docs/reference/method/MongoDBModelCollectionInfo-getName.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getName.txt
@@ -24,7 +24,8 @@ Definition
 Return Values
 -------------
 
-The collection name.
+The collection name. This corresponds to the ``name`` field returned in the
+``listCollections`` command reply.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-getOptions.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getOptions.txt
@@ -26,7 +26,8 @@ Definition
 Return Values
 -------------
 
-The collection options.
+The collection options. This corresponds to the ``options`` field returned in
+the ``listCollections`` command reply.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
@@ -1,0 +1,50 @@
+=========================================
+MongoDB\\Model\\CollectionInfo::getType()
+=========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\Model\\CollectionInfo::getType()
+
+   Return the collection type.
+
+   .. code-block:: php
+
+      function getType(): string
+
+Return Values
+-------------
+
+The collection type. This corresponds to the ``type`` field returned in the
+``listCollections`` command reply.
+
+Examples
+--------
+
+.. code-block:: php
+
+   <?php
+
+   $info = new CollectionInfo(['type' => 'collection', 'name' => 'foo']);
+
+   echo $info->getType();
+
+The output would then resemble::
+
+   collection
+
+See Also
+--------
+
+- :phpmethod:`MongoDB\\Database::createCollection()`
+- :manual:`listCollections </reference/command/listCollections>` command
+  reference in the MongoDB manual

--- a/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
@@ -2,6 +2,8 @@
 MongoDB\\Model\\CollectionInfo::getType()
 =========================================
 
+.. versionadded:: 1.9
+
 .. default-domain:: mongodb
 
 .. contents:: On this page

--- a/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
@@ -31,7 +31,7 @@ A boolean indicating whether the collection is a capped collection.
 
 This method is deprecated in favor of using
 :phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()` and accessing the
-`capped` key.
+``capped`` key.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
@@ -2,6 +2,8 @@
 MongoDB\\Model\\CollectionInfo::isCapped()
 ==========================================
 
+.. deprecated:: 1.9
+
 .. default-domain:: mongodb
 
 .. contents:: On this page
@@ -26,6 +28,9 @@ Return Values
 -------------
 
 A boolean indicating whether the collection is a capped collection.
+
+This method is deprecated in favor of using
+:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()`.
 
 Examples
 --------

--- a/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
@@ -30,7 +30,8 @@ Return Values
 A boolean indicating whether the collection is a capped collection.
 
 This method is deprecated in favor of using
-:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()`.
+:phpmethod:`MongoDB\\Model\\CollectionInfo::getOptions()` and accessing the
+`capped` key.
 
 Examples
 --------


### PR DESCRIPTION
PHPLIB-675

Adds missing documentation for new method and documents the deprecation of helpers relating to capped collections.