### PR TITLE
Skip unrelated builds for documentation

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,11 +6,15 @@ on:
       - "v*.*"
       - "master"
       - "feature/*"
+    paths-ignore:
+      - "docs/**"
   push:
     branches:
       - "v*.*"
       - "master"
       - "feature/*"
+    paths-ignore:
+      - "docs/**"
 
 jobs:
   phpcs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,15 @@ on:
       - "v*.*"
       - "master"
       - "feature/*"
+    paths:
+      - "docs/**"
   push:
     branches:
       - "v*.*"
       - "master"
       - "feature/*"
+    paths:
+      - "docs/**"
 
 jobs:
   giza:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,11 +6,15 @@ on:
       - "v*.*"
       - "master"
       - "feature/*"
+    paths-ignore:
+      - "docs/**"
   push:
     branches:
       - "v*.*"
       - "master"
       - "feature/*"
+    paths-ignore:
+      - "docs/**"
 
 jobs:
   psalm:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,11 +6,15 @@ on:
       - "v*.*"
       - "master"
       - "feature/*"
+    paths-ignore:
+      - "docs/**"
   push:
     branches:
       - "v*.*"
       - "master"
       - "feature/*"
+    paths-ignore:
+      - "docs/**"
 
 jobs:
   phpunit:


### PR DESCRIPTION
With this change, GitHub Actions will no longer run the `coding-standards`,`static-analysis`, and `tests` workflows when only documentation was changed. At the same time, the `docs` workflow is only run if files in the docs folder were changed.

I'll caution that this may cause issues with branch protection: since we require the `tests` workflow to be stable in order for a PR to be mergeable, this may prove to be unfeasible due to us having to override branch protection rules for such pull requests.