### PR TITLE
PHPLIB-987: Add more examples

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -37,6 +37,8 @@ following pages should help you get started:
 
 - :doc:`/reference/bson`
 
+Code examples can be found in the ``examples`` directory in the source code.
+
 If you have previously worked with the legacy ``mongo`` extension, it will be
 helpful to review the :doc:`/upgrade` for a summary of API changes between the
 old driver and this library.

--- a/examples/aggregate.php
+++ b/examples/aggregate.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace MongoDB\Examples;
+
+use MongoDB\Client;
+
+use function assert;
+use function dirname;
+use function getenv;
+use function is_object;
+use function MongoDB\BSON\fromPHP;
+use function MongoDB\BSON\toRelaxedExtendedJSON;
+use function printf;
+use function rand;
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
+
+function toJSON(object $document): string
+{
+    return toRelaxedExtendedJSON(fromPHP($document));
+}
+
+$client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
+
+$collection = $client->test->coll;
+$collection->drop();
+
+$documents = [];
+
+for ($i = 0; $i < 100; $i++) {
+    $documents[] = ['randomValue' => rand(0, 1000)];
+}
+
+$collection->insertMany($documents);
+
+$pipeline = [
+    [
+        '$group' => [
+            '_id' => null,
+            'totalCount' => ['$sum' => 1],
+            'evenCount' => [
+                '$sum' => ['$mod' => ['$randomValue', 2]],
+            ],
+            'oddCount' => [
+                '$sum' => ['$subtract' => [1, ['$mod' => ['$randomValue', 2]]]],
+            ],
+            'maxValue' => ['$max' => '$randomValue'],
+            'minValue' => ['$min' => '$randomValue'],
+        ],
+    ],
+];
+
+$cursor = $collection->aggregate($pipeline, ['batchSize' => 2]);
+
+foreach ($cursor as $document) {
+    assert(is_object($document));
+    printf("%s\n", toJSON($document));
+}

--- a/examples/aggregate.php
+++ b/examples/aggregate.php
@@ -51,7 +51,7 @@ $pipeline = [
     ],
 ];
 
