### PR TITLE
PHPLIB-980: Make uri parameter for MongoDB\Client::__construct nullable

### DIFF
--- a/docs/reference/method/MongoDBClient__construct.txt
+++ b/docs/reference/method/MongoDBClient__construct.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function __construct($uri = 'mongodb://127.0.0.1/', array $uriOptions = [], array $driverOptions = [])
+      function __construct(?string $uri = null, array $uriOptions = [], array $driverOptions = [])
 
    This constructor has the following parameters:
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -44,6 +44,8 @@ use function is_string;
 
 class Client
 {
+    public const DEFAULT_URI = 'mongodb://127.0.0.1/';
+
     /** @var array */
     private static $defaultTypeMap = [
         'array' => BSONArray::class,
@@ -91,14 +93,14 @@ class Client
      * @see https://mongodb.com/docs/manual/reference/connection-string/
      * @see https://php.net/manual/en/mongodb-driver-manager.construct.php
      * @see https://php.net/manual/en/mongodb.persistence.php#mongodb.persistence.typemaps
-     * @param string $uri           MongoDB connection string
-     * @param array  $uriOptions    Additional connection string options
-     * @param array  $driverOptions Driver-specific options
+     * @param string|null $uri           MongoDB connection string. If none is provided, this defaults to self::DEFAULT_URI.
+     * @param array       $uriOptions    Additional connection string options
+     * @param array       $driverOptions Driver-specific options
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverInvalidArgumentException for parameter/option parsing errors in the driver
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function __construct(string $uri = 'mongodb://127.0.0.1/', array $uriOptions = [], array $driverOptions = [])
+    public function __construct(?string $uri = null, array $uriOptions = [], array $driverOptions = [])
     {
         $driverOptions += ['typeMap' => self::$defaultTypeMap];
 
@@ -116,7 +118,7 @@ class Client
 
         $driverOptions['driver'] = $this->mergeDriverInfo($driverOptions['driver'] ?? []);
 
-        $this->uri = $uri;
+        $this->uri = $uri ?? self::DEFAULT_URI;
         $this->typeMap = $driverOptions['typeMap'];
 
         unset($driverOptions['typeMap']);


### PR DESCRIPTION
PHPLIB-980

I decided to only make the `$uri` parameter nullable. While we could widen the types of both options parameters (constructors are excluded from contravariance checks), I believe this is contra-productive. The signature of `MongoDB\Manager` historically allowed `null`, but it's preferable to not allow `null` and instead default to an empty array. This is something I'd like to change in version 2.0 of the extension.

This also becomes a non-issue starting with PHP 8, as users can use named parameters if they want to only pass a single option:
```php
$client = new Client(driverOptions: ['foo' => 'bar']);
```

This makes using `null` as an easy default value easier.

For convenience and documentation purposes, I've also extracted the default URI into a public constant.