### PR TITLE
PHPLIB-1023: Provide OS variant when building mongohoused

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -192,7 +192,7 @@ functions:
     - command: shell.exec
       params:
         script: |
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          VARIANT=${VARIANT} DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
     - command: shell.exec
       params:
         background: true
@@ -834,6 +834,8 @@ buildvariants:
   matrix_spec: { "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
   display_name: "Atlas Data Lake"
   run_on: debian11
+  expansions:
+    VARIANT: debian11
   tasks:
     - name: "test-atlas-data-lake"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -835,7 +835,7 @@ buildvariants:
   display_name: "Atlas Data Lake"
   run_on: debian11
   expansions:
-    VARIANT: debian11
+     VARIANT: debian11 # Referenced by ADL build script for downloading MQLRun
   tasks:
     - name: "test-atlas-data-lake"
 


### PR DESCRIPTION
PHPLIB-1023

This resolves error with our go config to make Atlas Data Lake tests run again. Previous build failures are resolved through the libmongoc update in https://github.com/mongodb/mongo-php-driver/pull/1377

[Patch Build](https://spruce.mongodb.com/version/63563b3fe3c3315544f9c980/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Eatlas-data-lake-test__php-edge-versions~latest-stable_driver-versions~latest-stable%24)