### PR TITLE
Fix typo in fullDocument option docs

### DIFF
--- a/docs/includes/apiargs-method-watch-option.yaml
+++ b/docs/includes/apiargs-method-watch-option.yaml
@@ -17,9 +17,9 @@ description: |
   operations.
 
   By default, change streams only return the delta of fields (via an
-  "udateDescription" field) for update operations and "fullDocument" is omitted.
-  Insert and replace operations always include the "fullDocument" field. Delete
-  operations omit the field as the document no longer exists.
+  "updateDescription" field) for update operations and "fullDocument" is
+  omitted. Insert and replace operations always include the "fullDocument"
+  field. Delete operations omit the field as the document no longer exists.
 
   Specify "updateLookup" to return the current majority-committed version of the
   updated document.


### PR DESCRIPTION
This typo originated in 2704fb05e3a96cc63544c2f6e0c33008740b6915