### PR TITLE
PHPLIB-1095: Queryable Encryption is "Public Technical Preview"

### DIFF
--- a/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
+++ b/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
@@ -89,6 +89,14 @@ description: |
   This option is available in MongoDB 6.0+ and will result in an exception at
   execution time if specified for an older server version.
 
+  .. note::
+
+     Queryable Encryption is in public preview and available for evaluation
+     purposes. It is not yet recommended for production deployments as breaking
+     changes may be introduced. See the
+     `Queryable Encryption Preview <https://www.mongodb.com/blog/post/mongodb-releases-queryable-encryption-preview/>`_
+     blog post for more information.
+
   .. versionadded:: 1.13
 interface: phpmethod
 operation: ~

--- a/docs/includes/apiargs-dropCollection-option.yaml
+++ b/docs/includes/apiargs-dropCollection-option.yaml
@@ -9,6 +9,14 @@ description: |
   server-side value for ``encryptedFields``. See the
   `Client Side Encryption specification <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst>`_
   for more information.
+
+  .. note::
+
+     Queryable Encryption is in public preview and available for evaluation
+     purposes. It is not yet recommended for production deployments as breaking
+     changes may be introduced. See the
+     `Queryable Encryption Preview <https://www.mongodb.com/blog/post/mongodb-releases-queryable-encryption-preview/>`_
+     blog post for more information.
 interface: phpmethod
 operation: ~
 optional: true

--- a/docs/tutorial/client-side-encryption.txt
+++ b/docs/tutorial/client-side-encryption.txt
@@ -248,7 +248,11 @@ Automatic Queryable Encryption
 .. note::
 
    Automatic queryable encryption is an enterprise only feature and requires
-   MongoDB 6.0+.
+   MongoDB 6.0+. Queryable Encryption is in public preview and available for
+   evaluation purposes. It is not yet recommended for production deployments as
+   breaking changes may be introduced. See the
+   `Queryable Encryption Preview <https://www.mongodb.com/blog/post/mongodb-releases-queryable-encryption-preview/>`_
+   blog post for more information.
 
 The following example uses a local key; however, other key providers such as AWS
 are also an option. The data in the ``encryptedIndexed`` and


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1095

This note was originally missed when introducing QE-related APIs in PHPLIB 1.13.

After merging to v1.13, I'll merge up through master and then request a docs build for each branch.