### PR TITLE
PHPLIB-1046: Fix snooty errors in documentation

### DIFF
--- a/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
+++ b/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
@@ -143,8 +143,10 @@ description: |
   collection.
 
   The ``indexOptionDefaults`` option accepts a ``storageEngine`` document,
-  which should take the following form::
+  which should take the following form:
 
+  .. code-block:: none
+  
      { <storage-engine-name>: <options> }
 
   Storage engine configurations specified when creating indexes are validated
@@ -212,8 +214,10 @@ description: |
 
   Allows users to specify configuration to the storage engine on a
   per-collection basis when creating a collection. The value of the
-  ``storageEngine`` option should take the following form::
+  ``storageEngine`` option should take the following form:
 
+  .. code-block:: none
+  
      { <storage-engine-name>: <options> }
 
   Storage engine configurations specified when creating collections are

--- a/docs/reference/class/MongoDBCollection.txt
+++ b/docs/reference/class/MongoDBCollection.txt
@@ -41,17 +41,16 @@ Definition
 Type Map Limitations
 --------------------
 
-   The :manual:`aggregate </reference/command/aggregate>` (when not using a
-   cursor), :manual:`distinct </reference/command/distinct>`, and
-   :manual:`findAndModify </reference/command/findAndModify>` helpers do not
-   support a ``typeMap`` option due to a driver limitation. The
-   :phpmethod:`aggregate() <MongoDB\\Collection::aggregate>`,
-   :phpmethod:`distinct() <MongoDB\\Collection::distinct>`,
-   :phpmethod:`findOneAndReplace() <MongoDB\\Collection::findOneAndReplace>`,
-   :phpmethod:`findOneAndUpdate() <MongoDB\\Collection::findOneAndUpdate>`, and
-   :phpmethod:`findOneAndDelete() <MongoDB\\Collection::findOneAndDelete>`
-   methods return BSON documents as `stdClass` objects and BSON arrays as
-   arrays.
+The :manual:`aggregate </reference/command/aggregate>` (when not using a
+cursor), :manual:`distinct </reference/command/distinct>`, and
+:manual:`findAndModify </reference/command/findAndModify>` helpers do not
+support a ``typeMap`` option due to a driver limitation. The
+:phpmethod:`aggregate() <MongoDB\\Collection::aggregate>`,
+:phpmethod:`distinct() <MongoDB\\Collection::distinct>`,
+:phpmethod:`findOneAndReplace() <MongoDB\\Collection::findOneAndReplace>`,
+:phpmethod:`findOneAndUpdate() <MongoDB\\Collection::findOneAndUpdate>`, and
+:phpmethod:`findOneAndDelete() <MongoDB\\Collection::findOneAndDelete>`
+methods return BSON documents as ``stdClass`` objects and BSON arrays as arrays.
 
 Methods
 -------

--- a/docs/reference/class/MongoDBCollection.txt
+++ b/docs/reference/class/MongoDBCollection.txt
@@ -23,7 +23,7 @@ Definition
    select a collection from the library's :phpclass:`MongoDB\\Client` or
    :phpclass:`MongoDB\\Database` classes. A collection may also be cloned from
    an existing :phpclass:`MongoDB\\Collection` object via the
-   :phpmethod:`withOptions() <MongoDB\\Collection::withOptions>` method.
+   :phpmethod:`withOptions() <MongoDB\\Collection::withOptions()>` method.
 
    :phpclass:`MongoDB\\Collection` supports the :php:`readConcern
    <mongodb-driver-readconcern>`, :php:`readPreference
@@ -45,11 +45,11 @@ The :manual:`aggregate </reference/command/aggregate>` (when not using a
 cursor), :manual:`distinct </reference/command/distinct>`, and
 :manual:`findAndModify </reference/command/findAndModify>` helpers do not
 support a ``typeMap`` option due to a driver limitation. The
-:phpmethod:`aggregate() <MongoDB\\Collection::aggregate>`,
-:phpmethod:`distinct() <MongoDB\\Collection::distinct>`,
-:phpmethod:`findOneAndReplace() <MongoDB\\Collection::findOneAndReplace>`,
-:phpmethod:`findOneAndUpdate() <MongoDB\\Collection::findOneAndUpdate>`, and
-:phpmethod:`findOneAndDelete() <MongoDB\\Collection::findOneAndDelete>`
+:phpmethod:`aggregate() <MongoDB\\Collection::aggregate()>`,
+:phpmethod:`distinct() <MongoDB\\Collection::distinct()>`,
+:phpmethod:`findOneAndReplace() <MongoDB\\Collection::findOneAndReplace()>`,
+:phpmethod:`findOneAndUpdate() <MongoDB\\Collection::findOneAndUpdate()>`, and
+:phpmethod:`findOneAndDelete() <MongoDB\\Collection::findOneAndDelete()>`
 methods return BSON documents as ``stdClass`` objects and BSON arrays as arrays.
 
 Methods

--- a/docs/reference/class/MongoDBDatabase.txt
+++ b/docs/reference/class/MongoDBDatabase.txt
@@ -22,7 +22,7 @@ Definition
    :php:`MongoDB\\Driver\\Manager <class.mongodb-driver-manager>` class or
    select a database from the library's :phpclass:`MongoDB\\Client` class. A
    database may also be cloned from an existing :phpclass:`MongoDB\\Database`
-   object via the :phpmethod:`withOptions() <MongoDB\\Database::withOptions>`
+   object via the :phpmethod:`withOptions() <MongoDB\\Database::withOptions()>`
    method.
 
    :phpclass:`MongoDB\\Database` supports the :php:`readConcern

--- a/docs/reference/class/MongoDBGridFSBucket.txt
+++ b/docs/reference/class/MongoDBGridFSBucket.txt
@@ -25,7 +25,7 @@ Definition
    You can construct a GridFS bucket using the driver's
    :php:`Manager <class.mongodb-driver-manager>` class, or select a bucket from
    the library's :phpclass:`MongoDB\\Database` class via the
-   :phpmethod:`selectGridFSBucket() <MongoDB\\Database::selectGridFSBucket>`
+   :phpmethod:`selectGridFSBucket() <MongoDB\\Database::selectGridFSBucket()>`
    method.
 
 Methods

--- a/docs/reference/method/MongoDBChangeStream-getCursorId.txt
+++ b/docs/reference/method/MongoDBChangeStream-getCursorId.txt
@@ -43,7 +43,9 @@ This example reports the cursor ID for a change stream.
 
    var_dump($changeStream->getCursorId());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\CursorId)#5 (1) {
      ["id"]=>

--- a/docs/reference/method/MongoDBClient-dropDatabase.txt
+++ b/docs/reference/method/MongoDBClient-dropDatabase.txt
@@ -58,7 +58,9 @@ The following example drops the ``test`` database:
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#8 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBClient-getReadConcern.txt
+++ b/docs/reference/method/MongoDBClient-getReadConcern.txt
@@ -41,7 +41,9 @@ Example
 
    var_dump($client->getReadConcern());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\ReadConcern)#5 (1) {
      ["level"]=>

--- a/docs/reference/method/MongoDBClient-getReadPreference.txt
+++ b/docs/reference/method/MongoDBClient-getReadPreference.txt
@@ -42,7 +42,9 @@ Example
 
    var_dump($client->getReadPreference());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\ReadPreference)#5 (1) {
      ["mode"]=>

