### PR TITLE
PHPLIB-843 and PHPLIB-856: clusteredIndex and changeStreamPreAndPostImages options

### DIFF
--- a/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
+++ b/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
@@ -28,6 +28,22 @@ operation: ~
 optional: true
 ---
 arg_name: option
+name: changeStreamPreAndPostImages
+type: document
+description: |
+  Used to configure support for pre- and post-images in change streams. See the
+  :manual:`create </reference/command/create>` command documentation for more
+  information.
+
+  This option is available in MongoDB 6.0+ and will result in an exception at
+  execution time if specified for an older server version.
+
+  .. versionadded:: 1.13
+interface: phpmethod
+operation: ~
+optional: true
+---
+arg_name: option
 name: clusteredIndex
 type: document
 description: |

--- a/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
+++ b/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
@@ -27,6 +27,23 @@ interface: phpmethod
 operation: ~
 optional: true
 ---
+arg_name: option
+name: clusteredIndex
+type: document
+description: |
+  A clustered index specification. See
+  :manual:`Clustered Collections </core/clustered-collections>` or the
+  :manual:`create </reference/command/create>` command documentation for more
+  information.
+
+  This option is available in MongoDB 5.3+ and will result in an exception at
+  execution time if specified for an older server version.
+
+  .. versionadded:: 1.13
+interface: phpmethod
+operation: ~
+optional: true
+---
 source:
   file: apiargs-common-option.yaml
   ref: collation

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -71,6 +71,10 @@ class CreateCollection implements Executable
      *  * capped (boolean): Specify true to create a capped collection. If set,
      *    the size option must also be specified. The default is false.
      *
+     *  * clusteredIndex (document): A clustered index specification.
+     *
+     *    This is not supported for server versions < 5.3.
+     *
      *  * collation (document): Collation specification.
      *
      *  * expireAfterSeconds: The TTL for documents in time series collections.
@@ -127,6 +131,10 @@ class CreateCollection implements Executable
 
         if (isset($options['capped']) && ! is_bool($options['capped'])) {
             throw InvalidArgumentException::invalidType('"capped" option', $options['capped'], 'boolean');
+        }
+
+        if (isset($options['clusteredIndex']) && ! is_array($options['clusteredIndex']) && ! is_object($options['clusteredIndex'])) {
+            throw InvalidArgumentException::invalidType('"clusteredIndex" option', $options['clusteredIndex'], 'array or object');
         }
 
         if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
@@ -236,7 +244,7 @@ class CreateCollection implements Executable
             }
         }
 
-        foreach (['collation', 'indexOptionDefaults', 'storageEngine', 'timeseries', 'validator'] as $option) {
+        foreach (['clusteredIndex', 'collation', 'indexOptionDefaults', 'storageEngine', 'timeseries', 'validator'] as $option) {
             if (isset($this->options[$option])) {
                 $cmd[$option] = (object) $this->options[$option];
             }

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -71,6 +71,11 @@ class CreateCollection implements Executable
      *  * capped (boolean): Specify true to create a capped collection. If set,
      *    the size option must also be specified. The default is false.
      *
+     *  * changeStreamPreAndPostImages (document): Used to configure support for
+     *    pre- and post-images in change streams.
+     *
+     *    This is not supported for server versions < 6.0.
+     *
      *  * clusteredIndex (document): A clustered index specification.
      *
      *    This is not supported for server versions < 5.3.
@@ -131,6 +136,10 @@ class CreateCollection implements Executable
 
         if (isset($options['capped']) && ! is_bool($options['capped'])) {
             throw InvalidArgumentException::invalidType('"capped" option', $options['capped'], 'boolean');
+        }
+
+        if (isset($options['changeStreamPreAndPostImages']) && ! is_array($options['changeStreamPreAndPostImages']) && ! is_object($options['changeStreamPreAndPostImages'])) {
+            throw InvalidArgumentException::invalidType('"changeStreamPreAndPostImages" option', $options['changeStreamPreAndPostImages'], 'array or object');
         }
 
         if (isset($options['clusteredIndex']) && ! is_array($options['clusteredIndex']) && ! is_object($options['clusteredIndex'])) {
@@ -244,7 +253,7 @@ class CreateCollection implements Executable
             }
         }
 
-        foreach (['clusteredIndex', 'collation', 'indexOptionDefaults', 'storageEngine', 'timeseries', 'validator'] as $option) {
+        foreach (['changeStreamPreAndPostImages', 'clusteredIndex', 'collation', 'indexOptionDefaults', 'storageEngine', 'timeseries', 'validator'] as $option) {
             if (isset($this->options[$option])) {
                 $cmd[$option] = (object) $this->options[$option];
             }

--- a/tests/Operation/CreateCollectionTest.php
+++ b/tests/Operation/CreateCollectionTest.php
@@ -29,6 +29,10 @@ class CreateCollectionTest extends TestCase
         }
 
         foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['clusteredIndex' => $value];
+        }
+
+        foreach ($this->getInvalidDocumentValues() as $value) {
             $options[][] = ['collation' => $value];
         }
 

--- a/tests/Operation/CreateCollectionTest.php
+++ b/tests/Operation/CreateCollectionTest.php
@@ -29,6 +29,10 @@ class CreateCollectionTest extends TestCase
         }
 
         foreach ($this->getInvalidDocumentValues() as $value) {
+            $options[][] = ['changeStreamPreAndPostImages' => $value];
+        }
+
+        foreach ($this->getInvalidDocumentValues() as $value) {
             $options[][] = ['clusteredIndex' => $value];
         }
 

