### PR TITLE
PHPLIB-715: Use flexible numeric comparisons in DocumentMatchConstraint

### DIFF
--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -35,12 +35,10 @@ use Symfony\Bridge\PhpUnit\ConstraintTrait;
 use function array_values;
 use function get_class;
 use function get_debug_type;
-use function in_array;
 use function is_array;
 use function is_float;
 use function is_int;
 use function is_object;
-use function is_scalar;
 use function method_exists;
 use function sprintf;
 

--- a/tests/SpecTests/DocumentsMatchConstraintTest.php
+++ b/tests/SpecTests/DocumentsMatchConstraintTest.php
@@ -43,6 +43,14 @@ class DocumentsMatchConstraintTest extends TestCase
         $this->assertResult(false, $c, [1, ['a' => 1, 'b' => 2]], 'Extra keys in embedded are not permitted');
     }
 
+    public function testFlexibleNumericComparison(): void
+    {
+        $c = new DocumentsMatchConstraint(['x' => 1, 'y' => 1.0]);
+        $this->assertResult(true, $c, ['x' => 1.0, 'y' => 1.0], 'Float instead of expected int matches');
+        $this->assertResult(true, $c, ['x' => 1, 'y' => 1], 'Int instead of expected float matches');
+        $this->assertResult(false, $c, ['x' => 'foo', 'y' => 1.0], 'Different type does not match');
+    }
+
     public function testIgnoreExtraKeysInEmbedded(): void
     {
         $c = new DocumentsMatchConstraint(['x' => 1, 'y' => ['a' => 1, 'b' => 2]], false, true);
@@ -62,15 +70,6 @@ class DocumentsMatchConstraintTest extends TestCase
         $this->assertResult(false, $c, [1, ['a' => 1], 3], 'Extra keys in root are not permitted');
         $this->assertResult(true, $c, [1, ['a' => 1, 'b' => 2]], 'Extra keys in embedded are permitted');
         $this->assertResult(false, $c, [1, ['a' => 2]], 'Keys must have the correct value');
-    }
-
-    public function testPlaceholders(): void
-    {
-        $c = new DocumentsMatchConstraint(['x' => '42', 'y' => 42, 'z' => ['a' => 24]], false, false, [24, 42]);
-
-        $this->assertResult(true, $c, ['x' => '42', 'y' => 'foo', 'z' => ['a' => 1]], 'Placeholders accept any value');
-        $this->assertResult(false, $c, ['x' => 42, 'y' => 'foo', 'z' => ['a' => 1]], 'Placeholder type must match');
-        $this->assertResult(true, $c, ['x' => '42', 'y' => 42, 'z' => ['a' => 24]], 'Exact match');
     }
 
     /**
@@ -146,13 +145,13 @@ class DocumentsMatchConstraintTest extends TestCase
                 ['foo' => ['foo' => 'bar', 'bar' => 'baz']],
             ],
             'Scalar value not equal' => [
-                'Field path "foo": Failed asserting that two values are equal.',
+                'Field path "foo": Failed asserting that two strings are equal.',
                 new DocumentsMatchConstraint(['foo' => 'bar']),
                 ['foo' => 'baz'],
             ],
             'Scalar type mismatch' => [
-                'Field path "foo": Failed asserting that two values are equal.',
-                new DocumentsMatchConstraint(['foo' => 42]),
+                'Field path "foo": \'42\' is not instance of expected type "bool".',
+                new DocumentsMatchConstraint(['foo' => true]),
                 ['foo' => '42'],
             ],
             'Type mismatch' => [

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -12,6 +12,7 @@ use MongoDB\Driver\Exception\Exception;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\GridFS\Bucket;
+use MongoDB\MapReduceResult;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\FindOneAndReplace;
 use MongoDB\Operation\FindOneAndUpdate;
@@ -206,6 +207,10 @@ final class Operation
              * is not used (e.g. Command Monitoring spec). */
             if ($result instanceof Cursor) {
                 $result = $result->toArray();
+            } elseif ($result instanceof MapReduceResult) {
+                /* For mapReduce operations, we ignore the mapReduce metadata
+                 * and only return the result iterator for evaluation. */
+                $result = iterator_to_array($result->getIterator());
             }
         } catch (Exception $e) {
             $exception = $e;
@@ -789,7 +794,7 @@ final class Operation
                 return ResultExpectation::ASSERT_SAME_DOCUMENTS;
 
             case 'mapReduce':
-                return ResultExpectation::ASSERT_SAME_DOCUMENTS;
+                return ResultExpectation::ASSERT_DOCUMENTS_MATCH;
 
             case 'replaceOne':
             case 'updateMany':

--- a/tests/SpecTests/RetryableReadsSpecTest.php
+++ b/tests/SpecTests/RetryableReadsSpecTest.php
@@ -26,7 +26,7 @@ class RetryableReadsSpecTest extends FunctionalTestCase
     ];
 
     /** @var array */
-    private static $incompleteTests = ['mapReduce: MapReduce succeeds with retry on' => 'PHPLIB-715'];
+    private static $incompleteTests = [];
 
     /**
      * Assert that the expected and actual command documents match.

--- a/tests/UnifiedSpecTests/Constraint/MatchesTest.php
+++ b/tests/UnifiedSpecTests/Constraint/MatchesTest.php
@@ -23,6 +23,14 @@ class MatchesTest extends FunctionalTestCase
         $this->assertResult(true, $c, ['y' => ['b' => 2, 'a' => 1], 'x' => 1], 'Root and embedded key order is not significant');
     }
 
+    public function testFlexibleNumericComparison(): void
+    {
+        $c = new Matches(['x' => 1, 'y' => 1.0]);
+        $this->assertResult(true, $c, ['x' => 1.0, 'y' => 1.0], 'Float instead of expected int matches');
+        $this->assertResult(true, $c, ['x' => 1, 'y' => 1], 'Int instead of expected float matches');
+        $this->assertResult(false, $c, ['x' => 'foo', 'y' => 1.0], 'Different type does not match');
+    }
+
     public function testDoNotAllowExtraRootKeys(): void
     {
         $c = new Matches(['x' => 1], null, false);


### PR DESCRIPTION
PHPLIB-715

This unskips a mapReduce test that fails due to strict numerical comparison. To fix this, I applied the same logic used in the unified spec tests. This comes at the cost of removing placeholder functionality in DocumentsMatchConstraint; however this wasn't used in the constraint at all. The transaction spec tests make use of the `42` placeholder, but the transaction spec tests covers these in the command listener it uses to assert the commands, so it's safe to remove without breaking other tests.