### PR TITLE
PHPLIB-1037: Don't error when creating context for sharded clusters using mongodb+srv connection string

### DIFF
--- a/tests/UnifiedSpecTests/UnifiedTestRunner.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunner.php
@@ -35,8 +35,6 @@ use function PHPUnit\Framework\assertIsArray;
 use function PHPUnit\Framework\assertIsString;
 use function PHPUnit\Framework\assertNotEmpty;
 use function PHPUnit\Framework\assertNotFalse;
-use function PHPUnit\Framework\assertStringContainsString;
-use function PHPUnit\Framework\assertStringStartsWith;
 use function preg_match;
 use function preg_replace;
 use function sprintf;
@@ -48,7 +46,6 @@ use function version_compare;
 use const DIRECTORY_SEPARATOR;
 use const FILTER_VALIDATE_BOOLEAN;
 use const PATH_SEPARATOR;
-use const PHP_URL_HOST;
 
 /**
  * Unified test runner.
@@ -531,14 +528,15 @@ final class UnifiedTestRunner
             // We assume the internal client URI has multiple mongos hosts
             $multiMongosUri = $this->internalClientUri;
 
-            /* TODO: If an SRV URI is provided, we can consider connecting and
-             * checking the topology for multiple mongoses and then selecting a
-             * single mongos to reconstruct a single mongos URI; however, that
-             * may omit necessary URI options provided by TXT records. */
-            assertStringStartsWith('mongodb://', $multiMongosUri);
-            assertStringContainsString(',', parse_url($multiMongosUri, PHP_URL_HOST));
-
-            $singleMongosUri = self::removeMultipleHosts($multiMongosUri);
+            if (strpos($multiMongosUri, 'mongodb+srv://') === 0) {
+                /* TODO: If an SRV URI is provided, we can consider connecting and
+                 * checking the topology for multiple mongoses and then selecting a
+                 * single mongos to reconstruct a single mongos URI; however, that
+                 * may omit necessary URI options provided by TXT records. */
+                $singleMongosUri = $multiMongosUri;
+            } else {
+                $singleMongosUri = self::removeMultipleHosts($multiMongosUri);
+            }
 
             $context->setUrisForUseMultipleMongoses($singleMongosUri, $multiMongosUri);
         }


### PR DESCRIPTION
PHPLIB-1037

The current logic makes some of the atlas tests fail as they are using a `mongodb+srv` URI. Since none of those tests currently use `useMultipleMongoses`, we remove the assertions that cause the failures to allow testing this scenario. I'm currently investigating how other drivers handle this to then correctly generate URIs with a single and with multiple mongoses based on the discovered servers.