### PR TITLE
PHPLIB-981: Add tests for examples

### DIFF
--- a/examples/aggregate.php
+++ b/examples/aggregate.php
@@ -22,7 +22,7 @@ function toJSON(object $document): string
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
-$collection = $client->test->coll;
+$collection = $client->test->aggregate;
 $collection->drop();
 
 $documents = [];

--- a/examples/bulk.php
+++ b/examples/bulk.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace MongoDB\Examples;
 
 use MongoDB\Client;
+use MongoDB\Driver\WriteConcern;
 
 use function assert;
 use function getenv;
@@ -30,7 +31,7 @@ for ($i = 0; $i < 10; $i++) {
     $documents[] = ['x' => $i];
 }
 
-$collection->insertMany($documents);
+$collection->insertMany($documents, ['writeConcern' => new WriteConcern('majority')]);
 
 $collection->bulkWrite(
     [

--- a/examples/bulk.php
+++ b/examples/bulk.php
@@ -22,7 +22,7 @@ function toJSON(object $document): string
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
-$collection = $client->test->coll;
+$collection = $client->test->bulk;
 $collection->drop();
 
 $documents = [];

--- a/examples/changestream.php
+++ b/examples/changestream.php
@@ -6,15 +6,12 @@ namespace MongoDB\Examples;
 use MongoDB\Client;
 
 use function assert;
-use function fprintf;
 use function getenv;
 use function is_object;
 use function MongoDB\BSON\fromPHP;
 use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 use function time;
-
-use const STDERR;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -53,7 +50,7 @@ while (true) {
     $changeStream->next();
 
     if (time() - $startTime > 3) {
-        fprintf(STDERR, "Aborting after 3 seconds...\n");
+        printf("Aborting after 3 seconds...\n");
         break;
     }
 }

--- a/examples/changestream.php
+++ b/examples/changestream.php
@@ -23,11 +23,11 @@ function toJSON(object $document): string
 // Change streams require a replica set or sharded cluster
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
-$collection = $client->test->coll;
+$collection = $client->test->changestream;
 $collection->drop();
 
 // Create collection before starting change stream; this is required on MongoDB 3.6
-$client->test->createCollection('coll');
+$client->test->createCollection('changestream');
 
 $changeStream = $collection->watch();
 

--- a/examples/changestream.php
+++ b/examples/changestream.php
@@ -26,6 +26,9 @@ $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 $collection = $client->test->coll;
 $collection->drop();
 
+// Create collection before starting change stream; this is required on MongoDB 3.6
+$client->test->createCollection('coll');
+
 $changeStream = $collection->watch();
 
 $documents = [];

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -10,15 +10,12 @@ use MongoDB\Driver\Monitoring\CommandSubscriber;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 
 use function assert;
-use function fprintf;
 use function get_class;
 use function getenv;
 use function is_object;
 use function MongoDB\BSON\fromPHP;
 use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
-
-use const STDERR;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -31,29 +28,29 @@ class CommandLogger implements CommandSubscriber
 {
     public function commandStarted(CommandStartedEvent $event): void
     {
-        fprintf(STDERR, "%s command started\n", $event->getCommandName());
+        printf("%s command started\n", $event->getCommandName());
 
-        fprintf(STDERR, "command: %s\n", toJson($event->getCommand()));
-        fprintf(STDERR, "\n");
+        printf("command: %s\n", toJson($event->getCommand()));
+        printf("\n");
     }
 
     public function commandSucceeded(CommandSucceededEvent $event): void
     {
-        fprintf(STDERR, "%s command succeeded\n", $event->getCommandName());
-        fprintf(STDERR, "reply: %s\n", toJson($event->getReply()));
-        fprintf(STDERR, "\n");
+        printf("%s command succeeded\n", $event->getCommandName());
+        printf("reply: %s\n", toJson($event->getReply()));
+        printf("\n");
     }
 
     public function commandFailed(CommandFailedEvent $event): void
     {
-        fprintf(STDERR, "%s command failed\n", $event->getCommandName());
-        fprintf(STDERR, "reply: %s\n", toJson($event->getReply()));
+        printf("%s command failed\n", $event->getCommandName());
+        printf("reply: %s\n", toJson($event->getReply()));
 
         $exception = $event->getError();
-        fprintf(STDERR, "exception: %s\n", get_class($exception));
-        fprintf(STDERR, "exception.code: %d\n", $exception->getCode());
-        fprintf(STDERR, "exception.message: %s\n", $exception->getMessage());
-        fprintf(STDERR, "\n");
+        printf("exception: %s\n", get_class($exception));
+        printf("exception.code: %d\n", $exception->getCode());
+        printf("exception.message: %s\n", $exception->getMessage());
+        printf("\n");
     }
 }
 

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -58,7 +58,7 @@ $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
 $client->getManager()->addSubscriber(new CommandLogger());
 
-$collection = $client->test->commandlogger;
+$collection = $client->test->command_logger;
 $collection->drop();
 
 $collection->insertMany([

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -58,7 +58,7 @@ $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
 $client->getManager()->addSubscriber(new CommandLogger());
 
-$collection = $client->test->coll;
+$collection = $client->test->commandlogger;
 $collection->drop();
 
 $collection->insertMany([

--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -98,7 +98,7 @@ $entry->emails[] = new PersistableEmail('private', 'secret@example.com');
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
-$collection = $client->test->coll;
+$collection = $client->test->persistable;
 $collection->drop();
 
 $collection->insertOne($entry);

--- a/examples/typemap.php
+++ b/examples/typemap.php
@@ -93,7 +93,7 @@ class TypeMapEmail implements Unserializable
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
-$collection = $client->test->coll;
+$collection = $client->test->typemap;
 $collection->drop();
 
 $document = [

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -24,11 +24,11 @@ function toJSON(object $document): string
 // Transactions require a replica set (MongoDB >= 4.0) or sharded cluster (MongoDB >= 4.2)
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
-$collection = $client->test->coll;
+$collection = $client->test->transaction;
 $collection->drop();
 
 // Create collection outside of transaction; this is required when using MongoDB < 4.4
-$client->test->createCollection('coll');
+$client->test->createCollection('transaction');
 
 $insertData = function (Session $session) use ($collection): void {
     $collection->insertMany(

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -24,11 +24,11 @@ function toJSON(object $document): string
 // Transactions require a replica set (MongoDB >= 4.0) or sharded cluster (MongoDB >= 4.2)
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
-$collection = $client->test->transaction;
+$collection = $client->test->with_transaction;
 $collection->drop();
 
 // Create collection outside of transaction; this is required when using MongoDB < 4.4
-$client->test->createCollection('transaction');
+$client->test->createCollection('with_transaction');
 
 $insertData = function (Session $session) use ($collection): void {
     $collection->insertMany(

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -27,6 +27,9 @@ $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 $collection = $client->test->coll;
 $collection->drop();
 
+// Create collection outside of transaction; this is required when using MongoDB < 4.4
+$client->test->createCollection('coll');
+
 $insertData = function (Session $session) use ($collection): void {
     $collection->insertMany(
         [

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.x-dev@5108834088c1d8cae3698df6ef6bf15fe6e76c53">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="examples/typemap.php">
     <PropertyNotSetInConstructor occurrences="5">
       <code>$address</code>
@@ -99,14 +99,10 @@
       <code>drop</code>
       <code>rename</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$id</code>
+    <MixedArgument occurrences="2">
       <code>$options['revision']</code>
       <code>$options['revision']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$id</code>
-    </MixedAssignment>
   </file>
   <file src="src/GridFS/Exception/CorruptFileException.php">
     <UnsafeInstantiation occurrences="4">
@@ -117,24 +113,12 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Exception/FileNotFoundException.php">
-    <MixedArgument occurrences="1">
-      <code>$json</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$json</code>
-    </MixedAssignment>
     <UnsafeInstantiation occurrences="2">
       <code>new static(sprintf('File "%s" not found in "%s"', $json, $namespace))</code>
       <code>new static(sprintf('File with name "%s" and revision "%d" not found in "%s"', $filename, $revision, $namespace))</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Exception/StreamException.php">
-    <MixedArgument occurrences="1">
-      <code>$idString</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$idString</code>
-    </MixedAssignment>
     <UnsafeInstantiation occurrences="3">
       <code>new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $filename))</code>
       <code>new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString))</code>
@@ -357,7 +341,7 @@
       <code>$args[1]</code>
       <code>$args[2]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="24">
+    <MixedArrayAccess occurrences="19">
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
@@ -396,7 +380,7 @@
       <code>$operations[$i][$type][2]</code>
       <code>$operations[$i][$type][2]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment occurrences="10">
       <code>$args</code>
       <code>$args</code>
       <code>$args[2]</code>
@@ -815,18 +799,16 @@
       <code>$typeMap['fieldPaths'][$fieldPath]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
-      <code>array|object</code>
+    <MixedInferredReturnType occurrences="2">
       <code>array|object|null</code>
       <code>array|object|null</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="1">
       <code>$type</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement occurrences="2">
       <code>$collectionInfo['options']['encryptedFields'] ?? null</code>
       <code>$encryptedFieldsMap[$databaseName . '.' . $collectionName] ?? null</code>
-      <code>toPHP(fromPHP($document), $typeMap)</code>
     </MixedReturnStatement>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -397,7 +397,10 @@
       <code>$args[1]</code>
       <code>$args[2]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="19">
+    <MixedArrayAccess occurrences="25">
+      <code>$args[0]</code>
+      <code>$args[0]</code>
+      <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -407,6 +410,9 @@
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
+      <code>$args[1]</code>
+      <code>$args[1]</code>
+      <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
@@ -431,7 +437,8 @@
       <code>$operations[$i][$type][2]</code>
       <code>$operations[$i][$type][2]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment occurrences="11">
+      <code>$args</code>
       <code>$args</code>
       <code>$args[2]</code>
       <code>$args[2]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+  <file src="examples/aggregate.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="examples/bulk.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="examples/changestream.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="examples/command_logger.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
+    </MixedReturnStatement>
+  </file>
   <file src="examples/typemap.php">
     <PropertyNotSetInConstructor occurrences="5">
       <code>$address</code>
@@ -8,6 +40,14 @@
       <code>$name</code>
       <code>$type</code>
     </PropertyNotSetInConstructor>
+  </file>
+  <file src="examples/with_transaction.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
+    </MixedReturnStatement>
   </file>
   <file src="src/Client.php">
     <MixedArgument occurrences="1">
@@ -99,10 +139,14 @@
       <code>drop</code>
       <code>rename</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="3">
+      <code>$id</code>
       <code>$options['revision']</code>
       <code>$options['revision']</code>
     </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$id</code>
+    </MixedAssignment>
   </file>
   <file src="src/GridFS/Exception/CorruptFileException.php">
     <UnsafeInstantiation occurrences="4">
@@ -113,12 +157,24 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Exception/FileNotFoundException.php">
+    <MixedArgument occurrences="1">
+      <code>$json</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$json</code>
+    </MixedAssignment>
     <UnsafeInstantiation occurrences="2">
       <code>new static(sprintf('File "%s" not found in "%s"', $json, $namespace))</code>
       <code>new static(sprintf('File with name "%s" and revision "%d" not found in "%s"', $filename, $revision, $namespace))</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Exception/StreamException.php">
+    <MixedArgument occurrences="1">
+      <code>$idString</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$idString</code>
+    </MixedAssignment>
     <UnsafeInstantiation occurrences="3">
       <code>new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $filename))</code>
       <code>new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString))</code>
@@ -343,8 +399,6 @@
     </MixedArgument>
     <MixedArrayAccess occurrences="19">
       <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -353,9 +407,6 @@
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
@@ -381,7 +432,6 @@
       <code>$operations[$i][$type][2]</code>
     </MixedArrayAssignment>
     <MixedAssignment occurrences="10">
-      <code>$args</code>
       <code>$args</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
@@ -799,16 +849,18 @@
       <code>$typeMap['fieldPaths'][$fieldPath]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="3">
+      <code>array|object</code>
       <code>array|object|null</code>
       <code>array|object|null</code>
     </MixedInferredReturnType>
     <MixedOperand occurrences="1">
       <code>$type</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement occurrences="3">
       <code>$collectionInfo['options']['encryptedFields'] ?? null</code>
       <code>$encryptedFieldsMap[$databaseName . '.' . $collectionName] ?? null</code>
+      <code>toPHP(fromPHP($document), $typeMap)</code>
     </MixedReturnStatement>
   </file>
 </files>

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -27,6 +27,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 
 use function array_key_exists;
+use function assert;
 use function count;
 use function current;
 use function is_array;
@@ -324,6 +325,8 @@ class BulkWrite implements Executable
         foreach ($this->operations as $i => $operation) {
             $type = key($operation);
             $args = current($operation);
+
+            assert(is_array($args));
 
             switch ($type) {
                 case self::DELETE_MANY:

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -27,7 +27,6 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 
 use function array_key_exists;
-use function assert;
 use function count;
 use function current;
 use function is_array;
@@ -325,8 +324,6 @@ class BulkWrite implements Executable
         foreach ($this->operations as $i => $operation) {
             $type = key($operation);
             $args = current($operation);
-
-            assert(is_array($args));
 
             switch ($type) {
                 case self::DELETE_MANY:

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -26,14 +26,14 @@ OUTPUT;
         ];
 
         $expectedOutput = <<<'OUTPUT'
-{ "_id" : { "$oid" : "%s" }, "x" : 0 }
-{ "_id" : { "$oid" : "%s" }, "y" : 1 }
-{ "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 2 }
-{ "_id" : { "$oid" : "%s" }, "x" : 3 }
-{ "_id" : { "$oid" : "%s" }, "x" : 5 }
-{ "_id" : { "$oid" : "%s" }, "x" : 6, "updateMany" : true }
-{ "_id" : { "$oid" : "%s" }, "x" : 7, "updateMany" : true }
-{ "_id" : { "$oid" : "%s" }, "x" : 10 }
+%s
+%s
+%s
+%s
+%s
+%s
+%s
+%s
 OUTPUT;
 
         yield 'bulk' => [
@@ -43,41 +43,41 @@ OUTPUT;
 
         $expectedOutput = <<<'OUTPUT'
 drop command started
-command: { "drop" : "coll", "$db" : "test", "lsid" : { %s }%S }
+command: %s
 
 drop command failed
-reply: { "ok" : 0.0, "errmsg" : "ns not found", "code" : 26, "codeName" : "NamespaceNotFound"%S }
+reply: %s
 exception: MongoDB\Driver\Exception\ServerException
 exception.code: 26
 exception.message: ns not found
 
 insert command started
-command: { "insert" : "coll", "ordered" : true, "$db" : "test", "lsid" : { %s }%S, "documents" : [ { "x" : 1, "_id" : { "$oid" : "%s" } }, { "x" : 2, "_id" : { "$oid" : "%s" } }, { "x" : 3, "_id" : { "$oid" : "%s" } } ] }
+command: %s
 
 insert command succeeded
-reply: { "n" : 3, %s }
+reply: %s
 
 update command started
-command: { "update" : "coll", "ordered" : true, "$db" : "test", "lsid" : { %s }%S, "updates" : [ { "q" : { "x" : { "$gt" : 1 } }, "u" : { "$set" : { "y" : 1 } }, "upsert" : false, "multi" : true } ] }
+command: %s
 
 update command succeeded
-reply: { "n" : 2, %s }
+reply: %s
 
 find command started
-command: { "find" : "coll", "filter" : {  }, "batchSize" : 2, "$db" : "test", "lsid" : { %s }%S }
+command: %s
 
 find command succeeded
-reply: { "cursor" : { "firstBatch" : [ { "_id" : { "$oid" : "%s" }, "x" : 1 }, { "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 1 } ], "id" : %d, "ns" : "test.coll" }, %s }
+reply: %s
 
-{ "_id" : { "$oid" : "%s" }, "x" : 1 }
-{ "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 1 }
+%s
+%s
 getMore command started
-command: { "getMore" : %d, "collection" : "coll", "batchSize" : 2, "$db" : "test", "lsid" : { %s }%S }
+command: %s
 
 getMore command succeeded
-reply: { "cursor" : { "nextBatch" : [ { "_id" : { "$oid" : "%s" }, "x" : 3, "y" : 1 } ], "id" : 0, "ns" : "test.coll" }, %s }
+reply: %s
 
-{ "_id" : { "$oid" : "%s" }, "x" : 3, "y" : 1 }
+%s
 OUTPUT;
 
         yield 'command_logger' => [
@@ -159,16 +159,16 @@ OUTPUT;
         $this->skipIfChangeStreamIsNotSupported();
 
         $expectedOutput = <<<'OUTPUT'
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 0 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 1 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 2 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 3 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 4 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 5 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 6 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 7 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 8 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 9 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+%s
+%s
+%s
+%s
+%s
+%s
+%s
+%s
+%s
+%s
 Aborting after 3 seconds...
 OUTPUT;
 
@@ -188,9 +188,9 @@ OUTPUT;
         $this->skipIfTransactionsAreNotSupported();
 
         $expectedOutput = <<<'OUTPUT'
-{ "_id" : { "$oid" : "%s" }, "x" : 1 }
-{ "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 1 }
-{ "_id" : { "$oid" : "%s" }, "x" : 3, "y" : 1 }
+%s
+%s
+%s
 OUTPUT;
 
         $this->testExample(__DIR__ . '/../examples/with_transaction.php', $expectedOutput);

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -11,6 +11,10 @@ final class ExamplesTest extends FunctionalTestCase
     {
         parent::setUp();
 
+        if ($this->isShardedCluster()) {
+            $this->markTestSkipped('Examples are not tested on sharded clusters.');
+        }
+
         self::createTestClient()->dropDatabase('test');
     }
 

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -45,11 +45,7 @@ OUTPUT;
 drop command started
 command: %s
 
-drop command failed
-reply: %s
-exception: MongoDB\Driver\Exception\ServerException
-exception.code: 26
-exception.message: ns not found
+drop command %a
 
 insert command started
 command: %s

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -16,16 +16,16 @@ final class ExamplesTest extends FunctionalTestCase
 
     public function dataExamples(): Generator
     {
+        $expectedOutput = <<<'OUTPUT'
+{ "_id" : null, "totalCount" : 100, "evenCount" : %d, "oddCount" : %d, "maxValue" : %d, "minValue" : %d }
+OUTPUT;
+
         yield 'aggregate' => [
             'file' => __DIR__ . '/../examples/aggregate.php',
-            'expectedOutput' => <<<'OUTPUT'
-{ "_id" : null, "totalCount" : 100, "evenCount" : %d, "oddCount" : %d, "maxValue" : %d, "minValue" : %d }
-OUTPUT
+            'expectedOutput' => $expectedOutput,
         ];
 
-        yield 'bulk' => [
-            'file' => __DIR__ . '/../examples/bulk.php',
-            'expectedOutput' => <<<'OUTPUT'
+        $expectedOutput = <<<'OUTPUT'
 { "_id" : { "$oid" : "%s" }, "x" : 0 }
 { "_id" : { "$oid" : "%s" }, "y" : 1 }
 { "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 2 }
@@ -34,12 +34,14 @@ OUTPUT
 { "_id" : { "$oid" : "%s" }, "x" : 6, "updateMany" : true }
 { "_id" : { "$oid" : "%s" }, "x" : 7, "updateMany" : true }
 { "_id" : { "$oid" : "%s" }, "x" : 10 }
-OUTPUT
+OUTPUT;
+
+        yield 'bulk' => [
+            'file' => __DIR__ . '/../examples/bulk.php',
+            'expectedOutput' => $expectedOutput,
         ];
 
-        yield 'command_logger' => [
-            'file' => __DIR__ . '/../examples/command_logger.php',
-            'expectedOutput' => <<<'OUTPUT'
+        $expectedOutput = <<<'OUTPUT'
 drop command started
 command: { "drop" : "coll", "$db" : "test", "lsid" : { %s }%S }
 
@@ -76,73 +78,79 @@ getMore command succeeded
 reply: { "cursor" : { "nextBatch" : [ { "_id" : { "$oid" : "%s" }, "x" : 3, "y" : 1 } ], "id" : 0, "ns" : "test.coll" }, %s }
 
 { "_id" : { "$oid" : "%s" }, "x" : 3, "y" : 1 }
-OUTPUT
+OUTPUT;
+
+        yield 'command_logger' => [
+            'file' => __DIR__ . '/../examples/command_logger.php',
+            'expectedOutput' => $expectedOutput,
         ];
+
+        $expectedOutput = <<<'OUTPUT'
+object(MongoDB\Examples\PersistableEntry)#%d (%d) {
+  ["id":"MongoDB\Examples\PersistableEntry":private]=>
+  object(MongoDB\BSON\ObjectId)#%d (%d) {
+    ["oid"]=>
+    string(24) "%s"
+  }
+  ["name"]=>
+  string(7) "alcaeus"
+  ["emails"]=>
+  array(2) {
+    [0]=>
+    object(MongoDB\Examples\PersistableEmail)#%d (%d) {
+      ["type"]=>
+      string(4) "work"
+      ["address"]=>
+      string(19) "alcaeus@example.com"
+    }
+    [1]=>
+    object(MongoDB\Examples\PersistableEmail)#%d (%d) {
+      ["type"]=>
+      string(7) "private"
+      ["address"]=>
+      string(18) "secret@example.com"
+    }
+  }
+}
+OUTPUT;
 
         yield 'persistable' => [
             'file' => __DIR__ . '/../examples/persistable.php',
-            'expectedOutput' => <<<'OUTPUT'
-%s/examples/persistable.php:%d:
-class MongoDB\Examples\PersistableEntry#%d (%d) {
-  private $id =>
-  class MongoDB\BSON\ObjectId#%d (%d) {
-    public $oid =>
+            'expectedOutput' => $expectedOutput,
+        ];
+
+        $expectedOutput = <<<'OUTPUT'
+object(MongoDB\Examples\TypeMapEntry)#%d (%d) {
+  ["id":"MongoDB\Examples\TypeMapEntry":private]=>
+  object(MongoDB\BSON\ObjectId)#%d (%d) {
+    ["oid"]=>
     string(24) "%s"
   }
-  public $name =>
+  ["name":"MongoDB\Examples\TypeMapEntry":private]=>
   string(7) "alcaeus"
-  public $emails =>
+  ["emails":"MongoDB\Examples\TypeMapEntry":private]=>
   array(2) {
-    [0] =>
-    class MongoDB\Examples\PersistableEmail#%d (%d) {
-      public $type =>
+    [0]=>
+    object(MongoDB\Examples\TypeMapEmail)#%d (%d) {
+      ["type":"MongoDB\Examples\TypeMapEmail":private]=>
       string(4) "work"
-      public $address =>
+      ["address":"MongoDB\Examples\TypeMapEmail":private]=>
       string(19) "alcaeus@example.com"
     }
-    [1] =>
-    class MongoDB\Examples\PersistableEmail#%d (%d) {
-      public $type =>
+    [1]=>
+    object(MongoDB\Examples\TypeMapEmail)#%d (%d) {
+      ["type":"MongoDB\Examples\TypeMapEmail":private]=>
       string(7) "private"
-      public $address =>
+      ["address":"MongoDB\Examples\TypeMapEmail":private]=>
       string(18) "secret@example.com"
     }
   }
 }
-OUTPUT
-        ];
+OUTPUT;
 
         yield 'typemap' => [
             'file' => __DIR__ . '/../examples/typemap.php',
-            'expectedOutput' => <<<'OUTPUT'
-%s/examples/typemap.php:%d:
-class MongoDB\Examples\TypeMapEntry#%d (%d) {
-  private $id =>
-  class MongoDB\BSON\ObjectId#%d (%d) {
-    public $oid =>
-    string(24) "%s"
-  }
-  private $name =>
-  string(7) "alcaeus"
-  private $emails =>
-  array(2) {
-    [0] =>
-    class MongoDB\Examples\TypeMapEmail#%d (%d) {
-      private $type =>
-      string(4) "work"
-      private $address =>
-      string(19) "alcaeus@example.com"
-    }
-    [1] =>
-    class MongoDB\Examples\TypeMapEmail#%d (%d) {
-      private $type =>
-      string(7) "private"
-      private $address =>
-      string(18) "secret@example.com"
-    }
-  }
-}
-OUTPUT
+            'expectedOutput' => $expectedOutput,
         ];
     }
 
@@ -151,16 +159,16 @@ OUTPUT
         $this->skipIfChangeStreamIsNotSupported();
 
         $expectedOutput = <<<'OUTPUT'
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 0 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 1 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 2 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 3 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 4 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 5 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 6 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 7 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 8 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
-{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 9 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 0 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 1 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 2 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 3 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 4 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 5 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 6 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 7 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 8 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }%S, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 9 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
 Aborting after 3 seconds...
 OUTPUT;
 

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace MongoDB\Tests;
+
+use Generator;
+
+/** @runTestsInSeparateProcesses */
+final class ExamplesTest extends FunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        self::createTestClient()->dropDatabase('test');
+    }
+
+    public function dataExamples(): Generator
+    {
+        yield 'aggregate' => [
+            'file' => __DIR__ . '/../examples/aggregate.php',
+            'expectedOutput' => <<<'OUTPUT'
+{ "_id" : null, "totalCount" : 100, "evenCount" : %d, "oddCount" : %d, "maxValue" : %d, "minValue" : %d }
+OUTPUT
+        ];
+
+        yield 'bulk' => [
+            'file' => __DIR__ . '/../examples/bulk.php',
+            'expectedOutput' => <<<'OUTPUT'
+{ "_id" : { "$oid" : "%s" }, "x" : 0 }
+{ "_id" : { "$oid" : "%s" }, "y" : 1 }
+{ "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 2 }
+{ "_id" : { "$oid" : "%s" }, "x" : 3 }
+{ "_id" : { "$oid" : "%s" }, "x" : 5 }
+{ "_id" : { "$oid" : "%s" }, "x" : 6, "updateMany" : true }
+{ "_id" : { "$oid" : "%s" }, "x" : 7, "updateMany" : true }
+{ "_id" : { "$oid" : "%s" }, "x" : 10 }
+OUTPUT
+        ];
+
+        yield 'command_logger' => [
+            'file' => __DIR__ . '/../examples/command_logger.php',
+            'expectedOutput' => <<<'OUTPUT'
+drop command started
+command: { "drop" : "coll", "$db" : "test", "lsid" : { %s }%S }
+
+drop command failed
+reply: { "ok" : 0.0, "errmsg" : "ns not found", "code" : 26, "codeName" : "NamespaceNotFound"%S }
+exception: MongoDB\Driver\Exception\ServerException
+exception.code: 26
+exception.message: ns not found
+
+insert command started
+command: { "insert" : "coll", "ordered" : true, "$db" : "test", "lsid" : { %s }%S, "documents" : [ { "x" : 1, "_id" : { "$oid" : "%s" } }, { "x" : 2, "_id" : { "$oid" : "%s" } }, { "x" : 3, "_id" : { "$oid" : "%s" } } ] }
+
+insert command succeeded
+reply: { "n" : 3, %s }
+
+update command started
+command: { "update" : "coll", "ordered" : true, "$db" : "test", "lsid" : { %s }%S, "updates" : [ { "q" : { "x" : { "$gt" : 1 } }, "u" : { "$set" : { "y" : 1 } }, "upsert" : false, "multi" : true } ] }
+
+update command succeeded
+reply: { "n" : 2, %s }
+
+find command started
+command: { "find" : "coll", "filter" : {  }, "batchSize" : 2, "$db" : "test", "lsid" : { %s }%S }
+
+find command succeeded
+reply: { "cursor" : { "firstBatch" : [ { "_id" : { "$oid" : "%s" }, "x" : 1 }, { "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 1 } ], "id" : %d, "ns" : "test.coll" }, %s }
+
+{ "_id" : { "$oid" : "%s" }, "x" : 1 }
+{ "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 1 }
+getMore command started
+command: { "getMore" : %d, "collection" : "coll", "batchSize" : 2, "$db" : "test", "lsid" : { %s }%S }
+
+getMore command succeeded
+reply: { "cursor" : { "nextBatch" : [ { "_id" : { "$oid" : "%s" }, "x" : 3, "y" : 1 } ], "id" : 0, "ns" : "test.coll" }, %s }
+
+{ "_id" : { "$oid" : "%s" }, "x" : 3, "y" : 1 }
+OUTPUT
+        ];
+
+        yield 'persistable' => [
+            'file' => __DIR__ . '/../examples/persistable.php',
+            'expectedOutput' => <<<'OUTPUT'
+%s/examples/persistable.php:%d:
+class MongoDB\Examples\PersistableEntry#%d (%d) {
+  private $id =>
+  class MongoDB\BSON\ObjectId#%d (%d) {
+    public $oid =>
+    string(24) "%s"
+  }
+  public $name =>
+  string(7) "alcaeus"
+  public $emails =>
+  array(2) {
+    [0] =>
+    class MongoDB\Examples\PersistableEmail#%d (%d) {
+      public $type =>
+      string(4) "work"
+      public $address =>
+      string(19) "alcaeus@example.com"
+    }
+    [1] =>
+    class MongoDB\Examples\PersistableEmail#%d (%d) {
+      public $type =>
+      string(7) "private"
+      public $address =>
+      string(18) "secret@example.com"
+    }
+  }
+}
+OUTPUT
+        ];
+
+        yield 'typemap' => [
+            'file' => __DIR__ . '/../examples/typemap.php',
+            'expectedOutput' => <<<'OUTPUT'
+%s/examples/typemap.php:%d:
+class MongoDB\Examples\TypeMapEntry#%d (%d) {
+  private $id =>
+  class MongoDB\BSON\ObjectId#%d (%d) {
+    public $oid =>
+    string(24) "%s"
+  }
+  private $name =>
+  string(7) "alcaeus"
+  private $emails =>
+  array(2) {
+    [0] =>
+    class MongoDB\Examples\TypeMapEmail#%d (%d) {
+      private $type =>
+      string(4) "work"
+      private $address =>
+      string(19) "alcaeus@example.com"
+    }
+    [1] =>
+    class MongoDB\Examples\TypeMapEmail#%d (%d) {
+      private $type =>
+      string(7) "private"
+      private $address =>
+      string(18) "secret@example.com"
+    }
+  }
+}
+OUTPUT
+        ];
+    }
+
+    public function testChangeStream(): void
+    {
+        $this->skipIfChangeStreamIsNotSupported();
+
+        $expectedOutput = <<<'OUTPUT'
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 0 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 1 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 2 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 3 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 4 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 5 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 6 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 7 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 8 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+{ "_id" : { "_data" : "%s" }, "operationType" : "insert", "clusterTime" : { "$timestamp" : { "t" : %d, "i" : %d } }, "wallTime" : { "$date" : "%s" }, "fullDocument" : { "_id" : { "$oid" : "%s" }, "x" : 9 }, "ns" : { "db" : "test", "coll" : "coll" }, "documentKey" : { "_id" : { "$oid" : "%s" } } }
+Aborting after 3 seconds...
+OUTPUT;
+
+        $this->testExample(__DIR__ . '/../examples/changestream.php', $expectedOutput);
+    }
+
+    /** @dataProvider dataExamples */
+    public function testExample(string $file, string $expectedOutput): void
+    {
+        require $file;
+
+        self::assertStringMatchesFormat($expectedOutput, $this->getActualOutputForAssertion());
+    }
+
+    public function testWithTransaction(): void
+    {
+        $this->skipIfTransactionsAreNotSupported();
+
+        $expectedOutput = <<<'OUTPUT'
+{ "_id" : { "$oid" : "%s" }, "x" : 1 }
+{ "_id" : { "$oid" : "%s" }, "x" : 2, "y" : 1 }
+{ "_id" : { "$oid" : "%s" }, "x" : 3, "y" : 1 }
+OUTPUT;
+
+        $this->testExample(__DIR__ . '/../examples/with_transaction.php', $expectedOutput);
+    }
+}


### PR DESCRIPTION
PHPLIB-981

This PR adds tests for the example scripts. To ensure good coverage, the tests attempt to match against the output of the example scripts. This requires a change in the examples to no longer output to `STDERR`, as PHPUnit considers any output to `STDERR` as condition to fail a test and doesn't allow asserting against it.

When running the tests, I noticed that the tests fail on sharded clusters, because the command replies are different. This would complicate the output matchers by quite a lot, so I'm wondering if it's actually worth matching against the actual command output, or if we're happy asserting that the rough information is the same.

I will likely also change the examples for type maps and persistable classes to no longer use `var_dump`. Having xdebug installed (which is likely on dev machines) produces different output for `var_dump`, making the tests fail on developer machines.