### PR TITLE
Note name of error code literal in findAndModify WC test

### DIFF
--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -100,7 +100,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         }
 
         $this->expectException(CommandException::class);
-        $this->expectExceptionCode(100);
+        $this->expectExceptionCode(100 /* UnsatisfiableWriteConcern */);
         $this->expectExceptionMessageMatches('/Write Concern error:/');
 
         $operation = new FindAndModify(


### PR DESCRIPTION
Re: https://github.com/mongodb/mongo-php-library/pull/983#discussion_r984969825