### PR TITLE
PHPLIB-1049: AWS authentication with temporary credentials in CSFLE

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -284,6 +284,9 @@ functions:
           ${PREPARE_SHELL}
           export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
           export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
+          export AWS_TEMP_ACCESS_KEY_ID="${client_side_encryption_aws_temp_access_key_id}"
+          export AWS_TEMP_SECRET_ACCESS_KEY="${client_side_encryption_aws_temp_secret_access_key_key}"
+          export AWS_TEMP_SESSION_TOKEN="${client_side_encryption_aws_temp_session_token}"
           export AZURE_TENANT_ID="${client_side_encryption_azure_tenant_id}"
           export AZURE_CLIENT_ID="${client_side_encryption_azure_client_id}"
           export AZURE_CLIENT_SECRET="${client_side_encryption_azure_client_secret}"
@@ -328,6 +331,9 @@ functions:
           ${PREPARE_SHELL}
           export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
           export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
+          export AWS_TEMP_ACCESS_KEY_ID="${client_side_encryption_aws_temp_access_key_id}"
+          export AWS_TEMP_SECRET_ACCESS_KEY="${client_side_encryption_aws_temp_secret_access_key_key}"
+          export AWS_TEMP_SESSION_TOKEN="${client_side_encryption_aws_temp_session_token}"
           export AZURE_TENANT_ID="${client_side_encryption_azure_tenant_id}"
           export AZURE_CLIENT_ID="${client_side_encryption_azure_client_id}"
           export AZURE_CLIENT_SECRET="${client_side_encryption_azure_client_secret}"
@@ -455,6 +461,36 @@ functions:
           - key: client_side_encryption_kmip_endpoint
             value: localhost:5698
 
+  "set aws temp creds":
+    - command: shell.exec
+      params:
+        shell: bash
+        script: |-
+          set -o errexit
+
+          export AWS_ACCESS_KEY_ID="${client_side_encryption_aws_access_key_id}"
+          export AWS_SECRET_ACCESS_KEY="${client_side_encryption_aws_secret_access_key}"
+          export AWS_DEFAULT_REGION="us-east-1"
+
+          pushd ${DRIVERS_TOOLS}/.evergreen/csfle
+          . ./activate_venv.sh
+          . ./set-temp-creds.sh
+          popd
+
+          if [ -z "$CSFLE_AWS_TEMP_ACCESS_KEY_ID" ]; then
+            echo "Failed to set AWS temporary credentials!"
+            exit 1
+          fi
+
+          cat <<EOT > aws-expansion.yml
+          client_side_encryption_aws_temp_access_key_id: "$CSFLE_AWS_TEMP_ACCESS_KEY_ID"
+          client_side_encryption_aws_temp_secret_access_key_key: "$CSFLE_AWS_TEMP_SECRET_ACCESS_KEY"
+          client_side_encryption_aws_temp_session_token: "$CSFLE_AWS_TEMP_SESSION_TOKEN"
+          EOT
+    - command: expansions.update
+      params:
+        file: aws-expansion.yml
+
 pre:
   - func: "fetch source"
   - func: "prepare resources"
@@ -513,6 +549,7 @@ tasks:
           vars:
             TOPOLOGY: "server"
         - func: "start kms servers"
+        - func: "set aws temp creds"
         - func: "run tests"
 
     - name: "test-replica_set"
@@ -522,6 +559,7 @@ tasks:
           vars:
             TOPOLOGY: "replica_set"
         - func: "start kms servers"
+        - func: "set aws temp creds"
         - func: "run tests"
 
     - name: "test-sharded_cluster"
@@ -531,6 +569,7 @@ tasks:
           vars:
             TOPOLOGY: "sharded_cluster"
         - func: "start kms servers"
+        - func: "set aws temp creds"
         - func: "run tests"
 
     - name: "test-atlas-data-lake"
@@ -547,6 +586,7 @@ tasks:
             AUTH: "auth"
             REQUIRE_API_VERSION: "yes"
         - func: "start kms servers"
+        - func: "set aws temp creds"
         - func: "run tests"
           vars:
             API_VERSION: "1"
@@ -559,6 +599,7 @@ tasks:
             TOPOLOGY: "server"
             ORCHESTRATION_FILE: "versioned-api-testing.json"
         - func: "start kms servers"
+        - func: "set aws temp creds"
         - func: "run tests"
           vars:
             TESTS: "versioned-api"
