### PR TITLE
PHPLIB-852: Always report 'wallTime' in the change stream event output

### DIFF
--- a/tests/UnifiedSpecTests/change-streams/change-streams.json
+++ b/tests/UnifiedSpecTests/change-streams/change-streams.json
@@ -1748,6 +1748,48 @@
           ]
         }
       ]
+    },
+    {
+      "description": "Test wallTime field is set in a change event",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "6.0.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "wallTime": {
+              "$$exists": true
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-852