-$cursor = $collection->aggregate($pipeline, ['batchSize' => 2]);
+$cursor = $collection->aggregate($pipeline);
 
 foreach ($cursor as $document) {
     assert(is_object($document));

--- a/examples/aggregate.php
+++ b/examples/aggregate.php
@@ -6,7 +6,6 @@ namespace MongoDB\Examples;
 use MongoDB\Client;
 
 use function assert;
-use function dirname;
 use function getenv;
 use function is_object;
 use function MongoDB\BSON\fromPHP;
@@ -14,7 +13,7 @@ use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 use function rand;
 
-require dirname(__FILE__) . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {

--- a/examples/bulk.php
+++ b/examples/bulk.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace MongoDB\Examples;
+
+use MongoDB\Client;
+
+use function assert;
+use function dirname;
+use function getenv;
+use function is_object;
+use function MongoDB\BSON\fromPHP;
+use function MongoDB\BSON\toRelaxedExtendedJSON;
+use function printf;
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
+
+function toJSON(object $document): string
+{
+    return toRelaxedExtendedJSON(fromPHP($document));
+}
+
+$client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
+
+$collection = $client->test->coll;
+$collection->drop();
+
+$documents = [];
+
+for ($i = 0; $i < 10; $i++) {
+    $documents[] = ['x' => $i];
+}
+
+$collection->insertMany($documents);
+
+$collection->bulkWrite(
+    [
+        [
+            'deleteMany' => [
+                ['x' => ['$gt' => 7]], // Filter
+            ],
+        ],
+        [
+            'deleteOne' => [
+                ['x' => 4], // Filter
+            ],
+        ],
+        [
+            'replaceOne' => [
+                ['x' => 1], // Filter
+                ['y' => 1], // Replacement
+            ],
+        ],
+        [
+            'updateMany' => [
+                ['x' => ['$gt' => 5]], // Filter
+                ['$set' => ['updateMany' => true]], // Update
+            ],
+        ],
+        [
+            'updateOne' => [
+                ['x' => 2], // Filter
+                ['$set' => ['y' => 2]], // Update
+            ],
+        ],
+        [
+            'insertOne' => [
+                ['x' => 10], // Document
+            ],
+        ],
+    ]
+);
+
+$cursor = $collection->find([], ['batchSize' => 2]);
+
+foreach ($cursor as $document) {
+    assert(is_object($document));
+    printf("%s\n", toJSON($document));
+}

--- a/examples/bulk.php
+++ b/examples/bulk.php
@@ -6,14 +6,13 @@ namespace MongoDB\Examples;
 use MongoDB\Client;
 
 use function assert;
-use function dirname;
 use function getenv;
 use function is_object;
 use function MongoDB\BSON\fromPHP;
 use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 
-require dirname(__FILE__) . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {

--- a/examples/bulk.php
+++ b/examples/bulk.php
@@ -71,7 +71,7 @@ $collection->bulkWrite(
     ]
 );
 
-$cursor = $collection->find([], ['batchSize' => 2]);
+$cursor = $collection->find([]);
 
 foreach ($cursor as $document) {
     assert(is_object($document));

--- a/examples/changestream.php
+++ b/examples/changestream.php
@@ -23,6 +23,7 @@ function toJSON(object $document): string
     return toRelaxedExtendedJSON(fromPHP($document));
 }
 
+// Change streams require a replica set or sharded cluster
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
 $collection = $client->test->coll;

--- a/examples/changestream.php
+++ b/examples/changestream.php
@@ -3,11 +3,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Examples;
 
-require '../vendor/autoload.php';
-
 use MongoDB\Client;
 
 use function assert;
+use function dirname;
 use function fprintf;
 use function getenv;
 use function is_object;
@@ -17,6 +16,8 @@ use function printf;
 use function time;
 
 use const STDERR;
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {

--- a/examples/changestream.php
+++ b/examples/changestream.php
@@ -6,7 +6,6 @@ namespace MongoDB\Examples;
 use MongoDB\Client;
 
 use function assert;
-use function dirname;
 use function fprintf;
 use function getenv;
 use function is_object;
@@ -17,7 +16,7 @@ use function time;
 
 use const STDERR;
 
-require dirname(__FILE__) . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -28,7 +28,6 @@ function toJSON(object $document): string
     return toRelaxedExtendedJSON(fromPHP($document));
 }
 
-// phpcs:disable Squiz.Classes.ClassFileName.NoMatch
 class CommandLogger implements CommandSubscriber
 {
     public function commandStarted(CommandStartedEvent $event): void

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Examples;
 
-require '../vendor/autoload.php';
-
 use MongoDB\Client;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
@@ -12,6 +10,7 @@ use MongoDB\Driver\Monitoring\CommandSubscriber;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 
 use function assert;
+use function dirname;
 use function fprintf;
 use function get_class;
 use function getenv;
@@ -21,6 +20,8 @@ use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 
 use const STDERR;
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -10,7 +10,6 @@ use MongoDB\Driver\Monitoring\CommandSubscriber;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 
 use function assert;
-use function dirname;
 use function fprintf;
 use function get_class;
 use function getenv;
@@ -21,7 +20,7 @@ use function printf;
 
 use const STDERR;
 
-require dirname(__FILE__) . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {

--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -9,7 +9,6 @@ use MongoDB\Client;
 use MongoDB\Model\BSONArray;
 use UnexpectedValueException;
 
-use function array_search;
 use function getenv;
 use function var_dump;
 
@@ -21,10 +20,10 @@ class PersistableEntry implements Persistable
     private $id;
 
     /** @var string */
-    private $name;
+    public $name;
 
     /** @var array<PersistableEmail> */
-    private $emails = [];
+    public $emails = [];
 
     public function __construct(string $name)
     {
@@ -35,36 +34,6 @@ class PersistableEntry implements Persistable
     public function getId(): ObjectId
     {
         return $this->id;
-    }
-
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    public function setName(string $name): void
-    {
-        $this->name = $name;
-    }
-
-    public function getEmails(): array
-    {
-        return $this->emails;
-    }
-
-    public function addEmail(PersistableEmail $email): void
-    {
-        $this->emails[] = $email;
-    }
-
-    public function deleteEmail(PersistableEmail $email): void
-    {
-        $index = array_search($email, $this->emails, true);
-        if ($index === false) {
-            return;
-        }
-
-        unset($this->emails[$index]);
     }
 
     public function bsonSerialize(): object
@@ -97,25 +66,15 @@ class PersistableEntry implements Persistable
 class PersistableEmail implements Persistable
 {
     /** @var string */
-    private $type;
+    public $type;
 
     /** @var string */
-    private $address;
+    public $address;
 
     public function __construct(string $type, string $address)
     {
         $this->type = $type;
         $this->address = $address;
-    }
-
-    public function getType(): string
-    {
-        return $this->type;
-    }
-
-    public function getAddress(): string
-    {
-        return $this->address;
     }
 
     public function bsonSerialize(): object
@@ -134,8 +93,8 @@ class PersistableEmail implements Persistable
 }
 
 $entry = new PersistableEntry('alcaeus');
-$entry->addEmail(new PersistableEmail('work', 'alcaeus@example.com'));
-$entry->addEmail(new PersistableEmail('private', 'secret@example.com'));
+$entry->emails[] = new PersistableEmail('work', 'alcaeus@example.com');
+$entry->emails[] = new PersistableEmail('private', 'secret@example.com');
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 

--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -1,0 +1,139 @@
+<?php
+declare(strict_types=1);
+
+namespace MongoDB\Examples;
+
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\Persistable;
+use MongoDB\Client;
+use stdClass;
+
+use function array_search;
+use function dirname;
+use function getenv;
+use function var_dump;
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
+
+class Entry implements Persistable
+{
+    /** @var ObjectId */
+    private $id;
+
+    /** @var string */
+    private $name;
+
+    /** @var array<Email> */
+    private $emails = [];
+
+    public function __construct(string $name)
+    {
+        $this->id = new ObjectId();
+        $this->name = $name;
+    }
+
+    public function getId(): ObjectId
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getEmails(): array
+    {
+        return $this->emails;
+    }
+
+    public function addEmail(Email $email): void
+    {
+        $this->emails[] = $email;
+    }
+
+    public function deleteEmail(Email $email): void
+    {
+        $index = array_search($email, $this->emails, true);
+        if ($index === false) {
+            return;
+        }
+
+        unset($this->emails[$index]);
+    }
+
+    public function bsonSerialize(): stdClass
+    {
+        return (object) [
+            '_id' => $this->id,
+            'name' => $this->name,
+            'emails' => $this->emails,
+        ];
+    }
+
+    public function bsonUnserialize(array $data): void
+    {
+        $this->id = $data['_id'];
+        $this->name = (string) $data['name'];
+        $this->emails = $data['emails']->getArrayCopy(); // Emails will be passed as a BSONArray instance
+    }
+}
+
+class Email implements Persistable
+{
+    /** @var string */
+    private $type;
+
+    /** @var string */
+    private $address;
+
+    public function __construct(string $type, string $address)
+    {
+        $this->type = $type;
+        $this->address = $address;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    public function bsonSerialize(): stdClass
+    {
+        return (object) [
+            'type' => $this->type,
+            'address' => $this->address,
+        ];
+    }
+
+    public function bsonUnserialize(array $data): void
+    {
+        $this->type = (string) $data['type'];
+        $this->address = (string) $data['address'];
+    }
+}
+
+$entry = new Entry('alcaeus');
+$entry->addEmail(new Email('work', 'alcaeus@example.com'));
+$entry->addEmail(new Email('private', 'secret@example.com'));
+
+$client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
+
+$collection = $client->test->coll;
+$collection->drop();
+
+$collection->insertOne($entry);
+
+$foundEntry = $collection->findOne([]);
+
+var_dump($foundEntry);

--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -6,7 +6,8 @@ namespace MongoDB\Examples;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Persistable;
 use MongoDB\Client;
-use stdClass;
+use MongoDB\Model\BSONArray;
+use UnexpectedValueException;
 
 use function array_search;
 use function dirname;
@@ -15,7 +16,7 @@ use function var_dump;
 
 require dirname(__FILE__) . '/../vendor/autoload.php';
 
-class Entry implements Persistable
+class PersistableEntry implements Persistable
 {
     /** @var ObjectId */
     private $id;
@@ -23,7 +24,7 @@ class Entry implements Persistable
     /** @var string */
     private $name;
 
-    /** @var array<Email> */
+    /** @var array<PersistableEmail> */
     private $emails = [];
 
     public function __construct(string $name)
@@ -52,12 +53,12 @@ class Entry implements Persistable
         return $this->emails;
     }
 
-    public function addEmail(Email $email): void
+    public function addEmail(PersistableEmail $email): void
     {
         $this->emails[] = $email;
     }
 
-    public function deleteEmail(Email $email): void
+    public function deleteEmail(PersistableEmail $email): void
     {
         $index = array_search($email, $this->emails, true);
         if ($index === false) {
@@ -67,7 +68,7 @@ class Entry implements Persistable
         unset($this->emails[$index]);
     }
 
-    public function bsonSerialize(): stdClass
+    public function bsonSerialize(): object
     {
         return (object) [
             '_id' => $this->id,
@@ -78,13 +79,23 @@ class Entry implements Persistable
 
     public function bsonUnserialize(array $data): void
     {
+        if (! $data['_id'] instanceof ObjectId) {
+            throw new UnexpectedValueException('_id field is not of the expected type');
+        }
+
+        if (! $data['emails'] instanceof BSONArray) {
+            throw new UnexpectedValueException('emails field is not of the expected type');
+        }
+
         $this->id = $data['_id'];
         $this->name = (string) $data['name'];
+
+        /** @psalm-suppress MixedPropertyTypeCoercion */
         $this->emails = $data['emails']->getArrayCopy(); // Emails will be passed as a BSONArray instance
     }
 }
 
-class Email implements Persistable
+class PersistableEmail implements Persistable
 {
     /** @var string */
     private $type;
@@ -108,7 +119,7 @@ class Email implements Persistable
         return $this->address;
     }
 
-    public function bsonSerialize(): stdClass
+    public function bsonSerialize(): object
     {
         return (object) [
             'type' => $this->type,
@@ -123,9 +134,9 @@ class Email implements Persistable
     }
 }
 
-$entry = new Entry('alcaeus');
-$entry->addEmail(new Email('work', 'alcaeus@example.com'));
-$entry->addEmail(new Email('private', 'secret@example.com'));
+$entry = new PersistableEntry('alcaeus');
+$entry->addEmail(new PersistableEmail('work', 'alcaeus@example.com'));
+$entry->addEmail(new PersistableEmail('private', 'secret@example.com'));
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
@@ -136,4 +147,5 @@ $collection->insertOne($entry);
 
 $foundEntry = $collection->findOne([]);
 
+/** @psalm-suppress ForbiddenCode */
 var_dump($foundEntry);

--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -10,11 +10,10 @@ use MongoDB\Model\BSONArray;
 use UnexpectedValueException;
 
 use function array_search;
-use function dirname;
 use function getenv;
 use function var_dump;
 
-require dirname(__FILE__) . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 class PersistableEntry implements Persistable
 {

--- a/examples/typemap.php
+++ b/examples/typemap.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace MongoDB\Examples;
+
+use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\Unserializable;
+use MongoDB\Client;
+use UnexpectedValueException;
+
+use function dirname;
+use function getenv;
+use function is_array;
+use function var_dump;
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
+
+class TypemapEntry implements Unserializable
+{
+    /** @var ObjectId */
+    private $id;
+
+    /** @var string */
+    private $name;
+
+    /** @var array<TypemapEmail> */
+    private $emails;
+
+    private function __construct()
+    {
+    }
+
+    public function getId(): ObjectId
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getEmails(): array
+    {
+        return $this->emails;
+    }
+
+    public function bsonUnserialize(array $data): void
+    {
+        if (! $data['_id'] instanceof ObjectId) {
+            throw new UnexpectedValueException('_id field is not of the expected type');
+        }
+
+        if (! is_array($data['emails'])) {
+            throw new UnexpectedValueException('emails field is not of the expected type');
+        }
+
+        $this->id = $data['_id'];
+        $this->name = (string) $data['name'];
+
+        /** @psalm-suppress MixedPropertyTypeCoercion */
+        $this->emails = $data['emails'];
+    }
+}
+
+class TypemapEmail implements Unserializable
+{
+    /** @var string */
+    private $type;
+
+    /** @var string */
+    private $address;
+
+    private function __construct()
+    {
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    public function bsonUnserialize(array $data): void
+    {
+        $this->type = (string) $data['type'];
+        $this->address = (string) $data['address'];
+    }
+}
+
+$client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
+
+$collection = $client->test->coll;
+$collection->drop();
+
+$document = [
+    'name' => 'alcaeus',
+    'emails' => [
+        ['type' => 'work', 'address' => 'alcaeus@example.com'],
+        ['type' => 'private', 'address' => 'secret@example.com'],
+    ],
+];
+
+$collection->insertOne($document);
+
+$typeMap = [
+    'root' => TypemapEntry::class, // Root object will be an Entry instance
+    'fieldPaths' => [
+        'emails' => 'array', // Emails field is used as PHP array
+        'emails.$' => TypemapEmail::class, // Each element in the emails array will be an Email instance
+    ],
+];
+
+$entry = $collection->findOne([], ['typeMap' => $typeMap]);
+
+/** @psalm-suppress ForbiddenCode */
+var_dump($entry);

--- a/examples/typemap.php
+++ b/examples/typemap.php
@@ -14,7 +14,7 @@ use function var_dump;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-class TypemapEntry implements Unserializable
+class TypeMapEntry implements Unserializable
 {
     /** @var ObjectId */
     private $id;
@@ -22,7 +22,7 @@ class TypemapEntry implements Unserializable
     /** @var string */
     private $name;
 
-    /** @var array<TypemapEmail> */
+    /** @var array<TypeMapEmail> */
     private $emails;
 
     private function __construct()
@@ -62,7 +62,7 @@ class TypemapEntry implements Unserializable
     }
 }
 
-class TypemapEmail implements Unserializable
+class TypeMapEmail implements Unserializable
 {
     /** @var string */
     private $type;
@@ -107,10 +107,10 @@ $document = [
 $collection->insertOne($document);
 
 $typeMap = [
-    'root' => TypemapEntry::class, // Root object will be an Entry instance
+    'root' => TypeMapEntry::class, // Root object will be an Entry instance
     'fieldPaths' => [
         'emails' => 'array', // Emails field is used as PHP array
-        'emails.$' => TypemapEmail::class, // Each element in the emails array will be an Email instance
+        'emails.$' => TypeMapEmail::class, // Each element in the emails array will be an Email instance
     ],
 ];
 

--- a/examples/typemap.php
+++ b/examples/typemap.php
@@ -8,12 +8,11 @@ use MongoDB\BSON\Unserializable;
 use MongoDB\Client;
 use UnexpectedValueException;
 
-use function dirname;
 use function getenv;
 use function is_array;
 use function var_dump;
 
-require dirname(__FILE__) . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 class TypemapEntry implements Unserializable
 {

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace MongoDB\Examples;
+
+use MongoDB\Client;
+use MongoDB\Driver\Session;
+
+use function assert;
+use function dirname;
+use function getenv;
+use function is_object;
+use function MongoDB\BSON\fromPHP;
+use function MongoDB\BSON\toRelaxedExtendedJSON;
+use function MongoDB\with_transaction;
+use function printf;
+
+require dirname(__FILE__) . '/../vendor/autoload.php';
+
+function toJSON(object $document): string
+{
+    return toRelaxedExtendedJSON(fromPHP($document));
+}
+
+$client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
+
+$collection = $client->test->coll;
+$collection->drop();
+
+$insertData = function (Session $session) use ($collection): void {
+    $collection->insertMany(
+        [
+            ['x' => 1],
+            ['x' => 2],
+            ['x' => 3],
+        ],
+        ['session' => $session]
+    );
+
+    $collection->updateMany(
+        ['x' => ['$gt' => 1]],
+        ['$set' => ['y' => 1]],
+        ['session' => $session]
+    );
+};
+
+$session = $client->startSession();
+
+with_transaction($session, $insertData);
+
+$cursor = $collection->find([], ['batchSize' => 2]);
+
+foreach ($cursor as $document) {
+    assert(is_object($document));
+    printf("%s\n", toJSON($document));
+}

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -48,7 +48,7 @@ $session = $client->startSession();
 
 with_transaction($session, $insertData);
 
-$cursor = $collection->find([], ['batchSize' => 2]);
+$cursor = $collection->find([]);
 
 foreach ($cursor as $document) {
     assert(is_object($document));

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -7,7 +7,6 @@ use MongoDB\Client;
 use MongoDB\Driver\Session;
 
 use function assert;
-use function dirname;
 use function getenv;
 use function is_object;
 use function MongoDB\BSON\fromPHP;
@@ -15,7 +14,7 @@ use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function MongoDB\with_transaction;
 use function printf;
 
-require dirname(__FILE__) . '/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -21,6 +21,7 @@ function toJSON(object $document): string
     return toRelaxedExtendedJSON(fromPHP($document));
 }
 
+// Transactions require a replica set (MongoDB >= 4.0) or sharded cluster (MongoDB >= 4.2)
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
 $collection = $client->test->coll;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -176,6 +176,10 @@
         <exclude-pattern>/tests/GridFS/UnusableStream.php</exclude-pattern>
     </rule>
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+        <exclude-pattern>/examples</exclude-pattern>
         <exclude-pattern>/tests/PHPUnit/ConstraintTrait.php</exclude-pattern>
+    </rule>
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>/examples</exclude-pattern>
     </rule>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.x-dev@5108834088c1d8cae3698df6ef6bf15fe6e76c53">
+  <file src="examples/typemap.php">
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>$address</code>
+      <code>$emails</code>
+      <code>$id</code>
+      <code>$name</code>
+      <code>$type</code>
+    </PropertyNotSetInConstructor>
+  </file>
   <file src="src/Client.php">
     <MixedArgument occurrences="1">
       <code>$driverOptions['driver'] ?? []</code>


### PR DESCRIPTION
PHPLIB-987

This PR adds more examples for every-day use of the PHP library. New examples:
* bulk writes (this shows the syntax for each bulk write operation)
* `with_transaction` helper
* Aggregation pipeline
* Serialisation and Deserialisation using `MongoDB\BSON\Persistable`
* Deserialisation using `typeMap` and `MongoDB\BSON\Unserializable`

The first commit in the PR fixes an issue where running the example code from outside of the examples directory causes fatal errors.