### PR TITLE
PHPLIB-1037: Ensure EntityMap is set before invoking observer callable

### DIFF
--- a/tests/UnifiedSpecTests/UnifiedTestRunner.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunner.php
@@ -125,7 +125,7 @@ final class UnifiedTestRunner
              * succeeding or failing. Since the callable itself might throw, we
              * need to ensure doTearDown() will still be called. */
             try {
-                if (isset($this->entityMapObserver)) {
+                if (isset($this->entityMapObserver, $this->entityMap)) {
                     call_user_func($this->entityMapObserver, $this->entityMap);
                 }
             } finally {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1037

This handles the case where a test fails prior to Context initialization (e.g. while populating initial data).

Patch build: https://spruce.mongodb.com/version/63633849e3c331270cf5886a/tasks