### PR TITLE
PHPLIB-596: Add tutorial for connecting to MongoDB

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -27,6 +27,8 @@ following pages should help you get started:
 
 - :doc:`/tutorial/install-php-library`
 
+- :doc:`/tutorial/connecting`
+
 - :doc:`/tutorial/crud`
 
 - :doc:`/tutorial/commands`

--- a/docs/reference/method/MongoDBClient__construct.txt
+++ b/docs/reference/method/MongoDBClient__construct.txt
@@ -49,12 +49,27 @@ initialized on demand, when the first operation is executed.
 Examples
 --------
 
+.. start-connecting-include
+
+Connecting to a Standalone server
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you do not specify a ``$uri`` value, the driver connects to a standalone
+:program:`mongod` on ``127.0.0.1`` via port ``27017``. To connect to a different
+server, pass the corresponding connection string as the first parameter when
+creating the :phpclass:`Client <MongoDB\\Client>` instance:
+
+.. code-block:: php
+
+   <?php
+
+   $client = new MongoDB\Client('mongodb://mongodb-deployment:27017');
+
 Connecting to a Replica Set
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you do not specify a ``$uri`` value, the driver connects to a standalone
-:program:`mongod` on ``127.0.0.1`` via port ``27017``. The following example
-demonstrates how to connect to a replica set with a custom read preference:
+The following example demonstrates how to connect to a replica set with a custom
+read preference:
 
 .. code-block:: php
 
@@ -105,6 +120,8 @@ The driver supports additional :php:`SSL options
 which may be specified in the constructor's ``$driverOptions`` parameter. Those
 options are covered in the :php:`MongoDB\\Driver\\Manager::__construct()
 <mongodb-driver-manager.construct>` documentation.
+
+.. end-connecting-include
 
 Specifying a Custom Type Map
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorial.txt
+++ b/docs/tutorial.txt
@@ -5,6 +5,7 @@ Tutorials
 
 .. toctree::
 
+   /tutorial/connecting
    /tutorial/crud
    /tutorial/collation
    /tutorial/commands

--- a/docs/tutorial/connecting.txt
+++ b/docs/tutorial/connecting.txt
@@ -10,7 +10,7 @@ Connecting to MongoDB
    :depth: 2
    :class: singlecol
 
-Creating a :phpclass:`Client <MongoDB\\Client>` instance
+Creating a Client instance
 --------------------------------------------------------
 
 .. include:: /reference/method/MongoDBClient__construct.txt

--- a/docs/tutorial/connecting.txt
+++ b/docs/tutorial/connecting.txt
@@ -1,0 +1,25 @@
+=====================
+Connecting to MongoDB
+=====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Creating a :phpclass:`Client <MongoDB\\Client>` instance
+--------------------------------------------------------
+
+.. include:: /reference/method/MongoDBClient__construct.txt
+   :start-after: start-connecting-include
+   :end-before: end-connecting-include
+
+Specifying connection options
+-----------------------------
+
+Connection options can be passed via the ``$uri`` parameter, or through the
+``$options`` and ``$driverOptions`` parameters. The available options are
+documented in the :phpmethod:`MongoDB\\Client::__construct()` reference.


### PR DESCRIPTION
PHPLIB-596

This PR adds a small tutorial with information about connecting to MongoDB. The examples are taken from the documentation for `MongoDB\Client::__construct`, but provides them in a spot that should be easier to find.

Note: I haven't been able to build docs locally, and an attempt to build docs in a GitHub CI build also failed with the same error:
```
~/Code/mongodb/docs-php-library 
[master|✔] ❯❯❯ giza make html
Traceback (most recent call last):
  File "/opt/homebrew/bin/giza", line 5, in <module>
    from giza.cmdline import main
  File "/opt/homebrew/lib/python3.10/site-packages/giza/cmdline.py", line 19, in <module>
    from giza.config.runtime import RuntimeStateConfig
  File "/opt/homebrew/lib/python3.10/site-packages/giza/config/runtime.py", line 25, in <module>
    from giza.config.sphinx_config import available_sphinx_builders
  File "/opt/homebrew/lib/python3.10/site-packages/giza/config/sphinx_config.py", line 20, in <module>
    import sphinx.make_mode
ModuleNotFoundError: No module named 'sphinx.make_mode'
```