### PR TITLE
Remove the words `easily` and `simply`

### DIFF
--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -224,7 +224,7 @@ class ReadableStream
         }
 
         /* If we are seeking to a subsequent chunk, we do not need to
-         * reinitalize the chunk iterator. Instead, we can simply move forward
+         * reinitalize the chunk iterator. Instead, we can move forward
          * to $this->chunkOffset.
          */
         $numChunks = $this->chunkOffset - $lastChunkOffset;

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -673,9 +673,9 @@ class WatchFunctionalTest extends FunctionalTestCase
         /* The spec requests that we assert that the cursor returned from the
          * aggregate command is not closed on the driver side. We will verify
          * this by checking that the cursor ID is non-zero and that libmongoc
-         * reports the cursor as alive. While the cursor ID is easily accessed
-         * through ChangeStream, we'll need to use reflection to access the
-         * internal Cursor and call isDead(). */
+         * reports the cursor as alive. While the cursor ID is accessed through
+         * ChangeStream, we'll need to use reflection to access the internal
+         * Cursor and call isDead(). */
         $this->assertNotEquals('0', (string) $changeStream->getCursorId());
 
         $rc = new ReflectionClass(ChangeStream::class);


### PR DESCRIPTION
In Symfony we try to be kind to newcomers, which means we try to avoid word like "simply", "easily" etc., because it depends on the knowledge of the reader and it can therefore be offensive.

I am not sure how this project or especially MongoDB is handling such things, but from my POV it doesn't hurt. :shrug: