### PR TITLE
PHPLIB-949: FLE - maxWireVersion should run on Mongo Server 4.0.x

### DIFF
--- a/tests/SpecTests/client-side-encryption/tests/maxWireVersion.json
+++ b/tests/SpecTests/client-side-encryption/tests/maxWireVersion.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "maxServerVersion": "4.0"
+      "maxServerVersion": "4.0.99"
     }
   ],
   "database_name": "default",


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-949

Sync with mongodb/specifications@e761591616849d9b507287811e77f7a359fb9587