### PR TITLE
PHPLIB-899: No longer use buildinfo command to detect Atlas Data Lake instances

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,7 +192,7 @@ functions:
     - command: shell.exec
       params:
         script: |
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          VARIANT=debian11 DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
     - command: shell.exec
       params:
         background: true

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,7 +192,7 @@ functions:
     - command: shell.exec
       params:
         script: |
-          VARIANT=debian11 DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          VARIANT=${VARIANT} DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
     - command: shell.exec
       params:
         background: true
@@ -834,6 +834,8 @@ buildvariants:
   matrix_spec: { "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
   display_name: "Atlas Data Lake"
   run_on: debian11
+  expansions:
+    VARIANT: debian11
   tasks:
     - name: "test-atlas-data-lake"
 


### PR DESCRIPTION
PHPLIB-899

This PR changes the detection logic for Atlas Data Lake to no longer use `buildInfo`, but rather rely on an externally set environment variable, as ADL no longer supports `buildInfo`. In addition, it changes the Evergreen build variant to use Ubuntu 18.04 as the built-in mongohoused didn't run on debian11.

Note that ADL tests will still fail due to CDRIVER-4502; this will be fixed in a separate pull request.