### PR TITLE
Update docs for encryptedFields create/drop collection option

### DIFF
--- a/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
+++ b/docs/includes/apiargs-MongoDBDatabase-method-createCollection-option.yaml
@@ -82,9 +82,9 @@ type: document
 description: |
   A document describing encrypted fields for queryable encryption. If omitted,
   the ``encryptedFieldsMap`` option within the ``autoEncryption`` driver option
-  will be consulted. See the
-  `Client Side Encryption specification <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst>`_
-  for more information.
+  will be consulted. See
+  `Field Encryption and Queryability <https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/encrypt-and-query/>`_
+  in the MongoDB manual for more information.
 
   This option is available in MongoDB 6.0+ and will result in an exception at
   execution time if specified for an older server version.

--- a/docs/includes/apiargs-dropCollection-option.yaml
+++ b/docs/includes/apiargs-dropCollection-option.yaml
@@ -6,9 +6,15 @@ description: |
   the ``encryptedFieldsMap`` option within the ``autoEncryption`` driver option
   will be consulted. If ``encryptedFieldsMap`` was defined but does not specify
   this collection, the library will make a final attempt to consult the
-  server-side value for ``encryptedFields``. See the
-  `Client Side Encryption specification <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst>`_
-  for more information.
+  server-side value for ``encryptedFields``. See
+  `Field Encryption and Queryability <https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/encrypt-and-query/>`_
+  in the MongoDB manual for more information.
+
+  .. note::
+
+     This option is not passed to the :manual:`drop </reference/command/drop>`
+     command. The library uses it to determine related metadata collections that
+     should be dropped in addition to an encrypted collection.
 interface: phpmethod
 operation: ~
 optional: true


### PR DESCRIPTION
The MongoDB manual reference is more helpful than the CSFLE specification. Additionally, clarify how the option is used by the drop collection helpers.

This is a general docs improvement that came up while iterating on #1050.