### PR TITLE
PHPLIB-912: Skip failing test until test is updated

### DIFF
--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -64,6 +64,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         'valid-pass/createEntities-operation: createEntities operation' => 'CSOT is not yet implemented (PHPC-1760)',
         'valid-pass/entity-cursor-iterateOnce: iterateOnce' => 'CSOT is not yet implemented (PHPC-1760)',
         'valid-pass/matches-lte-operator: special lte matching operator' => 'CSOT is not yet implemented (PHPC-1760)',
+        // Fails on sharded clusters
+        'change-streams/change-streams-showExpandedEvents: when showExpandedEvents is true, createIndex events are reported' => 'Fails on sharded clusters (PHPLIB-912)',
     ];
 
     /** @var UnifiedTestRunner */


### PR DESCRIPTION
PHPLIB-912

Until https://github.com/mongodb/specifications/pull/1293 is resolved, this will skip the test so as to make other test failures more visible.