### PR TITLE
PHPLIB-932: Use debian11 and include MongoDB 6.0 for load balancer testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -786,8 +786,7 @@ buildvariants:
 
 # Load balancer is available from MongoDB 5.0+
 - matrix_name: "test-loadBalanced"
-  # TODO: Add MongoDB 6.0 and use Debian 11 once BUILD-15237 is resolved
-  matrix_spec: { "os": "debian92", "mongodb-versions": ["5.0"], "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
+  matrix_spec: { "os": "debian11", "mongodb-versions": ["5.0", "6.0"], "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
   display_name: "Load balanced - ${mongodb-versions}"
   tasks:
     - name: "test-loadBalanced"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-932
Related to mongodb/mongo-php-driver@0a712a3265b856c5416eb2fedbbaefadd21db757