### PR TITLE
PHPLIB-911: Test with consistent version of crypt_shared

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -176,7 +176,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           MONGODB_VERSION=${VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
-    # run-orchestration generates expansion file with the MONGODB_URI for the cluster
+    # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:
         file: mo-expansion.yml
@@ -246,9 +246,16 @@ functions:
           export KMS_ENDPOINT_REQUIRE_CLIENT_CERT="${client_side_encryption_kms_endpoint_require_client_cert}"
           export KMS_TLS_CA_FILE="${client_side_encryption_kms_tls_ca_file}"
           export KMS_TLS_CERTIFICATE_KEY_FILE="${client_side_encryption_kms_tls_certificate_key_file}"
-          export CRYPT_SHARED_LIB_PATH="${client_side_encryption_crypt_shared_lib_path}"
           export PATH="${PHP_PATH}/bin:$PATH"
-          API_VERSION=${API_VERSION} PHP_VERSION=${PHP_VERSION} TESTS=${TESTS} AUTH=${AUTH} SSL=${SSL} MONGODB_URI="${MONGODB_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+
+          API_VERSION=${API_VERSION} \
+          CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH} \
+          MONGODB_URI="${MONGODB_URI}" \
+          PHP_VERSION=${PHP_VERSION} \
+          SKIP_CRYPT_SHARED=${SKIP_CRYPT_SHARED} \
+          SSL=${SSL} \
+          TESTS=${TESTS} \
+          sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run atlas data lake test":
      - command: shell.exec
@@ -258,7 +265,10 @@ functions:
          script: |
            ${PREPARE_SHELL}
            export PATH="${PHP_PATH}/bin:$PATH"
-           PHP_VERSION=${PHP_VERSION} TESTS="atlas-data-lake" AUTH=${AUTH} SSL=${SSL} MONGODB_URI="${MONGODB_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+
+           MONGODB_URI="mongodb://mhuser:pencil@127.0.0.1:27017" \
+           TESTS="atlas-data-lake" \
+           sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run serverless tests":
     - command: shell.exec
@@ -271,7 +281,12 @@ functions:
           export MONGODB_USERNAME=${SERVERLESS_ATLAS_USER}
           export MONGODB_PASSWORD=${SERVERLESS_ATLAS_PASSWORD}
           export PATH="${PHP_PATH}/bin:$PATH"
-          PHP_VERSION=${PHP_VERSION} TESTS="serverless" MONGODB_URI="${SERVERLESS_URI}" sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+
+          CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH} \
+          MONGODB_URI="${SERVERLESS_URI}" \
+          SKIP_CRYPT_SHARED=${SKIP_CRYPT_SHARED} \
+          TESTS="serverless" \
+          sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "cleanup":
     - command: shell.exec
@@ -377,18 +392,6 @@ functions:
             value: 127.0.0.1:8102
           - key: client_side_encryption_kmip_endpoint
             value: localhost:5698
-
-  "fetch crypt_shared":
-    - command: shell.exec
-      params:
-        script: |
-          # TODO: Specify same version provisioned by download-mongodb.sh (see: DRIVERS-2355)
-          python3 ${DRIVERS_TOOLS}/.evergreen/mongodl.py --component crypt_shared --version latest --only "**/mongo_crypt_v1.so" --out ${DRIVERS_TOOLS}/.evergreen/csfle --strip-path-components 1
-    - command: expansions.update
-      params:
-        updates:
-          - key: client_side_encryption_crypt_shared_lib_path
-            value: ${DRIVERS_TOOLS}/.evergreen/csfle/mongo_crypt_v1.so
 
 pre:
   - func: "fetch source"
@@ -521,15 +524,15 @@ tasks:
             SSL: "yes"
         # Note: "stop load balancer" will be called from "post"
 
-    - name: "test-crypt_shared"
+    - name: "test-skip_crypt_shared"
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
             TOPOLOGY: "replica_set"
         - func: "start kms servers"
-        - func: "fetch crypt_shared"
         - func: "run tests"
           vars:
+            SKIP_CRYPT_SHARED: "yes"
             TESTS: "csfle"
 
 # }}}
@@ -792,9 +795,9 @@ buildvariants:
   tasks:
     - name: "test-loadBalanced"
 
