### PR TITLE
[Documentation] Remove the words `easily` and `simply`

### DIFF
--- a/docs/tutorial/tailable-cursor.txt
+++ b/docs/tutorial/tailable-cursor.txt
@@ -98,10 +98,10 @@ preceding example to use the Iterator methods directly:
    Calling ``$cursor->next()`` after the ``while`` loop naturally ends would
    throw an exception, since all results on the cursor have been exhausted.
 
-The purpose of this example is simply to demonstrate the functional equivalence
-between ``foreach`` and manual iteration with PHP's :php:`Iterator <iterator>`
-API. For normal cursors, there is little reason to manually iterate results
-instead of a concise ``foreach`` loop.
+The purpose of this example is to demonstrate the functional equivalencebetween
+``foreach`` and manual iteration with PHP's :php:`Iterator <iterator>`API.
+For normal cursors, there is little reason to manually iterate results instead
+of a concise ``foreach`` loop.
 
 Iterating a Tailable Cursor
 ---------------------------

--- a/docs/tutorial/tailable-cursor.txt
+++ b/docs/tutorial/tailable-cursor.txt
@@ -98,7 +98,7 @@ preceding example to use the Iterator methods directly:
    Calling ``$cursor->next()`` after the ``while`` loop naturally ends would
    throw an exception, since all results on the cursor have been exhausted.
 
-The purpose of this example is to demonstrate the functional equivalencebetween
+The purpose of this example is to demonstrate the functional equivalence between
 ``foreach`` and manual iteration with PHP's :php:`Iterator <iterator>`API.
 For normal cursors, there is little reason to manually iterate results instead
 of a concise ``foreach`` loop.

--- a/docs/upgrade.txt
+++ b/docs/upgrade.txt
@@ -118,8 +118,8 @@ problematic:
   original BSON type.
 
 - Numerically-indexed PHP arrays would be serialized as BSON documents if there
-  was a gap in their key sequence. Such gaps were easily caused by unsetting a
-  key to remove an element and forgetting to numerically reindex the array.
+  was a gap in their key sequence. Such gaps were caused by unsetting a key to
+  remove an element and forgetting to numerically reindex the array.
 
 The |php-library|'s :phpclass:`BSONDocument <MongoDB\\Model\\BSONDocument>` and
 :phpclass:`BSONArray <MongoDB\\Model\\BSONArray>` classes address these concerns


### PR DESCRIPTION
Follows
* #1039 

In Symfony we try to be kind to newcomers, which means we try to avoid words like "simply", "easily" etc., because it depends on the knowledge of the reader and it can therefore be offensive.