### PR TITLE
Avoid some deprecations with PHP 8.1

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -137,9 +137,13 @@ class Collection
      */
     public function __construct(Manager $manager, $databaseName, $collectionName, array $options = [])
     {
+        $databaseName = (string) $databaseName
+
         if (strlen($databaseName) < 1) {
             throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
         }
+
+        $collectionName = (string) $collectionName
 
         if (strlen($collectionName) < 1) {
             throw new InvalidArgumentException('$collectionName is invalid: ' . $collectionName);
@@ -162,8 +166,8 @@ class Collection
         }
 
         $this->manager = $manager;
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
         $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;

--- a/src/Database.php
+++ b/src/Database.php
@@ -111,6 +111,8 @@ class Database
      */
     public function __construct(Manager $manager, $databaseName, array $options = [])
     {
+        $databaseName = (string) $databaseName;
+
         if (strlen($databaseName) < 1) {
             throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
         }
@@ -132,7 +134,7 @@ class Database
         }
 
         $this->manager = $manager;
-        $this->databaseName = (string) $databaseName;
+        $this->databaseName = $databaseName;
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
         $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;

--- a/src/Model/CollectionInfoCommandIterator.php
+++ b/src/Model/CollectionInfoCommandIterator.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Model;
 
 use IteratorIterator;
+use ReturnTypeWillChange;
 use Traversable;
 
 /**
@@ -53,6 +54,7 @@ class CollectionInfoCommandIterator extends IteratorIterator implements Collecti
      * @see http://php.net/iterator.current
      * @return CollectionInfo
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $info = parent::current();

--- a/src/Model/IndexInfoIteratorIterator.php
+++ b/src/Model/IndexInfoIteratorIterator.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Model;
 
 use IteratorIterator;
+use ReturnTypeWillChange;
 use Traversable;
 
 use function array_key_exists;
@@ -57,6 +58,7 @@ class IndexInfoIteratorIterator extends IteratorIterator implements IndexInfoIte
      * @see http://php.net/iterator.current
      * @return IndexInfo
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $info = parent::current();

--- a/tests/Model/BSONIteratorTest.php
+++ b/tests/Model/BSONIteratorTest.php
@@ -17,7 +17,7 @@ class BSONIteratorTest extends TestCase
     /**
      * @dataProvider provideTypeMapOptionsAndExpectedDocuments
      */
-    public function testValidValues(?array $typeMap = null, $binaryString, array $expectedDocuments): void
+    public function testValidValues(?array $typeMap, $binaryString, array $expectedDocuments): void
     {
         $bsonIt = new BSONIterator($binaryString, ['typeMap' => $typeMap]);
 

--- a/tests/Model/CachingIteratorTest.php
+++ b/tests/Model/CachingIteratorTest.php
@@ -122,7 +122,7 @@ class CachingIteratorTest extends TestCase
             /** @var int */
             private $i = 0;
 
-            public function current()
+            public function current(): int
             {
                 return $this->i;
             }
@@ -132,12 +132,12 @@ class CachingIteratorTest extends TestCase
                 $this->i++;
             }
 
-            public function key()
+            public function key(): int
             {
                 return $this->i;
             }
 
-            public function valid()
+            public function valid(): bool
             {
                 return $this->i == 0;
             }

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -152,7 +152,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideTypeMapOptionsAndExpectedDocuments
      */
-    public function testTypeMapOption(?array $typeMap = null, array $expectedDocuments): void
+    public function testTypeMapOption(?array $typeMap, array $expectedDocuments): void
     {
         $this->createFixtures(3);
 
@@ -167,7 +167,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideTypeMapOptionsAndExpectedDocuments
      */
-    public function testTypeMapOptionWithoutCursor(?array $typeMap = null, array $expectedDocuments): void
+    public function testTypeMapOptionWithoutCursor(?array $typeMap, array $expectedDocuments): void
     {
         if (version_compare($this->getServerVersion(), '3.6.0', '>=')) {
             $this->markTestSkipped('Aggregations with useCursor == false are not supported');

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -162,7 +162,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideTypeMapOptionsAndExpectedDocument
      */
-    public function testTypeMapOption(?array $typeMap = null, $expectedDocument): void
+    public function testTypeMapOption(?array $typeMap, $expectedDocument): void
     {
         $this->createFixtures(1);
 

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -235,7 +235,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideTypeMapOptionsAndExpectedDocuments
      */
-    public function testTypeMapOptionWithInlineResults(?array $typeMap = null, array $expectedDocuments): void
+    public function testTypeMapOptionWithInlineResults(?array $typeMap, array $expectedDocuments): void
     {
         $this->createFixtures(3);
 
@@ -282,7 +282,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideTypeMapOptionsAndExpectedDocuments
      */
-    public function testTypeMapOptionWithOutputCollection(?array $typeMap = null, array $expectedDocuments): void
+    public function testTypeMapOptionWithOutputCollection(?array $typeMap, array $expectedDocuments): void
     {
         $this->createFixtures(3);
 

--- a/tests/SpecTests/AtlasDataLakeSpecTest.php
+++ b/tests/SpecTests/AtlasDataLakeSpecTest.php
@@ -58,7 +58,7 @@ class AtlasDataLakeSpecTest extends FunctionalTestCase
      * @param string   $databaseName   Name of database under test
      * @param string   $collectionName Name of collection under test
      */
-    public function testAtlasDataLake(stdClass $test, ?array $runOn = null, array $data, ?string $databaseName = null, ?string $collectionName = null): void
+    public function testAtlasDataLake(stdClass $test, ?array $runOn, array $data, ?string $databaseName = null, ?string $collectionName = null): void
     {
         if (isset($runOn)) {
             $this->checkServerRequirements($runOn);

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -72,7 +72,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * @param string      $databaseName   Name of database under test
      * @param string      $collectionName Name of collection under test
      */
-    public function testClientSideEncryption(stdClass $test, ?array $runOn = null, array $data, ?array $keyVaultData = null, $jsonSchema = null, ?string $databaseName = null, ?string $collectionName = null): void
+    public function testClientSideEncryption(stdClass $test, ?array $runOn, array $data, ?array $keyVaultData = null, $jsonSchema = null, ?string $databaseName = null, ?string $collectionName = null): void
     {
         if (isset($runOn)) {
             $this->checkServerRequirements($runOn);

--- a/tests/SpecTests/ReadWriteConcernSpecTest.php
+++ b/tests/SpecTests/ReadWriteConcernSpecTest.php
@@ -45,7 +45,7 @@ class ReadWriteConcernSpecTest extends FunctionalTestCase
      * @param string   $databaseName   Name of database under test
      * @param string   $collectionName Name of collection under test
      */
-    public function testReadWriteConcern(stdClass $test, ?array $runOn = null, array $data, ?string $databaseName = null, ?string $collectionName = null): void
+    public function testReadWriteConcern(stdClass $test, ?array $runOn, array $data, ?string $databaseName = null, ?string $collectionName = null): void
     {
         if (isset(self::$incompleteTests[$this->dataDescription()])) {
             $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);

--- a/tests/SpecTests/RetryableReadsSpecTest.php
+++ b/tests/SpecTests/RetryableReadsSpecTest.php
@@ -53,7 +53,7 @@ class RetryableReadsSpecTest extends FunctionalTestCase
      * @group matrix-testing-exclude-server-4.4-driver-4.2
      * @group matrix-testing-exclude-server-5.0-driver-4.2
      */
-    public function testRetryableReads(stdClass $test, ?array $runOn = null, $data, string $databaseName, ?string $collectionName, ?string $bucketName): void
+    public function testRetryableReads(stdClass $test, ?array $runOn, $data, string $databaseName, ?string $collectionName, ?string $bucketName): void
     {
         if (isset($runOn)) {
             $this->checkServerRequirements($runOn);

--- a/tests/SpecTests/RetryableWritesSpecTest.php
+++ b/tests/SpecTests/RetryableWritesSpecTest.php
@@ -24,7 +24,7 @@ class RetryableWritesSpecTest extends FunctionalTestCase
      * @param array    $runOn Top-level "runOn" array with server requirements
      * @param array    $data  Top-level "data" array to initialize collection
      */
-    public function testRetryableWrites(stdClass $test, ?array $runOn = null, array $data): void
+    public function testRetryableWrites(stdClass $test, ?array $runOn, array $data): void
     {
         if ($this->isShardedCluster() && ! $this->isShardedClusterUsingReplicasets()) {
             $this->markTestSkipped('Transaction numbers are only allowed on a replica set member or mongos (PHPC-1415)');

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -114,7 +114,7 @@ class TransactionsSpecTest extends FunctionalTestCase
      * @dataProvider provideTransactionsTests
      * @group serverless
      */
-    public function testTransactions(stdClass $test, ?array $runOn = null, array $data, ?string $databaseName = null, ?string $collectionName = null): void
+    public function testTransactions(stdClass $test, ?array $runOn, array $data, ?string $databaseName = null, ?string $collectionName = null): void
     {
         $this->runTransactionTest($test, $runOn, $data, $databaseName, $collectionName);
     }
@@ -127,7 +127,7 @@ class TransactionsSpecTest extends FunctionalTestCase
     /**
      * @dataProvider provideTransactionsConvenientApiTests
      */
-    public function testTransactionsConvenientApi(stdClass $test, ?array $runOn = null, array $data, ?string $databaseName = null, ?string $collectionName = null): void
+    public function testTransactionsConvenientApi(stdClass $test, ?array $runOn, array $data, ?string $databaseName = null, ?string $collectionName = null): void
     {
         $this->runTransactionTest($test, $runOn, $data, $databaseName, $collectionName);
     }
@@ -146,7 +146,7 @@ class TransactionsSpecTest extends FunctionalTestCase
      * @param string   $databaseName   Name of database under test
      * @param string   $collectionName Name of collection under test
      */
-    private function runTransactionTest(stdClass $test, ?array $runOn = null, array $data, ?string $databaseName = null, ?string $collectionName = null): void
+    private function runTransactionTest(stdClass $test, ?array $runOn, array $data, ?string $databaseName = null, ?string $collectionName = null): void
     {
         if (isset(self::$incompleteTests[$this->dataDescription()])) {
             $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);

--- a/tests/UnifiedSpecTests/ExpectedError.php
+++ b/tests/UnifiedSpecTests/ExpectedError.php
@@ -68,7 +68,7 @@ final class ExpectedError
     /** @var ExpectedResult|null */
     private $expectedResult;
 
-    public function __construct(?stdClass $o = null, EntityMap $entityMap)
+    public function __construct(?stdClass $o, EntityMap $entityMap)
     {
         if ($o === null) {
             return;


### PR DESCRIPTION
They appear on the CI: https://github.com/mongodb/mongo-php-library/runs/3530599314#step:10:6237 and also when adding support to `doctrine/mongodb-odm`: https://github.com/doctrine/mongodb-odm/pull/2378/checks?check_run_id=3903213010#step:11:13