@@ -568,6 +609,7 @@ tasks:
       commands:
         - func: "create serverless instance"
         - func: "start kms servers"
+        - func: "set aws temp creds"
         - func: "run serverless tests"
 
     - name: "test-loadBalanced"
@@ -580,6 +622,7 @@ tasks:
             SSL: "yes"
         - func: "start load balancer"
         - func: "start kms servers"
+        - func: "set aws temp creds"
         - func: "run tests"
           vars:
             # Note: loadBalanced=true should already be appended to SINGLE_MONGOS_LB_URI

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -593,12 +593,13 @@ tasks:
           vars:
             TOPOLOGY: "replica_set"
         - func: "start kms servers"
+        - func: "set aws temp creds"
         - func: "run tests"
           vars:
             SKIP_CRYPT_SHARED: "yes"
             TESTS: "csfle"
 
-    - name: "test-without_aws_credentials"
+    - name: "test-without_aws_creds"
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
@@ -608,7 +609,7 @@ tasks:
           vars:
             client_side_encryption_aws_access_key_id: ""
             client_side_encryption_aws_secret_access_key: ""
-            TESTS: "csfle"
+            TESTS: "csfle-without-aws-creds"
 
 # }}}
 
@@ -879,8 +880,8 @@ buildvariants:
     - name: "test-skip_crypt_shared"
 
 # Run CSFLE tests without AWS credentials (for "On-demand AWS Credentials" prose test)