--- a/docs/reference/method/MongoDBClient-getTypeMap.txt
+++ b/docs/reference/method/MongoDBClient-getTypeMap.txt
@@ -45,7 +45,9 @@ Example
 
    var_dump($client->getTypeMap());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(3) {
      ["root"]=>

--- a/docs/reference/method/MongoDBClient-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBClient-getWriteConcern.txt
@@ -42,7 +42,9 @@ Example
 
    var_dump($client->getWriteConcern());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\WriteConcern)#4 (1) {
      ["j"]=>

--- a/docs/reference/method/MongoDBClient-listDatabaseNames.txt
+++ b/docs/reference/method/MongoDBClient-listDatabaseNames.txt
@@ -59,7 +59,9 @@ The following example lists all databases on the server:
        var_dump($databaseName);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(5) "local"
    string(4) "test"

--- a/docs/reference/method/MongoDBClient-listDatabases.txt
+++ b/docs/reference/method/MongoDBClient-listDatabases.txt
@@ -58,7 +58,9 @@ The following example lists all databases on the server:
        var_dump($databaseInfo);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\DatabaseInfo)#4 (3) {
      ["name"]=>

--- a/docs/reference/method/MongoDBClient-startSession.txt
+++ b/docs/reference/method/MongoDBClient-startSession.txt
@@ -53,7 +53,9 @@ The following example starts a new session:
 
    var_dump($session);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\Session)#2043 (4) {
      ["logicalSessionId"]=>

--- a/docs/reference/method/MongoDBClient__get.txt
+++ b/docs/reference/method/MongoDBClient__get.txt
@@ -17,7 +17,7 @@ Definition
 
    Selects a database on the server. This :php:`magic method <oop5.magic>` is
    an alias for the :phpmethod:`selectDatabase()
-   <MongoDB\\Client::selectDatabase>` method.
+   <MongoDB\\Client::selectDatabase()>` method.
 
    .. code-block:: php
 
@@ -37,7 +37,7 @@ Behavior
 
 The selected database inherits options such as read preference and type mapping
 from the :phpclass:`Client <MongoDB\\Client>` object. If you wish to override
-any options, use the :phpmethod:`MongoDB\\Client::selectDatabase` method.
+any options, use the :phpmethod:`MongoDB\\Client::selectDatabase()` method.
 
 .. note::
 

--- a/docs/reference/method/MongoDBCollection-createIndex.txt
+++ b/docs/reference/method/MongoDBCollection-createIndex.txt
@@ -66,7 +66,9 @@ the ``test`` database.
 
    var_dump($indexName);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(19) "borough_1_cuisine_1"
 
@@ -95,7 +97,9 @@ exists.
 
    var_dump($indexName);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(9) "borough_1"
 

--- a/docs/reference/method/MongoDBCollection-createIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-createIndexes.txt
@@ -53,7 +53,9 @@ fields that correspond to index options accepted by :phpmethod:`createIndex()
 
 For example, the following ``$indexes`` parameter creates two indexes. The first
 is an ascending unique index on the ``username`` field and the second is a
