### PR TITLE
PHPLIB-868: Add MongoDB 5.0 to load balancer CI matrix

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -247,7 +247,7 @@ functions:
           export KMS_TLS_CA_FILE="${client_side_encryption_kms_tls_ca_file}"
           export KMS_TLS_CERTIFICATE_KEY_FILE="${client_side_encryption_kms_tls_certificate_key_file}"
           export PATH="${PHP_PATH}/bin:$PATH"
-          MOCK_SERVICE_ID=${MOCK_SERVICE_ID} API_VERSION=${API_VERSION} PHP_VERSION=${PHP_VERSION} AUTH=${AUTH} SSL=${SSL} MONGODB_URI="${MONGODB_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          API_VERSION=${API_VERSION} PHP_VERSION=${PHP_VERSION} AUTH=${AUTH} SSL=${SSL} MONGODB_URI="${MONGODB_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run atlas data lake test":
      - command: shell.exec
@@ -752,9 +752,7 @@ buildvariants:
     - .serverless
 
 - matrix_name: "test-loadBalanced"
-  # TODO: Add "5.2" server version alongside "latest" following its GA release
-  # TODO: Revert driver-version to latest-stable after PHPC 1.13.0 is released (for CDRIVER-4207)
-  matrix_spec: { "versions": "latest", "php-edge-versions": "latest-stable", "driver-versions": "latest-dev" }
+  matrix_spec: { "versions": ["5.0", "latest"], "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
   display_name: "Load balanced - ${versions}"
   run_on: debian92-test
   tasks:

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -6,13 +6,11 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #   MONGODB_URI       Set the suggested connection MONGODB_URI (including credentials and topology info)
 #   API_VERSION       Optional API_VERSION environment variable for run-tests.php
 #   IS_MATRIX_TESTING Set to "true" to enable matrix testing. Defaults to empty string. If "true", DRIVER_MONGODB_VERSION and MONGODB_VERSION will also be checked.
-#   MOCK_SERVICE_ID   Set to "1" to enable service ID mocking for load balancers. Defaults to empty string.
 
 SSL=${SSL:-nossl}
 MONGODB_URI=${MONGODB_URI:-}
 API_VERSION=${API_VERSION:-}
 IS_MATRIX_TESTING=${IS_MATRIX_TESTING:-}
-MOCK_SERVICE_ID=${MOCK_SERVICE_ID:-}
 
 # For matrix testing, we have to determine the correct driver version
 if [ "${IS_MATRIX_TESTING}" = "true" ]; then
@@ -45,11 +43,6 @@ fi
 
 # Enable verbose output to see skipped and incomplete tests
 PHPUNIT_OPTS="${PHPUNIT_OPTS} -v"
-
-# For load balancer testing, we need to enable service ID mocking
-if [ "${MOCK_SERVICE_ID}" = "1" ]; then
-   PHPUNIT_OPTS="${PHPUNIT_OPTS} -d mongodb.mock_service_id=1"
-fi
 
 # Determine if MONGODB_URI already has a query string
 SUFFIX=$(echo "$MONGODB_URI" | grep -Eo "\?(.*)" | cat)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-868

Also removes remnants of service ID mocking (PHPC-2053). Related to https://github.com/mongodb/mongo-php-driver/pull/1321.