### PR TITLE
PHPLIB-599: Typing improvements

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -112,7 +112,6 @@
         </properties>
 
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation" />
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
@@ -126,7 +125,6 @@
         </properties>
 
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.UselessAnnotation" />
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
@@ -140,7 +138,6 @@
         </properties>
 
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification" />
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation" />
     </rule>
 
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -133,8 +133,6 @@
 
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
         <properties>
-            <!-- Requires PHP 7.2 -->
-            <property name="enableObjectTypeHint" value="false" />
             <!-- Requires PHP 8.0 -->
             <property name="enableStaticTypeHint" value="false" />
             <!-- Requires PHP 8.0 -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -105,8 +105,6 @@
     <!-- **************************************************************************** -->
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
         <properties>
-            <!-- Requires PHP 7.4 -->
-            <property name="enableObjectTypeHint" value="false" />
             <!-- Requires PHP 8.0 -->
             <property name="enableMixedTypeHint" value="false" />
             <!-- Requires PHP 8.0 -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -162,12 +162,9 @@
     </rule>
 
 
-    <!-- *********************************************************************************** -->
-    <!-- Require native type hints for all parameters, properties, and return types in tests -->
-    <!-- *********************************************************************************** -->
-    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
-        <exclude-pattern>src</exclude-pattern>
-    </rule>
+    <!-- *********************************************************** -->
+    <!-- Require native type hints for all code without a BC promise -->
+    <!-- *********************************************************** -->
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
         <exclude-pattern>src</exclude-pattern>
     </rule>

