### PR TITLE
PHPLIB-950: Run legacy CSFLE tests on serverless

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -212,6 +212,55 @@ functions:
     - command: expansions.update
       params:
         file: src/serverless-expansion.yml
+    - command: shell.exec
+      params:
+        shell: "bash"
+        script: |
+          ${PREPARE_SHELL}
+          
+          if [ -z "${SERVERLESS_MONGODB_VERSION}" ]; then
+            echo "expected SERVERLESS_MONGODB_VERSION to be set"
+            exit 1
+          fi
+          
+          # Download the enterprise server download for current platform to $MONGODB_BINARIES.
+          # This is required for tests that need mongocryptd.
+          # $MONGODB_BINARIES is added to the $PATH in fetch-source.
+          ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
+              --component archive \
+              --version ${SERVERLESS_MONGODB_VERSION} \
+              --edition enterprise \
+              --out $MONGODB_BINARIES \
+              --strip-path-components 2
+          
+          # Download the crypt_shared dynamic library for the current platform.
+          ${PYTHON3_BINARY} $DRIVERS_TOOLS/.evergreen/mongodl.py \
+            --component crypt_shared \
+            --version ${SERVERLESS_MONGODB_VERSION} \
+            --edition enterprise \
+            --out . \
+            --only "**/mongo_crypt_v1.*" \
+            --strip-path-components 1
+          
+          # Find the crypt_shared library file in the current directory and set the CRYPT_SHARED_LIB_PATH to
+          # the path of that file. Only look for .so, .dll, or .dylib files to prevent matching any other
+          # downloaded files.
+          CRYPT_SHARED_LIB_PATH="$(find $(pwd) -maxdepth 1 -type f \
+            -name 'mongo_crypt_v1.so' -o \
+            -name 'mongo_crypt_v1.dll' -o \
+            -name 'mongo_crypt_v1.dylib')"
+          
+          # If we're on Windows, convert the "cygdrive" path to Windows-style paths.
+          if [ "Windows_NT" = "$OS" ]; then
+              CRYPT_SHARED_LIB_PATH=$(cygpath -m $CRYPT_SHARED_LIB_PATH)
+          fi
+          
+          echo "CRYPT_SHARED_LIB_PATH: $CRYPT_SHARED_LIB_PATH" >> crypt-expansion.yml
+
+    # Load the expansion file to make an evergreen variable with the current unique version
+    - command: expansions.update
+      params:
+        file: crypt-expansion.yml
 
   "delete serverless instance":
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -567,6 +567,7 @@ tasks:
       tags: ["serverless"]
       commands:
         - func: "create serverless instance"
+        - func: "start kms servers"
         - func: "run serverless tests"
 
     - name: "test-loadBalanced"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -326,6 +326,19 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
+          export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
+          export AZURE_TENANT_ID="${client_side_encryption_azure_tenant_id}"
+          export AZURE_CLIENT_ID="${client_side_encryption_azure_client_id}"
+          export AZURE_CLIENT_SECRET="${client_side_encryption_azure_client_secret}"
+          export GCP_EMAIL="${client_side_encryption_gcp_email}"
+          export GCP_PRIVATE_KEY="${client_side_encryption_gcp_privatekey}"
+          export KMIP_ENDPOINT="${client_side_encryption_kmip_endpoint}"
+          export KMS_ENDPOINT_EXPIRED="${client_side_encryption_kms_endpoint_expired}"
+          export KMS_ENDPOINT_WRONG_HOST="${client_side_encryption_kms_endpoint_wrong_host}"
+          export KMS_ENDPOINT_REQUIRE_CLIENT_CERT="${client_side_encryption_kms_endpoint_require_client_cert}"
+          export KMS_TLS_CA_FILE="${client_side_encryption_kms_tls_ca_file}"
+          export KMS_TLS_CERTIFICATE_KEY_FILE="${client_side_encryption_kms_tls_certificate_key_file}"
           export MONGODB_IS_SERVERLESS=on
           export MONGODB_USERNAME=${SERVERLESS_ATLAS_USER}
           export MONGODB_PASSWORD=${SERVERLESS_ATLAS_PASSWORD}

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -55,6 +55,7 @@ use const PATH_SEPARATOR;
  *
  * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption
  * @group csfle
+ * @group serverless
  */
 class ClientSideEncryptionSpecTest extends FunctionalTestCase
 {

--- a/tests/SpecTests/client-side-encryption/tests/fle2-BypassQueryAnalysis.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-BypassQueryAnalysis.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-Compact.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-Compact.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-CreateCollection.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-DecryptExistingData.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-DecryptExistingData.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-Delete.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-EncryptedFields-vs-jsonSchema.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-EncryptedFields-vs-jsonSchema.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-EncryptedFieldsMap-defaults.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-EncryptedFieldsMap-defaults.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-FindOneAndUpdate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-InsertFind-Indexed.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-InsertFind-Indexed.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-InsertFind-Unindexed.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-InsertFind-Unindexed.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-MissingKey.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-MissingKey.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-NoEncryption.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-NoEncryption.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-Update.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/tests/SpecTests/client-side-encryption/tests/fle2-validatorAndPartialFieldExpression.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2-validatorAndPartialFieldExpression.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],


### PR DESCRIPTION
PHPLIB-950

Includes fixes required to get CSFLE running on Serverless in general:
* Needs mongocryptd or crypt_shared installed
* Needs secrets exported
* Needs KMS servers running

The download logic was shamelessly copied from the GO driver, as this isn't available through drivers-evergreen-tools. I've created DRIVERS-2459 to track this and will take a look when possible.