### PR TITLE
DOCSP-20374: Migrate docs.mongodb.com to mongodb.com/docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,7 +16,7 @@ If you've identified a security vulnerability in a driver or any other MongoDB
 project, please create a vulnerability report[^2].
 
 [^1]: https://github.com/mongodb/mongo-php-driver
-[^2]: https://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report
+[^2]: https://mongodb.com/docs/manual/tutorial/create-a-vulnerability-report
 -->
 
 ### Bug Report

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,5 +8,5 @@ contact_links:
     url: https://developer.mongodb.com/community/forums/
     about: For questions, discussions, or general technical support, visit the MongoDB Community Forums. The MongoDB Community Forums are a centralized place to connect with other MongoDB users, ask questions, and get answers.
   - name: Report a Security Vulnerability
-    url: https://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report
+    url: https://mongodb.com/docs/manual/tutorial/create-a-vulnerability-report
     about: If you believe you have discovered a vulnerability in MongoDB products or have experienced a security incident related to MongoDB products, please report the issue to aid in its resolution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ $JIRA_URL
 **Documentation**
 
 Documentation for this library may be found at:
-https://docs.mongodb.com/php-library/
+https://mongodb.com/docs/php-library/current/
 
 **Installation**
 
@@ -231,13 +231,13 @@ New major and minor releases will also require documentation updates to other
 projects:
 
  * Create a DOCSP ticket to add the new version to PHP's server and language