--- a/src/BulkWriteResult.php
+++ b/src/BulkWriteResult.php
@@ -35,8 +35,7 @@ class BulkWriteResult
     private $isAcknowledged;
 
     /**
-     * @param WriteResult $writeResult
-     * @param mixed[]     $insertedIds
+     * @param mixed[] $insertedIds
      */
     public function __construct(WriteResult $writeResult, array $insertedIds)
     {

--- a/src/BulkWriteResult.php
+++ b/src/BulkWriteResult.php
@@ -28,15 +28,12 @@ class BulkWriteResult
     /** @var WriteResult */
     private $writeResult;
 
-    /** @var mixed[] */
+    /** @var array */
     private $insertedIds;
 
     /** @var boolean */
     private $isAcknowledged;
 
-    /**
-     * @param mixed[] $insertedIds
-     */
     public function __construct(WriteResult $writeResult, array $insertedIds)
     {
         $this->writeResult = $writeResult;
@@ -89,7 +86,7 @@ class BulkWriteResult
      * field value. Any driver-generated ID will be a MongoDB\BSON\ObjectId
      * instance.
      *
-     * @return mixed[]
+     * @return array
      */
     public function getInsertedIds()
     {
@@ -164,7 +161,7 @@ class BulkWriteResult
      * This method should only be called if the write was acknowledged.
      *
      * @see BulkWriteResult::isAcknowledged()
-     * @return mixed[]
+     * @return array
      * @throws BadMethodCallException is the write result is unacknowledged
      */
     public function getUpsertedIds()

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -224,7 +224,7 @@ class ChangeStream implements Iterator
      * @param boolean $incrementKey Increment $key if there is a current result
      * @throws ResumeTokenException
      */
-    private function onIteration($incrementKey)
+    private function onIteration(bool $incrementKey)
     {
         /* If the cursorId is 0, the server has invalidated the cursor and we
          * will never perform another getMore nor need to resume since any

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -90,8 +90,6 @@ class ChangeStream implements Iterator
 
     /**
      * @internal
-     * @param ChangeStreamIterator $iterator
-     * @param callable             $resumeCallable
      */
     public function __construct(ChangeStreamIterator $iterator, callable $resumeCallable)
     {
@@ -194,8 +192,6 @@ class ChangeStream implements Iterator
      * Determines if an exception is a resumable error.
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resumable-error
-     * @param RuntimeException $exception
-     * @return boolean
      */
     private function isResumableError(RuntimeException $exception): bool
     {
@@ -251,8 +247,6 @@ class ChangeStream implements Iterator
 
     /**
      * Recreates the ChangeStreamIterator after a resumable server error.
-     *
-     * @return void
      */
     private function resume(): void
     {
@@ -265,7 +259,6 @@ class ChangeStream implements Iterator
     /**
      * Either resumes after a resumable error or re-throws the exception.
      *
-     * @param RuntimeException $exception
      * @throws RuntimeException
      */
     private function resumeOrThrow(RuntimeException $exception): void

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -197,7 +197,7 @@ class ChangeStream implements Iterator
      * @param RuntimeException $exception
      * @return boolean
      */
-    private function isResumableError(RuntimeException $exception)
+    private function isResumableError(RuntimeException $exception): bool
     {
         if ($exception instanceof ConnectionException) {
             return true;
@@ -224,7 +224,7 @@ class ChangeStream implements Iterator
      * @param boolean $incrementKey Increment $key if there is a current result
      * @throws ResumeTokenException
      */
-    private function onIteration(bool $incrementKey)
+    private function onIteration(bool $incrementKey): void
     {
         /* If the cursorId is 0, the server has invalidated the cursor and we
          * will never perform another getMore nor need to resume since any
@@ -254,7 +254,7 @@ class ChangeStream implements Iterator
      *
      * @return void
      */
-    private function resume()
+    private function resume(): void
     {
         $this->iterator = call_user_func($this->resumeCallable, $this->getResumeToken(), $this->hasAdvanced);
         $this->iterator->rewind();
@@ -268,7 +268,7 @@ class ChangeStream implements Iterator
      * @param RuntimeException $exception
      * @throws RuntimeException
      */
-    private function resumeOrThrow(RuntimeException $exception)
+    private function resumeOrThrow(RuntimeException $exception): void
     {
         if ($this->isResumableError($exception)) {
             $this->resume();

--- a/src/Client.php
+++ b/src/Client.php
@@ -290,7 +290,6 @@ class Client
      * List databases.
      *
      * @see ListDatabases::__construct() for supported options
-     * @param array $options
      * @return DatabaseInfoIterator
      * @throws UnexpectedValueException if the command response was malformed
      * @throws InvalidArgumentException for parameter/option parsing errors

--- a/src/Client.php
+++ b/src/Client.php
@@ -116,7 +116,7 @@ class Client
 
         $driverOptions['driver'] = $this->mergeDriverInfo($driverOptions['driver'] ?? []);
 
-        $this->uri = (string) $uri;
+        $this->uri = $uri;
         $this->typeMap = $driverOptions['typeMap'] ?? null;
 
         unset($driverOptions['typeMap']);

--- a/src/Client.php
+++ b/src/Client.php
@@ -98,7 +98,7 @@ class Client
      * @throws DriverInvalidArgumentException for parameter/option parsing errors in the driver
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function __construct($uri = 'mongodb://127.0.0.1/', array $uriOptions = [], array $driverOptions = [])
+    public function __construct(string $uri = 'mongodb://127.0.0.1/', array $uriOptions = [], array $driverOptions = [])
     {
         $driverOptions += ['typeMap' => self::$defaultTypeMap];
 
@@ -155,7 +155,7 @@ class Client
      * @param string $databaseName Name of the database to select
      * @return Database
      */
-    public function __get($databaseName)
+    public function __get(string $databaseName)
     {
         return $this->selectDatabase($databaseName);
     }
@@ -201,7 +201,7 @@ class Client
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function dropDatabase($databaseName, array $options = [])
+    public function dropDatabase(string $databaseName, array $options = [])
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
@@ -314,7 +314,7 @@ class Client
      * @return Collection
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function selectCollection($databaseName, $collectionName, array $options = [])
+    public function selectCollection(string $databaseName, string $collectionName, array $options = [])
     {
         $options += ['typeMap' => $this->typeMap];
 
@@ -330,7 +330,7 @@ class Client
      * @return Database
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function selectDatabase($databaseName, array $options = [])
+    public function selectDatabase(string $databaseName, array $options = [])
     {
         $options += ['typeMap' => $this->typeMap];
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -128,11 +128,11 @@ class Collection
      */
     public function __construct(Manager $manager, string $databaseName, string $collectionName, array $options = [])
     {
-        if (strlen((string) $databaseName) < 1) {
+        if (strlen($databaseName) < 1) {
             throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
         }
 
-        if (strlen((string) $collectionName) < 1) {
+        if (strlen($collectionName) < 1) {
             throw new InvalidArgumentException('$collectionName is invalid: ' . $collectionName);
         }
 
@@ -153,8 +153,8 @@ class Collection
         }
 
         $this->manager = $manager;
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
         $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -938,7 +938,6 @@ class Collection
      * Returns information for all indexes for the collection.
      *
      * @see ListIndexes::__construct() for supported options
-     * @param array $options
      * @return IndexInfoIterator
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -1007,9 +1006,9 @@ class Collection
      * Renames the collection.
      *
      * @see RenameCollection::__construct() for supported options
-     * @param string  $toCollectionName New name of the collection
-     * @param ?string $toDatabaseName   New database name of the collection. Defaults to the original database.
-     * @param array   $options          Additional options
+     * @param string      $toCollectionName New name of the collection
+     * @param string|null $toDatabaseName   New database name of the collection. Defaults to the original database.
+     * @param array       $options          Additional options
      * @return array|object Command result document
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -446,7 +446,7 @@ class Collection
      * @param string       $fieldName Field for which to return distinct values
      * @param array|object $filter    Query by which to filter documents
      * @param array        $options   Command options
-     * @return mixed[]
+     * @return array
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -126,7 +126,7 @@ class Collection
      * @param array   $options        Collection options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(Manager $manager, $databaseName, $collectionName, array $options = [])
+    public function __construct(Manager $manager, string $databaseName, string $collectionName, array $options = [])
     {
         if (strlen((string) $databaseName) < 1) {
             throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
@@ -452,7 +452,7 @@ class Collection
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function distinct($fieldName, $filter = [], array $options = [])
+    public function distinct(string $fieldName, $filter = [], array $options = [])
     {
         if (! isset($options['readPreference']) && ! is_in_transaction($options)) {
             $options['readPreference'] = $this->readPreference;

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -103,7 +103,6 @@ class ListCollections implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return CachingIterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
@@ -117,8 +116,6 @@ class ListCollections implements Executable
 
     /**
      * Create the listCollections command.
-     *
-     * @return Command
      */
     private function createCommand(): Command
     {

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -73,7 +73,7 @@ class ListCollections implements Executable
      * @param array  $options      Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, array $options = [])
+    public function __construct(string $databaseName, array $options = [])
     {
         if (isset($options['authorizedCollections']) && ! is_bool($options['authorizedCollections'])) {
             throw InvalidArgumentException::invalidType('"authorizedCollections" option', $options['authorizedCollections'], 'boolean');

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -103,10 +103,9 @@ class ListCollections implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return CachingIterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function execute(Server $server)
+    public function execute(Server $server): CachingIterator
     {
         $cursor = $server->executeReadCommand($this->databaseName, $this->createCommand(), $this->createOptions());
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -120,7 +120,7 @@ class ListCollections implements Executable
      *
      * @return Command
      */
-    private function createCommand()
+    private function createCommand(): Command
     {
         $cmd = ['listCollections' => 1];
 
@@ -146,7 +146,7 @@ class ListCollections implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -140,7 +140,6 @@ class ListCollections implements Executable
      * the command be executed on the primary.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -95,7 +95,7 @@ class ListCollections implements Executable
             throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
-        $this->databaseName = (string) $databaseName;
+        $this->databaseName = $databaseName;
         $this->options = $options;
     }
 

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -99,7 +99,6 @@ class ListDatabases implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array An array of database info structures
      * @throws UnexpectedValueException if the command response was malformed
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -119,8 +118,6 @@ class ListDatabases implements Executable
 
     /**
      * Create the listDatabases command.
-     *
-     * @return Command
      */
     private function createCommand(): Command
     {

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -103,7 +103,7 @@ class ListDatabases implements Executable
      * @throws UnexpectedValueException if the command response was malformed
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function execute(Server $server)
+    public function execute(Server $server): array
     {
         $cursor = $server->executeReadCommand('admin', $this->createCommand(), $this->createOptions());
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -122,7 +122,7 @@ class ListDatabases implements Executable
      *
      * @return Command
      */
-    private function createCommand()
+    private function createCommand(): Command
     {
         $cmd = ['listDatabases' => 1];
 
@@ -148,7 +148,7 @@ class ListDatabases implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -143,7 +143,6 @@ class ListDatabases implements Executable
      * the command be executed on the primary.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Database.php
+++ b/src/Database.php
@@ -257,8 +257,7 @@ class Database
      * Create a new collection explicitly.
      *
      * @see CreateCollection::__construct() for supported options
-     * @param string $collectionName
-     * @param array  $options
+     * @param array $options
      * @return array|object Command result document
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors

--- a/src/Database.php
+++ b/src/Database.php
@@ -257,7 +257,6 @@ class Database
      * Create a new collection explicitly.
      *
      * @see CreateCollection::__construct() for supported options
-     * @param array $options
      * @return array|object Command result document
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
@@ -452,7 +451,6 @@ class Database
      * Returns information for all collections in this database.
      *
      * @see ListCollections::__construct() for supported options
-     * @param array $options
      * @return CollectionInfoIterator
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -497,10 +495,10 @@ class Database
      * Rename a collection within this database.
      *
      * @see RenameCollection::__construct() for supported options
-     * @param string  $fromCollectionName Collection name
-     * @param string  $toCollectionName   New name of the collection
-     * @param ?string $toDatabaseName     New database name of the collection. Defaults to the original database.
-     * @param array   $options            Additional options
+     * @param string      $fromCollectionName Collection name
+     * @param string      $toCollectionName   New name of the collection
+     * @param string|null $toDatabaseName     New database name of the collection. Defaults to the original database.
+     * @param array       $options            Additional options
      * @return array|object Command result document
      * @throws UnsupportedException if options are unsupported on the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors

--- a/src/Database.php
+++ b/src/Database.php
@@ -106,7 +106,7 @@ class Database
      */
     public function __construct(Manager $manager, string $databaseName, array $options = [])
     {
-        if (strlen((string) $databaseName) < 1) {
+        if (strlen($databaseName) < 1) {
             throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
         }
 
@@ -127,7 +127,7 @@ class Database
         }
 
         $this->manager = $manager;
-        $this->databaseName = (string) $databaseName;
+        $this->databaseName = $databaseName;
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
         $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;

--- a/src/Database.php
+++ b/src/Database.php
@@ -104,7 +104,7 @@ class Database
      * @param array   $options      Database options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(Manager $manager, $databaseName, array $options = [])
+    public function __construct(Manager $manager, string $databaseName, array $options = [])
     {
         if (strlen((string) $databaseName) < 1) {
             throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
@@ -164,7 +164,7 @@ class Database
      * @param string $collectionName Name of the collection to select
      * @return Collection
      */
-    public function __get($collectionName)
+    public function __get(string $collectionName)
     {
         return $this->selectCollection($collectionName);
     }
@@ -264,7 +264,7 @@ class Database
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function createCollection($collectionName, array $options = [])
+    public function createCollection(string $collectionName, array $options = [])
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
@@ -340,7 +340,7 @@ class Database
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function dropCollection($collectionName, array $options = [])
+    public function dropCollection(string $collectionName, array $options = [])
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
@@ -477,7 +477,7 @@ class Database
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function modifyCollection($collectionName, array $collectionOptions, array $options = [])
+    public function modifyCollection(string $collectionName, array $collectionOptions, array $options = [])
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
@@ -537,7 +537,7 @@ class Database
      * @return Collection
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function selectCollection($collectionName, array $options = [])
+    public function selectCollection(string $collectionName, array $options = [])
     {
         $options += [
             'readConcern' => $this->readConcern,

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -29,7 +29,7 @@ class BadMethodCallException extends BaseBadMethodCallException implements Excep
      * @param string $class Class name
      * @return self
      */
-    public static function classIsImmutable($class)
+    public static function classIsImmutable(string $class)
     {
         return new static(sprintf('%s is immutable', $class));
     }
@@ -40,7 +40,7 @@ class BadMethodCallException extends BaseBadMethodCallException implements Excep
      * @param string $method Method name
      * @return self
      */
-    public static function unacknowledgedWriteResultAccess($method)
+    public static function unacknowledgedWriteResultAccess(string $method)
     {
         return new static(sprintf('%s should not be called for an unacknowledged write result', $method));
     }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -36,7 +36,7 @@ class InvalidArgumentException extends DriverInvalidArgumentException implements
      * @param string|string[] $expectedType Expected type
      * @return self
      */
-    public static function invalidType($name, $value, $expectedType)
+    public static function invalidType(string $name, $value, $expectedType)
     {
         if (is_array($expectedType)) {
             switch (count($expectedType)) {

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -32,7 +32,6 @@ use MongoDB\GridFS\Exception\StreamException;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Find;
-use stdClass;
 
 use function array_intersect_key;
 use function fopen;
@@ -640,9 +639,9 @@ class Bucket
     /**
      * Creates a path for an existing GridFS file.
      *
-     * @param stdClass $file GridFS file document
+     * @param object $file GridFS file document
      */
-    private function createPathForFile(stdClass $file): string
+    private function createPathForFile(object $file): string
     {
         if (! is_object($file->_id) || method_exists($file->_id, '__toString')) {
             $id = (string) $file->_id;
@@ -689,7 +688,7 @@ class Bucket
      * @param resource $stream GridFS stream
      * @throws InvalidArgumentException
      */
-    private function getRawFileDocumentForStream($stream): stdClass
+    private function getRawFileDocumentForStream($stream): object
     {
         if (! is_resource($stream) || get_resource_type($stream) != "stream") {
             throw InvalidArgumentException::invalidType('$stream', $stream, 'resource');
@@ -707,10 +706,10 @@ class Bucket
     /**
      * Opens a readable stream for the GridFS file.
      *
-     * @param stdClass $file GridFS file document
+     * @param object $file GridFS file document
      * @return resource
      */
-    private function openDownloadStreamByFile(stdClass $file)
+    private function openDownloadStreamByFile(object $file)
     {
         $path = $this->createPathForFile($file);
         $context = stream_context_create([

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -641,7 +641,6 @@ class Bucket
      * Creates a path for an existing GridFS file.
      *
      * @param stdClass $file GridFS file document
-     * @return string
      */
     private function createPathForFile(stdClass $file): string
     {
@@ -662,8 +661,6 @@ class Bucket
 
     /**
      * Creates a path for a new GridFS file, which does not yet have an ID.
-     *
-     * @return string
      */
     private function createPathForUpload(): string
     {
@@ -677,8 +674,6 @@ class Bucket
 
     /**
      * Returns the names of the files collection.
-     *
-     * @return string
      */
     private function getFilesNamespace(): string
     {
@@ -692,7 +687,6 @@ class Bucket
      * respect the Bucket's type map.
      *
      * @param resource $stream GridFS stream
-     * @return stdClass
      * @throws InvalidArgumentException
      */
     private function getRawFileDocumentForStream($stream): stdClass

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -137,7 +137,7 @@ class Bucket
      * @param array   $options      Bucket options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(Manager $manager, $databaseName, array $options = [])
+    public function __construct(Manager $manager, string $databaseName, array $options = [])
     {
         $options += [
             'bucketName' => self::$defaultBucketName,
@@ -282,7 +282,7 @@ class Bucket
      * @throws StreamException if the file could not be uploaded
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function downloadToStreamByName($filename, $destination, array $options = [])
+    public function downloadToStreamByName(string $filename, $destination, array $options = [])
     {
         if (! is_resource($destination) || get_resource_type($destination) != "stream") {
             throw InvalidArgumentException::invalidType('$destination', $destination, 'resource');
@@ -517,7 +517,7 @@ class Bucket
      * @throws FileNotFoundException if no file could be selected
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function openDownloadStreamByName($filename, array $options = [])
+    public function openDownloadStreamByName(string $filename, array $options = [])
     {
         $options += ['revision' => -1];
 
@@ -550,7 +550,7 @@ class Bucket
      * @param array  $options  Upload options
      * @return resource
      */
-    public function openUploadStream($filename, array $options = [])
+    public function openUploadStream(string $filename, array $options = [])
     {
         $options += ['chunkSizeBytes' => $this->chunkSizeBytes];
 
@@ -574,7 +574,7 @@ class Bucket
      * @throws FileNotFoundException if no file could be selected
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function rename($id, $newFilename)
+    public function rename($id, string $newFilename)
     {
         $updateResult = $this->collectionWrapper->updateFilenameForId($id, $newFilename);
 
@@ -620,7 +620,7 @@ class Bucket
      * @throws StreamException if the file could not be uploaded
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function uploadFromStream($filename, $source, array $options = [])
+    public function uploadFromStream(string $filename, $source, array $options = [])
     {
         if (! is_resource($source) || get_resource_type($source) != "stream") {
             throw InvalidArgumentException::invalidType('$source', $source, 'resource');

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -178,7 +178,7 @@ class Bucket
         }
 
         $this->manager = $manager;
-        $this->databaseName = (string) $databaseName;
+        $this->databaseName = $databaseName;
         $this->bucketName = $options['bucketName'];
         $this->chunkSizeBytes = $options['chunkSizeBytes'];
         $this->disableMD5 = $options['disableMD5'];

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -643,7 +643,7 @@ class Bucket
      * @param stdClass $file GridFS file document
      * @return string
      */
-    private function createPathForFile(stdClass $file)
+    private function createPathForFile(stdClass $file): string
     {
         if (! is_object($file->_id) || method_exists($file->_id, '__toString')) {
             $id = (string) $file->_id;
@@ -665,7 +665,7 @@ class Bucket
      *
      * @return string
      */
-    private function createPathForUpload()
+    private function createPathForUpload(): string
     {
         return sprintf(
             '%s://%s/%s.files',
@@ -680,7 +680,7 @@ class Bucket
      *
      * @return string
      */
-    private function getFilesNamespace()
+    private function getFilesNamespace(): string
     {
         return sprintf('%s.%s.files', $this->databaseName, $this->bucketName);
     }
@@ -695,7 +695,7 @@ class Bucket
      * @return stdClass
      * @throws InvalidArgumentException
      */
-    private function getRawFileDocumentForStream($stream)
+    private function getRawFileDocumentForStream($stream): stdClass
     {
         if (! is_resource($stream) || get_resource_type($stream) != "stream") {
             throw InvalidArgumentException::invalidType('$stream', $stream, 'resource');
@@ -732,7 +732,7 @@ class Bucket
     /**
      * Registers the GridFS stream wrapper if it is not already registered.
      */
-    private function registerStreamWrapper()
+    private function registerStreamWrapper(): void
     {
         if (in_array(self::$streamWrapperProtocol, stream_get_wrappers())) {
             return;

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -25,7 +25,6 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\UpdateResult;
 use MultipleIterator;
-use stdClass;
 
 use function abs;
 use function count;
@@ -78,7 +77,7 @@ class CollectionWrapper
      *
      * @param mixed $id
      */
-    public function deleteChunksByFilesId($id)
+    public function deleteChunksByFilesId($id): void
     {
         $this->chunksCollection->deleteMany(['files_id' => $id]);
     }
@@ -88,7 +87,7 @@ class CollectionWrapper
      *
      * @param mixed $id
      */
-    public function deleteFileAndChunksById($id)
+    public function deleteFileAndChunksById($id): void
     {
         $this->filesCollection->deleteOne(['_id' => $id]);
         $this->chunksCollection->deleteMany(['files_id' => $id]);
@@ -97,7 +96,7 @@ class CollectionWrapper
     /**
      * Drops the GridFS files and chunks collections.
      */
-    public function dropCollections()
+    public function dropCollections(): void
     {
         $this->filesCollection->drop(['typeMap' => []]);
         $this->chunksCollection->drop(['typeMap' => []]);
@@ -108,9 +107,8 @@ class CollectionWrapper
      *
      * @param mixed   $id        File ID
      * @param integer $fromChunk Starting chunk (inclusive)
-     * @return Cursor
      */
-    public function findChunksByFileId($id, int $fromChunk = 0)
+    public function findChunksByFileId($id, int $fromChunk = 0): Cursor
     {
         return $this->chunksCollection->find(
             [
@@ -138,9 +136,8 @@ class CollectionWrapper
      *
      * @see Bucket::downloadToStreamByName()
      * @see Bucket::openDownloadStreamByName()
-     * @return stdClass|null
      */
-    public function findFileByFilenameAndRevision(string $filename, int $revision)
+    public function findFileByFilenameAndRevision(string $filename, int $revision): ?object
     {
         $filename = $filename;
         $revision = $revision;
@@ -167,9 +164,8 @@ class CollectionWrapper
      * Finds a GridFS file document for a given ID.
      *
      * @param mixed $id
-     * @return stdClass|null
      */
-    public function findFileById($id)
+    public function findFileById($id): ?object
     {
         return $this->filesCollection->findOne(
             ['_id' => $id],
@@ -202,42 +198,22 @@ class CollectionWrapper
         return $this->filesCollection->findOne($filter, $options);
     }
 
-    /**
-     * Return the bucket name.
-     *
-     * @return string
-     */
-    public function getBucketName()
+    public function getBucketName(): string
     {
         return $this->bucketName;
     }
 
-    /**
-     * Return the chunks collection.
-     *
-     * @return Collection
-     */
-    public function getChunksCollection()
+    public function getChunksCollection(): Collection
     {
         return $this->chunksCollection;
     }
 
-    /**
-     * Return the database name.
-     *
-     * @return string
-     */
-    public function getDatabaseName()
+    public function getDatabaseName(): string
     {
         return $this->databaseName;
     }
 
-    /**
-     * Return the files collection.
-     *
-     * @return Collection
-     */
-    public function getFilesCollection()
+    public function getFilesCollection(): Collection
     {
         return $this->filesCollection;
     }
@@ -247,7 +223,7 @@ class CollectionWrapper
      *
      * @param array|object $chunk Chunk document
      */
-    public function insertChunk($chunk)
+    public function insertChunk($chunk): void
     {
         if (! $this->checkedIndexes) {
             $this->ensureIndexes();
@@ -263,7 +239,7 @@ class CollectionWrapper
      *
      * @param array|object $file File document
      */
-    public function insertFile($file)
+    public function insertFile($file): void
     {
         if (! $this->checkedIndexes) {
             $this->ensureIndexes();
@@ -276,9 +252,8 @@ class CollectionWrapper
      * Updates the filename field in the file document for a given ID.
      *
      * @param mixed $id
-     * @return UpdateResult
      */
-    public function updateFilenameForId($id, string $filename)
+    public function updateFilenameForId($id, string $filename): UpdateResult
     {
         return $this->filesCollection->updateOne(
             ['_id' => $id],

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -64,7 +64,7 @@ class CollectionWrapper
      * @param array   $collectionOptions Collection options
      * @throws InvalidArgumentException
      */
-    public function __construct(Manager $manager, $databaseName, $bucketName, array $collectionOptions = [])
+    public function __construct(Manager $manager, string $databaseName, string $bucketName, array $collectionOptions = [])
     {
         $this->databaseName = (string) $databaseName;
         $this->bucketName = (string) $bucketName;
@@ -110,7 +110,7 @@ class CollectionWrapper
      * @param integer $fromChunk Starting chunk (inclusive)
      * @return Cursor
      */
-    public function findChunksByFileId($id, $fromChunk = 0)
+    public function findChunksByFileId($id, int $fromChunk = 0)
     {
         return $this->chunksCollection->find(
             [
@@ -142,7 +142,7 @@ class CollectionWrapper
      * @param integer $revision
      * @return stdClass|null
      */
-    public function findFileByFilenameAndRevision($filename, $revision)
+    public function findFileByFilenameAndRevision(string $filename, int $revision)
     {
         $filename = (string) $filename;
         $revision = (integer) $revision;
@@ -281,7 +281,7 @@ class CollectionWrapper
      * @param string $filename
      * @return UpdateResult
      */
-    public function updateFilenameForId($id, $filename)
+    public function updateFilenameForId($id, string $filename)
     {
         return $this->filesCollection->updateOne(
             ['_id' => $id],

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -66,8 +66,8 @@ class CollectionWrapper
      */
     public function __construct(Manager $manager, string $databaseName, string $bucketName, array $collectionOptions = [])
     {
-        $this->databaseName = (string) $databaseName;
-        $this->bucketName = (string) $bucketName;
+        $this->databaseName = $databaseName;
+        $this->bucketName = $bucketName;
 
         $this->filesCollection = new Collection($manager, $databaseName, sprintf('%s.files', $bucketName), $collectionOptions);
         $this->chunksCollection = new Collection($manager, $databaseName, sprintf('%s.chunks', $bucketName), $collectionOptions);
@@ -142,8 +142,8 @@ class CollectionWrapper
      */
     public function findFileByFilenameAndRevision(string $filename, int $revision)
     {
-        $filename = (string) $filename;
-        $revision = (integer) $revision;
+        $filename = $filename;
+        $revision = $revision;
 
         if ($revision < 0) {
             $skip = abs($revision) - 1;
@@ -282,7 +282,7 @@ class CollectionWrapper
     {
         return $this->filesCollection->updateOne(
             ['_id' => $id],
-            ['$set' => ['filename' => (string) $filename]]
+            ['$set' => ['filename' => $filename]]
         );
     }
 

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -138,8 +138,6 @@ class CollectionWrapper
      *
      * @see Bucket::downloadToStreamByName()
      * @see Bucket::openDownloadStreamByName()
-     * @param string  $filename
-     * @param integer $revision
      * @return stdClass|null
      */
     public function findFileByFilenameAndRevision(string $filename, int $revision)
@@ -277,8 +275,7 @@ class CollectionWrapper
     /**
      * Updates the filename field in the file document for a given ID.
      *
-     * @param mixed  $id
-     * @param string $filename
+     * @param mixed $id
      * @return UpdateResult
      */
     public function updateFilenameForId($id, string $filename)
@@ -375,8 +372,6 @@ class CollectionWrapper
 
     /**
      * Returns whether the files collection is empty.
-     *
-     * @return boolean
      */
     private function isFilesCollectionEmpty(): bool
     {

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -292,7 +292,7 @@ class CollectionWrapper
     /**
      * Create an index on the chunks collection if it does not already exist.
      */
-    private function ensureChunksIndex()
+    private function ensureChunksIndex(): void
     {
         $expectedIndex = ['files_id' => 1, 'n' => 1];
 
@@ -308,7 +308,7 @@ class CollectionWrapper
     /**
      * Create an index on the files collection if it does not already exist.
      */
-    private function ensureFilesIndex()
+    private function ensureFilesIndex(): void
     {
         $expectedIndex = ['filename' => 1, 'uploadDate' => 1];
 
@@ -327,7 +327,7 @@ class CollectionWrapper
      * This method is called once before the first write operation on a GridFS
      * bucket. Indexes are only be created if the files collection is empty.
      */
-    private function ensureIndexes()
+    private function ensureIndexes(): void
     {
         if ($this->checkedIndexes) {
             return;
@@ -378,7 +378,7 @@ class CollectionWrapper
      *
      * @return boolean
      */
-    private function isFilesCollectionEmpty()
+    private function isFilesCollectionEmpty(): bool
     {
         return null === $this->filesCollection->findOne([], [
             'readPreference' => new ReadPreference(ReadPreference::RP_PRIMARY),

--- a/src/GridFS/Exception/CorruptFileException.php
+++ b/src/GridFS/Exception/CorruptFileException.php
@@ -29,7 +29,7 @@ class CorruptFileException extends RuntimeException
      * @param integer $expectedIndex Expected index number
      * @return self
      */
-    public static function missingChunk($expectedIndex)
+    public static function missingChunk(int $expectedIndex)
     {
         return new static(sprintf('Chunk not found for index "%d"', $expectedIndex));
     }
@@ -41,7 +41,7 @@ class CorruptFileException extends RuntimeException
      * @param integer $expectedIndex Expected index number
      * @return self
      */
-    public static function unexpectedIndex($index, $expectedIndex)
+    public static function unexpectedIndex(int $index, int $expectedIndex)
     {
         return new static(sprintf('Expected chunk to have index "%d" but found "%d"', $expectedIndex, $index));
     }
@@ -53,7 +53,7 @@ class CorruptFileException extends RuntimeException
      * @param integer $expectedSize Expected size
      * @return self
      */
-    public static function unexpectedSize($size, $expectedSize)
+    public static function unexpectedSize(int $size, int $expectedSize)
     {
         return new static(sprintf('Expected chunk to have size "%d" but found "%d"', $expectedSize, $size));
     }

--- a/src/GridFS/Exception/FileNotFoundException.php
+++ b/src/GridFS/Exception/FileNotFoundException.php
@@ -33,7 +33,7 @@ class FileNotFoundException extends RuntimeException
      * @param string  $namespace Namespace for the files collection
      * @return self
      */
-    public static function byFilenameAndRevision($filename, $revision, $namespace)
+    public static function byFilenameAndRevision(string $filename, int $revision, string $namespace)
     {
         return new static(sprintf('File with name "%s" and revision "%d" not found in "%s"', $filename, $revision, $namespace));
     }
@@ -45,7 +45,7 @@ class FileNotFoundException extends RuntimeException
      * @param string $namespace Namespace for the files collection
      * @return self
      */
-    public static function byId($id, $namespace)
+    public static function byId($id, string $namespace)
     {
         $json = toJSON(fromPHP(['_id' => $id]));
 

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -164,7 +164,7 @@ class ReadableStream
      * @return string
      * @throws InvalidArgumentException if $length is negative
      */
-    public function readBytes($length)
+    public function readBytes(int $length)
     {
         if ($length < 0) {
             throw new InvalidArgumentException(sprintf('$length must be >= 0; given: %d', $length));
@@ -199,7 +199,7 @@ class ReadableStream
      * @param integer $offset
      * @throws InvalidArgumentException if $offset is out of range
      */
-    public function seek($offset)
+    public function seek(int $offset)
     {
         if ($offset < 0 || $offset > $this->file->length) {
             throw new InvalidArgumentException(sprintf('$offset must be >= 0 and <= %d; given: %d', $this->file->length, $offset));

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -196,7 +196,6 @@ class ReadableStream
     /**
      * Seeks the chunk and buffer offsets for the next read operation.
      *
-     * @param integer $offset
      * @throws InvalidArgumentException if $offset is out of range
      */
     public function seek(int $offset)

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -20,7 +20,6 @@ namespace MongoDB\GridFS;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\Exception\CorruptFileException;
-use stdClass;
 
 use function ceil;
 use function floor;
@@ -58,7 +57,7 @@ class ReadableStream
     /** @var float|integer */
     private $expectedLastChunkSize = 0;
 
-    /** @var stdClass */
+    /** @var object */
     private $file;
 
     /** @var integer */
@@ -71,10 +70,10 @@ class ReadableStream
      * Constructs a readable GridFS stream.
      *
      * @param CollectionWrapper $collectionWrapper GridFS collection wrapper
-     * @param stdClass          $file              GridFS file document
+     * @param object            $file              GridFS file document
      * @throws CorruptFileException
      */
-    public function __construct(CollectionWrapper $collectionWrapper, stdClass $file)
+    public function __construct(CollectionWrapper $collectionWrapper, object $file)
     {
         if (! isset($file->chunkSize) || ! is_integer($file->chunkSize) || $file->chunkSize < 1) {
             throw new CorruptFileException('file.chunkSize is not an integer >= 1');
@@ -120,7 +119,7 @@ class ReadableStream
         // Nothing to do
     }
 
-    public function getFile(): stdClass
+    public function getFile(): object
     {
         return $this->file;
     }

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -261,7 +261,7 @@ class ReadableStream
      * @return boolean Whether there was a current chunk to read
      * @throws CorruptFileException if an expected chunk could not be read successfully
      */
-    private function initBufferFromCurrentChunk()
+    private function initBufferFromCurrentChunk(): bool
     {
         if ($this->chunkOffset === 0 && $this->numChunks === 0) {
             return false;
@@ -298,7 +298,7 @@ class ReadableStream
      * @return boolean Whether there was a next chunk to read
      * @throws CorruptFileException if an expected chunk could not be read successfully
      */
-    private function initBufferFromNextChunk()
+    private function initBufferFromNextChunk(): bool
     {
         if ($this->chunkOffset === $this->numChunks - 1) {
             return false;
@@ -314,7 +314,7 @@ class ReadableStream
     /**
      * Initializes the chunk iterator starting from the current offset.
      */
-    private function initChunksIterator()
+    private function initChunksIterator(): void
     {
         $this->chunksIterator = $this->collectionWrapper->findChunksByFileId($this->file->_id, $this->chunkOffset);
         $this->chunksIterator->rewind();

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -106,7 +106,7 @@ class ReadableStream
      * @see https://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.debuginfo
      * @return array
      */
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         return [
             'bucketName' => $this->collectionWrapper->getBucketName(),
@@ -115,37 +115,25 @@ class ReadableStream
         ];
     }
 
-    public function close()
+    public function close(): void
     {
         // Nothing to do
     }
 
-    /**
-     * Return the stream's file document.
-     *
-     * @return stdClass
-     */
-    public function getFile()
+    public function getFile(): stdClass
     {
         return $this->file;
     }
 
-    /**
-     * Return the stream's size in bytes.
-     *
-     * @return integer
-     */
-    public function getSize()
+    public function getSize(): int
     {
         return $this->length;
     }
 
     /**
      * Return whether the current read position is at the end of the stream.
-     *
-     * @return boolean
      */
-    public function isEOF()
+    public function isEOF(): bool
     {
         if ($this->chunkOffset === $this->numChunks - 1) {
             return $this->bufferOffset >= $this->expectedLastChunkSize;
@@ -161,10 +149,9 @@ class ReadableStream
      * if data is not available to be read.
      *
      * @param integer $length Number of bytes to read
-     * @return string
      * @throws InvalidArgumentException if $length is negative
      */
-    public function readBytes(int $length)
+    public function readBytes(int $length): string
     {
         if ($length < 0) {
             throw new InvalidArgumentException(sprintf('$length must be >= 0; given: %d', $length));
@@ -198,7 +185,7 @@ class ReadableStream
      *
      * @throws InvalidArgumentException if $offset is out of range
      */
-    public function seek(int $offset)
+    public function seek(int $offset): void
     {
         if ($offset < 0 || $offset > $this->file->length) {
             throw new InvalidArgumentException(sprintf('$offset must be >= 0 and <= %d; given: %d', $this->file->length, $offset));
@@ -246,10 +233,8 @@ class ReadableStream
      * Return the current position of the stream.
      *
      * This is the offset within the stream where the next byte would be read.
-     *
-     * @return integer
      */
-    public function tell()
+    public function tell(): int
     {
         return ($this->chunkOffset * $this->chunkSize) + $this->bufferOffset;
     }

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -89,8 +89,8 @@ class ReadableStream
         }
 
         $this->file = $file;
-        $this->chunkSize = (integer) $file->chunkSize;
-        $this->length = (integer) $file->length;
+        $this->chunkSize = $file->chunkSize;
+        $this->length = $file->length;
 
         $this->collectionWrapper = $collectionWrapper;
 

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -281,7 +281,6 @@ class StreamWrapper
      * Initialize the protocol from the given path.
      *
      * @see StreamWrapper::stream_open()
-     * @param string $path
      */
     private function initProtocol(string $path): void
     {
@@ -293,7 +292,6 @@ class StreamWrapper
      * Initialize the internal stream for reading.
      *
      * @see StreamWrapper::stream_open()
-     * @return boolean
      */
     private function initReadableStream(): bool
     {
@@ -311,7 +309,6 @@ class StreamWrapper
      * Initialize the internal stream for writing.
      *
      * @see StreamWrapper::stream_open()
-     * @return boolean
      */
     private function initWritableStream(): bool
     {

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -256,7 +256,7 @@ class StreamWrapper
      *
      * @return array
      */
-    private function getStatTemplate()
+    private function getStatTemplate(): array
     {
         return [
             // phpcs:disable Squiz.Arrays.ArrayDeclaration.IndexNoNewline
@@ -283,7 +283,7 @@ class StreamWrapper
      * @see StreamWrapper::stream_open()
      * @param string $path
      */
-    private function initProtocol(string $path)
+    private function initProtocol(string $path): void
     {
         $parts = explode('://', $path, 2);
         $this->protocol = $parts[0] ?: 'gridfs';
@@ -295,7 +295,7 @@ class StreamWrapper
      * @see StreamWrapper::stream_open()
      * @return boolean
      */
-    private function initReadableStream()
+    private function initReadableStream(): bool
     {
         $context = stream_context_get_options($this->context);
 
@@ -313,7 +313,7 @@ class StreamWrapper
      * @see StreamWrapper::stream_open()
      * @return boolean
      */
-    private function initWritableStream()
+    private function initWritableStream(): bool
     {
         $context = stream_context_get_options($this->context);
 

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -64,10 +64,8 @@ class StreamWrapper
 
     /**
      * Return the stream's file document.
-     *
-     * @return stdClass
      */
-    public function getFile()
+    public function getFile(): stdClass
     {
         return $this->stream->getFile();
     }
@@ -77,7 +75,7 @@ class StreamWrapper
      *
      * @param string $protocol Protocol to use for stream_wrapper_register()
      */
-    public static function register(string $protocol = 'gridfs')
+    public static function register(string $protocol = 'gridfs'): void
     {
         if (in_array($protocol, stream_get_wrappers())) {
             stream_wrapper_unregister($protocol);
@@ -91,7 +89,7 @@ class StreamWrapper
      *
      * @see https://php.net/manual/en/streamwrapper.stream-close.php
      */
-    public function stream_close()
+    public function stream_close(): void
     {
         if (! $this->stream) {
             return;
@@ -104,9 +102,8 @@ class StreamWrapper
      * Returns whether the file pointer is at the end of the stream.
      *
      * @see https://php.net/manual/en/streamwrapper.stream-eof.php
-     * @return boolean
      */
-    public function stream_eof()
+    public function stream_eof(): bool
     {
         if (! $this->stream instanceof ReadableStream) {
             return false;
@@ -123,9 +120,8 @@ class StreamWrapper
      * @param string      $mode       Mode used to open the file (only "r" and "w" are supported)
      * @param integer     $options    Additional flags set by the streams API
      * @param string|null $openedPath Not used
-     * @return boolean
      */
-    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath)
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
     {
         $this->initProtocol($path);
         $this->mode = $mode;
@@ -149,9 +145,8 @@ class StreamWrapper
      *
      * @see https://php.net/manual/en/streamwrapper.stream-read.php
      * @param integer $length Number of bytes to read
-     * @return string
      */
-    public function stream_read(int $length)
+    public function stream_read(int $length): string
     {
         if (! $this->stream instanceof ReadableStream) {
             return '';
@@ -168,7 +163,7 @@ class StreamWrapper
      * @param integer $whence One of SEEK_SET, SEEK_CUR, or SEEK_END
      * @return boolean True if the position was updated and false otherwise
      */
-    public function stream_seek(int $offset, int $whence = SEEK_SET)
+    public function stream_seek(int $offset, int $whence = SEEK_SET): bool
     {
         $size = $this->stream->getSize();
 
@@ -198,9 +193,8 @@ class StreamWrapper
      * Return information about the stream.
      *
      * @see https://php.net/manual/en/streamwrapper.stream-stat.php
-     * @return array
      */
-    public function stream_stat()
+    public function stream_stat(): array
     {
         $stat = $this->getStatTemplate();
 
@@ -230,7 +224,7 @@ class StreamWrapper
      * @see https://php.net/manual/en/streamwrapper.stream-tell.php
      * @return integer The current position of the stream
      */
-    public function stream_tell()
+    public function stream_tell(): int
     {
         return $this->stream->tell();
     }
@@ -242,7 +236,7 @@ class StreamWrapper
      * @param string $data Data to write
      * @return integer The number of bytes written
      */
-    public function stream_write(string $data)
+    public function stream_write(string $data): int
     {
         if (! $this->stream instanceof WritableStream) {
             return 0;

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -246,8 +246,6 @@ class StreamWrapper
 
     /**
      * Returns a stat template with default values.
-     *
-     * @return array
      */
     private function getStatTemplate(): array
     {

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -18,7 +18,6 @@
 namespace MongoDB\GridFS;
 
 use MongoDB\BSON\UTCDateTime;
-use stdClass;
 
 use function explode;
 use function in_array;
@@ -65,7 +64,7 @@ class StreamWrapper
     /**
      * Return the stream's file document.
      */
-    public function getFile(): stdClass
+    public function getFile(): object
     {
         return $this->stream->getFile();
     }

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -77,7 +77,7 @@ class StreamWrapper
      *
      * @param string $protocol Protocol to use for stream_wrapper_register()
      */
-    public static function register($protocol = 'gridfs')
+    public static function register(string $protocol = 'gridfs')
     {
         if (in_array($protocol, stream_get_wrappers())) {
             stream_wrapper_unregister($protocol);
@@ -119,13 +119,13 @@ class StreamWrapper
      * Opens the stream.
      *
      * @see https://php.net/manual/en/streamwrapper.stream-open.php
-     * @param string  $path       Path to the file resource
-     * @param string  $mode       Mode used to open the file (only "r" and "w" are supported)
-     * @param integer $options    Additional flags set by the streams API
-     * @param string  $openedPath Not used
+     * @param string      $path       Path to the file resource
+     * @param string      $mode       Mode used to open the file (only "r" and "w" are supported)
+     * @param integer     $options    Additional flags set by the streams API
+     * @param string|null $openedPath Not used
      * @return boolean
      */
-    public function stream_open($path, $mode, $options, &$openedPath)
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath)
     {
         $this->initProtocol($path);
         $this->mode = $mode;
@@ -151,7 +151,7 @@ class StreamWrapper
      * @param integer $length Number of bytes to read
      * @return string
      */
-    public function stream_read($length)
+    public function stream_read(int $length)
     {
         if (! $this->stream instanceof ReadableStream) {
             return '';
@@ -168,7 +168,7 @@ class StreamWrapper
      * @param integer $whence One of SEEK_SET, SEEK_CUR, or SEEK_END
      * @return boolean True if the position was updated and false otherwise
      */
-    public function stream_seek($offset, $whence = SEEK_SET)
+    public function stream_seek(int $offset, int $whence = SEEK_SET)
     {
         $size = $this->stream->getSize();
 
@@ -242,7 +242,7 @@ class StreamWrapper
      * @param string $data Data to write
      * @return integer The number of bytes written
      */
-    public function stream_write($data)
+    public function stream_write(string $data)
     {
         if (! $this->stream instanceof WritableStream) {
             return 0;
@@ -283,7 +283,7 @@ class StreamWrapper
      * @see StreamWrapper::stream_open()
      * @param string $path
      */
-    private function initProtocol($path)
+    private function initProtocol(string $path)
     {
         $parts = explode('://', $path, 2);
         $this->protocol = $parts[0] ?: 'gridfs';

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -154,9 +154,8 @@ class WritableStream
      * Return internal properties for debugging purposes.
      *
      * @see https://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.debuginfo
-     * @return array
      */
-    public function __debugInfo()
+    public function __debugInfo(): array
     {
         return [
             'bucketName' => $this->collectionWrapper->getBucketName(),
@@ -168,7 +167,7 @@ class WritableStream
     /**
      * Closes an active stream and flushes all buffered data to GridFS.
      */
-    public function close()
+    public function close(): void
     {
         if ($this->isClosed) {
             // TODO: Should this be an error condition? e.g. BadMethodCallException
@@ -185,10 +184,8 @@ class WritableStream
 
     /**
      * Return the stream's file document.
-     *
-     * @return stdClass
      */
-    public function getFile()
+    public function getFile(): stdClass
     {
         return (object) $this->file;
     }
@@ -197,10 +194,8 @@ class WritableStream
      * Return the stream's size in bytes.
      *
      * Note: this value will increase as more data is written to the stream.
-     *
-     * @return integer
      */
-    public function getSize()
+    public function getSize(): int
     {
         return $this->length + strlen($this->buffer);
     }
@@ -213,9 +208,8 @@ class WritableStream
      * always the end of the stream.
      *
      * @see WritableStream::getSize()
-     * @return integer
      */
-    public function tell()
+    public function tell(): int
     {
         return $this->getSize();
     }
@@ -227,13 +221,12 @@ class WritableStream
      * which point a chunk document will be inserted and the buffer reset.
      *
      * @param string $data Binary data to write
-     * @return integer
      */
-    public function writeBytes(string $data)
+    public function writeBytes(string $data): int
     {
         if ($this->isClosed) {
             // TODO: Should this be an error condition? e.g. BadMethodCallException
-            return;
+            return 0;
         }
 
         $bytesRead = 0;

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -103,7 +103,7 @@ class WritableStream
      * @param array             $options           Upload options
      * @throws InvalidArgumentException
      */
-    public function __construct(CollectionWrapper $collectionWrapper, $filename, array $options = [])
+    public function __construct(CollectionWrapper $collectionWrapper, string $filename, array $options = [])
     {
         $options += [
             '_id' => new ObjectId(),
@@ -229,7 +229,7 @@ class WritableStream
      * @param string $data Binary data to write
      * @return integer
      */
-    public function writeBytes($data)
+    public function writeBytes(string $data)
     {
         if ($this->isClosed) {
             // TODO: Should this be an error condition? e.g. BadMethodCallException

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -22,7 +22,6 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException;
-use stdClass;
 
 use function array_intersect_key;
 use function hash_final;
@@ -185,7 +184,7 @@ class WritableStream
     /**
      * Return the stream's file document.
      */
-    public function getFile(): stdClass
+    public function getFile(): object
     {
         return (object) $this->file;
     }

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -146,7 +146,7 @@ class WritableStream
         $this->file = [
             '_id' => $options['_id'],
             'chunkSize' => $this->chunkSize,
-            'filename' => (string) $filename,
+            'filename' => $filename,
         ] + array_intersect_key($options, ['aliases' => 1, 'contentType' => 1, 'metadata' => 1]);
     }
 

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -251,7 +251,7 @@ class WritableStream
         return $bytesRead;
     }
 
-    private function abort()
+    private function abort(): void
     {
         try {
             $this->collectionWrapper->deleteChunksByFilesId($this->file['_id']);
@@ -285,7 +285,7 @@ class WritableStream
         return $this->file['_id'];
     }
 
-    private function insertChunkFromBuffer()
+    private function insertChunkFromBuffer(): void
     {
         if (strlen($this->buffer) == 0) {
             return;

--- a/src/InsertManyResult.php
+++ b/src/InsertManyResult.php
@@ -28,15 +28,12 @@ class InsertManyResult
     /** @var WriteResult */
     private $writeResult;
 
-    /** @var mixed[] */
+    /** @var array */
     private $insertedIds;
 
     /** @var boolean */
     private $isAcknowledged;
 
-    /**
-     * @param mixed[] $insertedIds
-     */
     public function __construct(WriteResult $writeResult, array $insertedIds)
     {
         $this->writeResult = $writeResult;
@@ -71,7 +68,7 @@ class InsertManyResult
      * field value. Any driver-generated ID will be a MongoDB\BSON\ObjectId
      * instance.
      *
-     * @return mixed[]
+     * @return array
      */
     public function getInsertedIds()
     {

--- a/src/InsertManyResult.php
+++ b/src/InsertManyResult.php
@@ -35,8 +35,7 @@ class InsertManyResult
     private $isAcknowledged;
 
     /**
-     * @param WriteResult $writeResult
-     * @param mixed[]     $insertedIds
+     * @param mixed[] $insertedIds
      */
     public function __construct(WriteResult $writeResult, array $insertedIds)
     {

--- a/src/InsertOneResult.php
+++ b/src/InsertOneResult.php
@@ -35,8 +35,7 @@ class InsertOneResult
     private $isAcknowledged;
 
     /**
-     * @param WriteResult $writeResult
-     * @param mixed       $insertedId
+     * @param mixed $insertedId
      */
     public function __construct(WriteResult $writeResult, $insertedId)
     {

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -79,7 +79,7 @@ class MapReduceResult implements IteratorAggregate
      */
     public function getExecutionTimeMS()
     {
-        return (integer) $this->executionTimeMS;
+        return $this->executionTimeMS;
     }
 
     /**

--- a/src/Model/BSONArray.php
+++ b/src/Model/BSONArray.php
@@ -51,7 +51,6 @@ class BSONArray extends ArrayObject implements JsonSerializable, Serializable, U
      *
      * @see https://php.net/oop5.magic#object.set-state
      * @see https://php.net/var-export
-     * @param array $properties
      * @return self
      */
     public static function __set_state(array $properties)

--- a/src/Model/BSONDocument.php
+++ b/src/Model/BSONDocument.php
@@ -50,9 +50,7 @@ class BSONDocument extends ArrayObject implements JsonSerializable, Serializable
      * by default.
      *
      * @see https://php.net/arrayobject.construct
-     * @param array   $input
-     * @param integer $flags
-     * @param string  $iteratorClass
+     * @param array $input
      */
     public function __construct(array $input = [], int $flags = ArrayObject::ARRAY_AS_PROPS, string $iteratorClass = 'ArrayIterator')
     {

--- a/src/Model/BSONDocument.php
+++ b/src/Model/BSONDocument.php
@@ -54,7 +54,7 @@ class BSONDocument extends ArrayObject implements JsonSerializable, Serializable
      * @param integer $flags
      * @param string  $iteratorClass
      */
-    public function __construct($input = [], $flags = ArrayObject::ARRAY_AS_PROPS, $iteratorClass = 'ArrayIterator')
+    public function __construct(array $input = [], int $flags = ArrayObject::ARRAY_AS_PROPS, string $iteratorClass = 'ArrayIterator')
     {
         parent::__construct($input, $flags, $iteratorClass);
     }

--- a/src/Model/BSONDocument.php
+++ b/src/Model/BSONDocument.php
@@ -50,7 +50,6 @@ class BSONDocument extends ArrayObject implements JsonSerializable, Serializable
      * by default.
      *
      * @see https://php.net/arrayobject.construct
-     * @param array $input
      */
     public function __construct(array $input = [], int $flags = ArrayObject::ARRAY_AS_PROPS, string $iteratorClass = 'ArrayIterator')
     {
@@ -62,7 +61,6 @@ class BSONDocument extends ArrayObject implements JsonSerializable, Serializable
      *
      * @see https://php.net/oop5.magic#object.set-state
      * @see https://php.net/var-export
-     * @param array $properties
      * @return self
      */
     public static function __set_state(array $properties)

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -130,7 +130,6 @@ class BSONIterator implements Iterator
 
     /**
      * @see https://php.net/iterator.valid
-     * @return boolean
      */
     #[ReturnTypeWillChange]
     public function valid(): bool

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -133,12 +133,12 @@ class BSONIterator implements Iterator
      * @return boolean
      */
     #[ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->current !== null;
     }
 
-    private function advance()
+    private function advance(): void
     {
         if ($this->position === $this->bufferLength) {
             return;

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -68,7 +68,7 @@ class BSONIterator implements Iterator
      * @param array  $options Iterator options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($data, array $options = [])
+    public function __construct(string $data, array $options = [])
     {
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
             throw InvalidArgumentException::invalidType('"typeMap" option', $options['typeMap'], 'array');

--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -155,7 +155,7 @@ class CachingIterator implements Countable, Iterator
     /**
      * Ensures that the inner iterator is fully consumed and cached.
      */
-    private function exhaustIterator()
+    private function exhaustIterator(): void
     {
         while (! $this->iteratorExhausted) {
             $this->next();
@@ -165,7 +165,7 @@ class CachingIterator implements Countable, Iterator
     /**
      * Stores the current item in the cache.
      */
-    private function storeCurrentItem()
+    private function storeCurrentItem(): void
     {
         if (! $this->iterator->valid()) {
             return;

--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -72,10 +72,8 @@ class CachingIterator implements Countable, Iterator
 
     /**
      * @see https://php.net/countable.count
-     * @return integer
      */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         $this->exhaustIterator();
 
@@ -108,10 +106,8 @@ class CachingIterator implements Countable, Iterator
 
     /**
      * @see https://php.net/iterator.next
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         if (! $this->iteratorExhausted) {
             $this->iteratorAdvanced = true;
@@ -127,10 +123,8 @@ class CachingIterator implements Countable, Iterator
 
     /**
      * @see https://php.net/iterator.rewind
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         /* If the iterator has advanced, exhaust it now so that future iteration
          * can rely on the cache.
@@ -144,10 +138,8 @@ class CachingIterator implements Countable, Iterator
 
     /**
      * @see https://php.net/iterator.valid
-     * @return boolean
      */
-    #[ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->key() !== null;
     }

--- a/src/Model/CallbackIterator.php
+++ b/src/Model/CallbackIterator.php
@@ -64,30 +64,24 @@ class CallbackIterator implements Iterator
 
     /**
      * @see https://php.net/iterator.next
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         $this->iterator->next();
     }
 
     /**
      * @see https://php.net/iterator.rewind
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         $this->iterator->rewind();
     }
 
     /**
      * @see https://php.net/iterator.valid
-     * @return boolean
      */
-    #[ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->iterator->valid();
     }

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -76,7 +76,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      * @param array|object|null $initialResumeToken
      * @param object|null       $postBatchResumeToken
      */
-    public function __construct(Cursor $cursor, int $firstBatchSize, $initialResumeToken, $postBatchResumeToken)
+    public function __construct(Cursor $cursor, int $firstBatchSize, $initialResumeToken, ?object $postBatchResumeToken)
     {
         if (! is_integer($firstBatchSize)) {
             throw InvalidArgumentException::invalidType('$firstBatchSize', $firstBatchSize, 'integer');

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -273,7 +273,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      *
      * @return boolean
      */
-    private function isAtEndOfBatch()
+    private function isAtEndOfBatch(): bool
     {
         return $this->batchPosition + 1 >= $this->batchSize;
     }
@@ -284,7 +284,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#updating-the-cached-resume-token
      * @param boolean $incrementBatchPosition
      */
-    private function onIteration(bool $incrementBatchPosition)
+    private function onIteration(bool $incrementBatchPosition): void
     {
         $this->isValid = parent::valid();
 

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -76,7 +76,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      * @param array|object|null $initialResumeToken
      * @param object|null       $postBatchResumeToken
      */
-    public function __construct(Cursor $cursor, $firstBatchSize, $initialResumeToken, $postBatchResumeToken)
+    public function __construct(Cursor $cursor, int $firstBatchSize, $initialResumeToken, $postBatchResumeToken)
     {
         if (! is_integer($firstBatchSize)) {
             throw InvalidArgumentException::invalidType('$firstBatchSize', $firstBatchSize, 'integer');
@@ -284,7 +284,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#updating-the-cached-resume-token
      * @param boolean $incrementBatchPosition
      */
-    private function onIteration($incrementBatchPosition)
+    private function onIteration(bool $incrementBatchPosition)
     {
         $this->isValid = parent::valid();
 

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -177,10 +177,8 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 
     /**
      * @see https://php.net/iteratoriterator.rewind
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         /* Determine if advancing the iterator will execute a getMore command
          * (i.e. we are already positioned at the end of the current batch). If
@@ -205,10 +203,8 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 
     /**
      * @see https://php.net/iteratoriterator.rewind
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->isRewindNop) {
             return;
@@ -220,10 +216,8 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 
     /**
      * @see https://php.net/iteratoriterator.valid
-     * @return boolean
      */
-    #[ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->isValid;
     }

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -71,10 +71,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 
     /**
      * @internal
-     * @param Cursor            $cursor
-     * @param integer           $firstBatchSize
      * @param array|object|null $initialResumeToken
-     * @param object|null       $postBatchResumeToken
      */
     public function __construct(Cursor $cursor, int $firstBatchSize, $initialResumeToken, ?object $postBatchResumeToken)
     {
@@ -270,8 +267,6 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 
     /**
      * Return whether the iterator is positioned at the end of the batch.
-     *
-     * @return boolean
      */
     private function isAtEndOfBatch(): bool
     {
@@ -282,7 +277,6 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      * Perform housekeeping after an iteration event.
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#updating-the-cached-resume-token
-     * @param boolean $incrementBatchPosition
      */
     private function onIteration(bool $incrementBatchPosition): void
     {

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -86,8 +86,6 @@ class CollectionInfo implements ArrayAccess
 
     /**
      * Return information about the _id index for the collection.
-     *
-     * @return array
      */
     public function getIdIndex(): array
     {
@@ -98,7 +96,6 @@ class CollectionInfo implements ArrayAccess
      * Return the "info" property of the server response.
      *
      * @see https://mongodb.com/docs/manual/reference/command/listCollections/#output
-     * @return array
      */
     public function getInfo(): array
     {

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -131,7 +131,6 @@ class CollectionInfo implements ArrayAccess
      * Return the collection type.
      *
      * @see https://mongodb.com/docs/manual/reference/command/listCollections/#output
-     * @return string
      */
     public function getType(): string
     {

--- a/src/Model/CollectionInfoCommandIterator.php
+++ b/src/Model/CollectionInfoCommandIterator.php
@@ -18,7 +18,6 @@
 namespace MongoDB\Model;
 
 use IteratorIterator;
-use ReturnTypeWillChange;
 use Traversable;
 
 /**
@@ -49,10 +48,8 @@ class CollectionInfoCommandIterator extends IteratorIterator implements Collecti
      *
      * @see CollectionInfoIterator::current()
      * @see https://php.net/iterator.current
-     * @return CollectionInfo
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): CollectionInfo
     {
         $info = parent::current();
 

--- a/src/Model/CollectionInfoCommandIterator.php
+++ b/src/Model/CollectionInfoCommandIterator.php
@@ -37,10 +37,7 @@ class CollectionInfoCommandIterator extends IteratorIterator implements Collecti
     /** @var string|null */
     private $databaseName;
 
-    /**
-     * @param string|null $databaseName
-     */
-    public function __construct(Traversable $iterator, $databaseName = null)
+    public function __construct(Traversable $iterator, ?string $databaseName = null)
     {
         parent::__construct($iterator);
 

--- a/src/Model/DatabaseInfoLegacyIterator.php
+++ b/src/Model/DatabaseInfoLegacyIterator.php
@@ -37,9 +37,6 @@ class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
     /** @var array */
     private $databases;
 
-    /**
-     * @param array $databases
-     */
     public function __construct(array $databases)
     {
         $this->databases = $databases;

--- a/src/Model/DatabaseInfoLegacyIterator.php
+++ b/src/Model/DatabaseInfoLegacyIterator.php
@@ -17,8 +17,6 @@
 
 namespace MongoDB\Model;
 
-use ReturnTypeWillChange;
-
 use function current;
 use function key;
 use function next;
@@ -52,9 +50,8 @@ class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
      *
      * @see DatabaseInfoIterator::current()
      * @see https://php.net/iterator.current
-     * @return DatabaseInfo
      */
-    public function current()
+    public function current(): DatabaseInfo
     {
         return new DatabaseInfo(current($this->databases));
     }
@@ -63,10 +60,8 @@ class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
      * Return the key of the current element.
      *
      * @see https://php.net/iterator.key
-     * @return integer
      */
-    #[ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         return key($this->databases);
     }
@@ -75,10 +70,8 @@ class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
      * Move forward to next element.
      *
      * @see https://php.net/iterator.next
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         next($this->databases);
     }
@@ -87,10 +80,8 @@ class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
      * Rewind the Iterator to the first element.
      *
      * @see https://php.net/iterator.rewind
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->databases);
     }
@@ -99,10 +90,8 @@ class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
      * Checks if current position is valid.
      *
      * @see https://php.net/iterator.valid
-     * @return boolean
      */
-    #[ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return key($this->databases) !== null;
     }

--- a/src/Model/IndexInfoIteratorIterator.php
+++ b/src/Model/IndexInfoIteratorIterator.php
@@ -18,7 +18,6 @@
 namespace MongoDB\Model;
 
 use IteratorIterator;
-use ReturnTypeWillChange;
 use Traversable;
 
 use function array_key_exists;
@@ -53,10 +52,8 @@ class IndexInfoIteratorIterator extends IteratorIterator implements IndexInfoIte
      *
      * @see IndexInfoIterator::current()
      * @see https://php.net/iterator.current
-     * @return IndexInfo
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): IndexInfo
     {
         $info = parent::current();
 

--- a/src/Model/IndexInfoIteratorIterator.php
+++ b/src/Model/IndexInfoIteratorIterator.php
@@ -41,10 +41,7 @@ class IndexInfoIteratorIterator extends IteratorIterator implements IndexInfoIte
     /** @var string|null $ns */
     private $ns;
 
-    /**
-     * @param string|null $ns
-     */
-    public function __construct(Traversable $iterator, $ns = null)
+    public function __construct(Traversable $iterator, ?string $ns = null)
     {
         parent::__construct($iterator);
 

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -19,7 +19,6 @@ namespace MongoDB\Model;
 
 use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
-use ReturnTypeWillChange;
 
 use function is_array;
 use function is_float;
@@ -77,10 +76,8 @@ class IndexInput implements Serializable
 
     /**
      * Return the index name.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->index['name'];
     }
@@ -90,10 +87,8 @@ class IndexInput implements Serializable
      *
      * @see \MongoDB\Collection::createIndexes()
      * @see https://php.net/mongodb-bson-serializable.bsonserialize
-     * @return array
      */
-    #[ReturnTypeWillChange]
-    public function bsonSerialize()
+    public function bsonSerialize(): array
     {
         return $this->index;
     }

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -246,8 +246,8 @@ class Aggregate implements Executable, Explainable
             unset($options['batchSize']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = isset($collectionName) ? (string) $collectionName : null;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName ?? null;
         $this->pipeline = $pipeline;
         $this->options = $options;
     }

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -256,7 +256,6 @@ class Aggregate implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return Traversable
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if read concern or write concern is used and unsupported
@@ -307,7 +306,6 @@ class Aggregate implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -247,7 +247,7 @@ class Aggregate implements Executable, Explainable
         }
 
         $this->databaseName = $databaseName;
-        $this->collectionName = $collectionName ?? null;
+        $this->collectionName = $collectionName;
         $this->pipeline = $pipeline;
         $this->options = $options;
     }
@@ -315,8 +315,6 @@ class Aggregate implements Executable, Explainable
 
     /**
      * Create the aggregate command document.
-     *
-     * @return array
      */
     private function createCommandDocument(): array
     {

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -320,7 +320,7 @@ class Aggregate implements Executable, Explainable
      *
      * @return array
      */
-    private function createCommandDocument()
+    private function createCommandDocument(): array
     {
         $cmd = [
             'aggregate' => $this->collectionName ?? 1,

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -137,7 +137,7 @@ class Aggregate implements Executable, Explainable
      * @param array       $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $pipeline, array $options = [])
+    public function __construct(string $databaseName, ?string $collectionName, array $pipeline, array $options = [])
     {
         $expectedIndex = 0;
 

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -354,7 +354,7 @@ class BulkWrite implements Executable
      * @see https://php.net/manual/en/mongodb-driver-bulkwrite.construct.php
      * @return array
      */
-    private function createBulkWriteOptions()
+    private function createBulkWriteOptions(): array
     {
         $options = ['ordered' => $this->options['ordered']];
 
@@ -377,7 +377,7 @@ class BulkWrite implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
      * @return array
      */
-    private function createExecuteOptions()
+    private function createExecuteOptions(): array
     {
         $options = [];
 

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -297,8 +297,8 @@ class BulkWrite implements Executable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->operations = $operations;
         $this->options = $options;
     }

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -127,7 +127,7 @@ class BulkWrite implements Executable
      * @param array   $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $operations, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $operations, array $options = [])
     {
         if (empty($operations)) {
             throw new InvalidArgumentException('$operations is empty');

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -351,7 +351,6 @@ class BulkWrite implements Executable
      * Create options for constructing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-bulkwrite.construct.php
-     * @return array
      */
     private function createBulkWriteOptions(): array
     {
@@ -374,7 +373,6 @@ class BulkWrite implements Executable
      * Create options for executing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
-     * @return array
      */
     private function createExecuteOptions(): array
     {

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -307,7 +307,6 @@ class BulkWrite implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return BulkWriteResult
      * @throws UnsupportedException if write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -90,7 +90,7 @@ class Count implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter = [], array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter = [], array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -183,7 +183,7 @@ class Count implements Executable, Explainable
      *
      * @return array
      */
-    private function createCommandDocument()
+    private function createCommandDocument(): array
     {
         $cmd = ['count' => $this->collectionName];
 
@@ -214,7 +214,7 @@ class Count implements Executable, Explainable
      * @see https://php.net/manual/en/mongodb-driver-server.executereadcommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -142,7 +142,6 @@ class Count implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return integer
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if read concern is used and unsupported
@@ -170,7 +169,6 @@ class Count implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -178,8 +178,6 @@ class Count implements Executable, Explainable
 
     /**
      * Create the count command document.
-     *
-     * @return array
      */
     private function createCommandDocument(): array
     {
@@ -210,7 +208,6 @@ class Count implements Executable, Explainable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executereadcommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -132,8 +132,8 @@ class Count implements Executable, Explainable
             unset($options['readConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->filter = $filter;
         $this->options = $options;
     }

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -121,7 +121,6 @@ class CountDocuments implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return integer
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if collation or read concern is used and unsupported

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -146,10 +146,7 @@ class CountDocuments implements Executable
         return (integer) $result->n;
     }
 
-    /**
-     * @return Aggregate
-     */
-    private function createAggregate()
+    private function createAggregate(): Aggregate
     {
         $pipeline = [
             ['$match' => (object) $this->filter],

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -93,7 +93,7 @@ class CountDocuments implements Executable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -107,8 +107,8 @@ class CountDocuments implements Executable
             throw InvalidArgumentException::invalidType('"skip" option', $options['skip'], 'integer');
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->filter = $filter;
 
         $this->aggregateOptions = array_intersect_key($options, ['collation' => 1, 'comment' => 1, 'hint' => 1, 'maxTimeMS' => 1, 'readConcern' => 1, 'readPreference' => 1, 'session' => 1]);

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -265,7 +265,6 @@ class CreateCollection implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object Command result document
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
@@ -282,8 +281,6 @@ class CreateCollection implements Executable
 
     /**
      * Create the create command.
-     *
-     * @return Command
      */
     private function createCommand(): Command
     {

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -256,8 +256,8 @@ class CreateCollection implements Executable
             }
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->options = $options;
     }
 

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -142,7 +142,7 @@ class CreateCollection implements Executable
      * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $options = [])
     {
         if (isset($options['autoIndexId']) && ! is_bool($options['autoIndexId'])) {
             throw InvalidArgumentException::invalidType('"autoIndexId" option', $options['autoIndexId'], 'boolean');

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -285,7 +285,7 @@ class CreateCollection implements Executable
      *
      * @return Command
      */
-    private function createCommand()
+    private function createCommand(): Command
     {
         $cmd = ['create' => $this->collectionName];
 
@@ -310,7 +310,7 @@ class CreateCollection implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -305,7 +305,6 @@ class CreateCollection implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -135,7 +135,6 @@ class CreateIndexes implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return string[] The names of the created indexes
      * @throws UnsupportedException if write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -179,7 +178,6 @@ class CreateIndexes implements Executable
      * Create one or more indexes for the collection using the createIndexes
      * command.
      *
-     * @param Server $server
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     private function executeCommand(Server $server): void

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -84,7 +84,7 @@ class CreateIndexes implements Executable
      * @param array   $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $indexes, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $indexes, array $options = [])
     {
         if (empty($indexes)) {
             throw new InvalidArgumentException('$indexes is empty');

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -157,7 +157,6 @@ class CreateIndexes implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -160,7 +160,7 @@ class CreateIndexes implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 
@@ -182,7 +182,7 @@ class CreateIndexes implements Executable
      * @param Server $server
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    private function executeCommand(Server $server)
+    private function executeCommand(Server $server): void
     {
         $cmd = [
             'createIndexes' => $this->collectionName,

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -126,8 +126,8 @@ class CreateIndexes implements Executable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->options = $options;
     }
 

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -109,7 +109,6 @@ class DatabaseCommand implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -112,7 +112,7 @@ class DatabaseCommand implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -65,7 +65,7 @@ class DatabaseCommand implements Executable
      * @param array        $options      Options for command execution
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $command, array $options = [])
+    public function __construct(string $databaseName, $command, array $options = [])
     {
         if (! is_array($command) && ! is_object($command)) {
             throw InvalidArgumentException::invalidType('$command', $command, 'array or object');

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -92,7 +92,6 @@ class DatabaseCommand implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return Cursor
      */
     public function execute(Server $server)

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -83,7 +83,7 @@ class DatabaseCommand implements Executable
             throw InvalidArgumentException::invalidType('"typeMap" option', $options['typeMap'], 'array');
         }
 
-        $this->databaseName = (string) $databaseName;
+        $this->databaseName = $databaseName;
         $this->command = $command instanceof Command ? $command : new Command($command);
         $this->options = $options;
     }

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -217,7 +217,7 @@ class Delete implements Executable, Explainable
      *
      * @return array
      */
-    private function createDeleteOptions()
+    private function createDeleteOptions(): array
     {
         $deleteOptions = ['limit' => $this->limit];
 
@@ -238,7 +238,7 @@ class Delete implements Executable, Explainable
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
      * @return array
      */
-    private function createExecuteOptions()
+    private function createExecuteOptions(): array
     {
         $options = [];
 

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -142,7 +142,6 @@ class Delete implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return DeleteResult
      * @throws UnsupportedException if hint or write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -175,7 +174,6 @@ class Delete implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -97,7 +97,7 @@ class Delete implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, $limit, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, int $limit, array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -131,8 +131,8 @@ class Delete implements Executable, Explainable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->filter = $filter;
         $this->limit = $limit;
         $this->options = $options;

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -212,8 +212,6 @@ class Delete implements Executable, Explainable
      *
      * Note that these options are different from the bulk write options, which
      * are created in createExecuteOptions().
-     *
-     * @return array
      */
     private function createDeleteOptions(): array
     {
@@ -234,7 +232,6 @@ class Delete implements Executable, Explainable
      * Create options for executing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
-     * @return array
      */
     private function createExecuteOptions(): array
     {

--- a/src/Operation/DeleteMany.php
+++ b/src/Operation/DeleteMany.php
@@ -77,7 +77,6 @@ class DeleteMany implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return DeleteResult
      * @throws UnsupportedException if collation is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -91,7 +90,6 @@ class DeleteMany implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/DeleteMany.php
+++ b/src/Operation/DeleteMany.php
@@ -68,7 +68,7 @@ class DeleteMany implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         $this->delete = new Delete($databaseName, $collectionName, $filter, 0, $options);
     }

--- a/src/Operation/DeleteOne.php
+++ b/src/Operation/DeleteOne.php
@@ -77,7 +77,6 @@ class DeleteOne implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return DeleteResult
      * @throws UnsupportedException if collation is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -91,7 +90,6 @@ class DeleteOne implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/DeleteOne.php
+++ b/src/Operation/DeleteOne.php
@@ -68,7 +68,7 @@ class DeleteOne implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         $this->delete = new Delete($databaseName, $collectionName, $filter, 1, $options);
     }

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -131,7 +131,6 @@ class Distinct implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return mixed[]
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if read concern is used and unsupported
@@ -163,7 +162,6 @@ class Distinct implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -131,7 +131,7 @@ class Distinct implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return mixed[]
+     * @return array
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if read concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -171,8 +171,6 @@ class Distinct implements Executable, Explainable
 
     /**
      * Create the distinct command document.
-     *
-     * @return array
      */
     private function createCommandDocument(): array
     {
@@ -202,7 +200,6 @@ class Distinct implements Executable, Explainable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executereadcommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -86,7 +86,7 @@ class Distinct implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $fieldName, $filter = [], array $options = [])
+    public function __construct(string $databaseName, string $collectionName, string $fieldName, $filter = [], array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -120,9 +120,9 @@ class Distinct implements Executable, Explainable
             unset($options['readConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
-        $this->fieldName = (string) $fieldName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
+        $this->fieldName = $fieldName;
         $this->filter = $filter;
         $this->options = $options;
     }

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -176,7 +176,7 @@ class Distinct implements Executable, Explainable
      *
      * @return array
      */
-    private function createCommandDocument()
+    private function createCommandDocument(): array
     {
         $cmd = [
             'distinct' => $this->collectionName,
@@ -206,7 +206,7 @@ class Distinct implements Executable, Explainable
      * @see https://php.net/manual/en/mongodb-driver-server.executereadcommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -135,7 +135,7 @@ class DropCollection implements Executable
      *
      * @return Command
      */
-    private function createCommand()
+    private function createCommand(): Command
     {
         $cmd = ['drop' => $this->collectionName];
 
@@ -152,7 +152,7 @@ class DropCollection implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -89,8 +89,8 @@ class DropCollection implements Executable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->options = $options;
     }
 

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -147,7 +147,6 @@ class DropCollection implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -71,7 +71,7 @@ class DropCollection implements Executable
      * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $options = [])
     {
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
             throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -98,7 +98,6 @@ class DropCollection implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object Command result document
      * @throws UnsupportedException if write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -132,8 +131,6 @@ class DropCollection implements Executable
 
     /**
      * Create the drop command.
-     *
-     * @return Command
      */
     private function createCommand(): Command
     {

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -89,7 +89,6 @@ class DropDatabase implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object Command result document
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
@@ -106,8 +105,6 @@ class DropDatabase implements Executable
 
     /**
      * Create the dropDatabase command.
-     *
-     * @return Command
      */
     private function createCommand(): Command
     {

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -109,7 +109,7 @@ class DropDatabase implements Executable
      *
      * @return Command
      */
-    private function createCommand()
+    private function createCommand(): Command
     {
         $cmd = ['dropDatabase' => 1];
 
@@ -126,7 +126,7 @@ class DropDatabase implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -63,7 +63,7 @@ class DropDatabase implements Executable
      * @param array  $options      Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, array $options = [])
+    public function __construct(string $databaseName, array $options = [])
     {
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
             throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -121,7 +121,6 @@ class DropDatabase implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -81,7 +81,7 @@ class DropDatabase implements Executable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
+        $this->databaseName = $databaseName;
         $this->options = $options;
     }
 

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -139,7 +139,7 @@ class DropIndexes implements Executable
      *
      * @return Command
      */
-    private function createCommand()
+    private function createCommand(): Command
     {
         $cmd = [
             'dropIndexes' => $this->collectionName,
@@ -161,7 +161,7 @@ class DropIndexes implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -77,7 +77,7 @@ class DropIndexes implements Executable
      */
     public function __construct(string $databaseName, string $collectionName, string $indexName, array $options = [])
     {
-        $indexName = (string) $indexName;
+        $indexName = $indexName;
 
         if ($indexName === '') {
             throw new InvalidArgumentException('$indexName cannot be empty');
@@ -103,8 +103,8 @@ class DropIndexes implements Executable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->indexName = $indexName;
         $this->options = $options;
     }

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -113,7 +113,6 @@ class DropIndexes implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object Command result document
      * @throws UnsupportedException if write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -136,8 +135,6 @@ class DropIndexes implements Executable
 
     /**
      * Create the dropIndexes command.
-     *
-     * @return Command
      */
     private function createCommand(): Command
     {

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -75,7 +75,7 @@ class DropIndexes implements Executable
      * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $indexName, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, string $indexName, array $options = [])
     {
         $indexName = (string) $indexName;
 

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -156,7 +156,6 @@ class DropIndexes implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -105,7 +105,6 @@ class EstimatedDocumentCount implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return integer
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if collation or read concern is used and unsupported
@@ -120,7 +119,6 @@ class EstimatedDocumentCount implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -79,8 +79,8 @@ class EstimatedDocumentCount implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, array $options = [])
     {
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
 
         if (isset($options['maxTimeMS']) && ! is_integer($options['maxTimeMS'])) {
             throw InvalidArgumentException::invalidType('"maxTimeMS" option', $options['maxTimeMS'], 'integer');

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -77,7 +77,7 @@ class EstimatedDocumentCount implements Executable, Explainable
      * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $options = [])
     {
         $this->databaseName = (string) $databaseName;
         $this->collectionName = (string) $collectionName;

--- a/src/Operation/Executable.php
+++ b/src/Operation/Executable.php
@@ -32,7 +32,6 @@ interface Executable
     /**
      * Execute the operation.
      *
-     * @param Server $server
      * @return mixed
      */
     public function execute(Server $server);

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -78,7 +78,7 @@ class Explain implements Executable
      * @param array       $options      Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, Explainable $explainable, array $options = [])
+    public function __construct(string $databaseName, Explainable $explainable, array $options = [])
     {
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {
             throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -105,7 +105,6 @@ class Explain implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object
      * @throws UnsupportedException if the server does not support explaining the operation
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -127,9 +126,6 @@ class Explain implements Executable
 
     /**
      * Create the explain command.
-     *
-     * @param Server $server
-     * @return Command
      */
     private function createCommand(Server $server): Command
     {

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -144,7 +144,6 @@ class Explain implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -131,7 +131,7 @@ class Explain implements Executable
      * @param Server $server
      * @return Command
      */
-    private function createCommand(Server $server)
+    private function createCommand(Server $server): Command
     {
         $cmd = ['explain' => $this->explainable->getCommandDocument($server)];
 
@@ -150,7 +150,7 @@ class Explain implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/Explainable.php
+++ b/src/Operation/Explainable.php
@@ -30,7 +30,6 @@ interface Explainable extends Executable
     /**
      * Returns the command document for this operation.
      *
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server);

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -292,8 +292,8 @@ class Find implements Executable, Explainable
             trigger_error('The "maxScan" option is deprecated and will be removed in a future release', E_USER_DEPRECATED);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->filter = $filter;
         $this->options = $options;
     }

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -160,7 +160,7 @@ class Find implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -382,7 +382,7 @@ class Find implements Executable, Explainable
      * @see https://php.net/manual/en/mongodb-driver-server.executequery.php
      * @return array
      */
-    private function createExecuteOptions()
+    private function createExecuteOptions(): array
     {
         $options = [];
 
@@ -405,7 +405,7 @@ class Find implements Executable, Explainable
      *
      * @return array
      */
-    private function createQueryOptions()
+    private function createQueryOptions(): array
     {
         $options = [];
 

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -378,7 +378,6 @@ class Find implements Executable, Explainable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executequery.php
-     * @return array
      */
     private function createExecuteOptions(): array
     {
@@ -400,8 +399,6 @@ class Find implements Executable, Explainable
      *
      * Note that these are separate from the options for executing the command,
      * which are created in createExecuteOptions().
-     *
-     * @return array
      */
     private function createQueryOptions(): array
     {

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -302,7 +302,6 @@ class Find implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return Cursor
      * @throws UnsupportedException if read concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -327,7 +326,6 @@ class Find implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -218,7 +218,6 @@ class FindAndModify implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object|null
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if hint or write concern is used and unsupported
@@ -261,7 +260,6 @@ class FindAndModify implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -129,7 +129,7 @@ class FindAndModify implements Executable, Explainable
      * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $options)
+    public function __construct(string $databaseName, string $collectionName, array $options)
     {
         $options += ['remove' => false];
 

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -209,8 +209,8 @@ class FindAndModify implements Executable, Explainable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->options = $options;
     }
 

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -269,8 +269,6 @@ class FindAndModify implements Executable, Explainable
 
     /**
      * Create the findAndModify command document.
-     *
-     * @return array
      */
     private function createCommandDocument(): array
     {
@@ -313,7 +311,6 @@ class FindAndModify implements Executable, Explainable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -274,7 +274,7 @@ class FindAndModify implements Executable, Explainable
      *
      * @return array
      */
-    private function createCommandDocument()
+    private function createCommandDocument(): array
     {
         $cmd = ['findAndModify' => $this->collectionName];
 
@@ -317,7 +317,7 @@ class FindAndModify implements Executable, Explainable
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -117,7 +117,6 @@ class FindOne implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object|null
      * @throws UnsupportedException if collation or read concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -134,7 +133,6 @@ class FindOne implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -103,7 +103,7 @@ class FindOne implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         $this->find = new Find(
             $databaseName,

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -108,7 +108,6 @@ class FindOneAndDelete implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object|null
      * @throws UnsupportedException if collation or write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -122,7 +121,6 @@ class FindOneAndDelete implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -81,7 +81,7 @@ class FindOneAndDelete implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -151,7 +151,6 @@ class FindOneAndReplace implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object|null
      * @throws UnsupportedException if collation or write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -165,7 +164,6 @@ class FindOneAndReplace implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -100,7 +100,7 @@ class FindOneAndReplace implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, $replacement, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, $replacement, array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -104,7 +104,7 @@ class FindOneAndUpdate implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, $update, array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -155,7 +155,6 @@ class FindOneAndUpdate implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object|null
      * @throws UnsupportedException if collation or write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -169,7 +168,6 @@ class FindOneAndUpdate implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -165,7 +165,7 @@ class InsertMany implements Executable
      * @see https://php.net/manual/en/mongodb-driver-bulkwrite.construct.php
      * @return array
      */
-    private function createBulkWriteOptions()
+    private function createBulkWriteOptions(): array
     {
         $options = ['ordered' => $this->options['ordered']];
 
@@ -184,7 +184,7 @@ class InsertMany implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
      * @return array
      */
-    private function createExecuteOptions()
+    private function createExecuteOptions(): array
     {
         $options = [];
 

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -162,7 +162,6 @@ class InsertMany implements Executable
      * Create options for constructing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-bulkwrite.construct.php
-     * @return array
      */
     private function createBulkWriteOptions(): array
     {
@@ -181,7 +180,6 @@ class InsertMany implements Executable
      * Create options for executing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
-     * @return array
      */
     private function createExecuteOptions(): array
     {

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -125,8 +125,8 @@ class InsertMany implements Executable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->documents = $documents;
         $this->options = $options;
     }

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -79,7 +79,7 @@ class InsertMany implements Executable
      * @param array            $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $documents, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $documents, array $options = [])
     {
         if (empty($documents)) {
             throw new InvalidArgumentException('$documents is empty');

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -135,7 +135,6 @@ class InsertMany implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return InsertManyResult
      * @throws UnsupportedException if write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -135,7 +135,7 @@ class InsertOne implements Executable
      * @see https://php.net/manual/en/mongodb-driver-bulkwrite.construct.php
      * @return array
      */
-    private function createBulkWriteOptions()
+    private function createBulkWriteOptions(): array
     {
         $options = [];
 
@@ -154,7 +154,7 @@ class InsertOne implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
      * @return array
      */
-    private function createExecuteOptions()
+    private function createExecuteOptions(): array
     {
         $options = [];
 

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -73,7 +73,7 @@ class InsertOne implements Executable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $document, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $document, array $options = [])
     {
         if (! is_array($document) && ! is_object($document)) {
             throw InvalidArgumentException::invalidType('$document', $document, 'array or object');

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -109,7 +109,6 @@ class InsertOne implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return InsertOneResult
      * @throws UnsupportedException if write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -132,7 +132,6 @@ class InsertOne implements Executable
      * Create options for constructing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-bulkwrite.construct.php
-     * @return array
      */
     private function createBulkWriteOptions(): array
     {
@@ -151,7 +150,6 @@ class InsertOne implements Executable
      * Create options for executing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
-     * @return array
      */
     private function createExecuteOptions(): array
     {

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -99,8 +99,8 @@ class InsertOne implements Executable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->document = $document;
         $this->options = $options;
     }

--- a/src/Operation/ListCollectionNames.php
+++ b/src/Operation/ListCollectionNames.php
@@ -70,7 +70,6 @@ class ListCollectionNames implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return Iterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Operation/ListCollectionNames.php
+++ b/src/Operation/ListCollectionNames.php
@@ -61,7 +61,7 @@ class ListCollectionNames implements Executable
      * @param array  $options      Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, array $options = [])
+    public function __construct(string $databaseName, array $options = [])
     {
         $this->listCollections = new ListCollectionsCommand($databaseName, ['nameOnly' => true] + $options);
     }

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -74,7 +74,6 @@ class ListCollections implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return CollectionInfoIterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -64,7 +64,7 @@ class ListCollections implements Executable
      * @param array  $options      Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, array $options = [])
+    public function __construct(string $databaseName, array $options = [])
     {
         $this->databaseName = (string) $databaseName;
         $this->listCollections = new ListCollectionsCommand($databaseName, ['nameOnly' => false] + $options);

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -66,7 +66,7 @@ class ListCollections implements Executable
      */
     public function __construct(string $databaseName, array $options = [])
     {
-        $this->databaseName = (string) $databaseName;
+        $this->databaseName = $databaseName;
         $this->listCollections = new ListCollectionsCommand($databaseName, ['nameOnly' => false] + $options);
     }
 

--- a/src/Operation/ListDatabaseNames.php
+++ b/src/Operation/ListDatabaseNames.php
@@ -72,7 +72,6 @@ class ListDatabaseNames implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return Iterator
      * @throws UnexpectedValueException if the command response was malformed
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Operation/ListDatabaseNames.php
+++ b/src/Operation/ListDatabaseNames.php
@@ -72,7 +72,6 @@ class ListDatabaseNames implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return Iterator
      * @throws UnexpectedValueException if the command response was malformed
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -70,7 +70,6 @@ class ListDatabases implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return DatabaseInfoIterator
      * @throws UnexpectedValueException if the command response was malformed
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -83,8 +83,8 @@ class ListIndexes implements Executable
             throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->options = $options;
     }
 

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -92,7 +92,6 @@ class ListIndexes implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return IndexInfoIterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
@@ -125,8 +124,6 @@ class ListIndexes implements Executable
      * Returns information for all indexes for this collection using the
      * listIndexes command.
      *
-     * @param Server $server
-     * @return IndexInfoIteratorIterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     private function executeCommand(Server $server): IndexInfoIteratorIterator

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -110,7 +110,7 @@ class ListIndexes implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 
@@ -129,7 +129,7 @@ class ListIndexes implements Executable
      * @return IndexInfoIteratorIterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    private function executeCommand(Server $server)
+    private function executeCommand(Server $server): IndexInfoIteratorIterator
     {
         $cmd = ['listIndexes' => $this->collectionName];
 

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -73,7 +73,7 @@ class ListIndexes implements Executable
      * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $options = [])
     {
         if (isset($options['maxTimeMS']) && ! is_integer($options['maxTimeMS'])) {
             throw InvalidArgumentException::invalidType('"maxTimeMS" option', $options['maxTimeMS'], 'integer');

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -107,7 +107,6 @@ class ListIndexes implements Executable
      * the command be executed on the primary.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -251,8 +251,8 @@ class MapReduce implements Executable
 
         $this->checkOutDeprecations($out);
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->map = $map;
         $this->reduce = $reduce;
         $this->out = $out;

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -158,7 +158,7 @@ class MapReduce implements Executable
      * @param array               $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, JavascriptInterface $map, JavascriptInterface $reduce, $out, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, JavascriptInterface $map, JavascriptInterface $reduce, $out, array $options = [])
     {
         if (! is_string($out) && ! is_array($out) && ! is_object($out)) {
             throw InvalidArgumentException::invalidType('$out', $out, 'string or array or object');
@@ -400,7 +400,7 @@ class MapReduce implements Executable
      * @param boolean $hasOutputCollection
      * @return array
      */
-    private function createOptions($hasOutputCollection)
+    private function createOptions(bool $hasOutputCollection)
     {
         $options = [];
 

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -312,7 +312,7 @@ class MapReduce implements Executable
      * @param string|array|object $out
      * @return void
      */
-    private function checkOutDeprecations($out)
+    private function checkOutDeprecations($out): void
     {
         if (is_string($out)) {
             return;
@@ -334,7 +334,7 @@ class MapReduce implements Executable
      *
      * @return Command
      */
-    private function createCommand()
+    private function createCommand(): Command
     {
         $cmd = [
             'mapReduce' => $this->collectionName,
@@ -366,7 +366,7 @@ class MapReduce implements Executable
      * @return callable
      * @throws UnexpectedValueException if the command response was malformed
      */
-    private function createGetIteratorCallable(stdClass $result, Server $server)
+    private function createGetIteratorCallable(stdClass $result, Server $server): callable
     {
         // Inline results can be wrapped with an ArrayIterator
         if (isset($result->results) && is_array($result->results)) {
@@ -400,7 +400,7 @@ class MapReduce implements Executable
      * @param boolean $hasOutputCollection
      * @return array
      */
-    private function createOptions(bool $hasOutputCollection)
+    private function createOptions(bool $hasOutputCollection): array
     {
         $options = [];
 

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -263,7 +263,6 @@ class MapReduce implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return MapReduceResult
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if read concern or write concern is used and unsupported
@@ -310,7 +309,6 @@ class MapReduce implements Executable
 
     /**
      * @param string|array|object $out
-     * @return void
      */
     private function checkOutDeprecations($out): void
     {
@@ -331,8 +329,6 @@ class MapReduce implements Executable
 
     /**
      * Create the mapReduce command.
-     *
-     * @return Command
      */
     private function createCommand(): Command
     {
@@ -361,9 +357,6 @@ class MapReduce implements Executable
     /**
      * Creates a callable for MapReduceResult::getIterator().
      *
-     * @param stdClass $result
-     * @param Server   $server
-     * @return callable
      * @throws UnexpectedValueException if the command response was malformed
      */
     private function createGetIteratorCallable(stdClass $result, Server $server): callable
@@ -397,7 +390,6 @@ class MapReduce implements Executable
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executereadcommand.php
      * @see https://php.net/manual/en/mongodb-driver-server.executereadwritecommand.php
-     * @param boolean $hasOutputCollection
      * @return array
      */
     private function createOptions(bool $hasOutputCollection): array

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -390,7 +390,6 @@ class MapReduce implements Executable
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executereadcommand.php
      * @see https://php.net/manual/en/mongodb-driver-server.executereadwritecommand.php
-     * @return array
      */
     private function createOptions(bool $hasOutputCollection): array
     {

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -134,7 +134,7 @@ class ModifyCollection implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -131,7 +131,6 @@ class ModifyCollection implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -70,7 +70,7 @@ class ModifyCollection implements Executable
      * @param array  $options           Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, array $collectionOptions, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $collectionOptions, array $options = [])
     {
         if (empty($collectionOptions)) {
             throw new InvalidArgumentException('$collectionOptions is empty');

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -102,7 +102,6 @@ class ModifyCollection implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object Command result document
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -92,8 +92,8 @@ class ModifyCollection implements Executable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->collectionOptions = $collectionOptions;
         $this->options = $options;
     }

--- a/src/Operation/RenameCollection.php
+++ b/src/Operation/RenameCollection.php
@@ -104,7 +104,6 @@ class RenameCollection implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return array|object Command result document
      * @throws UnsupportedException if write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -127,8 +126,6 @@ class RenameCollection implements Executable
 
     /**
      * Create the renameCollection command.
-     *
-     * @return Command
      */
     private function createCommand(): Command
     {

--- a/src/Operation/RenameCollection.php
+++ b/src/Operation/RenameCollection.php
@@ -147,7 +147,6 @@ class RenameCollection implements Executable
      * Create options for executing the command.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
-     * @return array
      */
     private function createOptions(): array
     {

--- a/src/Operation/RenameCollection.php
+++ b/src/Operation/RenameCollection.php
@@ -130,7 +130,7 @@ class RenameCollection implements Executable
      *
      * @return Command
      */
-    private function createCommand()
+    private function createCommand(): Command
     {
         $cmd = [
             'renameCollection' => $this->fromNamespace,
@@ -152,7 +152,7 @@ class RenameCollection implements Executable
      * @see https://php.net/manual/en/mongodb-driver-server.executewritecommand.php
      * @return array
      */
-    private function createOptions()
+    private function createOptions(): array
     {
         $options = [];
 

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -107,7 +107,6 @@ class ReplaceOne implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return UpdateResult
      * @throws UnsupportedException if collation is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -80,7 +80,7 @@ class ReplaceOne implements Executable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, $replacement, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, $replacement, array $options = [])
     {
         if (! is_array($replacement) && ! is_object($replacement)) {
             throw InvalidArgumentException::invalidType('$replacement', $replacement, 'array or object');

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -243,7 +243,7 @@ class Update implements Executable, Explainable
      * @see https://php.net/manual/en/mongodb-driver-bulkwrite.construct.php
      * @return array
      */
-    private function createBulkWriteOptions()
+    private function createBulkWriteOptions(): array
     {
         $options = [];
 
@@ -266,7 +266,7 @@ class Update implements Executable, Explainable
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
      * @return array
      */
-    private function createExecuteOptions()
+    private function createExecuteOptions(): array
     {
         $options = [];
 
@@ -289,7 +289,7 @@ class Update implements Executable, Explainable
      *
      * @return array
      */
-    private function createUpdateOptions()
+    private function createUpdateOptions(): array
     {
         $updateOptions = [
             'multi' => $this->options['multi'],

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -175,8 +175,8 @@ class Update implements Executable, Explainable
             unset($options['writeConcern']);
         }
 
-        $this->databaseName = (string) $databaseName;
-        $this->collectionName = (string) $collectionName;
+        $this->databaseName = $databaseName;
+        $this->collectionName = $collectionName;
         $this->filter = $filter;
         $this->update = $update;
         $this->options = $options;

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -112,7 +112,7 @@ class Update implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, $update, array $options = [])
     {
         if (! is_array($filter) && ! is_object($filter)) {
             throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -186,7 +186,6 @@ class Update implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return UpdateResult
      * @throws UnsupportedException if hint or write concern is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -219,7 +218,6 @@ class Update implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -239,7 +239,6 @@ class Update implements Executable, Explainable
      * Create options for constructing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-bulkwrite.construct.php
-     * @return array
      */
     private function createBulkWriteOptions(): array
     {
@@ -262,7 +261,6 @@ class Update implements Executable, Explainable
      * Create options for executing the bulk write.
      *
      * @see https://php.net/manual/en/mongodb-driver-server.executebulkwrite.php
-     * @return array
      */
     private function createExecuteOptions(): array
     {
@@ -284,8 +282,6 @@ class Update implements Executable, Explainable
      *
      * Note that these options are different from the bulk write options, which
      * are created in createExecuteOptions().
-     *
-     * @return array
      */
     private function createUpdateOptions(): array
     {

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -83,7 +83,7 @@ class UpdateMany implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, $update, array $options = [])
     {
         if (! is_array($update) && ! is_object($update)) {
             throw InvalidArgumentException::invalidType('$update', $update, 'array or object');

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -106,7 +106,6 @@ class UpdateMany implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return UpdateResult
      * @throws UnsupportedException if collation is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -120,7 +119,6 @@ class UpdateMany implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -106,7 +106,6 @@ class UpdateOne implements Executable, Explainable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return UpdateResult
      * @throws UnsupportedException if collation is used and unsupported
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -120,7 +119,6 @@ class UpdateOne implements Executable, Explainable
      * Returns the command document for this operation.
      *
      * @see Explainable::getCommandDocument()
-     * @param Server $server
      * @return array
      */
     public function getCommandDocument(Server $server)

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -83,7 +83,7 @@ class UpdateOne implements Executable, Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct($databaseName, $collectionName, $filter, $update, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, $filter, $update, array $options = [])
     {
         if (! is_array($update) && ! is_object($update)) {
             throw InvalidArgumentException::invalidType('$update', $update, 'array or object');

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -263,7 +263,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
         }
 
         $this->manager = $manager;
-        $this->databaseName = (string) $databaseName;
+        $this->databaseName = $databaseName;
         $this->collectionName = $collectionName;
         $this->pipeline = $pipeline;
 

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -264,7 +264,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
 
         $this->manager = $manager;
         $this->databaseName = (string) $databaseName;
-        $this->collectionName = $collectionName ?? null;
+        $this->collectionName = $collectionName;
         $this->pipeline = $pipeline;
 
         $this->aggregate = $this->createAggregate();

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -264,7 +264,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
 
         $this->manager = $manager;
         $this->databaseName = (string) $databaseName;
-        $this->collectionName = isset($collectionName) ? (string) $collectionName : null;
+        $this->collectionName = $collectionName ?? null;
         $this->pipeline = $pipeline;
 
         $this->aggregate = $this->createAggregate();

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -201,7 +201,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * @param array       $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(Manager $manager, $databaseName, $collectionName, array $pipeline, array $options = [])
+    public function __construct(Manager $manager, ?string $databaseName, ?string $collectionName, array $pipeline, array $options = [])
     {
         if (isset($collectionName) && ! isset($databaseName)) {
             throw new InvalidArgumentException('$collectionName should also be null if $databaseName is null');
@@ -415,7 +415,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * @return ChangeStreamIterator
      * @throws InvalidArgumentException
      */
-    private function resume($resumeToken = null, $hasAdvanced = false)
+    private function resume($resumeToken = null, bool $hasAdvanced = false)
     {
         if (isset($resumeToken) && ! is_array($resumeToken) && ! is_object($resumeToken)) {
             throw InvalidArgumentException::invalidType('$resumeToken', $resumeToken, 'array or object');

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -339,7 +339,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      *
      * @return Aggregate
      */
-    private function createAggregate()
+    private function createAggregate(): Aggregate
     {
         $pipeline = $this->pipeline;
         array_unshift($pipeline, ['$changeStream' => (object) $this->changeStreamOptions]);
@@ -353,7 +353,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * @param Server $server
      * @return ChangeStreamIterator
      */
-    private function createChangeStreamIterator(Server $server)
+    private function createChangeStreamIterator(Server $server): ChangeStreamIterator
     {
         return new ChangeStreamIterator(
             $this->executeAggregate($server),
@@ -372,7 +372,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * @param Server $server
      * @return Cursor
      */
-    private function executeAggregate(Server $server)
+    private function executeAggregate(Server $server): Cursor
     {
         addSubscriber($this);
 
@@ -415,7 +415,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * @return ChangeStreamIterator
      * @throws InvalidArgumentException
      */
-    private function resume($resumeToken = null, bool $hasAdvanced = false)
+    private function resume($resumeToken = null, bool $hasAdvanced = false): ChangeStreamIterator
     {
         if (isset($resumeToken) && ! is_array($resumeToken) && ! is_object($resumeToken)) {
             throw InvalidArgumentException::invalidType('$resumeToken', $resumeToken, 'array or object');
@@ -456,7 +456,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * @param Server $server
      * @return boolean
      */
-    private function shouldCaptureOperationTime(Server $server)
+    private function shouldCaptureOperationTime(Server $server): bool
     {
         if ($this->hasResumed) {
             return false;

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -317,7 +317,6 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @param Server $server
      * @return ChangeStream
      * @throws UnsupportedException if collation or read concern is used and unsupported
      * @throws RuntimeException for other driver errors (e.g. connection errors)
@@ -336,8 +335,6 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * Create the aggregate command for a change stream.
      *
      * This method is also used to recreate the aggregate command when resuming.
-     *
-     * @return Aggregate
      */
     private function createAggregate(): Aggregate
     {
@@ -349,9 +346,6 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
 
     /**
      * Create a ChangeStreamIterator by executing the aggregate command.
-     *
-     * @param Server $server
-     * @return ChangeStreamIterator
      */
     private function createChangeStreamIterator(Server $server): ChangeStreamIterator
     {
@@ -368,9 +362,6 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      *
      * The command will be executed using APM so that we can capture data from
      * its response (e.g. firstBatch size, postBatchResumeToken).
-     *
-     * @param Server $server
-     * @return Cursor
      */
     private function executeAggregate(Server $server): Cursor
     {
@@ -411,8 +402,6 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resume-process
      * @param array|object|null $resumeToken
-     * @param bool              $hasAdvanced
-     * @return ChangeStreamIterator
      * @throws InvalidArgumentException
      */
     private function resume($resumeToken = null, bool $hasAdvanced = false): ChangeStreamIterator
@@ -453,8 +442,6 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      * Determine whether to capture operation time from an aggregate response.
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#startatoperationtime
-     * @param Server $server
-     * @return boolean
      */
     private function shouldCaptureOperationTime(Server $server): bool
     {

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -52,11 +52,10 @@ class WithTransaction
      * @see Client::startSession
      *
      * @param Session $session A session object as retrieved by Client::startSession
-     * @return void
      * @throws RuntimeException for driver errors while committing the transaction
      * @throws Exception for any other errors, including those thrown in the callback
      */
-    public function execute(Session $session)
+    public function execute(Session $session): void
     {
         $startTime = time();
 

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -123,7 +123,6 @@ class WithTransaction
      * Returns whether the time limit for retrying transactions in the convenient transaction API has passed
      *
      * @param int $startTime The time the transaction was started
-     * @return bool
      */
     private function isTransactionTimeLimitExceeded(int $startTime): bool
     {

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -125,7 +125,7 @@ class WithTransaction
      * @param int $startTime The time the transaction was started
      * @return bool
      */
-    private function isTransactionTimeLimitExceeded($startTime)
+    private function isTransactionTimeLimitExceeded(int $startTime)
     {
         return time() - $startTime >= 120;
     }

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -125,7 +125,7 @@ class WithTransaction
      * @param int $startTime The time the transaction was started
      * @return bool
      */
-    private function isTransactionTimeLimitExceeded(int $startTime)
+    private function isTransactionTimeLimitExceeded(int $startTime): bool
     {
         return time() - $startTime >= 120;
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -98,7 +98,6 @@ function apply_type_map_to_document($document, array $typeMap)
  * @internal
  * @param array|object $document Document containing fields mapped to values,
  *                               which denote order or an index type
- * @return string
  * @throws InvalidArgumentException
  */
 function generate_index_name($document): string
@@ -178,7 +177,6 @@ function get_encrypted_fields_from_server(string $databaseName, string $collecti
  *
  * @internal
  * @param array|object $document Update or replacement document
- * @return boolean
  * @throws InvalidArgumentException
  */
 function is_first_key_operator($document): bool
@@ -206,7 +204,6 @@ function is_first_key_operator($document): bool
  *
  * @internal
  * @param mixed $pipeline
- * @return boolean
  */
 function is_pipeline($pipeline): bool
 {
@@ -247,7 +244,6 @@ function is_pipeline($pipeline): bool
  *
  * @internal
  * @param array $options Command options
- * @return boolean
  */
 function is_in_transaction(array $options): bool
 {
@@ -266,7 +262,6 @@ function is_in_transaction(array $options): bool
  *
  * @internal
  * @param array $pipeline List of pipeline operations
- * @return boolean
  */
 function is_last_pipeline_operator_write(array $pipeline): bool
 {
@@ -289,7 +284,6 @@ function is_last_pipeline_operator_write(array $pipeline): bool
  * @internal
  * @see https://mongodb.com/docs/manual/reference/command/mapReduce/#output-inline
  * @param string|array|object $out Output specification
- * @return boolean
  * @throws InvalidArgumentException
  */
 function is_mapreduce_output_inline($out): bool
@@ -323,8 +317,6 @@ function is_mapreduce_output_inline($out): bool
  *
  * @internal
  * @see https://mongodb.com/docs/manual/reference/write-concern/
- * @param WriteConcern $writeConcern
- * @return boolean
  */
 function is_write_concern_acknowledged(WriteConcern $writeConcern): bool
 {
@@ -340,7 +332,6 @@ function is_write_concern_acknowledged(WriteConcern $writeConcern): bool
  * @internal
  * @param Server  $server  Server to check
  * @param integer $feature Feature constant (i.e. wire protocol version)
- * @return boolean
  */
 function server_supports_feature(Server $server, int $feature): bool
 {
@@ -356,7 +347,6 @@ function server_supports_feature(Server $server, int $feature): bool
  *
  * @internal
  * @param mixed $input
- * @return boolean
  */
 function is_string_array($input): bool
 {
@@ -470,7 +460,6 @@ function create_field_path_type_map(array $typeMap, string $fieldPath): array
  * @param Session  $session            A session object as retrieved by Client::startSession
  * @param callable $callback           A callback that will be invoked within the transaction
  * @param array    $transactionOptions Additional options that are passed to Session::startTransaction
- * @return void
  * @throws RuntimeException for driver errors while committing the transaction
  * @throws Exception for any other errors, including those thrown in the callback
  */
@@ -485,7 +474,6 @@ function with_transaction(Session $session, callable $callback, array $transacti
  *
  * @internal
  * @param array $options
- * @return Session|null
  */
 function extract_session_from_options(array $options): ?Session
 {
@@ -501,7 +489,6 @@ function extract_session_from_options(array $options): ?Session
  *
  * @internal
  * @param array $options
- * @return ReadPreference|null
  */
 function extract_read_preference_from_options(array $options): ?ReadPreference
 {
@@ -517,7 +504,6 @@ function extract_read_preference_from_options(array $options): ?ReadPreference
  * (if given)
  *
  * @internal
- * @return Server
  */
 function select_server(Manager $manager, array $options): Server
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -407,7 +407,6 @@ function recursive_copy($element)
  * @internal
  * @param array  $typeMap   The existing typeMap
  * @param string $fieldPath The field path to apply the root type to
- * @return array
  */
 function create_field_path_type_map(array $typeMap, string $fieldPath): array
 {
@@ -473,7 +472,6 @@ function with_transaction(Session $session, callable $callback, array $transacti
  * Returns the session option if it is set and valid.
  *
  * @internal
- * @param array $options
  */
 function extract_session_from_options(array $options): ?Session
 {
@@ -488,7 +486,6 @@ function extract_session_from_options(array $options): ?Session
  * Returns the readPreference option if it is set and valid.
  *
  * @internal
- * @param array $options
  */
 function extract_read_preference_from_options(array $options): ?ReadPreference
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -474,7 +474,7 @@ function create_field_path_type_map(array $typeMap, string $fieldPath): array
  * @throws RuntimeException for driver errors while committing the transaction
  * @throws Exception for any other errors, including those thrown in the callback
  */
-function with_transaction(Session $session, callable $callback, array $transactionOptions = [])
+function with_transaction(Session $session, callable $callback, array $transactionOptions = []): void
 {
     $operation = new WithTransaction($callback, $transactionOptions);
     $operation->execute($session);

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -91,9 +91,6 @@ class ClientFunctionalTest extends FunctionalTestCase
      * argument as its first and only parameter. If a DatabaseInfo matching
      * the given name is found, it will be passed to the callback, which may
      * perform additional assertions.
-     *
-     * @param string   $databaseName
-     * @param callable $callback
      */
     private function assertDatabaseExists(string $databaseName, ?callable $callback = null): void
     {

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -806,8 +806,6 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param array $executeBulkWriteOptions
      */
     private function createFixtures(int $n, array $executeBulkWriteOptions = []): void
     {

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -15,6 +15,7 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\MapReduceResult;
 use MongoDB\Operation\Count;
 use MongoDB\Tests\CommandObserver;
+use TypeError;
 
 use function array_filter;
 use function call_user_func;
@@ -32,9 +33,9 @@ class CollectionFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideInvalidDatabaseAndCollectionNames
      */
-    public function testConstructorDatabaseNameArgument($databaseName): void
+    public function testConstructorDatabaseNameArgument($databaseName, string $expectedExceptionClass): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException($expectedExceptionClass);
         // TODO: Move to unit test once ManagerInterface can be mocked (PHPC-378)
         new Collection($this->manager, $databaseName, $this->getCollectionName());
     }
@@ -42,9 +43,9 @@ class CollectionFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideInvalidDatabaseAndCollectionNames
      */
-    public function testConstructorCollectionNameArgument($collectionName): void
+    public function testConstructorCollectionNameArgument($collectionName, string $expectedExceptionClass): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException($expectedExceptionClass);
         // TODO: Move to unit test once ManagerInterface can be mocked (PHPC-378)
         new Collection($this->manager, $this->getDatabaseName(), $collectionName);
     }
@@ -52,8 +53,8 @@ class CollectionFunctionalTest extends FunctionalTestCase
     public function provideInvalidDatabaseAndCollectionNames()
     {
         return [
-            [null],
-            [''],
+            [null, TypeError::class],
+            ['', InvalidArgumentException::class],
         ];
     }
 

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -807,8 +807,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
     /**
      * Create data fixtures.
      *
-     * @param integer $n
-     * @param array   $executeBulkWriteOptions
+     * @param array $executeBulkWriteOptions
      */
     private function createFixtures(int $n, array $executeBulkWriteOptions = []): void
     {

--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -107,9 +107,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
     /**
      * Assert that the collections contain equivalent documents.
-     *
-     * @param Collection $expectedCollection
-     * @param Collection $actualCollection
      */
     private function assertEquivalentCollections(Collection $expectedCollection, Collection $actualCollection): void
     {
@@ -152,8 +149,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
     /**
      * Checks that the server version is within the allowed bounds (if any).
      *
-     * @param string|null $minServerVersion
-     * @param string|null $maxServerVersion
      * @throws PHPUnit_Framework_SkippedTestError
      */
     private function checkServerVersion(?string $minServerVersion, ?string $maxServerVersion): void
@@ -260,10 +255,9 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
     /**
      * Executes an "outcome" block.
      *
-     * @param array            $operation
-     * @param array            $outcome
-     * @param mixed            $result
-     * @param RuntimeException $exception
+     * @param array $operation
+     * @param array $outcome
+     * @param mixed $result
      * @return mixed
      * @throws LogicException if the operation is unsupported
      */
@@ -300,8 +294,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
      *
      * If no result can be extracted, null will be returned.
      *
-     * @param array            $operation
-     * @param RuntimeException $exception
+     * @param array $operation
      * @return mixed
      */
     private function extractResultFromException(array $operation, array $outcome, RuntimeException $exception)

--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -167,7 +167,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
     /**
      * Executes an "operation" block.
      *
-     * @param array $operation
      * @return mixed
      * @throws LogicException if the operation is unsupported
      */
@@ -255,8 +254,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
     /**
      * Executes an "outcome" block.
      *
-     * @param array $operation
-     * @param array $outcome
      * @param mixed $result
      * @return mixed
      * @throws LogicException if the operation is unsupported
@@ -294,7 +291,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
      *
      * If no result can be extracted, null will be returned.
      *
-     * @param array $operation
      * @return mixed
      */
     private function extractResultFromException(array $operation, array $outcome, RuntimeException $exception)
@@ -325,7 +321,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
     /**
      * Executes the "result" section of an "outcome" block.
      *
-     * @param array $operation
      * @param mixed $expectedResult
      * @param mixed $actualResult
      * @throws LogicException if the operation is unsupported
@@ -491,9 +486,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
     /**
      * Initializes data in the test collections.
-     *
-     * @param array $initialData
-     * @param array $expectedData
      */
     private function initializeData(array $initialData, ?array $expectedData = null): void
     {
@@ -508,9 +500,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
     /**
      * Prepares a request element for a bulkWrite operation.
-     *
-     * @param array $request
-     * @return array
      */
     private function prepareBulkWriteRequest(array $request): array
     {
@@ -553,9 +542,6 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
 
     /**
      * Prepares arguments for findOneAndReplace and findOneAndUpdate operations.
-     *
-     * @param array $arguments
-     * @return array
      */
     private function prepareFindAndModifyArguments(array $arguments): array
     {

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -11,6 +11,7 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateIndexes;
+use TypeError;
 
 use function array_key_exists;
 use function current;
@@ -23,9 +24,9 @@ class DatabaseFunctionalTest extends FunctionalTestCase
     /**
      * @dataProvider provideInvalidDatabaseNames
      */
-    public function testConstructorDatabaseNameArgument($databaseName): void
+    public function testConstructorDatabaseNameArgument($databaseName, string $expectedExceptionClass): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException($expectedExceptionClass);
         // TODO: Move to unit test once ManagerInterface can be mocked (PHPC-378)
         new Database($this->manager, $databaseName);
     }
@@ -33,8 +34,8 @@ class DatabaseFunctionalTest extends FunctionalTestCase
     public function provideInvalidDatabaseNames()
     {
         return [
-            [null],
-            [''],
+            [null, TypeError::class],
+            ['', InvalidArgumentException::class],
         ];
     }
 

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -1958,8 +1958,6 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
     /**
      * Return the test collection name.
-     *
-     * @return string
      */
     protected function getCollectionName(): string
     {

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -615,8 +615,6 @@ abstract class FunctionalTestCase extends TestCase
 
     /**
      * Checks if the failCommand command is supported on this server version
-     *
-     * @return bool
      */
     private function isFailCommandSupported(): bool
     {
@@ -627,8 +625,6 @@ abstract class FunctionalTestCase extends TestCase
 
     /**
      * Checks if the failCommand command is enabled by checking the enableTestCommands parameter
-     *
-     * @return bool
      */
     private function isFailCommandEnabled(): bool
     {

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -305,8 +305,6 @@ abstract class FunctionalTestCase extends TestCase
      * If the "writeConcern" option is not specified but is supported by the
      * server, a majority write concern will be used. This is helpful for tests
      * using transactions or secondary reads.
-     *
-     * @param array $options
      */
     protected function createCollection(array $options = []): void
     {
@@ -322,8 +320,6 @@ abstract class FunctionalTestCase extends TestCase
      * If the "writeConcern" option is not specified but is supported by the
      * server, a majority write concern will be used. This is helpful for tests
      * using transactions or secondary reads.
-     *
-     * @param array $options
      */
     protected function dropCollection(array $options = []): void
     {

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -782,10 +782,6 @@ CMD;
      * argument as its first and only parameter. If an IndexInfo matching the
      * given name is found, it will be passed to the callback, which may perform
      * additional assertions.
-     *
-     * @param string   $collectionName
-     * @param string   $indexName
-     * @param callable $callback
      */
     private function assertIndexExists(string $collectionName, string $indexName, ?callable $callback = null): void
     {
@@ -814,9 +810,6 @@ CMD;
 
     /**
      * Asserts that an index with the given name does not exist for the collection.
-     *
-     * @param string $collectionName
-     * @param string $indexName
      */
     private function assertIndexNotExists(string $collectionName, string $indexName): void
     {

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -830,8 +830,6 @@ CMD;
 
     /**
      * Return a list of invalid stream values.
-     *
-     * @return array
      */
     private function getInvalidStreamValues(): array
     {

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -42,7 +42,6 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
      *
      * Note: this will seek to the beginning of the stream before reading.
      *
-     * @param string   $expectedContents
      * @param resource $stream
      */
     protected function assertStreamContents(string $expectedContents, $stream): void
@@ -55,7 +54,6 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
     /**
      * Creates an in-memory stream with the given data.
      *
-     * @param string $data
      * @return resource
      */
     protected function createStream(string $data = '')

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MongoDB\Tests\Model;
 
 use MongoDB\Collection;
@@ -11,6 +13,7 @@ use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\FunctionalTestCase;
+use TypeError;
 
 use function array_merge;
 use function sprintf;
@@ -38,13 +41,8 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
      */
     public function testFirstBatchArgumentTypeCheck($firstBatchSize): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(TypeError::class);
         new ChangeStreamIterator($this->collection->find(), $firstBatchSize, null, null);
-    }
-
-    public function provideInvalidIntegerValues()
-    {
-        return $this->wrapValuesForDataProvider($this->getInvalidIntegerValues());
     }
 
     public function testInitialResumeToken(): void
@@ -73,7 +71,7 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
      */
     public function testPostBatchResumeTokenArgumentTypeCheck($postBatchResumeToken): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(TypeError::class);
         new ChangeStreamIterator($this->collection->find(), 0, null, $postBatchResumeToken);
     }
 

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/* Enable strict types to disable type coercion for arguments. Without this, the
+ * non-int test values 3.14 and true would be silently coerced to integers,
+ * which is not what we're expecting to test here. */
 declare(strict_types=1);
 
 namespace MongoDB\Tests\Model;

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -340,8 +340,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
     /**
      * Create data fixtures.
      *
-     * @param integer $n
-     * @param array   $executeBulkWriteOptions
+     * @param array $executeBulkWriteOptions
      */
     private function createFixtures(int $n, array $executeBulkWriteOptions = []): void
     {

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -339,8 +339,6 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param array $executeBulkWriteOptions
      */
     private function createFixtures(int $n, array $executeBulkWriteOptions = []): void
     {

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -313,8 +313,6 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param integer $n
      */
     private function createFixtures(int $n): void
     {

--- a/tests/Operation/CreateIndexesFunctionalTest.php
+++ b/tests/Operation/CreateIndexesFunctionalTest.php
@@ -223,9 +223,6 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
      * argument as its first and only parameter. If an IndexInfo matching the
      * given name is found, it will be passed to the callback, which may perform
      * additional assertions.
-     *
-     * @param string   $indexName
-     * @param callable $callback
      */
     private function assertIndexExists(string $indexName, ?callable $callback = null): void
     {

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -129,8 +129,6 @@ class DeleteFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param integer $n
      */
     private function createFixtures(int $n): void
     {

--- a/tests/Operation/DeleteTest.php
+++ b/tests/Operation/DeleteTest.php
@@ -1,5 +1,8 @@
 <?php
 
+/* Enable strict types to disable type coercion for arguments. Without this, the
+ * non-int test values 3.14 and true would be silently coerced to integers,
+ * which is not what we're expecting to test here. */
 declare(strict_types=1);
 
 namespace MongoDB\Tests\Operation;

--- a/tests/Operation/DeleteTest.php
+++ b/tests/Operation/DeleteTest.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Delete;
-
-use function array_merge;
+use TypeError;
 
 class DeleteTest extends TestCase
 {
@@ -16,6 +17,15 @@ class DeleteTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         new Delete($this->getDatabaseName(), $this->getCollectionName(), $filter, 0);
+    }
+
+    /**
+     * @dataProvider provideInvalidIntegerValues
+     */
+    public function testConstructorLimitArgumentMustBeInt($limit): void
+    {
+        $this->expectException(TypeError::class);
+        new Delete($this->getDatabaseName(), $this->getCollectionName(), [], $limit);
     }
 
     /**
@@ -30,7 +40,7 @@ class DeleteTest extends TestCase
 
     public function provideInvalidLimitValues()
     {
-        return $this->wrapValuesForDataProvider(array_merge($this->getInvalidIntegerValues(), [-1, 2]));
+        return $this->wrapValuesForDataProvider([-1, 2]);
     }
 
     /**

--- a/tests/Operation/DropDatabaseFunctionalTest.php
+++ b/tests/Operation/DropDatabaseFunctionalTest.php
@@ -78,9 +78,6 @@ class DropDatabaseFunctionalTest extends FunctionalTestCase
 
     /**
      * Asserts that a database with the given name does not exist on the server.
-     *
-     * @param Server $server
-     * @param string $databaseName
      */
     private function assertDatabaseDoesNotExist(Server $server, string $databaseName): void
     {

--- a/tests/Operation/DropIndexesFunctionalTest.php
+++ b/tests/Operation/DropIndexesFunctionalTest.php
@@ -149,8 +149,6 @@ class DropIndexesFunctionalTest extends FunctionalTestCase
      * argument as its first and only parameter. If an IndexInfo matching the
      * given name is found, it will be passed to the callback, which may perform
      * additional assertions.
-     *
-     * @param callable $callback
      */
     private function assertIndexExists($indexName, ?callable $callback = null): void
     {

--- a/tests/Operation/ExplainFunctionalTest.php
+++ b/tests/Operation/ExplainFunctionalTest.php
@@ -425,8 +425,6 @@ class ExplainFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param integer $n
      */
     private function createFixtures(int $n): void
     {

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -199,8 +199,6 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param integer $n
      */
     private function createFixtures(int $n): void
     {

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -246,8 +246,6 @@ class FindFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param array $executeBulkWriteOptions
      */
     private function createFixtures(int $n, array $executeBulkWriteOptions = []): void
     {

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -247,8 +247,7 @@ class FindFunctionalTest extends FunctionalTestCase
     /**
      * Create data fixtures.
      *
-     * @param integer $n
-     * @param array   $executeBulkWriteOptions
+     * @param array $executeBulkWriteOptions
      */
     private function createFixtures(int $n, array $executeBulkWriteOptions = []): void
     {

--- a/tests/Operation/FindOneFunctionalTest.php
+++ b/tests/Operation/FindOneFunctionalTest.php
@@ -40,8 +40,6 @@ class FindOneFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param integer $n
      */
     private function createFixtures(int $n): void
     {

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -294,8 +294,6 @@ class MapReduceFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param integer $n
      */
     private function createFixtures(int $n): void
     {

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -267,8 +267,6 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
     /**
      * Create data fixtures.
-     *
-     * @param integer $n
      */
     private function createFixtures(int $n): void
     {

--- a/tests/PHPUnit/Functions.php
+++ b/tests/PHPUnit/Functions.php
@@ -1255,7 +1255,7 @@ if (! function_exists('PHPUnit\Framework\assertObjectHasAttribute')) {
      * @throws InvalidArgumentException
      * @throws Exception
      */
-    function assertObjectHasAttribute(string $attributeName, $object, string $message = ''): void
+    function assertObjectHasAttribute(string $attributeName, object $object, string $message = ''): void
     {
         Assert::assertObjectHasAttribute(...func_get_args());
     }
@@ -1273,7 +1273,7 @@ if (! function_exists('PHPUnit\Framework\assertObjectNotHasAttribute')) {
      * @throws InvalidArgumentException
      * @throws Exception
      */
-    function assertObjectNotHasAttribute(string $attributeName, $object, string $message = ''): void
+    function assertObjectNotHasAttribute(string $attributeName, object $object, string $message = ''): void
     {
         Assert::assertObjectNotHasAttribute(...func_get_args());
     }

--- a/tests/PHPUnit/Functions.php
+++ b/tests/PHPUnit/Functions.php
@@ -1249,8 +1249,6 @@ if (! function_exists('PHPUnit\Framework\assertObjectHasAttribute')) {
      *
      * @see Assert::assertObjectHasAttribute
      *
-     * @param object $object
-     *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      * @throws Exception
@@ -1266,8 +1264,6 @@ if (! function_exists('PHPUnit\Framework\assertObjectNotHasAttribute')) {
      * Asserts that an object does not have a specified attribute.
      *
      * @see Assert::assertObjectNotHasAttribute
-     *
-     * @param object $object
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
@@ -1952,9 +1948,6 @@ if (! function_exists('PHPUnit\Framework\assertStringStartsNotWith')) {
      *
      * @see Assert::assertStringStartsNotWith
      *
-     * @param string $prefix
-     * @param string $string
-     *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException
      */
@@ -2221,9 +2214,6 @@ if (! function_exists('PHPUnit\Framework\assertJsonStringNotEqualsJsonString')) 
      * Asserts that two given JSON encoded objects or arrays are not equal.
      *
      * @see Assert::assertJsonStringNotEqualsJsonString
-     *
-     * @param string $expectedJson
-     * @param string $actualJson
      *
      * @throws ExpectationFailedException
      * @throws InvalidArgumentException

--- a/tests/SpecTests/CommandExpectations.php
+++ b/tests/SpecTests/CommandExpectations.php
@@ -198,9 +198,6 @@ class CommandExpectations implements CommandSubscriber
 
     /**
      * Assert that the command expectations match the monitored events.
-     *
-     * @param FunctionalTestCase $test    Test instance
-     * @param Context            $context Execution context
      */
     public function assert(FunctionalTestCase $test, Context $context): void
     {

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -317,8 +317,6 @@ final class Context
      * Prepare options readConcern, readPreference, and writeConcern options by
      * creating value objects.
      *
-     * @param array $options
-     * @return array
      * @throws LogicException if any option keys are unsupported
      */
     public function prepareOptions(array $options): array

--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -132,8 +132,7 @@ class DocumentsMatchConstraint extends Constraint
     }
 
     /**
-     * @param string $expectedType
-     * @param mixed  $actualValue
+     * @param mixed $actualValue
      */
     private function assertBSONType(string $expectedType, $actualValue): void
     {
@@ -275,10 +274,6 @@ class DocumentsMatchConstraint extends Constraint
     /**
      * Compares two documents recursively.
      *
-     * @param ArrayObject $expected
-     * @param ArrayObject $actual
-     * @param boolean     $ignoreExtraKeys
-     * @param string      $keyPrefix
      * @throws RuntimeException if the documents do not match
      */
     private function assertEquals(ArrayObject $expected, ArrayObject $actual, bool $ignoreExtraKeys, string $keyPrefix = ''): void
@@ -412,8 +407,7 @@ class DocumentsMatchConstraint extends Constraint
      * value within the array or document will then be prepared recursively.
      *
      * @param array|object $bson
-     * @param boolean      $isRoot   If true, ensure an array value is converted to a document
-     * @param boolean      $sortKeys
+     * @param boolean      $isRoot If true, ensure an array value is converted to a document
      * @return BSONDocument|BSONArray
      * @throws InvalidArgumentException if $bson is not an array or object
      */

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -97,8 +97,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
 
     /**
      * Assert data within the outcome collection.
-     *
-     * @param array $expectedDocuments
      */
     protected function assertOutcomeCollectionData(array $expectedDocuments, int $resultExpectation = ResultExpectation::ASSERT_SAME_DOCUMENT): void
     {
@@ -131,7 +129,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     /**
      * Checks server version and topology requirements.
      *
-     * @param array $runOn
      * @throws SkippedTest if the server requirements are not met
      */
     protected function checkServerRequirements(array $runOn): void
@@ -222,8 +219,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
 
     /**
      * Insert data fixtures into the test collection.
-     *
-     * @param array $documents
      */
     protected function insertDataFixtures(array $documents, ?string $collectionName = null): void
     {
@@ -292,8 +287,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
 
     /**
      * Checks if server version and topology requirements are satifised.
-     *
-     * @param array|null $topologies
      */
     private function isServerRequirementSatisifed(?string $minServerVersion, ?string $maxServerVersion, ?array $topologies = null, ?string $serverlessMode = null): bool
     {

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -87,7 +87,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      *
      * @param array|object $expectedDocument
      * @param array|object $actualDocument
-     * @param string       $message
      */
     public static function assertDocumentsMatch($expectedDocument, $actualDocument, string $message = ''): void
     {
@@ -100,7 +99,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      * Assert data within the outcome collection.
      *
      * @param array $expectedDocuments
-     * @param int   $resultExpectation
      */
     protected function assertOutcomeCollectionData(array $expectedDocuments, int $resultExpectation = ResultExpectation::ASSERT_SAME_DOCUMENT): void
     {
@@ -161,7 +159,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      * This decodes the file through the driver's extended JSON parser to ensure
      * proper handling of special types.
      *
-     * @param string $json
      * @return array|object
      */
     protected function decodeJson(string $json)
@@ -172,7 +169,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     /**
      * Return the test context.
      *
-     * @return Context
      * @throws LogicException if the context has not been set
      */
     protected function getContext(): Context
@@ -186,8 +182,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
 
     /**
      * Set the test context.
-     *
-     * @param Context $context
      */
     protected function setContext(Context $context): void
     {
@@ -229,8 +223,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     /**
      * Insert data fixtures into the test collection.
      *
-     * @param array       $documents
-     * @param string|null $collectionName
+     * @param array $documents
      */
     protected function insertDataFixtures(array $documents, ?string $collectionName = null): void
     {
@@ -257,7 +250,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     /**
      * Return the corresponding topology constants for the current topology.
      *
-     * @return string
      * @throws UnexpectedValueException if topology is neither single nor RS nor sharded
      */
     private function getTopology(): string
@@ -301,10 +293,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     /**
      * Checks if server version and topology requirements are satifised.
      *
-     * @param string|null $minServerVersion
-     * @param string|null $maxServerVersion
-     * @param array|null  $topologies
-     * @return boolean
+     * @param array|null $topologies
      */
     private function isServerRequirementSatisifed(?string $minServerVersion, ?string $maxServerVersion, ?array $topologies = null, ?string $serverlessMode = null): bool
     {

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -100,8 +100,6 @@ final class Operation
     /**
      * This method is exclusively used to prepare nested operations for the
      * withTransaction session operation
-     *
-     * @return Operation
      */
     private static function fromConvenientTransactions(stdClass $operation): Operation
     {
@@ -291,7 +289,6 @@ final class Operation
     /**
      * Executes the client operation and return its result.
      *
-     * @param Client  $client
      * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the collection operation is unsupported
@@ -322,8 +319,7 @@ final class Operation
     /**
      * Executes the collection operation and return its result.
      *
-     * @param Collection $collection
-     * @param Context    $context    Execution context
+     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the collection operation is unsupported
      */
@@ -464,8 +460,7 @@ final class Operation
     /**
      * Executes the database operation and return its result.
      *
-     * @param Database $database
-     * @param Context  $context  Execution context
+     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the database operation is unsupported
      */
@@ -519,7 +514,6 @@ final class Operation
     /**
      * Executes the GridFS bucket operation and return its result.
      *
-     * @param Bucket  $bucket
      * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the database operation is unsupported
@@ -562,9 +556,7 @@ final class Operation
     /**
      * Executes the session operation and return its result.
      *
-     * @param Session            $session
-     * @param FunctionalTestCase $test
-     * @param Context            $context Execution context
+     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the session operation is unsupported
      */
@@ -673,9 +665,6 @@ final class Operation
     }
 
     /**
-     * @param string $databaseName
-     * @param string $collectionName
-     *
      * @return array
      */
     private function getIndexNames(Context $context, string $databaseName, string $collectionName): array
@@ -838,7 +827,6 @@ final class Operation
     /**
      * Prepares a request element for a bulkWrite operation.
      *
-     * @param stdClass $request
      * @return array
      * @throws LogicException if the bulk write request is unsupported
      */

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -187,9 +187,7 @@ final class Operation
     /**
      * Execute the operation and assert its outcome.
      *
-     * @param FunctionalTestCase $test             Test instance
-     * @param Context            $context          Execution context
-     * @param bool               $bubbleExceptions If true, any exception that was caught is rethrown
+     * @param bool $bubbleExceptions If true, any exception that was caught is rethrown
      */
     public function assert(FunctionalTestCase $test, Context $context, bool $bubbleExceptions = false): void
     {
@@ -235,7 +233,6 @@ final class Operation
     /**
      * Executes the operation with a given context.
      *
-     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the operation is unsupported
      */
@@ -289,7 +286,6 @@ final class Operation
     /**
      * Executes the client operation and return its result.
      *
-     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the collection operation is unsupported
      */
@@ -319,7 +315,6 @@ final class Operation
     /**
      * Executes the collection operation and return its result.
      *
-     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the collection operation is unsupported
      */
@@ -460,7 +455,6 @@ final class Operation
     /**
      * Executes the database operation and return its result.
      *
-     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the database operation is unsupported
      */
@@ -514,7 +508,6 @@ final class Operation
     /**
      * Executes the GridFS bucket operation and return its result.
      *
-     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the database operation is unsupported
      */
@@ -556,7 +549,6 @@ final class Operation
     /**
      * Executes the session operation and return its result.
      *
-     * @param Context $context Execution context
      * @return mixed
      * @throws LogicException if the session operation is unsupported
      */
@@ -664,9 +656,6 @@ final class Operation
         }
     }
 
-    /**
-     * @return array
-     */
     private function getIndexNames(Context $context, string $databaseName, string $collectionName): array
     {
         return array_map(
@@ -827,7 +816,6 @@ final class Operation
     /**
      * Prepares a request element for a bulkWrite operation.
      *
-     * @return array
      * @throws LogicException if the bulk write request is unsupported
      */
     private function prepareBulkWriteRequest(stdClass $request): array

--- a/tests/SpecTests/ResultExpectation.php
+++ b/tests/SpecTests/ResultExpectation.php
@@ -45,9 +45,6 @@ final class ResultExpectation
     /** @var callable */
     private $assertionCallable;
 
-    /**
-     * @param mixed $expectedValue
-     */
     private function __construct(int $assertionType, $expectedValue)
     {
         switch ($assertionType) {

--- a/tests/SpecTests/ResultExpectation.php
+++ b/tests/SpecTests/ResultExpectation.php
@@ -46,8 +46,7 @@ final class ResultExpectation
     private $assertionCallable;
 
     /**
-     * @param integer $assertionType
-     * @param mixed   $expectedValue
+     * @param mixed $expectedValue
      */
     private function __construct(int $assertionType, $expectedValue)
     {
@@ -352,7 +351,6 @@ final class ResultExpectation
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst#test-format
      * @param mixed $result
-     * @return boolean
      */
     private static function isErrorResult($result): bool
     {

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -352,7 +352,6 @@ class TransactionsSpecTest extends FunctionalTestCase
     /**
      * Work around potential error executing distinct on sharded clusters.
      *
-     * @param array $operations
      * @see https://github.com/mongodb/specifications/tree/master/source/transactions/tests#why-do-tests-that-run-distinct-sometimes-fail-with-staledbversion
      */
     private function preventStaleDbVersionError(array $operations): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -174,8 +174,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid array values.
-     *
-     * @return array
      */
     protected function getInvalidArrayValues(bool $includeNull = false): array
     {
@@ -184,8 +182,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid boolean values.
-     *
-     * @return array
      */
     protected function getInvalidBooleanValues(bool $includeNull = false): array
     {
@@ -194,8 +190,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid document values.
-     *
-     * @return array
      */
     protected function getInvalidDocumentValues(bool $includeNull = false): array
     {
@@ -204,8 +198,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid integer values.
-     *
-     * @return array
      */
     protected function getInvalidIntegerValues(bool $includeNull = false): array
     {
@@ -214,8 +206,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid ReadPreference values.
-     *
-     * @return array
      */
     protected function getInvalidReadConcernValues(bool $includeNull = false): array
     {
@@ -224,8 +214,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid ReadPreference values.
-     *
-     * @return array
      */
     protected function getInvalidReadPreferenceValues(bool $includeNull = false): array
     {
@@ -234,8 +222,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid Session values.
-     *
-     * @return array
      */
     protected function getInvalidSessionValues(bool $includeNull = false): array
     {
@@ -244,8 +230,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid string values.
-     *
-     * @return array
      */
     protected function getInvalidStringValues(bool $includeNull = false): array
     {
@@ -254,8 +238,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid WriteConcern values.
-     *
-     * @return array
      */
     protected function getInvalidWriteConcernValues(bool $includeNull = false): array
     {
@@ -274,7 +256,6 @@ abstract class TestCase extends BaseTestCase
      * Wrap a list of values for use as a single-argument data provider.
      *
      * @param array $values List of values
-     * @return array
      */
     protected function wrapValuesForDataProvider(array $values): array
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,8 +35,6 @@ abstract class TestCase extends BaseTestCase
 {
     /**
      * Return the connection URI.
-     *
-     * @return string
      */
     public static function getUri(): string
     {
@@ -158,8 +156,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return the test collection name.
-     *
-     * @return string
      */
     protected function getCollectionName(): string
     {
@@ -170,8 +166,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return the test database name.
-     *
-     * @return string
      */
     protected function getDatabaseName(): string
     {
@@ -180,8 +174,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid array values.
-     *
-     * @param boolean $includeNull
      *
      * @return array
      */
@@ -193,8 +185,6 @@ abstract class TestCase extends BaseTestCase
     /**
      * Return a list of invalid boolean values.
      *
-     * @param boolean $includeNull
-     *
      * @return array
      */
     protected function getInvalidBooleanValues(bool $includeNull = false): array
@@ -204,8 +194,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid document values.
-     *
-     * @param boolean $includeNull
      *
      * @return array
      */
@@ -217,8 +205,6 @@ abstract class TestCase extends BaseTestCase
     /**
      * Return a list of invalid integer values.
      *
-     * @param boolean $includeNull
-     *
      * @return array
      */
     protected function getInvalidIntegerValues(bool $includeNull = false): array
@@ -228,8 +214,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid ReadPreference values.
-     *
-     * @param boolean $includeNull
      *
      * @return array
      */
@@ -241,8 +225,6 @@ abstract class TestCase extends BaseTestCase
     /**
      * Return a list of invalid ReadPreference values.
      *
-     * @param boolean $includeNull
-     *
      * @return array
      */
     protected function getInvalidReadPreferenceValues(bool $includeNull = false): array
@@ -252,8 +234,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return a list of invalid Session values.
-     *
-     * @param boolean $includeNull
      *
      * @return array
      */
@@ -265,8 +245,6 @@ abstract class TestCase extends BaseTestCase
     /**
      * Return a list of invalid string values.
      *
-     * @param boolean $includeNull
-     *
      * @return array
      */
     protected function getInvalidStringValues(bool $includeNull = false): array
@@ -277,8 +255,6 @@ abstract class TestCase extends BaseTestCase
     /**
      * Return a list of invalid WriteConcern values.
      *
-     * @param boolean $includeNull
-     *
      * @return array
      */
     protected function getInvalidWriteConcernValues(bool $includeNull = false): array
@@ -288,8 +264,6 @@ abstract class TestCase extends BaseTestCase
 
     /**
      * Return the test namespace.
-     *
-     * @return string
      */
     protected function getNamespace(): string
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -134,6 +134,11 @@ abstract class TestCase extends BaseTestCase
         return $this->wrapValuesForDataProvider($this->getInvalidDocumentValues());
     }
 
+    public function provideInvalidIntegerValues()
+    {
+        return $this->wrapValuesForDataProvider($this->getInvalidIntegerValues());
+    }
+
     protected function assertDeprecated(callable $execution): void
     {
         $errors = [];

--- a/tests/UnifiedSpecTests/Context.php
+++ b/tests/UnifiedSpecTests/Context.php
@@ -91,8 +91,6 @@ final class Context
 
     /**
      * Create entities for "createEntities".
-     *
-     * @param array $createEntities
      */
     public function createEntities(array $entities): void
     {

--- a/tests/UnifiedSpecTests/EventCollector.php
+++ b/tests/UnifiedSpecTests/EventCollector.php
@@ -163,8 +163,7 @@ final class EventCollector implements CommandSubscriber
         return sprintf('%s:%d', $server->getHost(), $server->getPort());
     }
 
-    /** @param object $event */
-    private static function getEventName($event): string
+    private static function getEventName(object $event): string
     {
         static $eventNamesByClass = null;
 


### PR DESCRIPTION
This PR handles PHPLIB-600 and PHPLIB-602, adding parameter types and return types where applicable.

Rules for phpcs have been updated to require argument types; no changes were made to return types as most of the classes are non-final (something we may want to address for 2.0).