### PR TITLE
PHPLIB-1044: Ensure ExplainFunctionalTest does not optimise pipeline on MongoDB 6.3

### DIFF
--- a/tests/Operation/ExplainFunctionalTest.php
+++ b/tests/Operation/ExplainFunctionalTest.php
@@ -365,7 +365,8 @@ class ExplainFunctionalTest extends FunctionalTestCase
 
         $this->createFixtures(3);
 
-        $pipeline = [['$group' => ['_id' => null]]];
+        // Use a $sort stage to ensure the aggregate does not get optimised to a query
+        $pipeline = [['$group' => ['_id' => null]], ['$sort' => ['_id' => 1]]];
         $operation = new Aggregate($this->getDatabaseName(), $this->getCollectionName(), $pipeline);
 
         $explainOperation = new Explain($this->getDatabaseName(), $operation, ['verbosity' => Explain::VERBOSITY_QUERY, 'typeMap' => ['root' => 'array', 'document' => 'array']]);


### PR DESCRIPTION
PHPLIB-1044

The aggregation pipeline previously used to test an explain is optimised to a query on MongoDB 6.3, leading to different explain output. Adding a `$sort` stage removes the optimisation potential (for now) and fixes the test.