-- matrix_name: "test-csfle-without_aws_credentials"
+- matrix_name: "test-csfle-without_aws_creds"
   matrix_spec: { "os": "debian11", "mongodb-versions": "6.0", "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
-  display_name: "CSFLE without_aws_credentials - ${mongodb-versions}"
+  display_name: "CSFLE without_aws_creds - ${mongodb-versions}"
   tasks:
-    - name: "test-without_aws_credentials"
+    - name: "test-without_aws_creds"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -76,6 +76,10 @@ case "$TESTS" in
       php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group csfle
       ;;
 
+   csfle-without-aws-creds)
+      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group csfle-without-aws-creds
+      ;;
+
    versioned-api)
       php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group versioned-api
       ;;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ The following environment variables are used for [CSFLE testing](https://github.
  * `AWS_ACCESS_KEY_ID`
  * `AWS_SECRET_ACCESS_KEY`
  * `AWS_TEMP_ACCESS_KEY_ID`
- * 'AWS_TEMP_SECRET_ACCESS_KEY'
+ * `AWS_TEMP_SECRET_ACCESS_KEY`
  * `AWS_TEMP_SESSION_TOKEN`
  * `AZURE_TENANT_ID`
  * `AZURE_CLIENT_ID`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,9 @@ The following environment variables are used for [CSFLE testing](https://github.
 
  * `AWS_ACCESS_KEY_ID`
  * `AWS_SECRET_ACCESS_KEY`
+ * `AWS_TEMP_ACCESS_KEY_ID`
+ * 'AWS_TEMP_SECRET_ACCESS_KEY'
+ * `AWS_TEMP_SESSION_TOKEN`
  * `AZURE_TENANT_ID`
  * `AZURE_CLIENT_ID`
  * `AZURE_CLIENT_SECRET`

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -1646,6 +1646,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 15: On-demand AWS Credentials
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#on-demand-aws-credentials
+     * @group csfle-without-aws-creds
      * @testWith [true]
      *           [false]
      */

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -63,8 +63,6 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
     /** @var array */
     private static $incompleteTests = [
-        'awsTemporary: Insert a document with auto encryption using the AWS provider with temporary credentials' => 'Not yet implemented (PHPC-1751)',
-        'awsTemporary: Insert with invalid temporary credentials' => 'Not yet implemented (PHPC-1751)',
         'azureKMS: Insert a document with auto encryption using Azure KMS provider' => 'RHEL platform is missing Azure root certificate (PHPLIB-619)',
         'explain: Explain a find with deterministic encryption' => 'crypt_shared does not add apiVersion field to explain commands (PHPLIB-947, SERVER-69564)',
         'timeoutMS: timeoutMS applied to listCollections to get collection schema' => 'Not yet implemented (PHPC-1760)',

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -15,6 +15,7 @@ use function array_diff_key;
 use function array_keys;
 use function getenv;
 use function implode;
+use function sprintf;
 
 /**
  * Execution context for spec tests.
@@ -227,59 +228,39 @@ final class Context
 
     public static function getAWSCredentials(): array
     {
-        if (! getenv('AWS_ACCESS_KEY_ID') || ! getenv('AWS_SECRET_ACCESS_KEY')) {
-            Assert::markTestSkipped('Please configure AWS credentials to use AWS KMS provider.');
-        }
-
         return [
-            'accessKeyId' => getenv('AWS_ACCESS_KEY_ID'),
-            'secretAccessKey' => getenv('AWS_SECRET_ACCESS_KEY'),
+            'accessKeyId' => static::getEnv('AWS_ACCESS_KEY_ID'),
+            'secretAccessKey' => static::getEnv('AWS_SECRET_ACCESS_KEY'),
         ];
     }
 
     public static function getAzureCredentials(): array
     {
-        if (! getenv('AZURE_TENANT_ID') || ! getenv('AZURE_CLIENT_ID') || ! getenv('AZURE_CLIENT_SECRET')) {
-            Assert::markTestSkipped('Please configure Azure credentials to use Azure KMS provider.');
-        }
-
         return [
-            'tenantId' => getenv('AZURE_TENANT_ID'),
-            'clientId' => getenv('AZURE_CLIENT_ID'),
-            'clientSecret' => getenv('AZURE_CLIENT_SECRET'),
+            'tenantId' => static::getEnv('AZURE_TENANT_ID'),
+            'clientId' => static::getEnv('AZURE_CLIENT_ID'),
+            'clientSecret' => static::getEnv('AZURE_CLIENT_SECRET'),
         ];
     }
 
     public static function getKmipEndpoint(): string
     {
-        if (! getenv('KMIP_ENDPOINT')) {
-            Assert::markTestSkipped('Please configure KMIP endpoint to use KMIP KMS provider.');
-        }
-
-        return getenv('KMIP_ENDPOINT');
+        return static::getEnv('KMIP_ENDPOINT');
     }
 
     public static function getKmsTlsOptions(): array
     {
-        if (! getenv('KMS_TLS_CA_FILE') || ! getenv('KMS_TLS_CERTIFICATE_KEY_FILE')) {
-            Assert::markTestSkipped('Please configure KMS TLS options.');
-        }
-
         return [
-            'tlsCAFile' => getenv('KMS_TLS_CA_FILE'),
-            'tlsCertificateKeyFile' => getenv('KMS_TLS_CERTIFICATE_KEY_FILE'),
+            'tlsCAFile' => static::getEnv('KMS_TLS_CA_FILE'),
+            'tlsCertificateKeyFile' => static::getEnv('KMS_TLS_CERTIFICATE_KEY_FILE'),
         ];
     }
 
     public static function getGCPCredentials(): array
     {
-        if (! getenv('GCP_EMAIL') || ! getenv('GCP_PRIVATE_KEY')) {
-            Assert::markTestSkipped('Please configure GCP credentials to use GCP KMS provider.');
-        }
-
         return [
-            'email' => getenv('GCP_EMAIL'),
-            'privateKey' => getenv('GCP_PRIVATE_KEY'),
+            'email' => static::getEnv('GCP_EMAIL'),
+            'privateKey' => static::getEnv('GCP_PRIVATE_KEY'),
         ];
     }
 
@@ -451,6 +432,17 @@ final class Context
         $driverOptions += ['disableClientPersistence' => true];
 
         return FunctionalTestCase::createTestClient($uri, $options, $driverOptions);
+    }
+
+    private static function getEnv(string $name): string
+    {
+        $value = getenv($name);
+
+        if ($value === false) {
+            Assert::markTestSkipped(sprintf('Environment variable "%s" is not defined', $name));
+        }
+
+        return $value;
     }
 
     private function prepareGridFSBucketOptions(array $options, $bucketPrefix)

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -103,6 +103,7 @@ class UnifiedSpecTest extends FunctionalTestCase
 
     /**
      * @dataProvider provideClientSideEncryptionTests
+     * @group csfle
      */
     public function testClientSideEncryption(UnifiedTestCase $test): void
     {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1049
https://jira.mongodb.org/browse/PHPLIB-866

Patch build: https://spruce.mongodb.com/version/63984a949ccd4e45e88e709b/tasks

Note: the two failures for the `test-requireApiVersion` task are unrelated and will be addressed in a separate PR.