### PR TITLE
Refer Windows users to GitHub releases instead of PECL for DLLs

### DIFF
--- a/docs/faq.txt
+++ b/docs/faq.txt
@@ -75,8 +75,8 @@ wrap the script in ``<pre>`` tags to properly format its output:
 Loading an Incompatible DLL on Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PECL builds Windows binaries for various combinations of PHP version,
-thread-safety (TS or NTS), and architecture (x86 or x64). Failure to select the
+Windows binaries are available for various combinations of PHP version,
+thread safety (TS or NTS), and architecture (x86 or x64). Failure to select the
 correct binary will result in an error when attempting to load the extension DLL
 at runtime:
 
@@ -88,13 +88,16 @@ Ensure that you have downloaded a DLL that corresponds to the following PHP
 runtime properties:
 
 - PHP version (``PHP_VERSION``)
-- Thread-safety (``PHP_ZTS``)
+- Thread safety (``PHP_ZTS``)
 - Architecture (``PHP_INT_SIZE``)
 
 In addition to the aforementioned constants, these properties can also be
 inferred from :php:`phpinfo() <phpinfo>`. If your system has multiple PHP
 runtimes installed, double-check that you are examining the ``phpinfo()`` output
 for the correct environment.
+
+The aforementioned ``detect-extension`` script can also be used to determine the
+appropriate DLL for your PHP environment.
 
 Server Selection Failures
 -------------------------

--- a/docs/tutorial/install-php-library.txt
+++ b/docs/tutorial/install-php-library.txt
@@ -41,17 +41,18 @@ file:
 
    extension=mongodb.so
 
-Windows users can download precompiled binaries of the extension from
-`PECL <https://pecl.php.net/package/mongodb>`_. After extracting the
-``php_mongodb.dll`` file to PHP's extension directory, add the following line to
-your ``php.ini`` file:
+Windows users can download precompiled binaries of the extension from its
+`GitHub releases <https://github.com/mongodb/mongo-php-driver/releases>`__.
+After downloading the appropriate archive for your PHP environment, extract the
+``php_mongodb.dll`` file to PHP's extension directory and add the following line
+to your ``php.ini`` file:
 
 .. code-block:: ini
 
    extension=php_mongodb.dll
 
-Additional considerations for Windows are discussed in the
-:php:`Windows installation documentation <manual/en/mongodb.installation.windows.php>`.
+See :php:`Installing the MongoDB PHP Driver on Windows <manual/en/mongodb.installation.windows.php>`
+for additional information.
 
 Installing the Library
 ----------------------
@@ -85,8 +86,8 @@ Manual Installation Without Composer
 
 While not recommended, you may also manually install the library using a source
 archive attached to the
-`GitHub releases <https://github.com/mongodb/mongo-php-library/releases>`_. When
-installing the library without Composer, you must ensure that all library
+`GitHub releases <https://github.com/mongodb/mongo-php-library/releases>`__.
+When installing the library without Composer, you must ensure that all library
 classes *and* functions are loaded for your application:
 
 #. If you are using a `PSR-4 <https://www.php-fig.org/psr/psr-4/>`_ autoloader,


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-2143

As of ext-mongodb 1.15.0 (PHPC-2143), DLLs are attached to GitHub release notes.