-# CSFLE crypt_shared is available from MongoDB 6.0+
-- matrix_name: "test-csfle-crypt_shared"
+# CSFLE crypt_shared is available from MongoDB 6.0+, so explicitly test without it to allow use of mongocryptd
+- matrix_name: "test-csfle-skip_crypt_shared"
   matrix_spec: { "os": "debian11", "mongodb-versions": "6.0", "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
-  display_name: "CSFLE crypt_shared - ${mongodb-versions}"
+  display_name: "CSFLE skip_crypt_shared - ${mongodb-versions}"
   tasks:
-    - name: "test-crypt_shared"
+    - name: "test-skip_crypt_shared"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 set -o errexit  # Exit the script with error if any of the commands fail
 
-# Supported/used environment variables:
-#   SSL               Set to "yes" to enable SSL. Defaults to "nossl"
-#   MONGODB_URI       Set the suggested connection MONGODB_URI (including credentials and topology info)
-#   API_VERSION       Optional API_VERSION environment variable for run-tests.php
-#   IS_MATRIX_TESTING Set to "true" to enable matrix testing. Defaults to empty string. If "true", DRIVER_MONGODB_VERSION and MONGODB_VERSION will also be checked.
-
-SSL=${SSL:-nossl}
-MONGODB_URI=${MONGODB_URI:-}
-API_VERSION=${API_VERSION:-}
-IS_MATRIX_TESTING=${IS_MATRIX_TESTING:-}
+# Supported environment variables
+API_VERSION=${API_VERSION:-} # Optional API_VERSION environment variable
+CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH:-}" # Optional path to crypt_shared library
+DRIVER_MONGODB_VERSION={$DRIVER_MONGODB_VERSION:-} # Required if IS_MATRIX_TESTING is "true"
+IS_MATRIX_TESTING=${IS_MATRIX_TESTING:-} # Specify "true" to enable matrix testing. Defaults to empty string. If "true", DRIVER_MONGODB_VERSION and MONGODB_VERSION will also be checked.
+MONGODB_URI=${MONGODB_URI:-} # Connection string (including credentials and topology info)
+MONGODB_VERSION=${MONGODB_VERSION:-} # Required if IS_MATRIX_TESTING is "true"
+SKIP_CRYPT_SHARED="${SKIP_CRYPT_SHARED:-no}" # Specify "yes" to ignore CRYPT_SHARED_LIB_PATH. Defaults to "no"
+SSL=${SSL:-no} # Specify "yes" to enable SSL. Defaults to "no"
+TESTS=${TESTS:-} # Optional test group. Defaults to all tests
 
 # For matrix testing, we have to determine the correct driver version
 if [ "${IS_MATRIX_TESTING}" = "true" ]; then
@@ -42,7 +42,7 @@ if [ "${IS_MATRIX_TESTING}" = "true" ]; then
 fi
 
 # Enable verbose output to see skipped and incomplete tests
-PHPUNIT_OPTS="${PHPUNIT_OPTS} -v"
+PHPUNIT_OPTS="${PHPUNIT_OPTS} -v --configuration phpunit.evergreen.xml"
 
 # Determine if MONGODB_URI already has a query string
 SUFFIX=$(echo "$MONGODB_URI" | grep -Eo "\?(.*)" | cat)
@@ -57,29 +57,34 @@ fi
 
 echo "Running tests with URI: $MONGODB_URI"
 
-# Disable failing PHPUnit due to deprecations
+# Disable PHPUnit test failures due to deprecations
+# See: https://symfony.com/doc/current/components/phpunit_bridge.html#internal-deprecations
 export SYMFONY_DEPRECATIONS_HELPER=999999
 
-# Run the tests, and store the results in a Evergreen compatible JSON results file
+# Export environment vars that may be referenced by the test suite
+export API_VERSION="${API_VERSION}"
+export CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}"
+export MONGODB_URI="${MONGODB_URI}"
+
+# Run the tests, and store the results in a junit result file
 case "$TESTS" in
    atlas-data-lake*)
-      MONGODB_URI="mongodb://mhuser:pencil@127.0.0.1:27017"
-      php vendor/bin/simple-phpunit --configuration phpunit.evergreen.xml --testsuite "Atlas Data Lake Test Suite" $PHPUNIT_OPTS
+      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --testsuite "Atlas Data Lake Test Suite"
       ;;
 
    csfle)
-      php vendor/bin/simple-phpunit --configuration phpunit.evergreen.xml --group csfle $PHPUNIT_OPTS
+      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group csfle
       ;;
 
    versioned-api)
-      php vendor/bin/simple-phpunit --configuration phpunit.evergreen.xml --group versioned-api $PHPUNIT_OPTS
+      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group versioned-api
       ;;
 
    serverless)
-      php vendor/bin/simple-phpunit --configuration phpunit.evergreen.xml --group serverless $PHPUNIT_OPTS
+      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group serverless
       ;;
 
    *)
-      php vendor/bin/simple-phpunit --configuration phpunit.evergreen.xml $PHPUNIT_OPTS
+      php vendor/bin/simple-phpunit $PHPUNIT_OPTS
       ;;
 esac


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-911

Use the crypt_shared library provisioned by download-mongodb.sh and add an additional task to disable the library and fall back to mongocryptd.

This also revises how we pass environment variables into run-tests.sh and the test suite, and restructures run-tests.sh a bit.

Related to https://github.com/mongodb/mongo-php-driver/pull/1353 for [PHPC-2135](https://jira.mongodb.org/browse/PHPC-2135).

Full patch build: https://spruce.mongodb.com/version/630faa3fe3c3315a7b34afd5/tasks