--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -12,6 +12,8 @@ use MongoDB\Driver\Cursor;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\GridFS\Bucket;
+use MongoDB\Model\CollectionInfo;
+use MongoDB\Model\DatabaseInfo;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\DatabaseCommand;
 use MongoDB\Operation\FindOneAndReplace;
@@ -23,6 +25,7 @@ use stdClass;
 use Throwable;
 
 use function array_diff_key;
+use function array_intersect_key;
 use function array_key_exists;
 use function array_map;
 use function current;
@@ -260,7 +263,12 @@ final class Operation
                 return iterator_to_array($client->listDatabaseNames($args));
 
             case 'listDatabases':
-                return iterator_to_array($client->listDatabases($args));
+                return array_map(
+                    function (DatabaseInfo $info) {
+                        return $info->__debugInfo();
+                    },
+                    iterator_to_array($client->listDatabases($args))
+                );
 
             default:
                 Assert::fail('Unsupported client operation: ' . $this->name);
@@ -457,7 +465,12 @@ final class Operation
                 );
 
             case 'listIndexes':
-                return iterator_to_array($collection->listIndexes($args));
+                return array_map(
+                    function (IndexInfo $info) {
+                        return $info->__debugInfo();
+                    },
+                    iterator_to_array($collection->listIndexes($args))
+                );
 
             case 'mapReduce':
                 assertArrayHasKey('map', $args);
@@ -579,7 +592,12 @@ final class Operation
                 return iterator_to_array($database->listCollectionNames($args));
 
             case 'listCollections':
-                return iterator_to_array($database->listCollections($args));
+                return array_map(
+                    function (CollectionInfo $info) {
+                        return $info->__debugInfo();
+                    },
+                    iterator_to_array($database->listCollections($args))
+                );
 
             case 'runCommand':
                 assertArrayHasKey('command', $args);

--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -599,6 +599,22 @@ final class Operation
                     iterator_to_array($database->listCollections($args))
                 );
 
+            case 'modifyCollection':
+                assertArrayHasKey('collection', $args);
+                assertIsString($args['collection']);
+
+                /* ModifyCollection takes collection and command options
+                 * separately, so we must split the array after initially
+                 * filtering out the collection name.
+                 *
+                 * The typeMap option is intentionally omitted since it is
+                 * specific to PHPLIB and will never appear in spec tests. */
+                $options = array_diff_key($args, ['collection' => 1]);
+                $collectionOptions = array_diff_key($options, ['session' => 1, 'writeConcern' => 1]);
+                $options = array_intersect_key($options, ['session' => 1, 'writeConcern' => 1]);
+
+                return $database->modifyCollection($args['collection'], $collectionOptions, $options);
+
             case 'runCommand':
                 assertArrayHasKey('command', $args);
                 assertInstanceOf(stdClass::class, $args['command']);

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -66,6 +66,7 @@ final class Util
             'dropCollection' => ['collection', 'session'],
             'listCollectionNames' => ['authorizedCollections', 'filter', 'maxTimeMS', 'session'],
             'listCollections' => ['authorizedCollections', 'filter', 'maxTimeMS', 'session'],