-2dsphere index on the ``loc`` field with a custom name::
+2dsphere index on the ``loc`` field with a custom name:
+
+.. code-block:: none
 
    [
        [ 'key' => [ 'username' => 1 ], 'unique' => true ],
@@ -81,7 +83,9 @@ custom name.
 
    var_dump($indexNames);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(2) {
      [0]=>

--- a/docs/reference/method/MongoDBCollection-createIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-createIndexes.txt
@@ -13,7 +13,7 @@ MongoDB\\Collection::createIndexes()
 Definition
 ----------
 
-.. phpmethod:: MongoDB\\Collection::createIndexes($indexes)
+.. phpmethod:: MongoDB\\Collection::createIndexes()
 
    Create one or more indexes for the collection.
 

--- a/docs/reference/method/MongoDBCollection-deleteMany.txt
+++ b/docs/reference/method/MongoDBCollection-deleteMany.txt
@@ -68,7 +68,9 @@ that have ``"ny"`` as the value for the ``state`` field:
 
    printf("Deleted %d document(s)\n", $deleteResult->getDeletedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Deleted 2 document(s)
 

--- a/docs/reference/method/MongoDBCollection-deleteOne.txt
+++ b/docs/reference/method/MongoDBCollection-deleteOne.txt
@@ -70,7 +70,9 @@ has ``"ny"`` as the value for the ``state`` field:
 
    printf("Deleted %d document(s)\n", $deleteResult->getDeletedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Deleted 1 document(s)
 

--- a/docs/reference/method/MongoDBCollection-distinct.txt
+++ b/docs/reference/method/MongoDBCollection-distinct.txt
@@ -66,7 +66,9 @@ in the ``restaurants`` collection in the ``test`` database.
 
    var_dump($distinct);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(6) {
      [0]=>
@@ -100,7 +102,9 @@ the ``borough`` is ``Queens``:
 
    var_dump($distinct);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(75) {
      [0]=>

--- a/docs/reference/method/MongoDBCollection-drop.txt
+++ b/docs/reference/method/MongoDBCollection-drop.txt
@@ -59,7 +59,9 @@ database:
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#9 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-dropIndex.txt
+++ b/docs/reference/method/MongoDBCollection-dropIndex.txt
@@ -59,7 +59,9 @@ collection in the ``test`` database:
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#9 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-dropIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-dropIndexes.txt
@@ -60,7 +60,9 @@ The following drops all indexes from the ``restaurants`` collection in the
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#9 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-explain.txt
+++ b/docs/reference/method/MongoDBCollection-explain.txt
@@ -50,18 +50,18 @@ Explainable Commands
 
 Explainable commands include, but are not limited to:
 
-- :phpclass:`MongoDB\\Operation\\Aggregate`
-- :phpclass:`MongoDB\\Operation\\Count`
-- :phpclass:`MongoDB\\Operation\\DeleteMany`
-- :phpclass:`MongoDB\\Operation\\DeleteOne`
-- :phpclass:`MongoDB\\Operation\\Distinct`
-- :phpclass:`MongoDB\\Operation\\Find`
-- :phpclass:`MongoDB\\Operation\\FindOne`
-- :phpclass:`MongoDB\\Operation\\FindOneAndDelete`
-- :phpclass:`MongoDB\\Operation\\FindOneAndReplace`
-- :phpclass:`MongoDB\\Operation\\FindOneAndUpdate`
-- :phpclass:`MongoDB\\Operation\\UpdateMany`
-- :phpclass:`MongoDB\\Operation\\UpdateOne`
+- `MongoDB\\Operation\\Aggregate`
+- `MongoDB\\Operation\\Count`
+- `MongoDB\\Operation\\DeleteMany`
+- `MongoDB\\Operation\\DeleteOne`
+- `MongoDB\\Operation\\Distinct`
+- `MongoDB\\Operation\\Find`
+- `MongoDB\\Operation\\FindOne`
+- `MongoDB\\Operation\\FindOneAndDelete`
+- `MongoDB\\Operation\\FindOneAndReplace`
+- `MongoDB\\Operation\\FindOneAndUpdate`
+- `MongoDB\\Operation\\UpdateMany`
+- `MongoDB\\Operation\\UpdateOne`
 
 Examples
 --------

--- a/docs/reference/method/MongoDBCollection-explain.txt
+++ b/docs/reference/method/MongoDBCollection-explain.txt
@@ -50,18 +50,18 @@ Explainable Commands
 
 Explainable commands include, but are not limited to:
 
-- `MongoDB\\Operation\\Aggregate`
-- `MongoDB\\Operation\\Count`
-- `MongoDB\\Operation\\DeleteMany`
-- `MongoDB\\Operation\\DeleteOne`
-- `MongoDB\\Operation\\Distinct`
-- `MongoDB\\Operation\\Find`
-- `MongoDB\\Operation\\FindOne`
-- `MongoDB\\Operation\\FindOneAndDelete`
-- `MongoDB\\Operation\\FindOneAndReplace`
-- `MongoDB\\Operation\\FindOneAndUpdate`
-- `MongoDB\\Operation\\UpdateMany`
-- `MongoDB\\Operation\\UpdateOne`
+- ``MongoDB\Operation\Aggregate``
+- ``MongoDB\Operation\Count``
+- ``MongoDB\Operation\DeleteMany``
+- ``MongoDB\Operation\DeleteOne``
+- ``MongoDB\Operation\Distinct``
+- ``MongoDB\Operation\Find``
+- ``MongoDB\Operation\FindOne``
+- ``MongoDB\Operation\FindOneAndDelete``
+- ``MongoDB\Operation\FindOneAndReplace``
+- ``MongoDB\Operation\FindOneAndUpdate``
+- ``MongoDB\Operation\UpdateMany``
+- ``MongoDB\Operation\UpdateOne``
 
 Examples
 --------

--- a/docs/reference/method/MongoDBCollection-explain.txt
+++ b/docs/reference/method/MongoDBCollection-explain.txt
@@ -84,7 +84,9 @@ This example explains a count command.
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#29 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-explain.txt
+++ b/docs/reference/method/MongoDBCollection-explain.txt
@@ -50,18 +50,18 @@ Explainable Commands
 
 Explainable commands include, but are not limited to:
 
-   - :phpclass:`MongoDB\\Operation\\Aggregate`
-   - :phpclass:`MongoDB\\Operation\\Count`
-   - :phpclass:`MongoDB\\Operation\\DeleteMany`
-   - :phpclass:`MongoDB\\Operation\\DeleteOne`
-   - :phpclass:`MongoDB\\Operation\\Distinct`
-   - :phpclass:`MongoDB\\Operation\\Find`
-   - :phpclass:`MongoDB\\Operation\\FindOne`
-   - :phpclass:`MongoDB\\Operation\\FindOneAndDelete`
-   - :phpclass:`MongoDB\\Operation\\FindOneAndReplace`
-   - :phpclass:`MongoDB\\Operation\\FindOneAndUpdate`
-   - :phpclass:`MongoDB\\Operation\\UpdateMany`
-   - :phpclass:`MongoDB\\Operation\\UpdateOne`
+- :phpclass:`MongoDB\\Operation\\Aggregate`
+- :phpclass:`MongoDB\\Operation\\Count`
+- :phpclass:`MongoDB\\Operation\\DeleteMany`
+- :phpclass:`MongoDB\\Operation\\DeleteOne`
+- :phpclass:`MongoDB\\Operation\\Distinct`
+- :phpclass:`MongoDB\\Operation\\Find`
+- :phpclass:`MongoDB\\Operation\\FindOne`
+- :phpclass:`MongoDB\\Operation\\FindOneAndDelete`
+- :phpclass:`MongoDB\\Operation\\FindOneAndReplace`
+- :phpclass:`MongoDB\\Operation\\FindOneAndUpdate`
+- :phpclass:`MongoDB\\Operation\\UpdateMany`
+- :phpclass:`MongoDB\\Operation\\UpdateOne`
 
 Examples
 --------

--- a/docs/reference/method/MongoDBCollection-find.txt
+++ b/docs/reference/method/MongoDBCollection-find.txt
@@ -77,7 +77,9 @@ returned. It also limits the results to 5 documents.
       var_dump($restaurant);
    };
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#10 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-findOne.txt
+++ b/docs/reference/method/MongoDBCollection-findOne.txt
@@ -98,7 +98,9 @@ returned.
 
    var_dump($restaurant);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#10 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-findOneAndDelete.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndDelete.txt
@@ -73,7 +73,9 @@ The following example finds and deletes the document with ``restaurant_id`` of
 
    var_dump($deletedRestaurant);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#17 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-findOneAndReplace.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndReplace.txt
@@ -115,7 +115,9 @@ The following operation replaces the document with ``restaurant_id`` of
 
    var_dump($replacedRestaurant);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#18 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-findOneAndUpdate.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndUpdate.txt
@@ -74,7 +74,9 @@ setting its building number to ``"761"``:
 
    var_dump($updatedRestaurant);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#20 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-getCollectionName.txt
+++ b/docs/reference/method/MongoDBCollection-getCollectionName.txt
@@ -40,7 +40,9 @@ The following returns the collection name for the ``zips`` collection in the
 
    echo $collection->getCollectionName();
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    zips
 

--- a/docs/reference/method/MongoDBCollection-getDatabaseName.txt
+++ b/docs/reference/method/MongoDBCollection-getDatabaseName.txt
@@ -40,7 +40,9 @@ The following returns the database name for the ``zips`` collection in the
 
    echo $collection->getDatabaseName();
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    test
 

--- a/docs/reference/method/MongoDBCollection-getNamespace.txt
+++ b/docs/reference/method/MongoDBCollection-getNamespace.txt
@@ -41,7 +41,9 @@ database.
 
    echo $collection->getNamespace();
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    test.zips
 

--- a/docs/reference/method/MongoDBCollection-getReadConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getReadConcern.txt
@@ -41,7 +41,9 @@ Example
 
    var_dump($collection->getReadConcern());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\ReadConcern)#5 (1) {
      ["level"]=>

--- a/docs/reference/method/MongoDBCollection-getReadPreference.txt
+++ b/docs/reference/method/MongoDBCollection-getReadPreference.txt
@@ -42,7 +42,9 @@ Example
 
    var_dump($collection->getReadPreference());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\ReadPreference)#5 (1) {
      ["mode"]=>

--- a/docs/reference/method/MongoDBCollection-getTypeMap.txt
+++ b/docs/reference/method/MongoDBCollection-getTypeMap.txt
@@ -45,7 +45,9 @@ Example
 
    var_dump($collection->getTypeMap());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(3) {
      ["root"]=>

--- a/docs/reference/method/MongoDBCollection-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getWriteConcern.txt
@@ -42,7 +42,9 @@ Example
 
    var_dump($collection->getWriteConcern());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\WriteConcern)#5 (2) {
      ["w"]=>

--- a/docs/reference/method/MongoDBCollection-insertMany.txt
+++ b/docs/reference/method/MongoDBCollection-insertMany.txt
@@ -79,7 +79,9 @@ in the ``test`` database:
 
    var_dump($insertManyResult->getInsertedIds());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Inserted 2 document(s)
    array(2) {

--- a/docs/reference/method/MongoDBCollection-insertOne.txt
+++ b/docs/reference/method/MongoDBCollection-insertOne.txt
@@ -71,7 +71,9 @@ The following operation inserts a document into the ``users`` collection in the
 
    var_dump($insertOneResult->getInsertedId());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Inserted 1 document(s)
    object(MongoDB\BSON\ObjectId)#11 (1) {

--- a/docs/reference/method/MongoDBCollection-listIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-listIndexes.txt
@@ -57,7 +57,9 @@ collection in the ``test`` database:
       var_dump($index);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\IndexInfo)#8 (4) {
      ["v"]=>

--- a/docs/reference/method/MongoDBCollection-mapReduce.txt
+++ b/docs/reference/method/MongoDBCollection-mapReduce.txt
@@ -92,7 +92,9 @@ each state.
       var_dump($pop);
    };
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(stdClass)#2293 (2) {
       ["_id"]=>

--- a/docs/reference/method/MongoDBCollection-rename.txt
+++ b/docs/reference/method/MongoDBCollection-rename.txt
@@ -61,7 +61,7 @@ database to ``places``:
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
 
    object(MongoDB\Model\BSONDocument)#9 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBCollection-rename.txt
+++ b/docs/reference/method/MongoDBCollection-rename.txt
@@ -63,6 +63,8 @@ database to ``places``:
 
 The output would then resemble:
 
+.. code-block:: none
+
    object(MongoDB\Model\BSONDocument)#9 (1) {
      ["storage":"ArrayObject":private]=>
      array(1) {

--- a/docs/reference/method/MongoDBCollection-replaceOne.txt
+++ b/docs/reference/method/MongoDBCollection-replaceOne.txt
@@ -77,7 +77,9 @@ The following example replaces the document with ``restaurant_id`` of
    printf("Matched %d document(s)\n", $updateResult->getMatchedCount());
    printf("Modified %d document(s)\n", $updateResult->getModifiedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Matched 1 document(s)
    Modified 1 document(s)

--- a/docs/reference/method/MongoDBCollection-updateMany.txt
+++ b/docs/reference/method/MongoDBCollection-updateMany.txt
@@ -67,7 +67,9 @@ The following example updates all of the documents with the ``borough`` of
    printf("Matched %d document(s)\n", $updateResult->getMatchedCount());
    printf("Modified %d document(s)\n", $updateResult->getModifiedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Matched 5656 document(s)
    Modified 5656 document(s)

--- a/docs/reference/method/MongoDBCollection-updateOne.txt
+++ b/docs/reference/method/MongoDBCollection-updateOne.txt
@@ -69,7 +69,9 @@ The following example updates one document with the ``restaurant_id`` of
    printf("Matched %d document(s)\n", $updateResult->getMatchedCount());
    printf("Modified %d document(s)\n", $updateResult->getModifiedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Matched 1 document(s)
    Modified 1 document(s)

--- a/docs/reference/method/MongoDBDatabase-command.txt
+++ b/docs/reference/method/MongoDBDatabase-command.txt
@@ -57,7 +57,9 @@ result document:
 
    var_dump($c->toArray()[0]);
 
-The output would resemble::
+The output would resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#11 (1) {
      ["storage":"ArrayObject":private]=>
@@ -81,7 +83,9 @@ multiple result documents:
 
    var_dump($c->toArray());
 
-The output would resemble::
+The output would resemble:
+
+.. code-block:: none
 
    array(3) {
      [0]=>

--- a/docs/reference/method/MongoDBDatabase-createCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-createCollection.txt
@@ -79,7 +79,9 @@ database with document validation criteria:
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#11 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBDatabase-drop.txt
+++ b/docs/reference/method/MongoDBDatabase-drop.txt
@@ -58,7 +58,9 @@ The following example drops the ``test`` database:
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#8 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBDatabase-dropCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-dropCollection.txt
@@ -58,7 +58,9 @@ The following example drops the ``users`` collection in the ``test`` database:
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#8 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBDatabase-getDatabaseName.txt
+++ b/docs/reference/method/MongoDBDatabase-getDatabaseName.txt
@@ -39,6 +39,8 @@ The following example prints the name of a database object:
 
    echo $db->getDatabaseName();
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    test

--- a/docs/reference/method/MongoDBDatabase-getReadConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadConcern.txt
@@ -41,7 +41,9 @@ Example
 
    var_dump($database->getReadConcern());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\ReadConcern)#5 (1) {
      ["level"]=>

--- a/docs/reference/method/MongoDBDatabase-getReadPreference.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadPreference.txt
@@ -42,7 +42,9 @@ Example
 
    var_dump($database->getReadPreference());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\ReadPreference)#5 (1) {
      ["mode"]=>

--- a/docs/reference/method/MongoDBDatabase-getTypeMap.txt
+++ b/docs/reference/method/MongoDBDatabase-getTypeMap.txt
@@ -45,7 +45,9 @@ Example
 
    var_dump($database->getTypeMap());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(3) {
      ["root"]=>

--- a/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
@@ -42,7 +42,9 @@ Example
 
    var_dump($database->getWriteConcern());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\WriteConcern)#5 (2) {
      ["w"]=>

--- a/docs/reference/method/MongoDBDatabase-listCollectionNames.txt
+++ b/docs/reference/method/MongoDBDatabase-listCollectionNames.txt
@@ -52,7 +52,9 @@ The following example lists all of the collections in the ``test`` database:
        var_dump($collectionName);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(11) "restaurants"
    string(5) "users"
@@ -77,7 +79,9 @@ in the ``test`` database:
        var_dump($collectionName);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(11) "restaurants"
    string(6) "restos"

--- a/docs/reference/method/MongoDBDatabase-listCollections.txt
+++ b/docs/reference/method/MongoDBDatabase-listCollections.txt
@@ -51,7 +51,9 @@ The following example lists all of the collections in the ``test`` database:
        var_dump($collectionInfo);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\CollectionInfo)#3 (2) {
      ["name"]=>
@@ -94,7 +96,9 @@ in the ``test`` database:
        var_dump($collectionInfo);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\CollectionInfo)#3 (2) {
      ["name"]=>

--- a/docs/reference/method/MongoDBDatabase-modifyCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-modifyCollection.txt
@@ -63,7 +63,9 @@ The following example changes the expiration time of a TTL collection in the
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(stdClass)#2779 {
      ["expireAfterSeconds_old"]=>

--- a/docs/reference/method/MongoDBDatabase-renameCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-renameCollection.txt
@@ -61,7 +61,7 @@ database to ``places``:
 
    var_dump($result);
 
-The output would then resemble::
+The output would then resemble:
 
    object(MongoDB\Model\BSONDocument)#8 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBDatabase-renameCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-renameCollection.txt
@@ -63,6 +63,8 @@ database to ``places``:
 
 The output would then resemble:
 
+.. code-block:: none
+
    object(MongoDB\Model\BSONDocument)#8 (1) {
      ["storage":"ArrayObject":private]=>
      array(1) {

--- a/docs/reference/method/MongoDBDatabase__get.txt
+++ b/docs/reference/method/MongoDBDatabase__get.txt
@@ -35,7 +35,7 @@ Behavior
 
 The selected collection inherits options such as read preference and type
 mapping from the :phpclass:`Database <MongoDB\\Database>` object. If you wish to
-override any options, use the :phpmethod:`MongoDB\\Database::selectCollection`
+override any options, use the :phpmethod:`MongoDB\\Database::selectCollection()`
 method.
 
 .. note::
@@ -43,7 +43,7 @@ method.
    To select collections whose names contain special characters, such as
    ``.``, use complex syntax, as in ``$database->{'that.database'}``.
 
-   Alternatively, :phpmethod:`MongoDB\\Database::selectCollection` supports
+   Alternatively, :phpmethod:`MongoDB\\Database::selectCollection()` supports
    selecting collections whose names contain special characters.
 
 Examples

--- a/docs/reference/method/MongoDBGridFSBucket-downloadToStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-downloadToStream.txt
@@ -54,7 +54,9 @@ Examples
 
    var_dump(stream_get_contents($destination, -1, 0));
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(6) "foobar"
 

--- a/docs/reference/method/MongoDBGridFSBucket-downloadToStreamByName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-downloadToStreamByName.txt
@@ -58,7 +58,9 @@ Examples
 
    var_dump(stream_get_contents($destination, -1, 0));
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(6) "foobar"
 

--- a/docs/reference/method/MongoDBGridFSBucket-find.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-find.txt
@@ -75,7 +75,9 @@ Examples
 
    var_dump($cursor->toArray());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(1) {
      [0]=>

--- a/docs/reference/method/MongoDBGridFSBucket-findOne.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-findOne.txt
@@ -78,7 +78,9 @@ Examples
 
    var_dump($fileDocument);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#3004 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBGridFSBucket-getBucketName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getBucketName.txt
@@ -37,6 +37,8 @@ Examples
 
    var_dump($bucket->getBucketName());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(2) "fs"

--- a/docs/reference/method/MongoDBGridFSBucket-getChunkSizeBytes.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getChunkSizeBytes.txt
@@ -39,6 +39,8 @@ Examples
 
    var_dump($bucket->getChunkSizeBytes());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    int(261120)

--- a/docs/reference/method/MongoDBGridFSBucket-getChunksCollection.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getChunksCollection.txt
@@ -39,6 +39,8 @@ Examples
 
    var_dump((string) $bucket->getChunksCollection());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(14) "test.fs.chunks"

--- a/docs/reference/method/MongoDBGridFSBucket-getDatabaseName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getDatabaseName.txt
@@ -37,7 +37,9 @@ Examples
 
    var_dump($bucket->getDatabaseName());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(4) "test"
 

--- a/docs/reference/method/MongoDBGridFSBucket-getFileDocumentForStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getFileDocumentForStream.txt
@@ -54,7 +54,9 @@ Examples
 
    fclose($stream);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#4956 (1) {
      ["storage":"ArrayObject":private]=>

--- a/docs/reference/method/MongoDBGridFSBucket-getFileIdForStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getFileIdForStream.txt
@@ -55,7 +55,9 @@ Examples
 
    fclose($stream);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\BSON\ObjectId)#3005 (1) {
      ["oid"]=>

--- a/docs/reference/method/MongoDBGridFSBucket-getFilesCollection.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getFilesCollection.txt
@@ -41,7 +41,9 @@ Examples
 
    var_dump($filesCollection->getCollectionName());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(8) "fs.files"
 

--- a/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
@@ -42,7 +42,9 @@ Example
 
    var_dump($bucket->getReadConcern());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\ReadConcern)#3 (1) {
      ["level"]=>

--- a/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
@@ -43,7 +43,9 @@ Example
 
    var_dump($bucket->getReadPreference());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\ReadPreference)#3 (1) {
      ["mode"]=>

--- a/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
@@ -46,7 +46,9 @@ Example
 
    var_dump($bucket->getTypeMap());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(3) {
      ["root"]=>

--- a/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
@@ -43,7 +43,9 @@ Example
 
    var_dump($bucket->getWriteConcern());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Driver\WriteConcern)#3 (2) {
      ["w"]=>

--- a/docs/reference/method/MongoDBGridFSBucket-openDownloadStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-openDownloadStream.txt
@@ -55,7 +55,9 @@ Examples
 
    var_dump(stream_get_contents($downloadStream));
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(6) "foobar"
 

--- a/docs/reference/method/MongoDBGridFSBucket-openDownloadStreamByName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-openDownloadStreamByName.txt
@@ -57,7 +57,9 @@ Examples
 
    var_dump(stream_get_contents($bucket->openDownloadStreamByName('filename')));
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(6) "foobar"
 

--- a/docs/reference/method/MongoDBGridFSBucket-openUploadStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-openUploadStream.txt
@@ -56,7 +56,9 @@ Examples
    $downloadStream = $bucket->openDownloadStreamByName('filename');
    var_dump(stream_get_contents($downloadStream));
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(6) "foobar"
 

--- a/docs/reference/method/MongoDBGridFSBucket-rename.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-rename.txt
@@ -50,6 +50,8 @@ Examples
 
    var_dump(stream_get_contents($bucket->openDownloadStreamByName('b')));
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    string(6) "foobar"

--- a/docs/reference/method/MongoDBGridFSBucket-uploadFromStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-uploadFromStream.txt
@@ -60,7 +60,9 @@ Examples
 
    var_dump($id);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\BSON\ObjectId)#3009 (1) {
      ["oid"]=>

--- a/docs/reference/method/MongoDBGridFSBucket__construct.txt
+++ b/docs/reference/method/MongoDBGridFSBucket__construct.txt
@@ -53,7 +53,9 @@ Examples
 
    var_dump($bucket);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\GridFS\Bucket)#3053 (2) {
      ["bucketName"]=>

