### PR TITLE
Remove `<?php` in code examples

### DIFF
--- a/docs/reference/method/MongoDBChangeStream-current.txt
+++ b/docs/reference/method/MongoDBChangeStream-current.txt
@@ -40,8 +40,6 @@ This example reports events while iterating a change stream.
 
 .. code-block:: php
 
-   <?php
-
    $uri = 'mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet';
 
    $collection = (new MongoDB\Client($uri))->test->inventory;

--- a/docs/reference/method/MongoDBChangeStream-getCursorId.txt
+++ b/docs/reference/method/MongoDBChangeStream-getCursorId.txt
@@ -33,8 +33,6 @@ This example reports the cursor ID for a change stream.
 
 .. code-block:: php
 
-   <?php
-
    $uri = 'mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet';
 
    $collection = (new MongoDB\Client($uri))->test->inventory;

--- a/docs/reference/method/MongoDBChangeStream-getResumeToken.txt
+++ b/docs/reference/method/MongoDBChangeStream-getResumeToken.txt
@@ -40,8 +40,6 @@ the ``startAfter`` option.
 
 .. code-block:: php
 
-   <?php
-
    $uri = 'mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet';
 
    $collection = (new MongoDB\Client($uri))->test->inventory;

--- a/docs/reference/method/MongoDBChangeStream-key.txt
+++ b/docs/reference/method/MongoDBChangeStream-key.txt
@@ -38,8 +38,6 @@ This example reports the index of events while iterating a change stream.
 
 .. code-block:: php
 
-   <?php
-
    $uri = 'mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet';
 
    $collection = (new MongoDB\Client($uri))->test->inventory;

--- a/docs/reference/method/MongoDBClient-dropDatabase.txt
+++ b/docs/reference/method/MongoDBClient-dropDatabase.txt
@@ -50,8 +50,6 @@ The following example drops the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client;
 
    $result = $client->dropDatabase('test');

--- a/docs/reference/method/MongoDBClient-getReadConcern.txt
+++ b/docs/reference/method/MongoDBClient-getReadConcern.txt
@@ -33,8 +33,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client('mongodb://127.0.0.1/', [
        'readConcernLevel' => 'majority',
    ]);

--- a/docs/reference/method/MongoDBClient-getReadPreference.txt
+++ b/docs/reference/method/MongoDBClient-getReadPreference.txt
@@ -34,8 +34,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client('mongodb://127.0.0.1/', [
        'readPreference' => 'primaryPreferred',
    ]);