-   [compatibility tables](https://docs.mongodb.com/drivers/php/#compatibility)
+   [compatibility tables](https://mongodb.com/docs/drivers/php/#compatibility)
    in the driver docs portal. See
    [mongodb/docs-ecosystem#642](https://github.com/mongodb/docs-ecosystem/pull/642)
    for an example.
 
  * Create a DOCSP ticket to update the "current" and "upcoming" navigation links
-   in the library's [documentation](https://docs.mongodb.com/php-library/). This
+   in the library's [documentation](https://mongodb.com/docs/php-library/current). This
    will require updating
    [mongodb/docs-php-library](https://github.com/mongodb/docs-php-library).
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ extension may be found in
 
 ## Documentation
 
- - https://docs.mongodb.com/php-library/
- - https://docs.mongodb.com/ecosystem/drivers/php/
+ - https://mongodb.com/docs/php-library/current
+ - https://mongodb.com/docs/ecosystem/drivers/php/
 
 ## Installation
 
@@ -33,7 +33,7 @@ root:
     $ composer require mongodb/mongodb
 
 Additional installation instructions may be found in the
-[library documentation](https://docs.mongodb.com/php-library/current/tutorial/install-php-library/).
+[library documentation](https://mongodb.com/docs/php-library/current/tutorial/install-php-library/).
 
 Since this library is a high-level abstraction for the driver, it also requires
 that the `mongodb` extension be installed:
@@ -53,13 +53,13 @@ project in MongoDB's JIRA. Extension-related issues should be reported in the
 project.
 
 For general questions and support requests, please use one of MongoDB's
-[Technical Support](https://docs.mongodb.com/manual/support/) channels.
+[Technical Support](https://mongodb.com/docs/manual/support/) channels.
 
 ### Security Vulnerabilities
 
 If you've identified a security vulnerability in a driver or any other MongoDB
 project, please report it according to the instructions in
-[Create a Vulnerability Report](https://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report).
+[Create a Vulnerability Report](https://mongodb.com/docs/manual/tutorial/create-a-vulnerability-report).
 
 ## Development
 

--- a/docs/includes/apiargs-MongoDBClient-method-listDatabases-option.yaml
+++ b/docs/includes/apiargs-MongoDBClient-method-listDatabases-option.yaml
@@ -4,7 +4,7 @@ type: boolean
 description: |
   A flag that determines which databases are returned based on the user
   privileges when access control is enabled. For more information, see the
-  `listDatabases command documentation <https://docs.mongodb.com/manual/reference/command/listDatabases/>`_.
+  `listDatabases command documentation <https://mongodb.com/docs/manual/reference/command/listDatabases/>`_.
 
   For servers < 4.0.5, this option is ignored.
 
@@ -36,4 +36,3 @@ source:
   ref: session
 post: |
   .. versionadded:: 1.3
-...

--- a/docs/includes/apiargs-MongoDBCollection-common-param.yaml
+++ b/docs/includes/apiargs-MongoDBCollection-common-param.yaml
@@ -25,7 +25,7 @@ description: |
   Specifies the field and value combinations to update and any relevant update
   operators. ``$update`` uses MongoDB's :method:`update operators
   </reference/operator/update>`. Starting with MongoDB 4.2, an `aggregation
-  pipeline <https://docs.mongodb.com/master/reference/command/update/#update-with-an-aggregation-pipeline>`_
+  pipeline <https://mongodb.com/docs/master/reference/command/update/#update-with-an-aggregation-pipeline>`_
   can be passed as this parameter.
 interface: phpmethod
 operation: ~

--- a/docs/includes/apiargs-MongoDBDatabase-method-listCollections-option.yaml
+++ b/docs/includes/apiargs-MongoDBDatabase-method-listCollections-option.yaml
@@ -4,7 +4,7 @@ type: boolean
 description: |
   A flag that determines which collections are returned based on the user
   privileges when access control is enabled. For more information, see the
-  `listCollections command documentation <https://docs.mongodb.com/manual/reference/command/listCollections/>`_.
+  `listCollections command documentation <https://mongodb.com/docs/manual/reference/command/listCollections/>`_.
 
   For servers < 4.0, this option is ignored.
 

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -34,7 +34,7 @@ use function in_array;
  *
  * @api
  * @see \MongoDB\Collection::watch()
- * @see http://docs.mongodb.org/manual/reference/command/changeStream/
+ * @see https://www.mongodb.com/docs/manual/reference/method/db.watch/#mongodb-method-db.watch
  */
 class ChangeStream implements Iterator
 {

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -34,7 +34,7 @@ use function in_array;
  *
  * @api
  * @see \MongoDB\Collection::watch()
- * @see https://www.mongodb.com/docs/manual/reference/method/db.watch/#mongodb-method-db.watch
+ * @see https://mongodb.com/docs/manual/reference/method/db.watch/#mongodb-method-db.watch
  */
 class ChangeStream implements Iterator
 {

--- a/src/Client.php
+++ b/src/Client.php
@@ -88,7 +88,7 @@ class Client
      *
      * Other options are documented in MongoDB\Driver\Manager::__construct().
      *
-     * @see http://docs.mongodb.org/manual/reference/connection-string/
+     * @see http://mongodb.com/docs/manual/reference/connection-string/
      * @see http://php.net/manual/en/mongodb-driver-manager.construct.php
      * @see http://php.net/manual/en/mongodb.persistence.php#mongodb.persistence.typemaps
      * @param string $uri           MongoDB connection string

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -183,7 +183,7 @@ class Collection
     /**
      * Return the collection namespace (e.g. "db.collection").
      *
-     * @see https://www.mongodb.com/docs/manual/core/databases-and-collections/
+     * @see https://mongodb.com/docs/manual/core/databases-and-collections/
      * @return string
      */
     public function __toString()
@@ -622,7 +622,7 @@ class Collection
      * Finds documents matching the query.
      *
      * @see Find::__construct() for supported options
-     * @see https://www.mongodb.com/docs/manual/crud/#read-operations
+     * @see https://mongodb.com/docs/manual/crud/#read-operations
      * @param array|object $filter  Query by which to filter documents
      * @param array        $options Additional options
      * @return Cursor
@@ -655,7 +655,7 @@ class Collection
      * Finds a single document matching the query.
      *
      * @see FindOne::__construct() for supported options
-     * @see https://www.mongodb.com/docs/manual/crud/#read-operations
+     * @see https://mongodb.com/docs/manual/crud/#read-operations
      * @param array|object $filter  Query by which to filter documents
      * @param array        $options Additional options
      * @return array|object|null

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -368,8 +368,8 @@ class Collection
      * If the "name" option is unspecified, a name will be generated from the
      * "key" document.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/createIndexes/
-     * @see http://docs.mongodb.org/manual/reference/method/db.collection.createIndex/
+     * @see http://mongodb.com/docs/manual/reference/command/createIndexes/
+     * @see http://mongodb.com/docs/manual/reference/method/db.collection.createIndex/
      * @see CreateIndexes::__construct() for supported command options
      * @param array[] $indexes List of index specifications
      * @param array   $options Command options
@@ -395,7 +395,7 @@ class Collection
      * Deletes all documents matching the filter.
      *
      * @see DeleteMany::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/delete/
+     * @see http://mongodb.com/docs/manual/reference/command/delete/
      * @param array|object $filter  Query by which to delete documents
      * @param array        $options Command options
      * @return DeleteResult
@@ -419,7 +419,7 @@ class Collection
      * Deletes at most one document matching the filter.
      *
      * @see DeleteOne::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/delete/
+     * @see http://mongodb.com/docs/manual/reference/command/delete/
      * @param array|object $filter  Query by which to delete documents
      * @param array        $options Command options
      * @return DeleteResult
@@ -593,7 +593,7 @@ class Collection
      * Explains explainable commands.
      *
      * @see Explain::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/explain/
+     * @see http://mongodb.com/docs/manual/reference/command/explain/
      * @param Explainable $explainable Command on which to run explain
      * @param array       $options     Additional options
      * @return array|object
@@ -690,7 +690,7 @@ class Collection
      * The document to return may be null if no document matched the filter.
      *
      * @see FindOneAndDelete::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see http://mongodb.com/docs/manual/reference/command/findAndModify/
      * @param array|object $filter  Query by which to filter documents
      * @param array        $options Command options
      * @return array|object|null
@@ -726,7 +726,7 @@ class Collection
      * to return the updated document.
      *
      * @see FindOneAndReplace::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see http://mongodb.com/docs/manual/reference/command/findAndModify/
      * @param array|object $filter      Query by which to filter documents
      * @param array|object $replacement Replacement document
      * @param array        $options     Command options
@@ -763,7 +763,7 @@ class Collection
      * to return the updated document.
      *
      * @see FindOneAndReplace::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see http://mongodb.com/docs/manual/reference/command/findAndModify/
      * @param array|object $filter  Query by which to filter documents
      * @param array|object $update  Update to apply to the matched document
      * @param array        $options Command options
@@ -823,7 +823,7 @@ class Collection
     /**
      * Return the collection namespace.
      *
-     * @see https://docs.mongodb.org/manual/reference/glossary/#term-namespace
+     * @see https://mongodb.com/docs/manual/reference/glossary/#term-namespace
      * @return string
      */
     public function getNamespace()
@@ -877,7 +877,7 @@ class Collection
      * Inserts multiple documents.
      *
      * @see InsertMany::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/insert/
+     * @see http://mongodb.com/docs/manual/reference/command/insert/
      * @param array[]|object[] $documents The documents to insert
      * @param array            $options   Command options
      * @return InsertManyResult
@@ -900,7 +900,7 @@ class Collection
      * Inserts one document.
      *
      * @see InsertOne::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/insert/
+     * @see http://mongodb.com/docs/manual/reference/command/insert/
      * @param array|object $document The document to insert
      * @param array        $options  Command options
      * @return InsertOneResult
@@ -940,7 +940,7 @@ class Collection
      * Executes a map-reduce aggregation on the collection.
      *
      * @see MapReduce::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/mapReduce/
+     * @see http://mongodb.com/docs/manual/reference/command/mapReduce/
      * @param JavascriptInterface $map     Map function
      * @param JavascriptInterface $reduce  Reduce function
      * @param string|array|object $out     Output specification
@@ -1025,7 +1025,7 @@ class Collection
      * Replaces at most one document matching the filter.
      *
      * @see ReplaceOne::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see http://mongodb.com/docs/manual/reference/command/update/
      * @param array|object $filter      Query by which to filter documents
      * @param array|object $replacement Replacement document
      * @param array        $options     Command options
@@ -1050,7 +1050,7 @@ class Collection
      * Updates all documents matching the filter.
      *
      * @see UpdateMany::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see http://mongodb.com/docs/manual/reference/command/update/
      * @param array|object $filter  Query by which to filter documents
      * @param array|object $update  Update to apply to the matched documents
      * @param array        $options Command options
@@ -1075,7 +1075,7 @@ class Collection
      * Updates at most one document matching the filter.
      *
      * @see UpdateOne::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see http://mongodb.com/docs/manual/reference/command/update/
      * @param array|object $filter  Query by which to filter documents
      * @param array|object $update  Update to apply to the matched document
      * @param array        $options Command options

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -183,7 +183,7 @@ class Collection
     /**
      * Return the collection namespace (e.g. "db.collection").
      *
-     * @see https://docs.mongodb.org/manual/faq/developers/#faq-dev-namespace
+     * @see https://www.mongodb.com/docs/manual/core/databases-and-collections/
      * @return string
      */
     public function __toString()
@@ -622,7 +622,7 @@ class Collection
      * Finds documents matching the query.
      *
      * @see Find::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/core/read-operations-introduction/
+     * @see https://www.mongodb.com/docs/manual/crud/#read-operations
      * @param array|object $filter  Query by which to filter documents
      * @param array        $options Additional options
      * @return Cursor
@@ -655,7 +655,7 @@ class Collection
      * Finds a single document matching the query.
      *
      * @see FindOne::__construct() for supported options
-     * @see http://docs.mongodb.org/manual/core/read-operations-introduction/
+     * @see https://www.mongodb.com/docs/manual/crud/#read-operations
      * @param array|object $filter  Query by which to filter documents
      * @param array        $options Additional options
      * @return array|object|null

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -34,7 +34,7 @@ use function is_object;
  * Wrapper for the listCollections command.
  *
  * @internal
- * @see http://docs.mongodb.org/manual/reference/command/listCollections/
+ * @see http://mongodb.com/docs/manual/reference/command/listCollections/
  */
 class ListCollections implements Executable
 {

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -35,7 +35,7 @@ use function is_object;
  * Wrapper for the ListDatabases command.
  *
  * @internal
- * @see http://docs.mongodb.org/manual/reference/command/listDatabases/
+ * @see http://mongodb.com/docs/manual/reference/command/listDatabases/
  */
 class ListDatabases implements Executable
 {

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -33,7 +33,7 @@ use function call_user_func;
  *
  * @api
  * @see \MongoDB\Collection::mapReduce()
- * @see https://docs.mongodb.com/manual/reference/command/mapReduce/
+ * @see https://mongodb.com/docs/manual/reference/command/mapReduce/
  */
 class MapReduceResult implements IteratorAggregate
 {

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -97,7 +97,7 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the "info" property of the server response.
      *
-     * @see https://docs.mongodb.com/manual/reference/command/listCollections/#output
+     * @see https://mongodb.com/docs/manual/reference/command/listCollections/#output
      * @return array
      */
     public function getInfo(): array
@@ -108,7 +108,7 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the collection name.
      *
-     * @see https://docs.mongodb.com/manual/reference/command/listCollections/#output
+     * @see https://mongodb.com/docs/manual/reference/command/listCollections/#output
      * @return string
      */
     public function getName()
@@ -119,7 +119,7 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the collection options.
      *
-     * @see https://docs.mongodb.com/manual/reference/command/listCollections/#output
+     * @see https://mongodb.com/docs/manual/reference/command/listCollections/#output
      * @return array
      */
     public function getOptions()
@@ -130,7 +130,7 @@ class CollectionInfo implements ArrayAccess
     /**
      * Return the collection type.
      *
-     * @see https://docs.mongodb.com/manual/reference/command/listCollections/#output
+     * @see https://mongodb.com/docs/manual/reference/command/listCollections/#output
      * @return string
      */
     public function getType(): string

--- a/src/Model/CollectionInfoCommandIterator.php
+++ b/src/Model/CollectionInfoCommandIterator.php
@@ -30,7 +30,7 @@ use Traversable;
  * @internal
  * @see \MongoDB\Database::listCollections()
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-collections.rst
- * @see http://docs.mongodb.org/manual/reference/command/listCollections/
+ * @see http://mongodb.com/docs/manual/reference/command/listCollections/
  */
 class CollectionInfoCommandIterator extends IteratorIterator implements CollectionInfoIterator
 {

--- a/src/Model/DatabaseInfo.php
+++ b/src/Model/DatabaseInfo.php
@@ -31,7 +31,7 @@ use function array_key_exists;
  *
  * @api
  * @see \MongoDB\Client::listDatabases()
- * @see http://docs.mongodb.org/manual/reference/command/listDatabases/
+ * @see http://mongodb.com/docs/manual/reference/command/listDatabases/
  */
 class DatabaseInfo implements ArrayAccess
 {

--- a/src/Model/DatabaseInfoLegacyIterator.php
+++ b/src/Model/DatabaseInfoLegacyIterator.php
@@ -32,7 +32,7 @@ use function reset;
  *
  * @internal
  * @see \MongoDB\Client::listDatabases()
- * @see http://docs.mongodb.org/manual/reference/command/listDatabases/
+ * @see http://mongodb.com/docs/manual/reference/command/listDatabases/
  */
 class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
 {

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -37,7 +37,7 @@ use function array_search;
  * @api
  * @see \MongoDB\Collection::listIndexes()
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst
- * @see http://docs.mongodb.org/manual/reference/method/db.collection.createIndex/
+ * @see http://mongodb.com/docs/manual/reference/method/db.collection.createIndex/
  */
 class IndexInfo implements ArrayAccess
 {
@@ -136,7 +136,7 @@ class IndexInfo implements ArrayAccess
     /**
      * Return whether this is a sparse index.
      *
-     * @see http://docs.mongodb.org/manual/core/index-sparse/
+     * @see http://mongodb.com/docs/manual/core/index-sparse/
      * @return boolean
      */
     public function isSparse()
@@ -157,7 +157,7 @@ class IndexInfo implements ArrayAccess
     /**
      * Return whether this is a TTL index.
      *
-     * @see http://docs.mongodb.org/manual/core/index-ttl/
+     * @see http://mongodb.com/docs/manual/core/index-ttl/
      * @return boolean
      */
     public function isTtl()
@@ -168,7 +168,7 @@ class IndexInfo implements ArrayAccess
     /**
      * Return whether this is a unique index.
      *
-     * @see http://docs.mongodb.org/manual/core/index-unique/
+     * @see http://mongodb.com/docs/manual/core/index-unique/
      * @return boolean
      */
     public function isUnique()

--- a/src/Model/IndexInfoIteratorIterator.php
+++ b/src/Model/IndexInfoIteratorIterator.php
@@ -33,8 +33,8 @@ use function array_key_exists;
  * @internal
  * @see \MongoDB\Collection::listIndexes()
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst
- * @see http://docs.mongodb.org/manual/reference/command/listIndexes/
- * @see http://docs.mongodb.org/manual/reference/system-collections/
+ * @see http://mongodb.com/docs/manual/reference/command/listIndexes/
+ * @see http://mongodb.com/docs/manual/reference/system-collections/
  */
 class IndexInfoIteratorIterator extends IteratorIterator implements IndexInfoIterator
 {

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -36,7 +36,7 @@ use function sprintf;
  * @internal
  * @see \MongoDB\Collection::createIndexes()
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst
- * @see http://docs.mongodb.org/manual/reference/method/db.collection.createIndex/
+ * @see http://mongodb.com/docs/manual/reference/method/db.collection.createIndex/
  */
 class IndexInput implements Serializable
 {

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -47,7 +47,7 @@ use function sprintf;
  *
  * @api
  * @see \MongoDB\Collection::aggregate()
- * @see http://docs.mongodb.org/manual/reference/command/aggregate/
+ * @see http://mongodb.com/docs/manual/reference/command/aggregate/
  */
 class Aggregate implements Executable, Explainable
 {

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -39,7 +39,7 @@ use function is_string;
  *
  * @api
  * @see \MongoDB\Collection::count()
- * @see http://docs.mongodb.org/manual/reference/command/count/
+ * @see http://mongodb.com/docs/manual/reference/command/count/
  */
 class Count implements Executable, Explainable
 {

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -113,7 +113,7 @@ class CreateCollection implements Executable
      *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
      *
      * @see http://source.wiredtiger.com/2.4.1/struct_w_t___s_e_s_s_i_o_n.html#a358ca4141d59c345f401c58501276bbb
-     * @see https://docs.mongodb.org/manual/core/document-validation/
+     * @see https://www.mongodb.com/docs/manual/core/schema-validation/
      * @param string $databaseName   Database name
      * @param string $collectionName Collection name
      * @param array  $options        Command options

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -113,7 +113,7 @@ class CreateCollection implements Executable
      *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
      *
      * @see http://source.wiredtiger.com/2.4.1/struct_w_t___s_e_s_s_i_o_n.html#a358ca4141d59c345f401c58501276bbb
-     * @see https://www.mongodb.com/docs/manual/core/schema-validation/
+     * @see https://mongodb.com/docs/manual/core/schema-validation/
      * @param string $databaseName   Database name
      * @param string $collectionName Collection name
      * @param array  $options        Command options

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -39,7 +39,7 @@ use const E_USER_DEPRECATED;
  *
  * @api
  * @see \MongoDB\Database::createCollection()
- * @see http://docs.mongodb.org/manual/reference/command/create/
+ * @see http://mongodb.com/docs/manual/reference/command/create/
  */
 class CreateCollection implements Executable
 {

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -39,7 +39,7 @@ use function sprintf;
  * @api
  * @see \MongoDB\Collection::createIndex()
  * @see \MongoDB\Collection::createIndexes()
- * @see http://docs.mongodb.org/manual/reference/command/createIndexes/
+ * @see http://mongodb.com/docs/manual/reference/command/createIndexes/
  */
 class CreateIndexes implements Executable
 {

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -39,7 +39,7 @@ use function MongoDB\server_supports_feature;
  * classes.
  *
  * @internal
- * @see http://docs.mongodb.org/manual/reference/command/delete/
+ * @see http://mongodb.com/docs/manual/reference/command/delete/
  */
 class Delete implements Executable, Explainable
 {

--- a/src/Operation/DeleteMany.php
+++ b/src/Operation/DeleteMany.php
@@ -28,7 +28,7 @@ use MongoDB\Exception\UnsupportedException;
  *
  * @api
  * @see \MongoDB\Collection::deleteOne()
- * @see http://docs.mongodb.org/manual/reference/command/delete/
+ * @see http://mongodb.com/docs/manual/reference/command/delete/
  */
 class DeleteMany implements Executable, Explainable
 {

--- a/src/Operation/DeleteOne.php
+++ b/src/Operation/DeleteOne.php
@@ -28,7 +28,7 @@ use MongoDB\Exception\UnsupportedException;
  *
  * @api
  * @see \MongoDB\Collection::deleteOne()
- * @see http://docs.mongodb.org/manual/reference/command/delete/
+ * @see http://mongodb.com/docs/manual/reference/command/delete/
  */
 class DeleteOne implements Executable, Explainable
 {

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -38,7 +38,7 @@ use function MongoDB\create_field_path_type_map;
  *
  * @api
  * @see \MongoDB\Collection::distinct()
- * @see http://docs.mongodb.org/manual/reference/command/distinct/
+ * @see http://mongodb.com/docs/manual/reference/command/distinct/
  */
 class Distinct implements Executable, Explainable
 {

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -34,7 +34,7 @@ use function is_array;
  * @api
  * @see \MongoDB\Collection::drop()
  * @see \MongoDB\Database::dropCollection()
- * @see http://docs.mongodb.org/manual/reference/command/drop/
+ * @see http://mongodb.com/docs/manual/reference/command/drop/
  */
 class DropCollection implements Executable
 {

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -33,7 +33,7 @@ use function is_array;
  * @api
  * @see \MongoDB\Client::dropDatabase()
  * @see \MongoDB\Database::drop()
- * @see http://docs.mongodb.org/manual/reference/command/dropDatabase/
+ * @see http://mongodb.com/docs/manual/reference/command/dropDatabase/
  */
 class DropDatabase implements Executable
 {

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -34,7 +34,7 @@ use function is_integer;
  *
  * @api
  * @see \MongoDB\Collection::dropIndexes()
- * @see http://docs.mongodb.org/manual/reference/command/dropIndexes/
+ * @see http://mongodb.com/docs/manual/reference/command/dropIndexes/
  */
 class DropIndexes implements Executable
 {

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -36,7 +36,7 @@ use function MongoDB\server_supports_feature;
  *
  * @api
  * @see \MongoDB\Collection::estimatedDocumentCount()
- * @see http://docs.mongodb.org/manual/reference/command/count/
+ * @see http://mongodb.com/docs/manual/reference/command/count/
  */
 class EstimatedDocumentCount implements Executable, Explainable
 {

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -35,7 +35,7 @@ use function MongoDB\server_supports_feature;
  *
  * @api
  * @see \MongoDB\Collection::explain()
- * @see http://docs.mongodb.org/manual/reference/command/explain/
+ * @see http://mongodb.com/docs/manual/reference/command/explain/
  */
 class Explain implements Executable
 {

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -41,8 +41,8 @@ use const E_USER_DEPRECATED;
  *
  * @api
  * @see \MongoDB\Collection::find()
- * @see http://docs.mongodb.org/manual/tutorial/query-documents/
- * @see http://docs.mongodb.org/manual/reference/operator/query-modifier/
+ * @see http://mongodb.com/docs/manual/tutorial/query-documents/
+ * @see http://mongodb.com/docs/manual/reference/operator/query-modifier/
  */
 class Find implements Executable, Explainable
 {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -44,7 +44,7 @@ use function MongoDB\server_supports_feature;
  * FindOneAndUpdate operation classes.
  *
  * @internal
- * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+ * @see http://mongodb.com/docs/manual/reference/command/findAndModify/
  */
 class FindAndModify implements Executable, Explainable
 {

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -29,8 +29,8 @@ use function current;
  *
  * @api
  * @see \MongoDB\Collection::findOne()
- * @see http://docs.mongodb.org/manual/tutorial/query-documents/
- * @see http://docs.mongodb.org/manual/reference/operator/query-modifier/
+ * @see http://mongodb.com/docs/manual/tutorial/query-documents/
+ * @see http://mongodb.com/docs/manual/reference/operator/query-modifier/
  */
 class FindOne implements Executable, Explainable
 {

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -30,7 +30,7 @@ use function is_object;
  *
  * @api
  * @see \MongoDB\Collection::findOneAndDelete()
- * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+ * @see http://mongodb.com/docs/manual/reference/command/findAndModify/
  */
 class FindOneAndDelete implements Executable, Explainable
 {

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -32,7 +32,7 @@ use function MongoDB\is_first_key_operator;
  *
  * @api
  * @see \MongoDB\Collection::findOneAndReplace()
- * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+ * @see http://mongodb.com/docs/manual/reference/command/findAndModify/
  */
 class FindOneAndReplace implements Executable, Explainable
 {

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -33,7 +33,7 @@ use function MongoDB\is_pipeline;
  *
  * @api
  * @see \MongoDB\Collection::findOneAndUpdate()
- * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+ * @see http://mongodb.com/docs/manual/reference/command/findAndModify/
  */
 class FindOneAndUpdate implements Executable, Explainable
 {

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -36,7 +36,7 @@ use function sprintf;
  *
  * @api
  * @see \MongoDB\Collection::insertMany()
- * @see http://docs.mongodb.org/manual/reference/command/insert/
+ * @see http://mongodb.com/docs/manual/reference/command/insert/
  */
 class InsertMany implements Executable
 {

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -35,7 +35,7 @@ use function is_object;
  *
  * @api
  * @see \MongoDB\Collection::insertOne()
- * @see http://docs.mongodb.org/manual/reference/command/insert/
+ * @see http://mongodb.com/docs/manual/reference/command/insert/
  */
 class InsertOne implements Executable
 {

--- a/src/Operation/ListCollectionNames.php
+++ b/src/Operation/ListCollectionNames.php
@@ -29,7 +29,7 @@ use MongoDB\Model\CallbackIterator;
  *
  * @api
  * @see \MongoDB\Database::listCollectionNames()
- * @see http://docs.mongodb.org/manual/reference/command/listCollections/
+ * @see http://mongodb.com/docs/manual/reference/command/listCollections/
  */
 class ListCollectionNames implements Executable
 {

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -29,7 +29,7 @@ use MongoDB\Model\CollectionInfoIterator;
  *
  * @api
  * @see \MongoDB\Database::listCollections()
- * @see http://docs.mongodb.org/manual/reference/command/listCollections/
+ * @see http://mongodb.com/docs/manual/reference/command/listCollections/
  */
 class ListCollections implements Executable
 {

--- a/src/Operation/ListDatabaseNames.php
+++ b/src/Operation/ListDatabaseNames.php
@@ -32,7 +32,7 @@ use function array_column;
  *
  * @api
  * @see \MongoDB\Client::listDatabaseNames()
- * @see http://docs.mongodb.org/manual/reference/command/ListDatabases/
+ * @see https://www.mongodb.com/docs/manual/reference/command/listDatabases/#mongodb-dbcommand-dbcmd.listDatabases
  */
 class ListDatabaseNames implements Executable
 {

--- a/src/Operation/ListDatabaseNames.php
+++ b/src/Operation/ListDatabaseNames.php
@@ -32,7 +32,7 @@ use function array_column;
  *
  * @api
  * @see \MongoDB\Client::listDatabaseNames()
- * @see https://www.mongodb.com/docs/manual/reference/command/listDatabases/#mongodb-dbcommand-dbcmd.listDatabases
+ * @see https://mongodb.com/docs/manual/reference/command/listDatabases/#mongodb-dbcommand-dbcmd.listDatabases
  */
 class ListDatabaseNames implements Executable
 {

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -30,7 +30,7 @@ use MongoDB\Model\DatabaseInfoLegacyIterator;
  *
  * @api
  * @see \MongoDB\Client::listDatabases()
- * @see https://www.mongodb.com/docs/manual/reference/command/listDatabases/#mongodb-dbcommand-dbcmd.listDatabases`
+ * @see https://mongodb.com/docs/manual/reference/command/listDatabases/#mongodb-dbcommand-dbcmd.listDatabases`
  */
 class ListDatabases implements Executable
 {

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -30,7 +30,7 @@ use MongoDB\Model\DatabaseInfoLegacyIterator;
  *
  * @api
  * @see \MongoDB\Client::listDatabases()
- * @see http://docs.mongodb.org/manual/reference/command/ListDatabases/
+ * @see https://www.mongodb.com/docs/manual/reference/command/listDatabases/#mongodb-dbcommand-dbcmd.listDatabases`
  */
 class ListDatabases implements Executable
 {

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -35,7 +35,7 @@ use function is_integer;
  *
  * @api
  * @see \MongoDB\Collection::listIndexes()
- * @see http://docs.mongodb.org/manual/reference/command/listIndexes/
+ * @see http://mongodb.com/docs/manual/reference/command/listIndexes/
  */
 class ListIndexes implements Executable
 {

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -49,7 +49,7 @@ use const E_USER_DEPRECATED;
  *
  * @api
  * @see \MongoDB\Collection::mapReduce()
- * @see https://docs.mongodb.com/manual/reference/command/mapReduce/
+ * @see https://mongodb.com/docs/manual/reference/command/mapReduce/
  */
 class MapReduce implements Executable
 {

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -32,7 +32,7 @@ use function is_array;
  *
  * @api
  * @see \MongoDB\Database::modifyCollection()
- * @see http://docs.mongodb.org/manual/reference/command/collMod/
+ * @see http://mongodb.com/docs/manual/reference/command/collMod/
  */
 class ModifyCollection implements Executable
 {

--- a/src/Operation/RenameCollection.php
+++ b/src/Operation/RenameCollection.php
@@ -34,7 +34,7 @@ use function is_bool;
  * @api
  * @see \MongoDB\Collection::rename()
  * @see \MongoDB\Database::renameCollection()
- * @see https://docs.mongodb.org/manual/reference/command/renameCollection/
+ * @see https://mongodb.com/docs/manual/reference/command/renameCollection/
  */
 class RenameCollection implements Executable
 {

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -33,7 +33,7 @@ use function MongoDB\is_pipeline;
  *
  * @api
  * @see \MongoDB\Collection::replaceOne()
- * @see http://docs.mongodb.org/manual/reference/command/update/
+ * @see http://mongodb.com/docs/manual/reference/command/update/
  */
 class ReplaceOne implements Executable
 {

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -42,7 +42,7 @@ use function MongoDB\server_supports_feature;
  * operation classes.
  *
  * @internal
- * @see http://docs.mongodb.org/manual/reference/command/update/
+ * @see http://mongodb.com/docs/manual/reference/command/update/
  */
 class Update implements Executable, Explainable
 {

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -33,7 +33,7 @@ use function MongoDB\is_pipeline;
  *
  * @api
  * @see \MongoDB\Collection::updateMany()
- * @see http://docs.mongodb.org/manual/reference/command/update/
+ * @see http://mongodb.com/docs/manual/reference/command/update/
  */
 class UpdateMany implements Executable, Explainable
 {

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -33,7 +33,7 @@ use function MongoDB\is_pipeline;
  *
  * @api
  * @see \MongoDB\Collection::updateOne()
- * @see http://docs.mongodb.org/manual/reference/command/update/
+ * @see http://mongodb.com/docs/manual/reference/command/update/
  */
 class UpdateOne implements Executable, Explainable
 {

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -52,7 +52,7 @@ use function MongoDB\server_supports_feature;
  *
  * @api
  * @see \MongoDB\Collection::watch()
- * @see https://docs.mongodb.com/manual/changeStreams/
+ * @see https://mongodb.com/docs/manual/changeStreams/
  */
 class Watch implements Executable, /* @internal */ CommandSubscriber
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -239,7 +239,7 @@ function is_last_pipeline_operator_write(array $pipeline): bool
  * This is used to determine if a mapReduce command requires a primary.
  *
  * @internal
- * @see https://docs.mongodb.com/manual/reference/command/mapReduce/#output-inline
+ * @see https://mongodb.com/docs/manual/reference/command/mapReduce/#output-inline
  * @param string|array|object $out Output specification
  * @return boolean
  * @throws InvalidArgumentException
@@ -274,7 +274,7 @@ function is_mapreduce_output_inline($out): bool
  * check the fsync option since that was never supported in the PHP driver.
  *
  * @internal
- * @see https://docs.mongodb.com/manual/reference/write-concern/
+ * @see https://mongodb.com/docs/manual/reference/write-concern/
  * @param WriteConcern $writeConcern
  * @return boolean
  */

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -354,7 +354,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         /* When renaming an unsharded collection, mongos requires the source
         * and target database to both exist on the primary shard. In practice,
         * this means we need to create the target database explicitly.
-        * See: https://docs.mongodb.com/manual/reference/command/renameCollection/#unsharded-collections
+        * See: https://mongodb.com/docs/manual/reference/command/renameCollection/#unsharded-collections
         */
         if ($this->isShardedCluster()) {
             $toDatabase->foo->insertOne(['_id' => 1]);

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -258,7 +258,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         /* When renaming an unsharded collection, mongos requires the source
         * and target database to both exist on the primary shard. In practice, this
         * means we need to create the target database explicitly.
-        * See: https://docs.mongodb.com/manual/reference/command/renameCollection/#unsharded-collections
+        * See: https://mongodb.com/docs/manual/reference/command/renameCollection/#unsharded-collections
         */
         if ($this->isShardedCluster()) {
             $toDatabase->foo->insertOne(['_id' => 1]);

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -1286,7 +1286,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $client = static::createTestClient();
 
-        /* The WC is required: https://docs.mongodb.com/manual/core/transactions/#transactions-and-locks */
+        /* The WC is required: https://mongodb.com/docs/manual/core/transactions/#transactions-and-locks */
         $client->hr->dropCollection('employees', ['writeConcern' => new WriteConcern('majority')]);
         $client->reporting->dropCollection('events', ['writeConcern' => new WriteConcern('majority')]);
 
@@ -1466,7 +1466,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
         $client = static::createTestClient();
 
-        /* The WC is required: https://docs.mongodb.com/manual/core/transactions/#transactions-and-locks */
+        /* The WC is required: https://mongodb.com/docs/manual/core/transactions/#transactions-and-locks */
         $client->hr->dropCollection('employees', ['writeConcern' => new WriteConcern('majority')]);
         $client->reporting->dropCollection('events', ['writeConcern' => new WriteConcern('majority')]);
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-20374

We've moved the docs to mongodb.com/docs/* for better SEO. This PR modifies URLs founds in the php-lib