### PR TITLE
PHPLIB-951: Assert operation before argument validation

### DIFF
--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -20,6 +20,7 @@ use function array_fill_keys;
 use function array_key_exists;
 use function array_keys;
 use function implode;
+use function PHPUnit\Framework\assertArrayHasKey;
 use function PHPUnit\Framework\assertContains;
 use function PHPUnit\Framework\assertEmpty;
 use function PHPUnit\Framework\assertIsArray;
@@ -141,6 +142,8 @@ final class Util
 
     public static function assertArgumentsBySchema(string $executingObjectName, string $operation, array $args): void
     {
+        assertArrayHasKey($executingObjectName, self::$args);
+        assertArrayHasKey($operation, self::$args[$executingObjectName]);
         self::assertHasOnlyKeys($args, self::$args[$executingObjectName][$operation]);
     }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-951

This prevents a potential PHP warning for accessing a nonexistent array key if the operation doesn't exist, which was responsible for some Astrolabe test failures.

Since assertArgumentsBySchema() is called before the switch statement in Operation execute methods, we don't yet know that the operation exists. With this change, we should never hit default cases in those switch statements; however, they can remain in place for now.

Patch build for [drivers-atlas-testing](https://spruce.mongodb.com/task/drivers_atlas_testing_tests_php__driver~php_master_platform~ubuntu_18.04_runtime~php_74_validate_workload_executor_patch_c7e1bedc4ad19fbaf619153666a49b47a7744e82_636114d032f41762d7b215cd_22_11_01_12_45_23/logs?execution=0) using this PR branch.