### PR TITLE
Allow getting information of write errors

### DIFF
--- a/src/BulkWriteResult.php
+++ b/src/BulkWriteResult.php
@@ -189,4 +189,13 @@ class BulkWriteResult
     {
         return $this->isAcknowledged;
     }
+
+    /**
+     * Returns an array of WriteResult with errors ocurred during insert
+     * or empty if there was none
+     */
+    public function getWriteErrors()
+    {
+        return $this->writeResult->getWriteErrors();
+    }
 }

--- a/src/DeleteResult.php
+++ b/src/DeleteResult.php
@@ -67,4 +67,13 @@ class DeleteResult
     {
         return $this->isAcknowledged;
     }
+
+    /**
+     * Returns an array of WriteResult with errors ocurred during insert
+     * or empty if there was none
+     */
+    public function getWriteErrors()
+    {
+        return $this->writeResult->getWriteErrors();
+    }
 }

--- a/src/InsertManyResult.php
+++ b/src/InsertManyResult.php
@@ -91,4 +91,13 @@ class InsertManyResult
     {
         return $this->writeResult->isAcknowledged();
     }
+
+    /**
+     * Returns an array of WriteResult with errors ocurred during insert
+     * or empty if there was none
+     */
+    public function getWriteErrors()
+    {
+        return $this->writeResult->getWriteErrors();
+    }
 }

--- a/src/InsertOneResult.php
+++ b/src/InsertOneResult.php
@@ -93,4 +93,13 @@ class InsertOneResult
     {
         return $this->writeResult->isAcknowledged();
     }
+
+    /**
+     * Returns an array of WriteResult with errors ocurred during insert
+     * or empty if there was none
+     */
+    public function getWriteErrors()
+    {
+        return $this->writeResult->getWriteErrors();
+    }
 }

--- a/src/UpdateResult.php
+++ b/src/UpdateResult.php
@@ -135,4 +135,13 @@ class UpdateResult
     {
         return $this->isAcknowledged;
     }
+
+    /**
+     * Returns an array of WriteResult with errors ocurred during insert
+     * or empty if there was none
+     */
+    public function getWriteErrors()
+    {
+        return $this->writeResult->getWriteErrors();
+    }
 }


### PR DESCRIPTION
Adding a function to get the array of write errors or an empty array if everything went ok on write operations results:
- BulkWriteResult
- DeleteResult
- InsertManyResult
- InsertOneResult
- UpdateResult
Currently we are able to know if inserts/updates/deletes are done but if all or some of them fails we do not know why. The purpose of this pull request is to be able to access to errors (MongoDB\Driver\WriteError) so we can debug them at least.