+            'modifyCollection' => ['collection', 'changeStreamPreAndPostImages'],
             // Note: commandName is not used by PHP
             'runCommand' => ['command', 'session', 'commandName'],
         ],

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -62,7 +62,7 @@ final class Util
         Database::class => [
             'aggregate' => ['pipeline', 'session', 'useCursor', 'allowDiskUse', 'batchSize', 'bypassDocumentValidation', 'collation', 'comment', 'explain', 'hint', 'let', 'maxAwaitTimeMS', 'maxTimeMS'],
             'createChangeStream' => ['pipeline', 'session', 'fullDocument', 'resumeAfter', 'startAfter', 'startAtOperationTime', 'batchSize', 'collation', 'maxAwaitTimeMS'],
-            'createCollection' => ['collection', 'session', 'autoIndexId', 'capped', 'collation', 'expireAfterSeconds', 'flags', 'indexOptionDefaults', 'max', 'maxTimeMS', 'size', 'storageEngine', 'timeseries', 'validationAction', 'validationLevel', 'validator'],
+            'createCollection' => ['collection', 'session', 'autoIndexId', 'capped', 'changeStreamPreAndPostImages', 'clusteredIndex', 'collation', 'expireAfterSeconds', 'flags', 'indexOptionDefaults', 'max', 'maxTimeMS', 'size', 'storageEngine', 'timeseries', 'validationAction', 'validationLevel', 'validator'],
             'dropCollection' => ['collection', 'session'],
             'listCollectionNames' => ['authorizedCollections', 'filter', 'maxTimeMS', 'session'],
             'listCollections' => ['authorizedCollections', 'filter', 'maxTimeMS', 'session'],

--- a/tests/UnifiedSpecTests/collection-management/clustered-indexes.json
+++ b/tests/UnifiedSpecTests/collection-management/clustered-indexes.json
@@ -1,0 +1,177 @@
+{
+  "description": "clustered-indexes",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.3",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "ts-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "ts-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "createCollection with clusteredIndex",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        }
+      ]
+    },
+    {
+      "description": "listCollections includes clusteredIndex",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "filter": {
+              "name": {
+                "$eq": "test"
+              }
+            }
+          },
+          "expectResult": [
+            {
+              "name": "test",
+              "options": {
+                "clusteredIndex": {
+                  "key": {
+                    "_id": 1
+                  },
+                  "unique": true,
+                  "name": "test index",
+                  "v": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listIndexes returns the index",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "clusteredIndex": {
+              "key": {
+                "_id": 1
+              },
+              "unique": true,
+              "name": "test index"
+            }
+          }
+        },
+        {
+          "name": "listIndexes",
+          "object": "collection0",
+          "expectResult": [
+            {
+              "key": {
+                "_id": 1
+              },
+              "name": "test index",
+              "clustered": true,
+              "unique": true,
+              "v": {
+                "$$type": [
+                  "int",
+                  "long"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/UnifiedSpecTests/collection-management/createCollection-pre_and_post_images.json
+++ b/tests/UnifiedSpecTests/collection-management/createCollection-pre_and_post_images.json
@@ -1,0 +1,92 @@
+{
+  "description": "createCollection-pre_and_post_images",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "papi-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "createCollection with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "papi-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "papi-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": true
+                  }
+                },
+                "databaseName": "papi-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/UnifiedSpecTests/collection-management/modifyCollection-pre_and_post_images.json
+++ b/tests/UnifiedSpecTests/collection-management/modifyCollection-pre_and_post_images.json
@@ -1,0 +1,111 @@
+{
+  "description": "modifyCollection-pre_and_post_images",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "papi-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "modifyCollection to changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": false
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "papi-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": true
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "papi-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "collMod": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-843
https://jira.mongodb.org/browse/PHPLIB-856

Also adds missing `createCollection` option for [PHPLIB-814](https://jira.mongodb.org/browse/PHPLIB-814), which was included in the recently synced spec tests.