### PR TITLE
Remove redundant code in CSFLE legacy spec test runner

### DIFF
--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -131,11 +131,6 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $databaseName = $databaseName ?? $this->getDatabaseName();
         $collectionName = $collectionName ?? $this->getCollectionName();
 
-        // TODO: Remove this once SERVER-66901 is implemented (see: PHPLIB-884)
-        if (isset($test->clientOptions->autoEncryptOpts->encryptedFieldsMap)) {
-            $test->clientOptions->autoEncryptOpts->encryptedFieldsMap = $test->clientOptions->autoEncryptOpts->encryptedFieldsMap;
-        }
-
         try {
             $context = Context::fromClientSideEncryption($test, $databaseName, $collectionName);
         } catch (SkippedTestError $e) {


### PR DESCRIPTION
This was missed in a495bf5369f08048b5467803d9abdec35edac2bb for PHPLIB-884

Came across this while working on [PHPLIB-1049](https://jira.mongodb.org/browse/PHPLIB-1049). Completely my fault since https://github.com/mongodb/mongo-php-library/pull/945 was never reviewed.