### PR TITLE
PHPLIB-783, PHPLIB-784: Update load balancer testing config and CSFLE tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -767,7 +767,8 @@ buildvariants:
 
 - matrix_name: "test-loadBalanced"
   # TODO: Add "5.2" server version alongside "latest" following its GA release
-  matrix_spec: { "versions": "latest", "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
+  # TODO: Revert driver-version to latest-stable after PHPC 1.13.0 is released (for CDRIVER-4207)
+  matrix_spec: { "versions": "latest", "php-edge-versions": "latest-stable", "driver-versions": "latest-dev" }
   display_name: "Load balanced - ${versions}"
   run_on: debian92-test
   tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -175,7 +175,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          MONGODB_VERSION=${VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:
@@ -505,13 +505,12 @@ tasks:
         - func: "bootstrap mongo-orchestration"
           vars:
             TOPOLOGY: "sharded_cluster"
+            LOAD_BALANCER: "true"
             SSL: "yes"
         - func: "start load balancer"
         - func: "start kms servers"
         - func: "run tests"
           vars:
-            # Testing with HAProxy requires service ID mocking
-            MOCK_SERVICE_ID: 1
             # Note: loadBalanced=true should already be appended to SINGLE_MONGOS_LB_URI
             MONGODB_URI: "${SINGLE_MONGOS_LB_URI}"
             SSL: "yes"
@@ -767,7 +766,8 @@ buildvariants:
     - .serverless
 
 - matrix_name: "test-loadBalanced"
-  matrix_spec: { "versions": ["5.0", "latest"], "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
+  # TODO: Add "5.2" server version alongside "latest" following its GA release
+  matrix_spec: { "versions": "latest", "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
   display_name: "Load balanced - ${versions}"
   run_on: debian92-test
   tasks:

--- a/phpunit.evergreen.xml
+++ b/phpunit.evergreen.xml
@@ -12,6 +12,7 @@
 
     <php>
         <ini name="error_reporting" value="-1"/>
+        <ini name="memory_limit" value="-1"/>
         <env name="MONGODB_URI" value="mongodb://127.0.0.1:27017/?serverSelectionTimeoutMS=100"/>
         <env name="MONGODB_DATABASE" value="phplib_test"/>
     </php>

--- a/tests/Operation/ModifyCollectionFunctionalTest.php
+++ b/tests/Operation/ModifyCollectionFunctionalTest.php
@@ -5,8 +5,6 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\ModifyCollection;
 
-use function array_key_exists;
-
 class ModifyCollectionFunctionalTest extends FunctionalTestCase
 {
     /**
@@ -16,6 +14,10 @@ class ModifyCollectionFunctionalTest extends FunctionalTestCase
      */
     public function testCollMod(): void
     {
+        if ($this->isShardedCluster()) {
+            $this->markTestSkipped('Sharded clusters may report result inconsistently');
+        }
+
         $this->createCollection();
 
         $indexes = [['key' => ['lastAccess' => 1], 'expireAfterSeconds' => 3]];
@@ -30,19 +32,7 @@ class ModifyCollectionFunctionalTest extends FunctionalTestCase
         );
         $result = $modifyCollection->execute($this->getPrimaryServer());
 
-        if (array_key_exists('raw', $result)) {
-            /* Sharded environment, where we only assert if a shard had a successful update. For
-             * non-primary shards that don't have chunks for the collection, the result contains a
-             * "ns does not exist" error. */
-            foreach ($result['raw'] as $shard) {
-                if (array_key_exists('ok', $shard) && $shard['ok'] == 1) {
-                    $this->assertSame(3, $shard['expireAfterSeconds_old']);
-                    $this->assertSame(1000, $shard['expireAfterSeconds_new']);
-                }
-            }
-        } else {
-            $this->assertSame(3, $result['expireAfterSeconds_old']);
-            $this->assertSame(1000, $result['expireAfterSeconds_new']);
-        }
+        $this->assertSame(3, $result['expireAfterSeconds_old']);
+        $this->assertSame(1000, $result['expireAfterSeconds_new']);
     }
 }

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -665,8 +665,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $clientEncryptionInvalid = $client->createClientEncryption([
             'keyVaultNamespace' => 'keyvault.datakeys',
             'kmsProviders' => [
-                'azure' => Context::getAzureCredentials() + ['identityPlatformEndpoint' => 'example.com:443'],
-                'gcp' => Context::getGCPCredentials() + ['endpoint' => 'example.com:443'],
+                'azure' => Context::getAzureCredentials() + ['identityPlatformEndpoint' => 'doesnotexist.invalid:443'],
+                'gcp' => Context::getGCPCredentials() + ['endpoint' => 'doesnotexist.invalid:443'],
                 'kmip' => ['endpoint' => 'doesnotexist.local:5698'],
             ],
             'tlsOptions' => [
@@ -732,8 +732,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         yield 'Test 6' => [
             static function (self $test, ClientEncryption $clientEncryption, ClientEncryption $clientEncryptionInvalid) use ($awsMasterKey): void {
                 $test->expectException(RuntimeException::class);
-                $test->expectExceptionMessageMatches('#parse error#');
-                $clientEncryption->createDataKey('aws', ['masterKey' => $awsMasterKey + ['endpoint' => 'example.com']]);
+                $test->expectExceptionMessageMatches('#doesnotexist.invalid#');
+                $clientEncryption->createDataKey('aws', ['masterKey' => $awsMasterKey + ['endpoint' => 'doesnotexist.invalid']]);
             },
         ];
 
@@ -744,7 +744,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                 $test->assertSame('test', $clientEncryption->decrypt($encrypted));
 
                 $test->expectException(RuntimeException::class);
-                $test->expectExceptionMessageMatches('#parse error#');
+                $test->expectExceptionMessageMatches('#doesnotexist.invalid#');
                 $clientEncryptionInvalid->createDataKey('azure', ['masterKey' => $azureMasterKey]);
             },
         ];
@@ -756,7 +756,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                 $test->assertSame('test', $clientEncryption->decrypt($encrypted));
 
                 $test->expectException(RuntimeException::class);
-                $test->expectExceptionMessageMatches('#parse error#');
+                $test->expectExceptionMessageMatches('#doesnotexist.invalid#');
                 $clientEncryptionInvalid->createDataKey('gcp', ['masterKey' => $gcpMasterKey]);
             },
         ];
@@ -764,7 +764,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         yield 'Test 9' => [
             static function (self $test, ClientEncryption $clientEncryption, ClientEncryption $clientEncryptionInvalid) use ($gcpMasterKey): void {
                 $masterKey = $gcpMasterKey;
-                $masterKey['endpoint'] = 'example.com:443';
+                $masterKey['endpoint'] = 'doesnotexist.invalid:443';
 
                 $test->expectException(RuntimeException::class);
                 $test->expectExceptionMessageMatches('#Invalid KMS response#');


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-783
https://jira.mongodb.org/browse/PHPLIB-784

Upstream changes in drivers-evergreen-tools now require passing LOAD_BALANCER to run-orchestration.sh. Additionally, service ID mocking is no longer required as of server version 5.1.