--- a/docs/reference/method/MongoDBMapReduceResult-getCounts.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getCounts.txt
@@ -45,7 +45,9 @@ This example reports the count statistics for a map-reduce operation.
 
    var_dump($result->getCounts());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(4) {
      ["input"]=>

--- a/docs/reference/method/MongoDBMapReduceResult-getExecutionTimeMS.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getExecutionTimeMS.txt
@@ -46,7 +46,9 @@ This example reports the execution time for a map-reduce operation.
 
    var_dump($result->getExecutionTimeMS());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    int(244)
 

--- a/docs/reference/method/MongoDBMapReduceResult-getIterator.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getIterator.txt
@@ -15,7 +15,7 @@ Definition
 
 .. phpmethod:: MongoDB\\MapReduceResult::getIterator()
 
-   Returns a php:`Traversable <traversable>`, which may be used to iterate
+   Returns a :php:`Traversable <traversable>`, which may be used to iterate
    through the results of the map-reduce operation.
 
    .. code-block:: php

--- a/docs/reference/method/MongoDBMapReduceResult-getIterator.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getIterator.txt
@@ -49,7 +49,9 @@ This example iterates through the results of a map-reduce operation.
       var_dump($population);
    };
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(stdClass)#2293 (2) {
       ["_id"]=>

