### PR TITLE
PHPLIB-1043: Update observeSensitiveCommands tests for removed commands

### DIFF
--- a/tests/UnifiedSpecTests/command-monitoring/redacted-commands.json
+++ b/tests/UnifiedSpecTests/command-monitoring/redacted-commands.json
@@ -162,6 +162,11 @@
     },
     {
       "description": "getnonce",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -293,6 +298,11 @@
     },
     {
       "description": "copydbgetnonce",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.6.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -328,6 +338,11 @@
     },
     {
       "description": "copydbsaslstart",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -363,6 +378,11 @@
     },
     {
       "description": "copydb",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/tests/UnifiedSpecTests/valid-pass/observeSensitiveCommands.json
+++ b/tests/UnifiedSpecTests/valid-pass/observeSensitiveCommands.json
@@ -61,6 +61,11 @@
   "tests": [
     {
       "description": "getnonce is observed with observeSensitiveCommands=true",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -106,6 +111,11 @@
     },
     {
       "description": "getnonce is not observed with observeSensitiveCommands=false",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -127,6 +137,11 @@
     },
     {
       "description": "getnonce is not observed by default",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1043

Patch build with MongoDB 6.0 and latest: https://spruce.mongodb.com/version/638713bdd6d80a2f663ce1d7/tasks