### PR TITLE
PHPLIB-810: Temporarily skip stable API count test for server 6.0+

### DIFF
--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -1723,6 +1723,10 @@ class DocumentationExamplesTest extends FunctionalTestCase
             $this->markTestSkipped('Versioned API is not supported');
         }
 
+        if (version_compare($this->getServerVersion(), '5.9', '>=')) {
+            $this->markTestIncomplete('SERVER-63850 added count command to API version 1 in MongoDB 6.0.0-rc0 (see: PHPLIB-810)');
+        }
+
         $uriString = static::getUri(true);
 
         // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-810

This test expects an exception executing count via the stable API; however, 6.0.0-rc0 added count to the stable API so an exception is no longer raised. Driver changes are not yet specified but we can skip this test in the meantime.

This should prevent CI failures on server version "latest" and allow us to remove `failing-on-waterfall` from [PHPLIB-810](https://jira.mongodb.org/browse/PHPLIB-810).