--- a/docs/reference/method/MongoDBMapReduceResult-getTiming.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getTiming.txt
@@ -51,7 +51,9 @@ for a map-reduce operation.
 
    var_dump($result->getTiming());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(5) {
      ["mapTime"]=>

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
@@ -52,7 +52,9 @@ Examples
 
    var_dump($info->getCappedMax());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    int(100)
 

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
@@ -52,7 +52,9 @@ Examples
 
    var_dump($info->getCappedSize());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    int(1048576)
 

--- a/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
@@ -51,6 +51,8 @@ Examples
 
 The output would then resemble:
 
+.. code-block:: none
+
    array(4) {
      ["v"]=>
      int(2)

--- a/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
@@ -49,7 +49,7 @@ Examples
 
    var_dump($info->getIdIndex());
 
-The output would then resemble::
+The output would then resemble:
 
    array(4) {
      ["v"]=>

--- a/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
@@ -44,7 +44,7 @@ Examples
 
    var_dump($info->getInfo());
 
-The output would then resemble::
+The output would then resemble:
 
    array(1) {
      ["readOnly"]=>

--- a/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
@@ -46,6 +46,8 @@ Examples
 
 The output would then resemble:
 
+.. code-block:: none
+
    array(1) {
      ["readOnly"]=>
      bool(true)

--- a/docs/reference/method/MongoDBModelCollectionInfo-getName.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getName.txt
@@ -38,7 +38,9 @@ Examples
 
    echo $info->getName();
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    foo
 

--- a/docs/reference/method/MongoDBModelCollectionInfo-getOptions.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getOptions.txt
@@ -46,7 +46,9 @@ Examples
 
    var_dump($info->getOptions());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(2) {
      ["capped"]=>

--- a/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
@@ -40,7 +40,7 @@ Examples
 
    echo $info->getType();
 
-The output would then resemble::
+The output would then resemble:
 
    collection
 

--- a/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
@@ -42,6 +42,8 @@ Examples
 
 The output would then resemble:
 
+.. code-block:: none
+
    collection
 
 See Also

--- a/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
@@ -50,7 +50,9 @@ Examples
 
    var_dump($info->isCapped());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    bool(true)
 

--- a/docs/reference/method/MongoDBModelDatabaseInfo-getName.txt
+++ b/docs/reference/method/MongoDBModelDatabaseInfo-getName.txt
@@ -37,7 +37,9 @@ Examples
 
    echo $info->getName();
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    foo
 

--- a/docs/reference/method/MongoDBModelDatabaseInfo-getSizeOnDisk.txt
+++ b/docs/reference/method/MongoDBModelDatabaseInfo-getSizeOnDisk.txt
@@ -37,7 +37,9 @@ Examples
 
    var_dump($info->getSizeOnDisk());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    int(1048576)
 

--- a/docs/reference/method/MongoDBModelDatabaseInfo-isEmpty.txt
+++ b/docs/reference/method/MongoDBModelDatabaseInfo-isEmpty.txt
@@ -37,7 +37,9 @@ Examples
 
    var_dump($info->isEmpty());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    bool(true)
 

--- a/docs/reference/method/MongoDBModelIndexInfo-getKey.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-getKey.txt
@@ -41,7 +41,9 @@ Examples
 
    var_dump($info->getKey());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    array(1) {
      ["x"]=>

--- a/docs/reference/method/MongoDBModelIndexInfo-getName.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-getName.txt
@@ -42,7 +42,9 @@ Examples
 
    echo $info->getName();
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    x_1
 

--- a/docs/reference/method/MongoDBModelIndexInfo-getNamespace.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-getNamespace.txt
@@ -40,7 +40,9 @@ Examples
 
    echo $info->getNamespace();
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    foo.bar
 

--- a/docs/reference/method/MongoDBModelIndexInfo-getVersion.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-getVersion.txt
@@ -39,7 +39,9 @@ Examples
 
    var_dump($info->getVersion());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    int(1)
 

--- a/docs/reference/method/MongoDBModelIndexInfo-is2dSphere.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-is2dSphere.txt
@@ -46,7 +46,9 @@ Examples
        }
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    pos_2dsphere has 2dsphereIndexVersion: 3
 

--- a/docs/reference/method/MongoDBModelIndexInfo-isGeoHaystack.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isGeoHaystack.txt
@@ -46,7 +46,9 @@ Examples
        }
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    pos_geoHaystack_x_1 has bucketSize: 5
 

--- a/docs/reference/method/MongoDBModelIndexInfo-isSparse.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isSparse.txt
@@ -41,7 +41,9 @@ Examples
 
    var_dump($info->isSparse());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    bool(true)
 

--- a/docs/reference/method/MongoDBModelIndexInfo-isText.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isText.txt
@@ -45,7 +45,9 @@ Examples
        }
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    name_text has default language: english
 

--- a/docs/reference/method/MongoDBModelIndexInfo-isTtl.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isTtl.txt
@@ -41,7 +41,9 @@ Examples
 
    var_dump($info->isTtl());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    bool(true)
 

--- a/docs/reference/method/MongoDBModelIndexInfo-isUnique.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isUnique.txt
@@ -41,7 +41,9 @@ Examples
 
    var_dump($info->isUnique());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    bool(true)
 

--- a/docs/tutorial/collation.txt
+++ b/docs/tutorial/collation.txt
@@ -196,7 +196,7 @@ A collection called ``names`` contains the following documents:
    { "_id" : 4, "first_name" : "Jürgen" }
 
 The following :phpmethod:`findOneAndUpdate()
-<MongoDB\\Collection::findOneAndUpdate>` operation on the collection does not
+<MongoDB\\Collection::findOneAndUpdate()>` operation on the collection does not
 specify a collation.
 
 .. code-block:: php
@@ -214,7 +214,7 @@ Because ``Gunter`` is lexically first in the collection, the above operation
 returns no results and updates no documents.
 
 Consider the same :phpmethod:`findOneAndUpdate()
-<MongoDB\\Collection::findOneAndUpdate>` operation but with a collation
+<MongoDB\\Collection::findOneAndUpdate()>` operation but with a collation
 specified, which uses the locale ``de@collation=phonebook``.
 
 .. note::
@@ -349,7 +349,7 @@ Aggregation
 ~~~~~~~~~~~
 
 To use collation with an :phpmethod:`aggregate()
-<MongoDB\\Collection::aggregate>` operation, specify a collation in the
+<MongoDB\\Collection::aggregate()>` operation, specify a collation in the
 aggregation options.
 
 The following aggregation example uses a collection called ``names`` and groups

--- a/docs/tutorial/commands.txt
+++ b/docs/tutorial/commands.txt
@@ -52,7 +52,9 @@ in the ``restos`` collection in the ``test`` database:
 
    var_dump($results);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#27 (1) {
      ["storage":"ArrayObject":private]=>
@@ -240,7 +242,9 @@ custom read preference:
 
    var_dump($cursor->toArray()[0]);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#8 (1) {
      ["storage":"ArrayObject":private]=>
@@ -273,7 +277,9 @@ document, or access the first result in the array, as in the following:
 
    var_dump($cursor->toArray()[0]);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#2 (1) {
      ["storage":"ArrayObject":private]=>
@@ -307,7 +313,9 @@ iterating through the cursor returned by the ``listCollections`` command using a
    }
 
 The output would then be a list of the values for the ``name`` key, for
-instance::
+instance:
+
+.. code-block:: none
 
    persons
    posts

--- a/docs/tutorial/crud.txt
+++ b/docs/tutorial/crud.txt
@@ -539,7 +539,7 @@ updates to perform. The :phpmethod:`MongoDB\\Collection::updateMany()` reference
 describes each parameter in detail.
 
 The following example inserts three documents into an empty ``users`` collection
-in the ``test`` database and then uses the :query:`$set` operator to update the
+in the ``test`` database and then uses the :update:`$set` operator to update the
 documents matching the filter criteria to include the ``country`` field with
 value ``"us"``:
 

--- a/docs/tutorial/crud.txt
+++ b/docs/tutorial/crud.txt
@@ -61,7 +61,9 @@ The following example inserts a document while specifying the value for the
 
    var_dump($insertOneResult->getInsertedId());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Inserted 1 document(s)
    int(1)
@@ -113,7 +115,9 @@ The following example searches for the document with ``_id`` of ``"94301"``:
 
    var_dump($document);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#13 (1) {
      ["storage":"ArrayObject":private]=>
@@ -175,7 +179,9 @@ specified city and state values:
        echo $document['_id'], "\n";
    }
 
-The output would resemble::
+The output would resemble:
+
+.. code-block:: none
 
    07302
    07304
@@ -231,7 +237,9 @@ returned. It also limits the results to 5 documents.
       var_dump($restaurant);
    };
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#10 (1) {
      ["storage":"ArrayObject":private]=>
@@ -325,7 +333,9 @@ five most populous zip codes in the United States:
        printf("%s: %s, %s\n", $document['_id'], $document['city'], $document['state']);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    60623: CHICAGO, IL
    11226: BROOKLYN, NY
@@ -358,7 +368,9 @@ name starts with "garden" and the state is Texas:
       printf("%s: %s, %s\n", $document['_id'], $document['city'], $document['state']);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    78266: GARDEN RIDGE, TX
    79739: GARDEN CITY, TX
@@ -422,7 +434,9 @@ with them:
        printf("%s has %d zip codes\n", $state['_id'], $state['count']);
    }
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    TX has 1671 zip codes
    NY has 1595 zip codes
@@ -472,7 +486,9 @@ is ``"ny"`` to include a ``country`` field set to ``"us"``:
 
 Since the update operation uses the
 :phpmethod:`MongoDB\\Collection::updateOne()` method, which updates the first
-document to match the filter criteria, the results would then resemble::
+document to match the filter criteria, the results would then resemble:
+
+.. code-block:: none
 
    Matched 1 document(s)
    Modified 1 document(s)
@@ -498,7 +514,9 @@ value, as in this example:
    printf("Modified %d document(s)\n", $updateResult->getModifiedCount());
 
 The number of matched documents and the number of *modified* documents would
-therefore not be equal, and the output from the operation would resemble::
+therefore not be equal, and the output from the operation would resemble:
+
+.. code-block:: none
 
    Matched 1 document(s)
    Modified 0 document(s)
@@ -547,7 +565,9 @@ If an update operation results in no change to a document, such as setting the
 value of the field to its current value, the number of modified documents can be
 less than the number of *matched* documents. Since the update document with
 ``name`` of ``"Bob"`` results in no changes to the document, the output of the
-operation therefore resembles::
+operation therefore resembles:
+
+.. code-block:: none
 
    Matched 3 document(s)
    Modified 2 document(s)
@@ -573,7 +593,7 @@ replacement document that will replace the original document in MongoDB. The
 :phpmethod:`MongoDB\\Collection::replaceOne()` reference describes each
 parameter in detail.
 
-.. important:: 
+.. important::
 
    Replacement operations replace all of the fields in a document except the
    ``_id`` value. To avoid accidentally overwriting or deleting desired fields,
@@ -600,12 +620,14 @@ the ``test`` database, and then replaces that document with a new one:
    printf("Matched %d document(s)\n", $updateResult->getMatchedCount());
    printf("Modified %d document(s)\n", $updateResult->getModifiedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Matched 1 document(s)
    Modified 1 document(s)
 
-.. seealso:: 
+.. seealso::
 
    - :phpmethod:`MongoDB\\Collection::replaceOne()`
    - :phpmethod:`MongoDB\\Collection::findOneAndReplace()`
@@ -649,7 +671,9 @@ the ``upsert`` option set to ``true`` and an empty ``users`` collection in the
 
    var_dump($upsertedDocument);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Matched 0 document(s)
    Modified 0 document(s)
@@ -705,7 +729,9 @@ value is ``"ny"``:
 
    printf("Deleted %d document(s)\n", $deleteResult->getDeletedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Deleted 1 document(s)
 
@@ -739,7 +765,9 @@ value is ``"ny"``:
 
    printf("Deleted %d document(s)\n", $deleteResult->getDeletedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Deleted 2 document(s)
 

--- a/docs/tutorial/custom-types.txt
+++ b/docs/tutorial/custom-types.txt
@@ -152,7 +152,9 @@ back to ``LocalDateTime``.
     var_dump($document->date->toDateTime());
     ?>
 
-Which outputs::
+Which outputs:
+
+.. code-block:: none
 
     object(stdClass)#1 (1) {
       ["date"]=>

--- a/docs/tutorial/decimal128.txt
+++ b/docs/tutorial/decimal128.txt
@@ -48,7 +48,9 @@ field of a collection named ``inventory``:
 
    var_dump($item);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\BSONDocument)#9 (1) {
      ["storage":"ArrayObject":private]=>
@@ -86,7 +88,9 @@ The following example adds two ``Decimal128`` values and creates a new
 
    var_dump($sum);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\BSON\Decimal128)#4 (1) {
      ["dec"]=>
@@ -111,7 +115,9 @@ obtain the expected result:
 
    var_dump($sum);
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    object(MongoDB\BSON\Decimal128)#4 (1) {
      ["dec"]=>

--- a/docs/tutorial/example-data.txt
+++ b/docs/tutorial/example-data.txt
@@ -9,7 +9,7 @@ Some examples in this documentation use example data fixtures from
 `primer-dataset.json <https://raw.githubusercontent.com/mongodb/docs-assets/primer-dataset/primer-dataset.json>`_.
 
 Importing the dataset into MongoDB can be done in several ways. The following
-example imports the `zips.json` file into a `test.zips` collection:
+example imports the ``zips.json`` file into a ``test.zips`` collection:
 :php:`driver <mongodb>` directly:
 
 .. code-block:: php

--- a/docs/tutorial/example-data.txt
+++ b/docs/tutorial/example-data.txt
@@ -32,7 +32,9 @@ example imports the `zips.json` file into a `test.zips` collection:
    $result = $manager->executeBulkWrite('test.zips', $bulk);
    printf("Inserted %d documents\n", $result->getInsertedCount());
 
-The output would then resemble::
+The output would then resemble:
+
+.. code-block:: none
 
    Inserted 29353 documents
 

--- a/docs/tutorial/gridfs.txt
+++ b/docs/tutorial/gridfs.txt
@@ -23,7 +23,7 @@ Creating a GridFS Bucket
 You can construct a GridFS bucket using the PHP extension's
 :php:`MongoDB\\Driver\\Manager <class.mongodb-driver-manager>` class, or select
 a bucket from the |php-library|'s :phpclass:`MongoDB\\Database` class via the
-:phpmethod:`selectGridFSBucket() <MongoDB\\Database::selectGridFSBucket>`
+:phpmethod:`selectGridFSBucket() <MongoDB\\Database::selectGridFSBucket()>`
 method.
 
 The bucket can be constructed with various options:
@@ -112,9 +112,9 @@ number. Revision numbers are used to distinguish between files sharing the same
 ``filename`` metadata field, ordered by date of upload (i.e. the ``uploadDate``
 metadata field). The ``revision`` option accepted by
 :phpmethod:`openDownloadStreamByName()
-<MongoDB\\GridFS\\Bucket::openDownloadStreamByName>` and
+<MongoDB\\GridFS\\Bucket::openDownloadStreamByName()>` and
 :phpmethod:`downloadToStreamByName()
-<MongoDB\\GridFS\\Bucket::downloadToStreamByName>` can be positive or negative.
+<MongoDB\\GridFS\\Bucket::downloadToStreamByName()>` can be positive or negative.
 
 A positive ``revision`` number may be used to select files in order of the
 oldest upload date. A revision of ``0`` would denote the file with the oldest
@@ -157,7 +157,7 @@ You can delete a GridFS file by its ``_id``.
 Finding File Metadata
 ---------------------
 
-The :phpmethod:`find() <MongoDB\\GridFS\\Bucket::find>` method allows you to
+The :phpmethod:`find() <MongoDB\\GridFS\\Bucket::find()>` method allows you to
 retrieve documents from the GridFS files collection, which contain metadata
 about the GridFS files.
 
@@ -173,7 +173,7 @@ Accessing File Metadata for an Existing Stream
 ----------------------------------------------
 
 The :phpmethod:`getFileDocumentForStream()
-<MongoDB\\GridFS\\Bucket::getFileDocumentForStream>` method may be used to get
+<MongoDB\\GridFS\\Bucket::getFileDocumentForStream()>` method may be used to get
 the file document for an existing readable or writable GridFS stream.
 
 .. code-block:: php
@@ -193,16 +193,16 @@ the file document for an existing readable or writable GridFS stream.
    Since the file document for a writable stream is not committed to MongoDB
    until the stream is closed,
    :phpmethod:`getFileDocumentForStream()
-   <MongoDB\\GridFS\\Bucket::getFileDocumentForStream>` can only return an
+   <MongoDB\\GridFS\\Bucket::getFileDocumentForStream()>` can only return an
    in-memory document, which will be missing some fields (e.g. ``length``,
    ``md5``).
 
 The :phpmethod:`getFileIdForStream()
-<MongoDB\\GridFS\\Bucket::getFileIdForStream>` method may be used to get the
+<MongoDB\\GridFS\\Bucket::getFileIdForStream()>` method may be used to get the
 ``_id`` for an existing readable or writable GridFS stream. This is a
 convenience for accessing the ``_id`` property of the object returned by
 :phpmethod:`getFileDocumentForStream()
-<MongoDB\\GridFS\\Bucket::getFileDocumentForStream>`.
+<MongoDB\\GridFS\\Bucket::getFileDocumentForStream()>`.
 
 .. code-block:: php
 

--- a/docs/tutorial/indexes.txt
+++ b/docs/tutorial/indexes.txt
@@ -31,7 +31,7 @@ Create indexes with the :phpmethod:`MongoDB\\Collection::createIndex()` or
 reference for more details about each method.
 
 The following example creates an ascending index on the ``state`` field using
-the :phpmethod:`createIndex() <MongoDB\\Collection::createIndex>` method:
+the :phpmethod:`createIndex() <MongoDB\\Collection::createIndex()>` method:
 
 .. code-block:: php
 

--- a/docs/tutorial/indexes.txt
+++ b/docs/tutorial/indexes.txt
@@ -127,6 +127,7 @@ The following example drops a single index by its name, ``state_1``:
 The operation's output would resemble:
 
 .. code-block:: none
+
    object(MongoDB\Model\BSONDocument)#11 (1) {
      ["storage":"ArrayObject":private]=>
      array(2) {

--- a/docs/tutorial/indexes.txt
+++ b/docs/tutorial/indexes.txt
@@ -45,7 +45,9 @@ the :phpmethod:`createIndex() <MongoDB\\Collection::createIndex>` method:
 
 When you create an index, the method returns its name, which is automatically
 generated from its specification. The above example would output something
-similar to::
+similar to:
+
+.. code-block:: none
 
    string(7) "state_1"
 
@@ -71,7 +73,9 @@ The following example lists all indexes in the ``zips`` collection in the
        var_dump($indexInfo);
    }
 
-The output would resemble::
+The output would resemble:
+
+.. code-block:: none
 
    object(MongoDB\Model\IndexInfo)#10 (4) {
      ["v"]=>
@@ -120,8 +124,9 @@ The following example drops a single index by its name, ``state_1``:
 
    var_dump($result);
 
-The operation's output would resemble::
+The operation's output would resemble:
 
+.. code-block:: none
    object(MongoDB\Model\BSONDocument)#11 (1) {
      ["storage":"ArrayObject":private]=>
      array(2) {

--- a/docs/tutorial/modeling-bson-data.txt
+++ b/docs/tutorial/modeling-bson-data.txt
@@ -167,7 +167,7 @@ directly serialized. This is similar to how enums are handled by
 :php:`json_encode() <json-encode>`.
 
 Round-tripping a backed enum through BSON requires special handling. In the
-following example, the `bsonUnserialize()` method in the class containing the
+following example, the ``bsonUnserialize()`` method in the class containing the
 enum is responsible for converting the value back to an enum case:
 
 .. code-block:: php

--- a/docs/upgrade.txt
+++ b/docs/upgrade.txt
@@ -263,7 +263,7 @@ equivalent method(s) in the new driver.
 
    * - ``MongoCollection::group()``
      - Not implemented. Use :phpmethod:`MongoDB\\Database::command()`. See
-       :ref:`Group Command Helper` for an example.
+       :ref:`Group Command Helper <group-command-helper>` for an example.
 
    * - ``MongoCollection::insert()``
      - :phpmethod:`MongoDB\\Collection::insertOne()`
@@ -332,8 +332,8 @@ MongoCollection::save() Removed
 
 ``MongoCollection::save()``, which was syntactic sugar for an insert or upsert
 operation, has been removed in favor of explicitly using
-:phpmethod:`MongoDB\\Collection::insertOne` or
-:phpmethod:`MongoDB\\Collection::replaceOne` (with the ``upsert`` option).
+:phpmethod:`MongoDB\\Collection::insertOne()` or
+:phpmethod:`MongoDB\\Collection::replaceOne()` (with the ``upsert`` option).
 
 While the ``save`` method does have its uses for interactive environments, such
 as the ``mongo`` shell, it was intentionally excluded from the
@@ -344,6 +344,8 @@ handle the returned :phpclass:`MongoDB\\InsertOneResult` or
 :phpclass:`MongoDB\\UpdateResult`, respectively. This also helps avoid
 inadvertent and potentially dangerous :manual:`full-document replacements
 </tutorial/modify-documents>`.
+
+.. _group-command-helper:
 
 Group Command Helper
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/upgrade.txt
+++ b/docs/upgrade.txt
@@ -263,7 +263,7 @@ equivalent method(s) in the new driver.
 
    * - ``MongoCollection::group()``
      - Not implemented. Use :phpmethod:`MongoDB\\Database::command()`. See
-       `Group Command Helper`_ for an example.
+       :ref:`Group Command Helper` for an example.
 
    * - ``MongoCollection::insert()``
      - :phpmethod:`MongoDB\\Collection::insertOne()`


### PR DESCRIPTION
PHPLIB-1046

This PR fixes most of the errors reported when building docs with the Snooty tooling. A few errors are currently unfixable:
* `Unknown interpreted text role "php"`: This needs fixing on the tooling side
* `Error opening includes/....rst: No such file or directory`: This may need to be fixed in tooling or require local changes; waiting on feedback
* `Target not found: "phpmethod:phpmethod...."`: Waiting on feedback on how to fix