--- a/docs/reference/method/MongoDBClient-getTypeMap.txt
+++ b/docs/reference/method/MongoDBClient-getTypeMap.txt
@@ -33,8 +33,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client('mongodb://127.0.0.1/', [], [
        'typeMap' => [
            'root' => 'array',

--- a/docs/reference/method/MongoDBClient-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBClient-getWriteConcern.txt
@@ -34,8 +34,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client('mongodb://127.0.0.1/', [
        'journal' => true,
    ]);

--- a/docs/reference/method/MongoDBClient-listDatabaseNames.txt
+++ b/docs/reference/method/MongoDBClient-listDatabaseNames.txt
@@ -51,8 +51,6 @@ The following example lists all databases on the server:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client;
 
    foreach ($client->listDatabaseNames() as $databaseName) {

--- a/docs/reference/method/MongoDBClient-listDatabases.txt
+++ b/docs/reference/method/MongoDBClient-listDatabases.txt
@@ -50,8 +50,6 @@ The following example lists all databases on the server:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client;
 
    foreach ($client->listDatabases() as $databaseInfo) {

--- a/docs/reference/method/MongoDBClient-selectCollection.txt
+++ b/docs/reference/method/MongoDBClient-selectCollection.txt
@@ -53,8 +53,6 @@ The following example selects the ``users`` collection in the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client;
 
    $collection = $client->selectCollection('test', 'users');
@@ -63,8 +61,6 @@ The following example selects the ``users`` collection in the ``test`` database
 with a custom read preference:
 
 .. code-block:: php
-
-   <?php
 
    $client = new MongoDB\Client;
 

--- a/docs/reference/method/MongoDBClient-selectDatabase.txt
+++ b/docs/reference/method/MongoDBClient-selectDatabase.txt
@@ -53,8 +53,6 @@ The following example selects the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client;
 
    $db = $client->selectDatabase('test');
@@ -63,8 +61,6 @@ The following examples selects the ``test`` database with a custom read
 preference:
 
 .. code-block:: php
-
-   <?php
 
    $client = new MongoDB\Client;
 

--- a/docs/reference/method/MongoDBClient-startSession.txt
+++ b/docs/reference/method/MongoDBClient-startSession.txt
@@ -45,8 +45,6 @@ The following example starts a new session:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client;
 
    $session = $client->startSession();

--- a/docs/reference/method/MongoDBClient-watch.txt
+++ b/docs/reference/method/MongoDBClient-watch.txt
@@ -53,8 +53,6 @@ This example reports events while iterating a change stream.
 
 .. code-block:: php
 
-   <?php
-
    $uri = 'mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet';
 
    $client = new MongoDB\Client($uri);

--- a/docs/reference/method/MongoDBClient__construct.txt
+++ b/docs/reference/method/MongoDBClient__construct.txt
@@ -61,8 +61,6 @@ creating the :phpclass:`Client <MongoDB\\Client>` instance:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client('mongodb://mongodb-deployment:27017');
 
 Connecting to a Replica Set
@@ -72,8 +70,6 @@ The following example demonstrates how to connect to a replica set with a custom
 read preference:
 
 .. code-block:: php
-
-   <?php
 
    $client = new MongoDB\Client(
        'mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet',
@@ -91,8 +87,6 @@ SSL and authentication, as is used for `MongoDB Atlas
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client(
        'mongodb://myUsername:myPassword@rs1.example.com,rs2.example.com/?ssl=true&replicaSet=myReplicaSet&authSource=admin'
    );
@@ -101,8 +95,6 @@ Alternatively, the authentication credentials and URI parameters may be
 specified in the constructor's ``$uriOptions`` parameter:
 
 .. code-block:: php
-
-   <?php
 
    $client = new MongoDB\Client(
        'mongodb://rs1.example.com,rs2.example.com/'
@@ -133,8 +125,6 @@ example demonstrates how to have the library unserialize everything as a PHP
 array, as was done in the legacy ``mongo`` extension.
 
 .. code-block:: php
-
-   <?php
 
    $client = new MongoDB\Client(
        null,

--- a/docs/reference/method/MongoDBClient__get.txt
+++ b/docs/reference/method/MongoDBClient__get.txt
@@ -54,8 +54,6 @@ The following example selects the ``test`` and ``another-app`` databases:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client;
 
    $test = $client->test;

--- a/docs/reference/method/MongoDBCollection-aggregate.txt
+++ b/docs/reference/method/MongoDBCollection-aggregate.txt
@@ -67,8 +67,6 @@ group, and sorts the results by name.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->names;
 
    $cursor = $collection->aggregate(

--- a/docs/reference/method/MongoDBCollection-createIndex.txt
+++ b/docs/reference/method/MongoDBCollection-createIndex.txt
@@ -58,8 +58,6 @@ the ``test`` database.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'restaurants');
 
    $indexName = $collection->createIndex(['borough' => 1, 'cuisine' => 1]);
@@ -81,8 +79,6 @@ database. The partial index indexes only documents where the ``borough`` field
 exists.
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->selectCollection('test', 'restaurants');
 

--- a/docs/reference/method/MongoDBCollection-createIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-createIndexes.txt
@@ -72,8 +72,6 @@ custom name.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'restaurants');
 
    $indexNames = $collection->createIndexes([

--- a/docs/reference/method/MongoDBCollection-deleteMany.txt
+++ b/docs/reference/method/MongoDBCollection-deleteMany.txt
@@ -57,8 +57,6 @@ that have ``"ny"`` as the value for the ``state`` field:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 

--- a/docs/reference/method/MongoDBCollection-deleteOne.txt
+++ b/docs/reference/method/MongoDBCollection-deleteOne.txt
@@ -59,8 +59,6 @@ has ``"ny"`` as the value for the ``state`` field:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 

--- a/docs/reference/method/MongoDBCollection-distinct.txt
+++ b/docs/reference/method/MongoDBCollection-distinct.txt
@@ -58,8 +58,6 @@ in the ``restaurants`` collection in the ``test`` database.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $distinct = $collection->distinct('borough');
@@ -93,8 +91,6 @@ in the ``restaurants`` collection in the ``test`` database for documents where
 the ``borough`` is ``Queens``:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->restaurants;
 

--- a/docs/reference/method/MongoDBCollection-drop.txt
+++ b/docs/reference/method/MongoDBCollection-drop.txt
@@ -51,8 +51,6 @@ database:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $result = $collection->drop();

--- a/docs/reference/method/MongoDBCollection-dropIndex.txt
+++ b/docs/reference/method/MongoDBCollection-dropIndex.txt
@@ -51,8 +51,6 @@ collection in the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $result = $collection->dropIndex('borough_1');

--- a/docs/reference/method/MongoDBCollection-dropIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-dropIndexes.txt
@@ -52,8 +52,6 @@ The following drops all indexes from the ``restaurants`` collection in the
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $result = $collection->dropIndexes();

--- a/docs/reference/method/MongoDBCollection-explain.txt
+++ b/docs/reference/method/MongoDBCollection-explain.txt
@@ -70,8 +70,6 @@ This example explains a count command.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $count = new MongoDB\Operation\Count(

--- a/docs/reference/method/MongoDBCollection-findOneAndDelete.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndDelete.txt
@@ -56,8 +56,6 @@ The following example finds and deletes the document with ``restaurant_id`` of
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $deletedRestaurant = $collection->findOneAndDelete(

--- a/docs/reference/method/MongoDBCollection-findOneAndReplace.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndReplace.txt
@@ -97,8 +97,6 @@ The following operation replaces the document with ``restaurant_id`` of
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->teset->restaurants;
 
    $replacedRestaurant = $collection->findOneAndReplace(

--- a/docs/reference/method/MongoDBCollection-findOneAndUpdate.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndUpdate.txt
@@ -59,8 +59,6 @@ setting its building number to ``"761"``:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $updatedRestaurant = $collection->findOneAndUpdate(

--- a/docs/reference/method/MongoDBCollection-getCollectionName.txt
+++ b/docs/reference/method/MongoDBCollection-getCollectionName.txt
@@ -34,8 +34,6 @@ The following returns the collection name for the ``zips`` collection in the
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    echo $collection->getCollectionName();

--- a/docs/reference/method/MongoDBCollection-getDatabaseName.txt
+++ b/docs/reference/method/MongoDBCollection-getDatabaseName.txt
@@ -34,8 +34,6 @@ The following returns the database name for the ``zips`` collection in the
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    echo $collection->getDatabaseName();

--- a/docs/reference/method/MongoDBCollection-getNamespace.txt
+++ b/docs/reference/method/MongoDBCollection-getNamespace.txt
@@ -35,8 +35,6 @@ database.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    echo $collection->getNamespace();

--- a/docs/reference/method/MongoDBCollection-getReadConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getReadConcern.txt
@@ -33,8 +33,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'users', [
       'readConcern' => new MongoDB\Driver\ReadConcern('majority'),
    ]);

--- a/docs/reference/method/MongoDBCollection-getReadPreference.txt
+++ b/docs/reference/method/MongoDBCollection-getReadPreference.txt
@@ -34,8 +34,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'users', [
        'readPreference' => new MongoDB\Driver\ReadPreference('primaryPreferred'),
    ]);

--- a/docs/reference/method/MongoDBCollection-getTypeMap.txt
+++ b/docs/reference/method/MongoDBCollection-getTypeMap.txt
@@ -33,8 +33,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'users', [
        'typeMap' => [
            'root' => 'array',

--- a/docs/reference/method/MongoDBCollection-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBCollection-getWriteConcern.txt
@@ -34,8 +34,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'users', [
       'writeConcern' => new MongoDB\Driver\WriteConcern(1, 0, true),
    ]);

--- a/docs/reference/method/MongoDBCollection-insertMany.txt
+++ b/docs/reference/method/MongoDBCollection-insertMany.txt
@@ -58,8 +58,6 @@ in the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->users;
 
    $insertManyResult = $collection->insertMany([

--- a/docs/reference/method/MongoDBCollection-insertOne.txt
+++ b/docs/reference/method/MongoDBCollection-insertOne.txt
@@ -57,8 +57,6 @@ The following operation inserts a document into the ``users`` collection in the
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->users;
 
    $insertOneResult = $collection->insertOne([

--- a/docs/reference/method/MongoDBCollection-listIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-listIndexes.txt
@@ -49,8 +49,6 @@ collection in the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    foreach ($collection->listIndexes() as $index) {

--- a/docs/reference/method/MongoDBCollection-mapReduce.txt
+++ b/docs/reference/method/MongoDBCollection-mapReduce.txt
@@ -78,8 +78,6 @@ each state.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    $map = new MongoDB\BSON\Javascript('function() { emit(this.state, this.pop); }');

--- a/docs/reference/method/MongoDBCollection-rename.txt
+++ b/docs/reference/method/MongoDBCollection-rename.txt
@@ -53,8 +53,6 @@ database to ``places``:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $result = $collection->rename('places');

--- a/docs/reference/method/MongoDBCollection-replaceOne.txt
+++ b/docs/reference/method/MongoDBCollection-replaceOne.txt
@@ -59,8 +59,6 @@ The following example replaces the document with ``restaurant_id`` of
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $updateResult = $collection->replaceOne(

--- a/docs/reference/method/MongoDBCollection-watch.txt
+++ b/docs/reference/method/MongoDBCollection-watch.txt
@@ -53,8 +53,6 @@ This example reports events while iterating a change stream.
 
 .. code-block:: php
 
-   <?php
-
    $uri = 'mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet';
 
    $collection = (new MongoDB\Client($uri))->test->inventory;

--- a/docs/reference/method/MongoDBCollection-withOptions.txt
+++ b/docs/reference/method/MongoDBCollection-withOptions.txt
@@ -47,8 +47,6 @@ preference:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'restaurants');
 
    $newCollection = $sourceCollection->withOptions([

--- a/docs/reference/method/MongoDBDatabase-aggregate.txt
+++ b/docs/reference/method/MongoDBDatabase-aggregate.txt
@@ -60,8 +60,6 @@ running command operations.
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->admin;
 
    $cursor = $database->aggregate(

--- a/docs/reference/method/MongoDBDatabase-command.txt
+++ b/docs/reference/method/MongoDBDatabase-command.txt
@@ -52,8 +52,6 @@ and prints its result document:
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->test;
 
    $cursor = $database->command(['ping' => 1]);
@@ -79,8 +77,6 @@ which returns a cursor containing a result document for each collection in the
 generally use :phpmethod:`MongoDB\\Database::listCollections()` in practice.
 
 .. code-block:: php
-
-   <?php
 
    $database = (new MongoDB\Client)->test;
 

--- a/docs/reference/method/MongoDBDatabase-createCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-createCollection.txt
@@ -66,8 +66,6 @@ database with document validation criteria:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $result = $db->createCollection('users', [

--- a/docs/reference/method/MongoDBDatabase-drop.txt
+++ b/docs/reference/method/MongoDBDatabase-drop.txt
@@ -50,8 +50,6 @@ The following example drops the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $result = $db->drop();

--- a/docs/reference/method/MongoDBDatabase-dropCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-dropCollection.txt
@@ -50,8 +50,6 @@ The following example drops the ``users`` collection in the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $result = $db->dropCollection('users');

--- a/docs/reference/method/MongoDBDatabase-getDatabaseName.txt
+++ b/docs/reference/method/MongoDBDatabase-getDatabaseName.txt
@@ -33,8 +33,6 @@ The following example prints the name of a database object:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    echo $db->getDatabaseName();

--- a/docs/reference/method/MongoDBDatabase-getReadConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadConcern.txt
@@ -33,8 +33,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->selectDatabase('test', [
       'readConcern' => new MongoDB\Driver\ReadConcern('majority'),
    ]);

--- a/docs/reference/method/MongoDBDatabase-getReadPreference.txt
+++ b/docs/reference/method/MongoDBDatabase-getReadPreference.txt
@@ -34,8 +34,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->selectDatabase('test', [
        'readPreference' => new MongoDB\Driver\ReadPreference('primaryPreferred'),
    ]);

--- a/docs/reference/method/MongoDBDatabase-getTypeMap.txt
+++ b/docs/reference/method/MongoDBDatabase-getTypeMap.txt
@@ -33,8 +33,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->selectDatabase('test', [
        'typeMap' => [
            'root' => 'array',

--- a/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBDatabase-getWriteConcern.txt
@@ -34,8 +34,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->selectDatabase('test', [
       'writeConcern' => new MongoDB\Driver\WriteConcern(1, 0, true),
    ]);

--- a/docs/reference/method/MongoDBDatabase-listCollectionNames.txt
+++ b/docs/reference/method/MongoDBDatabase-listCollectionNames.txt
@@ -44,8 +44,6 @@ The following example lists all of the collections in the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->test;
 
    foreach ($database->listCollectionNames() as $collectionName) {
@@ -64,8 +62,6 @@ The following example lists all collections whose name starts with ``"rest"``
 in the ``test`` database:
 
 .. code-block:: php
-
-   <?php
 
    $database = (new MongoDB\Client)->test;
 

--- a/docs/reference/method/MongoDBDatabase-listCollections.txt
+++ b/docs/reference/method/MongoDBDatabase-listCollections.txt
@@ -43,8 +43,6 @@ The following example lists all of the collections in the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->test;
 
    foreach ($database->listCollections() as $collectionInfo) {
@@ -81,8 +79,6 @@ The following example lists all collections whose name starts with ``"rest"``
 in the ``test`` database:
 
 .. code-block:: php
-
-   <?php
 
    $database = (new MongoDB\Client)->test;
 

--- a/docs/reference/method/MongoDBDatabase-modifyCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-modifyCollection.txt
@@ -52,8 +52,6 @@ The following example changes the expiration time of a TTL collection in the
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $result = $db->modifyCollection('users', [

--- a/docs/reference/method/MongoDBDatabase-renameCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-renameCollection.txt
@@ -53,8 +53,6 @@ database to ``places``:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $result = $db->renameCollection('restaurants', 'places');

--- a/docs/reference/method/MongoDBDatabase-selectCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-selectCollection.txt
@@ -53,8 +53,6 @@ The following example selects the ``users`` collection in the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $collection = $db->selectCollection('users');
@@ -63,8 +61,6 @@ The following example selects the ``users`` collection in the ``test``
 database with a custom read preference:
 
 .. code-block:: php
-
-   <?php
 
    $db = (new MongoDB\Client)->test;
 

--- a/docs/reference/method/MongoDBDatabase-selectGridFSBucket.txt
+++ b/docs/reference/method/MongoDBDatabase-selectGridFSBucket.txt
@@ -54,8 +54,6 @@ database:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $bucket = $db->selectGridFSBucket();
@@ -64,8 +62,6 @@ The following example selects the custom ``images.files`` bucket in the ``test``
 database with a custom read preference:
 
 .. code-block:: php
-
-   <?php
 
    $db = (new MongoDB\Client)->test;
 

--- a/docs/reference/method/MongoDBDatabase-watch.txt
+++ b/docs/reference/method/MongoDBDatabase-watch.txt
@@ -53,8 +53,6 @@ This example reports events while iterating a change stream.
 
 .. code-block:: php
 
-   <?php
-
    $uri = 'mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet';
 
    $database = (new MongoDB\Client($uri))->test;

--- a/docs/reference/method/MongoDBDatabase-withOptions.txt
+++ b/docs/reference/method/MongoDBDatabase-withOptions.txt
@@ -47,8 +47,6 @@ preference:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $newDb = $db->withOptions([

--- a/docs/reference/method/MongoDBDatabase__get.txt
+++ b/docs/reference/method/MongoDBDatabase__get.txt
@@ -54,8 +54,6 @@ collections from the ``test`` database:
 
 .. code-block:: php
 
-   <?php
-
    $db = (new MongoDB\Client)->test;
 
    $users = $db->users;

--- a/docs/reference/method/MongoDBGridFSBucket-delete.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-delete.txt
@@ -42,8 +42,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket-downloadToStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-downloadToStream.txt
@@ -38,8 +38,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket-downloadToStreamByName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-downloadToStreamByName.txt
@@ -42,8 +42,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket-drop.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-drop.txt
@@ -31,8 +31,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->test;
 
    $bucket = $database->selectGridFSBucket();

--- a/docs/reference/method/MongoDBGridFSBucket-find.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-find.txt
@@ -51,8 +51,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket-findOne.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-findOne.txt
@@ -54,8 +54,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket-getBucketName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getBucketName.txt
@@ -31,8 +31,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    var_dump($bucket->getBucketName());

--- a/docs/reference/method/MongoDBGridFSBucket-getChunkSizeBytes.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getChunkSizeBytes.txt
@@ -33,8 +33,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    var_dump($bucket->getChunkSizeBytes());

--- a/docs/reference/method/MongoDBGridFSBucket-getChunksCollection.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getChunksCollection.txt
@@ -33,8 +33,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    var_dump((string) $bucket->getChunksCollection());

--- a/docs/reference/method/MongoDBGridFSBucket-getDatabaseName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getDatabaseName.txt
@@ -31,8 +31,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    var_dump($bucket->getDatabaseName());

--- a/docs/reference/method/MongoDBGridFSBucket-getFileDocumentForStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getFileDocumentForStream.txt
@@ -42,8 +42,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openUploadStream('filename');

--- a/docs/reference/method/MongoDBGridFSBucket-getFileIdForStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getFileIdForStream.txt
@@ -43,8 +43,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openUploadStream('filename');

--- a/docs/reference/method/MongoDBGridFSBucket-getFilesCollection.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getFilesCollection.txt
@@ -33,8 +33,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $filesCollection = $bucket->getFilesCollection();

--- a/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadConcern.txt
@@ -33,8 +33,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->selectDatabase('test');
    $bucket = $database->selectGridFSBucket([
       'readConcern' => new MongoDB\Driver\ReadConcern('majority'),

--- a/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getReadPreference.txt
@@ -34,8 +34,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->selectDatabase('test');
    $bucket = $database->selectGridFSBucket([
       'readPreference' => new MongoDB\Driver\ReadPreference('primaryPreferred'),

--- a/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getTypeMap.txt
@@ -33,8 +33,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->selectDatabase('test');
    $bucket = $database->selectGridFSBucket([
        'typeMap' => [

--- a/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getWriteConcern.txt
@@ -34,8 +34,6 @@ Example
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->selectDatabase('test');
    $bucket = $database->selectGridFSBucket([
       'writeConcern' => new MongoDB\Driver\WriteConcern(1, 0, true),

--- a/docs/reference/method/MongoDBGridFSBucket-openDownloadStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-openDownloadStream.txt
@@ -41,8 +41,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $uploadStream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket-openDownloadStreamByName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-openDownloadStreamByName.txt
@@ -45,8 +45,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket-openUploadStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-openUploadStream.txt
@@ -45,8 +45,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $uploadStream = $bucket->openUploadStream('filename');

--- a/docs/reference/method/MongoDBGridFSBucket-rename.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-rename.txt
@@ -36,8 +36,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket-uploadFromStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-uploadFromStream.txt
@@ -48,8 +48,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = fopen('php://temp', 'w+b');

--- a/docs/reference/method/MongoDBGridFSBucket__construct.txt
+++ b/docs/reference/method/MongoDBGridFSBucket__construct.txt
@@ -47,8 +47,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    var_dump($bucket);

--- a/docs/reference/method/MongoDBMapReduceResult-getCounts.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getCounts.txt
@@ -33,8 +33,6 @@ This example reports the count statistics for a map-reduce operation.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    $map = new MongoDB\BSON\Javascript('function() { emit(this.state, this.pop); }');

--- a/docs/reference/method/MongoDBMapReduceResult-getExecutionTimeMS.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getExecutionTimeMS.txt
@@ -34,8 +34,6 @@ This example reports the execution time for a map-reduce operation.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    $map = new MongoDB\BSON\Javascript('function() { emit(this.state, this.pop); }');

--- a/docs/reference/method/MongoDBMapReduceResult-getIterator.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getIterator.txt
@@ -35,8 +35,6 @@ This example iterates through the results of a map-reduce operation.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    $map = new MongoDB\BSON\Javascript('function() { emit(this.state, this.pop); }');

--- a/docs/reference/method/MongoDBMapReduceResult-getTiming.txt
+++ b/docs/reference/method/MongoDBMapReduceResult-getTiming.txt
@@ -39,8 +39,6 @@ for a map-reduce operation.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    $map = new MongoDB\BSON\Javascript('function() { emit(this.state, this.pop); }');

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedMax.txt
@@ -39,8 +39,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new CollectionInfo([
        'name' => 'foo',
        'options' => [

--- a/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getCappedSize.txt
@@ -40,8 +40,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new CollectionInfo([
        'name' => 'foo',
        'options' => [

--- a/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getIdIndex.txt
@@ -34,8 +34,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new CollectionInfo([
      'type' => 'view',
      'name' => 'foo',

--- a/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getInfo.txt
@@ -34,8 +34,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new CollectionInfo([
      'type' => 'view',
      'name' => 'foo',

--- a/docs/reference/method/MongoDBModelCollectionInfo-getName.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getName.txt
@@ -32,8 +32,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new CollectionInfo(['name' => 'foo']);
 
    echo $info->getName();

--- a/docs/reference/method/MongoDBModelCollectionInfo-getOptions.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getOptions.txt
@@ -34,8 +34,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new CollectionInfo([
        'name' => 'foo',
        'options' => [

--- a/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-getType.txt
@@ -34,8 +34,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new CollectionInfo(['type' => 'collection', 'name' => 'foo']);
 
    echo $info->getType();

--- a/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
+++ b/docs/reference/method/MongoDBModelCollectionInfo-isCapped.txt
@@ -38,8 +38,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new CollectionInfo([
        'name' => 'foo',
        'options' => [

--- a/docs/reference/method/MongoDBModelDatabaseInfo-getName.txt
+++ b/docs/reference/method/MongoDBModelDatabaseInfo-getName.txt
@@ -31,8 +31,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new DatabaseInfo(['name' => 'foo']);
 
    echo $info->getName();

--- a/docs/reference/method/MongoDBModelDatabaseInfo-getSizeOnDisk.txt
+++ b/docs/reference/method/MongoDBModelDatabaseInfo-getSizeOnDisk.txt
@@ -31,8 +31,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new DatabaseInfo(['sizeOnDisk' => 1048576]);
 
    var_dump($info->getSizeOnDisk());

--- a/docs/reference/method/MongoDBModelDatabaseInfo-isEmpty.txt
+++ b/docs/reference/method/MongoDBModelDatabaseInfo-isEmpty.txt
@@ -31,8 +31,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new DatabaseInfo(['empty' => true]);
 
    var_dump($info->isEmpty());

--- a/docs/reference/method/MongoDBModelIndexInfo-getKey.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-getKey.txt
@@ -33,8 +33,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new IndexInfo([
        'key' => ['x' => 1],
    ]);

--- a/docs/reference/method/MongoDBModelIndexInfo-getName.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-getName.txt
@@ -34,8 +34,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new IndexInfo([
        'name' => 'x_1',
    ]);

--- a/docs/reference/method/MongoDBModelIndexInfo-getNamespace.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-getNamespace.txt
@@ -32,8 +32,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new IndexInfo([
        'ns' => 'foo.bar',
    ]);

--- a/docs/reference/method/MongoDBModelIndexInfo-getVersion.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-getVersion.txt
@@ -31,8 +31,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new IndexInfo([
        'v' => 1,
    ]);

--- a/docs/reference/method/MongoDBModelIndexInfo-is2dSphere.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-is2dSphere.txt
@@ -34,8 +34,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'places');
 
    $collection->createIndex(['pos' => '2dsphere']);

--- a/docs/reference/method/MongoDBModelIndexInfo-isGeoHaystack.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isGeoHaystack.txt
@@ -38,8 +38,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'places');
 
    $collection->createIndex(['pos' => 'geoHaystack', 'x' => 1], ['bucketSize' => 5]);

--- a/docs/reference/method/MongoDBModelIndexInfo-isSparse.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isSparse.txt
@@ -33,8 +33,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new IndexInfo([
        'sparse' => true,
    ]);

--- a/docs/reference/method/MongoDBModelIndexInfo-isText.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isText.txt
@@ -33,8 +33,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->selectCollection('test', 'restaurants');
 
    $collection->createIndex(['name' => 'text']);

--- a/docs/reference/method/MongoDBModelIndexInfo-isTtl.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isTtl.txt
@@ -33,8 +33,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new IndexInfo([
        'expireAfterSeconds' => 100,
    ]);

--- a/docs/reference/method/MongoDBModelIndexInfo-isUnique.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isUnique.txt
@@ -33,8 +33,6 @@ Examples
 
 .. code-block:: php
 
-   <?php
-
    $info = new IndexInfo([
        'unique' => true,
    ]);

--- a/docs/tutorial/client-side-encryption.txt
+++ b/docs/tutorial/client-side-encryption.txt
@@ -33,8 +33,6 @@ more than one encryption key or create them dynamically.
 
 .. code-block:: php
 
-   <?php
-
    use MongoDB\BSON\Binary;
    use MongoDB\Client;
    use MongoDB\Driver\ClientEncryption;
@@ -71,8 +69,6 @@ automatically encrypted on insertion and decrypted when reading on the client
 side.
 
 .. code-block:: php
-
-   <?php
 
    use MongoDB\BSON\Binary;
    use MongoDB\Client;
@@ -136,8 +132,6 @@ encrypted fields.
 
 .. code-block:: php
 
-   <?php
-
    use MongoDB\BSON\Binary;
    use MongoDB\Client;
    use MongoDB\Driver\ClientEncryption;
@@ -191,8 +185,6 @@ encrypts and decrypts values in the document.
 
 .. code-block:: php
 
-   <?php
-
    use MongoDB\BSON\Binary;
    use MongoDB\Client;
    use MongoDB\Driver\ClientEncryption;
@@ -244,8 +236,6 @@ To use an alternate name when referencing an encryption key, use the
 
 .. code-block:: php
 
-   <?php
-
    use MongoDB\BSON\Binary;
    use MongoDB\Client;
    use MongoDB\Driver\ClientEncryption;
@@ -294,8 +284,6 @@ decrypted when querying on the client side. Additionally, it is possible to
 query on the ``encryptedIndexed`` field.
 
 .. code-block:: php
-
-   <?php
 
    use MongoDB\BSON\Binary;
    use MongoDB\Client;

--- a/docs/tutorial/collation.txt
+++ b/docs/tutorial/collation.txt
@@ -86,8 +86,6 @@ creation command specifies another collation.
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->test;
 
    $database->createCollection('contacts', [
@@ -106,8 +104,6 @@ collation with ``locale`` set to ``en_US``.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->address_book;
 
    $collection->createIndex(
@@ -123,8 +119,6 @@ following query uses the above index:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->address_book;
 
    $cursor = $collection->find(
@@ -139,8 +133,6 @@ collation, and the second uses a collation with a different ``strength`` value
 than the collation on the index.
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->address_book;
 
@@ -171,8 +163,6 @@ results. The following query and sort operation uses a German collation with the
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->contacts;
 
    $cursor = $collection->find(
@@ -201,8 +191,6 @@ specify a collation.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->names;
 
    $document = $collection->findOneAndUpdate(
@@ -225,8 +213,6 @@ specified, which uses the locale ``de@collation=phonebook``.
    the same characters without umlauts.
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->names;
 
@@ -264,8 +250,6 @@ numeric value greater than 100 and deletes it.
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->numbers;
 
    $document = $collection->findOneAndDelete(
@@ -290,8 +274,6 @@ first document it finds in which the lexical value of ``a`` is greater than
 ``"100"``.
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->numbers;
 
@@ -328,8 +310,6 @@ uses a case-insensitive query filter to delete all records in which the
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->recipes;
 
    $collection->deleteMany(
@@ -357,8 +337,6 @@ the ``first_name`` field together, counts the total number of results in each
 group, and sorts the results by German phonebook order.
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->names;
 

--- a/docs/tutorial/commands.txt
+++ b/docs/tutorial/commands.txt
@@ -35,8 +35,6 @@ and prints its result document:
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->test;
 
    $cursor = $database->command(['ping' => 1]);
@@ -66,8 +64,6 @@ Note that this example is illustrative; applications would generally use
 :phpmethod:`MongoDB\\Database::listCollections()` in practice.
 
 .. code-block:: php
-
-   <?php
 
    $database = (new MongoDB\Client)->test;
 
@@ -114,8 +110,6 @@ as the Client's default read preference. It then specifies a ``primary`` read
 preference when executing the ``createUser`` command on the ``test`` database:
 
 .. code-block:: php
-
-   <?php
 
    $client = new MongoDB\Client(
       'mongodb+srv://cluster0.example.com',

--- a/docs/tutorial/crud.txt
+++ b/docs/tutorial/crud.txt
@@ -51,8 +51,6 @@ The following example inserts a document while specifying the value for the
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->users;
 
    $insertOneResult = $collection->insertOne(['_id' => 1, 'name' => 'Alice']);
@@ -106,8 +104,6 @@ query.
 The following example searches for the document with ``_id`` of ``"94301"``:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->zips;
 
@@ -169,8 +165,6 @@ specified city and state values:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    $cursor = $collection->find(['city' => 'JERSEY CITY', 'state' => 'NJ']);
@@ -213,8 +207,6 @@ fields and uses a :manual:`projection
 returned. It also limits the results to 5 documents.
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->restaurants;
 
@@ -317,8 +309,6 @@ five most populous zip codes in the United States:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    $cursor = $collection->find(
@@ -354,8 +344,6 @@ The following example lists documents in the ``zips`` collection where the city
 name starts with "garden" and the state is Texas:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->zips;
 
@@ -394,8 +382,6 @@ following example finds restaurants whose name starts with "(Library)":
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $cursor = $collection->find([
@@ -419,8 +405,6 @@ The following example lists the 5 US states with the most zip codes associated
 with them:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->zips;
 
@@ -469,8 +453,6 @@ is ``"ny"`` to include a ``country`` field set to ``"us"``:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
@@ -498,8 +480,6 @@ update, as is the case where the update sets a field's value to its existing
 value, as in this example:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
@@ -544,8 +524,6 @@ documents matching the filter criteria to include the ``country`` field with
 value ``"us"``:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
@@ -606,8 +584,6 @@ the ``test`` database, and then replaces that document with a new one:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
@@ -649,8 +625,6 @@ the ``upsert`` option set to ``true`` and an empty ``users`` collection in the
 ``test`` database, therefore inserting the document into the database:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
@@ -718,8 +692,6 @@ value is ``"ny"``:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();
 
@@ -753,8 +725,6 @@ The following operation deletes all of the documents where the ``state`` field's
 value is ``"ny"``:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->users;
    $collection->drop();

--- a/docs/tutorial/decimal128.txt
+++ b/docs/tutorial/decimal128.txt
@@ -34,8 +34,6 @@ field of a collection named ``inventory``:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->inventory;
 
    $collection->insertOne([
@@ -80,8 +78,6 @@ The following example adds two ``Decimal128`` values and creates a new
 
 .. code-block:: php
 
-   <?php
-
    $lhs = new MongoDB\BSON\Decimal128('1.234');
    $rhs = new MongoDB\BSON\Decimal128('5.678');
    $sum = new MongoDB\BSON\Decimal128(bcadd($lhs, $rhs));
@@ -106,8 +102,6 @@ In the following example, we use a scale of three for :php:`bcadd() <bcadd>` to
 obtain the expected result:
 
 .. code-block:: php
-
-   <?php
 
    $lhs = new MongoDB\BSON\Decimal128('1.234');
    $rhs = new MongoDB\BSON\Decimal128('5.678');

--- a/docs/tutorial/example-data.txt
+++ b/docs/tutorial/example-data.txt
@@ -14,8 +14,6 @@ example imports the ``zips.json`` file into a ``test.zips`` collection:
 
 .. code-block:: php
 
-   <?php
-
    $filename = 'https://media.mongodb.org/zips.json';
    $lines = file($filename, FILE_IGNORE_NEW_LINES);
 

--- a/docs/tutorial/gridfs.txt
+++ b/docs/tutorial/gridfs.txt
@@ -48,8 +48,6 @@ To open an upload stream and write to it:
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openUploadStream('my-file.txt');
@@ -61,8 +59,6 @@ To open an upload stream and write to it:
 To upload the entire contents of a readable stream in one call:
 
 .. code-block:: php
-
-   <?php
 
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
@@ -79,8 +75,6 @@ To open a download stream and read from it:
 
 .. code-block:: php
 
-   <?php
-
    // In practice, $fileId denotes the _id of an existing file in GridFS
    $fileId = new MongoDB\BSON\ObjectId;
 
@@ -92,8 +86,6 @@ To open a download stream and read from it:
 To download the file all at once and write it to a writable stream:
 
 .. code-block:: php
-
-   <?php
 
    // In practice, $fileId denotes the _id of an existing file in GridFS
    $fileId = new MongoDB\BSON\ObjectId;
@@ -131,8 +123,6 @@ particular file:
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $stream = $bucket->openDownloadStreamByName('my-file.txt', ['revision' => 0]);
@@ -144,8 +134,6 @@ Deleting Files
 You can delete a GridFS file by its ``_id``.
 
 .. code-block:: php
-
-   <?php
 
    // In practice, $fileId denotes the _id of an existing file in GridFS
    $fileId = new MongoDB\BSON\ObjectId;
@@ -163,8 +151,6 @@ about the GridFS files.
 
 .. code-block:: php
 
-   <?php
-
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 
    $cursor = $bucket->find(['filename' => 'my-file.txt']);
@@ -177,8 +163,6 @@ The :phpmethod:`getFileDocumentForStream()
 the file document for an existing readable or writable GridFS stream.
 
 .. code-block:: php
-
-   <?php
 
    // In practice, $fileId denotes the _id of an existing file in GridFS
    $fileId = new MongoDB\BSON\ObjectId;
@@ -205,8 +189,6 @@ convenience for accessing the ``_id`` property of the object returned by
 <MongoDB\\GridFS\\Bucket::getFileDocumentForStream()>`.
 
 .. code-block:: php
-
-   <?php
 
    $bucket = (new MongoDB\Client)->test->selectGridFSBucket();
 

--- a/docs/tutorial/indexes.txt
+++ b/docs/tutorial/indexes.txt
@@ -35,8 +35,6 @@ the :phpmethod:`createIndex() <MongoDB\\Collection::createIndex()>` method:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->zips;
 
    $result = $collection->createIndex(['state' => 1]);
@@ -64,8 +62,6 @@ The following example lists all indexes in the ``zips`` collection in the
 ``test`` database:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->zips;
 
@@ -115,8 +111,6 @@ each method.
 The following example drops a single index by its name, ``state_1``:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->zips;
 

--- a/docs/tutorial/install-php-library.txt
+++ b/docs/tutorial/install-php-library.txt
@@ -73,8 +73,6 @@ Composer's autoloader as in the following example:
 
 .. code-block:: php
 
-   <?php
-
    require_once __DIR__ . '/vendor/autoload.php';
 
 Refer to Composer's `autoloading documentation

--- a/docs/tutorial/modeling-bson-data.txt
+++ b/docs/tutorial/modeling-bson-data.txt
@@ -74,8 +74,6 @@ Consider the following class definition:
 
 .. code-block:: php
 
-   <?php
-
    class Person implements MongoDB\BSON\Persistable
    {
        private MongoDB\BSON\ObjectId $id;
@@ -110,8 +108,6 @@ The following example constructs a ``Person`` object, inserts it into the
 database, and reads it back as an object of the same type:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->persons;
 
@@ -171,8 +167,6 @@ following example, the ``bsonUnserialize()`` method in the class containing the
 enum is responsible for converting the value back to an enum case:
 
 .. code-block:: php
-
-   <?php
 
    enum Role: int
    {

--- a/docs/tutorial/server-selection.txt
+++ b/docs/tutorial/server-selection.txt
@@ -26,8 +26,6 @@ Consider the following example application:
 
 .. code-block:: php
 
-   <?php
-
    /**
     * When constructing a Client, the library creates a MongoDB\Driver\Manager
     * object from the driver. In turn, the driver will either create a libmongoc

--- a/docs/tutorial/stable-api.txt
+++ b/docs/tutorial/stable-api.txt
@@ -22,8 +22,6 @@ introduced in future versions of the server.
 
 .. code-block:: php
 
-   <?php
-
    use MongoDB\Client;
    use MongoDB\Driver\ServerApi;
 
@@ -50,8 +48,6 @@ stable API, specify the ``strict`` option when creating the
 
 .. code-block:: php
 
-   <?php
-
    use MongoDB\Client;
    use MongoDB\Driver\ServerApi;
 
@@ -69,8 +65,6 @@ or behaviors that have been deprecated in the API version. This can be used in
 testing to ensure a smooth transition to a future API version.
 
 .. code-block:: php
-
-   <?php
 
    use MongoDB\Client;
    use MongoDB\Driver\ServerApi;

--- a/docs/tutorial/tailable-cursor.txt
+++ b/docs/tutorial/tailable-cursor.txt
@@ -56,8 +56,6 @@ results:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->restaurants;
 
    $cursor = $collection->find([], ['limit' => 5]);
@@ -78,8 +76,6 @@ With the inner workings of ``foreach`` under our belt, we can now translate the
 preceding example to use the Iterator methods directly:
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->restaurants;
 
@@ -113,8 +109,6 @@ to insert a new document into that collection each second.
 
 .. code-block:: php
 
-   <?php
-
    $database = (new MongoDB\Client)->test;
 
    $database->createCollection('capped', [
@@ -136,8 +130,6 @@ by using ``foreach`` to illustrate its shortcomings:
 
 .. code-block:: php
 
-   <?php
-
    $collection = (new MongoDB\Client)->test->capped;
 
    $cursor = $collection->find([], [
@@ -156,8 +148,6 @@ cursor. This is a ripe use case for directly controlling the iteration process
 using the :php:`Iterator <iterator>` interface.
 
 .. code-block:: php
-
-   <?php
 
    $collection = (new MongoDB\Client)->test->capped;
 

--- a/docs/upgrade.txt
+++ b/docs/upgrade.txt
@@ -130,8 +130,6 @@ everything as a PHP array:
 
 .. code-block:: php
 
-   <?php
-
    $client = new MongoDB\Client(
        'mongodb://127.0.0.1/',
        [],
@@ -356,8 +354,6 @@ demonstrates how to execute a group command using the
 :phpmethod:`MongoDB\\Database::command()` method:
 
 .. code-block:: php
-
-   <?php
 
    $database = (new MongoDB\Client)->selectDatabase('db_name');
    $cursor = $database->command([


### PR DESCRIPTION
Not sure if this works, but in the Symfony documentation we configured the syntax highlighting on a global level, so there is no need to add `<?php`, which also reduces some noise.
As you told me, there is some mongodb overall documentation stuff thingy, it might be a) not possible or b) it should be kept.

In this case, just close this PR, thanks.
