### PR TITLE
PHPLIB-873: Restrict unified change stream tests to replica sets

### DIFF
--- a/tests/UnifiedSpecTests/change-streams/change-streams.json
+++ b/tests/UnifiedSpecTests/change-streams/change-streams.json
@@ -5,8 +5,7 @@
     {
       "minServerVersion": "3.6",
       "topologies": [
-        "replicaset",
-        "sharded-replicaset"
+        "replicaset"
       ],
       "serverless": "forbid"
     }
@@ -314,10 +313,7 @@
       "description": "Test that comment is set on getMore",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.4.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.4.0"
         }
       ],
       "operations": [
@@ -405,10 +401,7 @@
       "description": "Test that comment is not set on getMore - pre 4.4",
       "runOnRequirements": [
         {
-          "maxServerVersion": "4.3.99",
-          "topologies": [
-            "replicaset"
-          ]
+          "maxServerVersion": "4.3.99"
         }
       ],
       "operations": [
@@ -621,6 +614,15 @@
     },
     {
       "description": "Test new structure in ns document MUST NOT err",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "maxServerVersion": "5.2.99"
+        },
+        {
+          "minServerVersion": "6.0"
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",
@@ -797,10 +799,7 @@
       "description": "$changeStream must be the first stage in a change stream pipeline sent to the server",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -873,10 +872,7 @@
       "description": "The server returns change stream responses in the specified server response format",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -926,10 +922,7 @@
       "description": "Executing a watch helper on a Collection results in notifications for changes to the specified collection",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -1014,10 +1007,7 @@
       "description": "Change Stream should allow valid aggregate pipeline stages",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -1104,10 +1094,7 @@
       "description": "Executing a watch helper on a Database results in notifications for changes to all collections in the specified database.",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.8.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.8.0"
         }
       ],
       "operations": [
@@ -1209,10 +1196,7 @@
       "description": "Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster.",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.8.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.8.0"
         }
       ],
       "operations": [
@@ -1333,10 +1317,7 @@
       "description": "Test insert, update, replace, and delete event types",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -1488,10 +1469,7 @@
       "description": "Test rename and invalidate event types",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0.1",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.0.1"
         }
       ],
       "operations": [
@@ -1568,10 +1546,7 @@
       "description": "Test drop and invalidate event types",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0.1",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.0.1"
         }
       ],
       "operations": [
@@ -1637,10 +1612,7 @@
       "description": "Test consecutive resume",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.1.7"
         }
       ],
       "operations": [


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-873

This is a temporary solution to address flaky test failures on sharded clusters.

Synced with mongodb/specifications@f07351c0c61cd79e0e7a197f78a5cfcc028c2966