### PR TITLE
PHPLIB-947: Skip legacy CSFLE explain test pending crypt_shared fix

### DIFF
--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -65,6 +65,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         'awsTemporary: Insert a document with auto encryption using the AWS provider with temporary credentials' => 'Not yet implemented (PHPC-1751)',
         'awsTemporary: Insert with invalid temporary credentials' => 'Not yet implemented (PHPC-1751)',
         'azureKMS: Insert a document with auto encryption using Azure KMS provider' => 'RHEL platform is missing Azure root certificate (PHPLIB-619)',
+        'explain: Explain a find with deterministic encryption' => 'crypt_shared does not add apiVersion field to explain commands (PHPLIB-947, SERVER-69564)',
         'timeoutMS: timeoutMS applied to listCollections to get collection schema' => 'Not yet implemented (PHPC-1760)',
         'timeoutMS: remaining timeoutMS applied to find to get keyvault data' => 'Not yet implemented (PHPC-1760)',
     ];


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-947

Patch build with CSFLE-related tasks: https://spruce.mongodb.com/version/6320bebb3e8e86529fdfe162/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note that the `test-requireApiVersion` on MongoDB 6.0 would have previously failed without this skip.