### PR TITLE
PHPLIB-909: Add more error response tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -704,13 +704,15 @@ axes:
     display_name: Driver Version
     values:
       - id: "oldest-supported"
-        display_name: "PHPC 1.15.0"
+        display_name: "PHPC 1.16.0"
         variables:
-          EXTENSION_VERSION: "1.15.0"
+          EXTENSION_BRANCH: "master"
+#          EXTENSION_VERSION: "1.16.0"
       - id: "latest-stable"
-        display_name: "PHPC (1.15.x)"
+        display_name: "PHPC (1.16.x)"
         variables:
-          EXTENSION_VERSION: "stable"
+          EXTENSION_BRANCH: "master"
+#          EXTENSION_VERSION: "stable"
       - id: "latest-dev"
         display_name: "PHPC (1.16-dev)"
         variables:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^7.2 || ^8.0",
         "ext-hash": "*",
         "ext-json": "*",
-        "ext-mongodb": "^1.15.0",
+        "ext-mongodb": "^1.16.0",
         "jean85/pretty-package-versions": "^1.2 || ^2.0.1",
         "symfony/polyfill-php80": "^1.19"
     },

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -65,11 +65,6 @@ class UnifiedSpecTest extends FunctionalTestCase
         'valid-pass/createEntities-operation: createEntities operation' => 'CSOT is not yet implemented (PHPC-1760)',
         'valid-pass/entity-cursor-iterateOnce: iterateOnce' => 'CSOT is not yet implemented (PHPC-1760)',
         'valid-pass/matches-lte-operator: special lte matching operator' => 'CSOT is not yet implemented (PHPC-1760)',
-        // BulkWriteException cannot access server response
-        'crud/bulkWrite-errorResponse: bulkWrite operations support errorResponse assertions' => 'BulkWriteException cannot access server response',
-        'crud/deleteOne-errorResponse: delete operations support errorResponse assertions' => 'BulkWriteException cannot access server response',
-        'crud/insertOne-errorResponse: insert operations support errorResponse assertions' => 'BulkWriteException cannot access server response',
-        'crud/updateOne-errorResponse: update operations support errorResponse assertions' => 'BulkWriteException cannot access server response',
     ];
 
     /** @var UnifiedTestRunner */


### PR DESCRIPTION
This is a follow-up to PHPLIB-909 that removes the 4 previously skipped tests now that `WriteResult` exposes the errors as sent from the server. Since there may be multiple replies, I decided to only check the first one - another option would be to pass the test if any error response matches, but I'm not sure if that's feasible.