### PR TITLE
PHPLIB-1051: Skip example tests when API version is required

### DIFF
--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -15,6 +15,10 @@ final class ExamplesTest extends FunctionalTestCase
             $this->markTestSkipped('Examples are not tested on sharded clusters.');
         }
 
+        if ($this->isApiVersionRequired()) {
+            $this->markTestSkipped('Examples are not tested with when the server requires specifying an API version.');
+        }
+
         self::createTestClient()->dropDatabase('test');
     }
 

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -388,6 +388,26 @@ abstract class FunctionalTestCase extends TestCase
         throw new UnexpectedValueException('Could not determine server storage engine');
     }
 
+    /**
+     * Returns whether clients must specify an API version by checking the
+     * requireApiVersion server parameter.
+     */
+    protected function isApiVersionRequired(): bool
+    {
+        try {
+            $cursor = $this->manager->executeCommand(
+                'admin',
+                new Command(['getParameter' => 1, 'requireApiVersion' => 1])
+            );
+
+            $document = current($cursor->toArray());
+        } catch (CommandException $e) {
+            return false;
+        }
+
+        return isset($document->requireApiVersion) && $document->requireApiVersion === true;
+    }
+
     protected function isEnterprise(): bool
     {
         $buildInfo = $this->getPrimaryServer()->executeCommand(


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1051

The example files create their client objects independently of the test suite, which injects an API version when it's required.

This fixes an issue originally introduced in b309cf8e4deb784705543addace0959ad13c0afc.

Patch build: https://spruce.mongodb.com/version/639927751e2d176a76153859/tasks