### PR TITLE
PHPLIB-1022: Codec implementation for better BSON decoding/encoding

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -172,9 +172,11 @@
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>/examples</exclude-pattern>
         <exclude-pattern>/tests/PHPUnit/ConstraintTrait.php</exclude-pattern>
+        <exclude-pattern>tests/Collection/CodecCollectionTest</exclude-pattern>
     </rule>
     <rule ref="Squiz.Classes.ClassFileName.NoMatch">
         <exclude-pattern>/examples</exclude-pattern>
+        <exclude-pattern>tests/Collection/CodecCollectionTest</exclude-pattern>
     </rule>
     <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
         <exclude-pattern>/tests/SpecTests/ClientSideEncryption/Prose*</exclude-pattern>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -14,4 +14,9 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <stubs>
+        <file name="stubs/BSON/BSON.stub.php"/>
+        <file name="stubs/BSON/Document.stub.php"/>
+        <file name="stubs/BSON/PackedArray.stub.php"/>
+    </stubs>
 </psalm>

--- a/src/Codec/Codec.php
+++ b/src/Codec/Codec.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MongoDB\Codec;
+
+/**
+ * @api
+ *
+ * @psalm-template B
+ * @psalm-template T
+ * @template-extends Decoder<B, T>
+ * @template-extends Encoder<B, T>
+ */
+interface Codec extends Decoder, Encoder
+{
+}

--- a/src/Codec/CodecLibrary.php
+++ b/src/Codec/CodecLibrary.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace MongoDB\Codec;
+
+use MongoDB\Exception\UnexpectedValueException;
+
+use function array_map;
+use function get_debug_type;
+use function sprintf;
+
+class CodecLibrary implements Codec
+{
+    /** @var array<Decoder> */
+    private $decoders = [];
+
+    /** @var array<Encoder> */
+    private $encoders = [];
+
+    /** @param Decoder|Encoder $items */
+    public function __construct(...$items)
+    {
+        array_map(
+            function ($item) {
+                if ($item instanceof Decoder) {
+                    $this->attachDecoder($item);
+                }
+
+                if ($item instanceof Encoder) {
+                    $this->attachEncoder($item);
+                }
+
+                // Yes, we'll silently discard everything. Please let me already have union types...
+            },
+            $items
+        );
+    }
+
+    /** @return static */
+    final public function attachCodec(Codec $codec): self
+    {
+        $this->decoders[] = $codec;
+        $this->encoders[] = $codec;
+        if ($codec instanceof KnowsCodecLibrary) {
+            $codec->attachLibrary($this);
+        }
+
+        return $this;
+    }
+
+    /** @return static */
+    final public function attachDecoder(Decoder $decoder): self
+    {
+        $this->decoders[] = $decoder;
+        if ($decoder instanceof KnowsCodecLibrary) {
+            $decoder->attachLibrary($this);
+        }
+
+        return $this;
+    }
+
+    /** @return static */
+    final public function attachEncoder(Encoder $encoder): self
+    {
+        $this->encoders[] = $encoder;
+        if ($encoder instanceof KnowsCodecLibrary) {
+            $encoder->attachLibrary($this);
+        }
+
+        return $this;
+    }
+
+    /** @param mixed $value */
+    final public function canDecode($value): bool
+    {
+        foreach ($this->decoders as $decoder) {
+            if ($decoder->canDecode($value)) {
+                return true;
+            }
+        }
+
+        return $value === null;
+    }
+
+    /** @param mixed $value */
+    final public function canEncode($value): bool
+    {
+        foreach ($this->encoders as $encoder) {
+            if ($encoder->canEncode($value)) {
+                return true;
+            }
+        }
+
+        return $value === null;
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    final public function decode($value)
+    {
+        foreach ($this->decoders as $decoder) {
+            if (! $decoder->canDecode($value)) {
+                continue;
+            }
+
+            return $decoder->decode($value);
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        throw new UnexpectedValueException(sprintf('No decoder found for value of type "%s"', get_debug_type($value)));
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    final public function encode($value)
+    {
+        foreach ($this->encoders as $encoder) {
+            if (! $encoder->canEncode($value)) {
+                continue;
+            }
+
+            return $encoder->encode($value);
+        }
+
+        if ($value === null) {
+            return null;
+        }
+
+        throw new UnexpectedValueException(sprintf('No encoder found for value of type "%s"', get_debug_type($value)));
+    }
+}

--- a/src/Codec/Decoder.php
+++ b/src/Codec/Decoder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MongoDB\Codec;
+
+/**
+ * @api
+ *
+ * @psalm-template B
+ * @psalm-template T
+ */
+interface Decoder
+{
+    /**
+     * @param mixed $value
+     * @psalm-assert-if-true B $value
+     */
+    public function canDecode($value): bool;
+
+    /**
+     * @param mixed $value
+     * @psalm-param B $value
+     * @return mixed
+     * @psalm-return T
+     */
+    public function decode($value);
+}

--- a/src/Codec/Encoder.php
+++ b/src/Codec/Encoder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MongoDB\Codec;
+
+/**
+ * @api
+ *
+ * @psalm-template B
+ * @psalm-template T
+ */
+interface Encoder
+{
+    /**
+     * @param mixed $value
+     * @psalm-assert-if-true T $value
+     */
+    public function canEncode($value): bool;
+
+    /**
+     * @param mixed $value
+     * @psalm-param T $value
+     * @return mixed
+     * @psalm-return B
+     */
+    public function encode($value);
+}

--- a/src/Codec/KnowsCodecLibrary.php
+++ b/src/Codec/KnowsCodecLibrary.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MongoDB\Codec;
+
+interface KnowsCodecLibrary
+{
+    public function attachLibrary(CodecLibrary $library): void;
+}

--- a/src/Codec/LazyBSONArrayCodec.php
+++ b/src/Codec/LazyBSONArrayCodec.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MongoDB\Codec;
+
+use MongoDB\BSON\PackedArray;
+use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Model\LazyBSONArray;
+
+use function array_values;
+use function sprintf;
+
+/**
+ * Codec for lazy decoding of BSON PackedArray instances
+ *
+ * @template-implements Codec<PackedArray, LazyBSONArray>
+ */
+class LazyBSONArrayCodec implements Codec, KnowsCodecLibrary
+{
+    /** @var CodecLibrary|null */
+    private $library = null;
+
+    public function attachLibrary(CodecLibrary $library): void
+    {
+        $this->library = $library;
+    }
+
+    /** @inheritDoc */
+    public function canDecode($value): bool
+    {
+        return $value instanceof PackedArray;
+    }
+
+    /** @inheritDoc */
+    public function canEncode($value): bool
+    {
+        return $value instanceof LazyBSONArray;
+    }
+
+    /** @inheritDoc */
+    public function decode($value): LazyBSONArray
+    {
+        if (! $value instanceof PackedArray) {
+            throw new UnexpectedValueException(sprintf('"%s" can only decode from "%s" instances', self::class, PackedArray::class));
+        }
+
+        return new LazyBSONArray($value, $this->getLibrary());
+    }
+
+    /** @inheritDoc */
+    public function encode($value): PackedArray
+    {
+        if (! $value instanceof LazyBSONArray) {
+            throw new UnexpectedValueException(sprintf('"%s" can only encode "%s" instances', self::class, LazyBSONArray::class));
+        }
+
+        $return = [];
+        foreach ($value as $offset => $offsetValue) {
+            $return[$offset] = $this->getLibrary()->canEncode($offsetValue) ? $this->getLibrary()->encode($offsetValue) : $offsetValue;
+        }
+
+        return PackedArray::fromPHP(array_values($return));
+    }
+
+    private function getLibrary(): CodecLibrary
+    {
+        return $this->library ?? $this->library = new CodecLibrary(new LazyBSONDocumentCodec(), $this);
+    }
+}

--- a/src/Codec/LazyBSONDocumentCodec.php
+++ b/src/Codec/LazyBSONDocumentCodec.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace MongoDB\Codec;
+
+use MongoDB\BSON\Document;
+use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Model\LazyBSONDocument;
+
+use function sprintf;
+
+/**
+ * Codec for lazy decoding of BSON Document instances
+ *
+ * @template-implements Codec<Document, LazyBSONDocument>
+ */
+class LazyBSONDocumentCodec implements Codec, KnowsCodecLibrary
+{
+    /** @var CodecLibrary|null */
+    private $library = null;
+
+    public function attachLibrary(CodecLibrary $library): void
+    {
+        $this->library = $library;
+    }
+
+    /** @inheritDoc */
+    public function canDecode($value): bool
+    {
+        return $value instanceof Document;
+    }
+
+    /** @inheritDoc */
+    public function canEncode($value): bool
+    {
+        return $value instanceof LazyBSONDocument;
+    }
+
+    /** @inheritDoc */
+    public function decode($value): LazyBSONDocument
+    {
+        if (! $value instanceof Document) {
+            throw new UnexpectedValueException(sprintf('"%s" can only decode from "%s" instances', self::class, Document::class));
+        }
+
+        return new LazyBSONDocument($value, $this->getLibrary());
+    }
+
+    /** @inheritDoc */
+    public function encode($value): Document
+    {
+        if (! $value instanceof LazyBSONDocument) {
+            throw new UnexpectedValueException(sprintf('"%s" can only encode "%s" instances', self::class, LazyBSONDocument::class));
+        }
+
+        $return = [];
+        foreach ($value as $field => $fieldValue) {
+            $return[$field] = $this->getLibrary()->canEncode($fieldValue) ? $this->getLibrary()->encode($fieldValue) : $fieldValue;
+        }
+
+        return Document::fromPHP($return);
+    }
+
+    private function getLibrary(): CodecLibrary
+    {
+        return $this->library ?? $this->library = new CodecLibrary($this, new LazyBSONArrayCodec());
+    }
+}

--- a/src/Model/AsListIterator.php
+++ b/src/Model/AsListIterator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MongoDB\Model;
+
+use IteratorIterator;
+use Traversable;
+
+/**
+ * @internal
+ * @template TKey as int
+ * @template TValue
+ * @template TIterator as Traversable<TKey, TValue>
+ *
+ * @template-extends IteratorIterator<int, TValue, TIterator>
+ */
+final class AsListIterator extends IteratorIterator
+{
+    /** @var int */
+    private $index = 0;
+
+    public function key(): ?int
+    {
+        return $this->valid() ? $this->index : null;
+    }
+
+    public function next(): void
+    {
+        $this->index++;
+
+        parent::next();
+    }
+
+    public function rewind(): void
+    {
+        $this->index = 0;
+
+        parent::rewind();
+    }
+}

--- a/src/Model/CallbackIterator.php
+++ b/src/Model/CallbackIterator.php
@@ -49,7 +49,7 @@ class CallbackIterator implements Iterator
     #[ReturnTypeWillChange]
     public function current()
     {
-        return ($this->callback)($this->iterator->current());
+        return ($this->callback)($this->iterator->current(), $this->iterator->key());
     }
 
     /**

--- a/src/Model/LazyBSONArray.php
+++ b/src/Model/LazyBSONArray.php
@@ -1,0 +1,273 @@
+<?php
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Model;
+
+use AppendIterator;
+use ArrayAccess;
+use ArrayIterator;
+use CallbackFilterIterator;
+use Iterator;
+use IteratorAggregate;
+use JsonSerializable;
+use MongoDB\BSON\PackedArray;
+use MongoDB\BSON\Serializable;
+use MongoDB\Codec\CodecLibrary;
+use MongoDB\Codec\LazyBSONArrayCodec;
+use MongoDB\Codec\LazyBSONDocumentCodec;
+use MongoDB\Exception\InvalidArgumentException;
+use ReturnTypeWillChange;
+
+use function array_key_exists;
+use function array_keys;
+use function array_merge;
+use function array_values;
+use function is_array;
+use function is_object;
+use function iterator_to_array;
+use function max;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_WARNING;
+
+/**
+ * Model class for a BSON array.
+ *
+ * The internal data will be filtered through array_values() during BSON
+ * serialization to ensure that it becomes a BSON array.
+ *
+ * @api
+ */
+class LazyBSONArray implements ArrayAccess, IteratorAggregate, JsonSerializable, Serializable
+{
+    /** @var ?CodecLibrary */
+    private $library;
+
+    /** @var PackedArray */
+    private $bson;
+
+    /** @var array<int, mixed> */
+    private $read = [];
+
+    /** @var array<int, true> */
+    private $notFound = [];
+
+    /** @var array<int, mixed> */
+    private $set = [];
+
+    /** @var array<int, true> */
+    private $unset = [];
+
+    /** @var bool */
+    private $entirePackedArrayRead = false;
+
+    /**
+     * Deep clone this lazy array.
+     */
+    public function __clone()
+    {
+        $this->bson = clone $this->bson;
+
+        foreach ($this->set as $key => $value) {
+            if (is_object($value)) {
+                $this->set[$key] = clone $value;
+            }
+        }
+    }
+
+    /**
+     * Constructs a lazy BSON array.
+     *
+     * @param PackedArray|array|null $input An input for a lazy array.
+     *        When given a BSON array, this is treated as input. For lists
+     *        this constructs a new BSON array using fromPHP.
+     */
+    public function __construct($input = null, ?CodecLibrary $library = null)
+    {
+        if ($input === null) {
+            $this->bson = PackedArray::fromPHP([]);
+        } elseif ($input instanceof PackedArray) {
+            $this->bson = $input;
+        } elseif (is_array($input)) {
+            $this->bson = PackedArray::fromPHP(array_values($input));
+        } else {
+            throw InvalidArgumentException::invalidType('input', $input, [PackedArray::class, 'array', 'null']);
+        }
+
+        $this->library = $library;
+    }
+
+    public function bsonSerialize(): array
+    {
+        // Always use LazyBSONArrayCodec for BSON serialisation
+        $codec = new LazyBSONArrayCodec();
+        $codec->attachLibrary($this->getLibrary());
+
+        // @psalm-suppress InvalidReturnStatement
+        return $codec->encode($this)->toPHP();
+    }
+
+    /** @return Iterator<int, mixed> */
+    public function getIterator(): Iterator
+    {
+        $itemIterator = new AppendIterator();
+        // Iterate through all fields in the BSON array
+        $itemIterator->append($this->bson->getIterator());
+        // Then iterate over all fields that were set
+        $itemIterator->append(new ArrayIterator($this->set));
+
+        $seen = [];
+
+        // Use AsArrayIterator to ensure we're indexing from 0 without gaps
+        return new AsListIterator(
+            new CallbackIterator(
+                new CallbackFilterIterator(
+                    $itemIterator,
+                    /** @param mixed $value */
+                    function ($value, int $offset) use (&$seen): bool {
+                        // Skip keys that were unset or handled in a previous iterator
+                        return ! isset($this->unset[$offset]) && ! isset($seen[$offset]);
+                    }
+                ),
+                /**
+                 * @param mixed $value
+                 * @return mixed
+                 */
+                function ($value, int $offset) use (&$seen) {
+                    // Mark key as seen, skipping any future occurrences
+                    $seen[$offset] = true;
+
+                    // Return actual value (potentially overridden by offsetSet)
+                    return $this->offsetGet($offset);
+                }
+            )
+        );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return iterator_to_array($this);
+    }
+
+    /** @param mixed $offset */
+    public function offsetExists($offset): bool
+    {
+        $offset = (int) $offset;
+        $this->ensureOffsetRead($offset);
+
+        return ! isset($this->unset[$offset]) && ! isset($this->notFound[$offset]);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return mixed
+     */
+    #[ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        $offset = (int) $offset;
+        $this->ensureOffsetRead($offset);
+
+        if (isset($this->unset[$offset]) || isset($this->notFound[$offset])) {
+            trigger_error(sprintf('Undefined offset: %d', $offset), E_USER_WARNING);
+        }
+
+        return array_key_exists($offset, $this->set) ? $this->set[$offset] : $this->read[$offset];
+    }
+
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if ($offset === null) {
+            $this->readEntirePackedArray();
+
+            $offset = max(array_merge(
+                array_keys($this->read),
+                array_keys($this->set),
+            )) + 1;
+        } else {
+            $offset = (int) $offset;
+        }
+
+        $this->set[$offset] = $value;
+        unset($this->unset[$offset]);
+        unset($this->notFound[$offset]);
+    }
+
+    /** @param mixed $offset */
+    public function offsetUnset($offset): void
+    {
+        $offset = (int) $offset;
+        $this->unset[$offset] = true;
+        unset($this->set[$offset]);
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    private function decodeBSONValue($value)
+    {
+        return $this->getLibrary()->canDecode($value)
+            ? $this->getLibrary()->decode($value)
+            : $value;
+    }
+
+    private function ensureOffsetRead(int $offset): void
+    {
+        if (isset($this->set[$offset]) || isset($this->notFound[$offset]) || array_key_exists($offset, $this->read)) {
+            return;
+        }
+
+        if (! $this->bson->has($offset)) {
+            $this->notFound[$offset] = true;
+
+            return;
+        }
+
+        $value = $this->bson->get($offset);
+
+        // Decode value using the codec library if a codec exists
+        $this->read[$offset] = $this->decodeBSONValue($value);
+    }
+
+    private function getLibrary(): CodecLibrary
+    {
+        return $this->library ?? $this->library = new CodecLibrary(new LazyBSONDocumentCodec(), new LazyBSONArrayCodec());
+    }
+
+    private function readEntirePackedArray(): void
+    {
+        if ($this->entirePackedArrayRead) {
+            return;
+        }
+
+        $this->entirePackedArrayRead = true;
+
+        foreach ($this->bson as $key => $value) {
+            if (isset($this->read[$key])) {
+                continue;
+            }
+
+            $this->read[$key] = $this->decodeBSONValue($value);
+        }
+    }
+}

--- a/src/Model/LazyBSONDocument.php
+++ b/src/Model/LazyBSONDocument.php
@@ -1,0 +1,254 @@
+<?php
+/*
+ * Copyright 2016-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Model;
+
+use AppendIterator;
+use ArrayAccess;
+use ArrayIterator;
+use CallbackFilterIterator;
+use Iterator;
+use IteratorAggregate;
+use JsonSerializable;
+use MongoDB\BSON\Document;
+use MongoDB\BSON\Serializable;
+use MongoDB\Codec\CodecLibrary;
+use MongoDB\Codec\LazyBSONArrayCodec;
+use MongoDB\Codec\LazyBSONDocumentCodec;
+use MongoDB\Exception\InvalidArgumentException;
+use ReturnTypeWillChange;
+
+use function array_key_exists;
+use function is_array;
+use function is_object;
+use function iterator_to_array;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_WARNING;
+
+/**
+ * Model class for a BSON document.
+ *
+ * The internal data will be cast to an object during BSON serialization to
+ * ensure that it becomes a BSON document.
+ *
+ * @api
+ */
+class LazyBSONDocument implements ArrayAccess, IteratorAggregate, JsonSerializable, Serializable
+{
+    /** @var CodecLibrary|null */
+    private $library;
+
+    /** @var Document */
+    private $bson;
+
+    /** @var array<string, mixed> */
+    private $read = [];
+
+    /** @var array<string, true> */
+    private $notFound = [];
+
+    /** @var array<string, mixed> */
+    private $set = [];
+
+    /** @var array<string, true> */
+    private $unset = [];
+
+    /**
+     * Deep clone this lazy document.
+     */
+    public function __clone()
+    {
+        $this->bson = clone $this->bson;
+
+        foreach ($this->set as $key => $value) {
+            if (is_object($value)) {
+                $this->set[$key] = clone $value;
+            }
+        }
+    }
+
+    /**
+     * Constructs a lazy BSON document.
+     *
+     * @param Document|array|object|null $input An input for a lazy object.
+     *        When given a BSON document, this is treated as input. For arrays
+     *        and objects this constructs a new BSON document using fromPHP.
+     */
+    public function __construct($input = null, ?CodecLibrary $library = null)
+    {
+        if ($input === null) {
+            $this->bson = Document::fromPHP([]);
+        } elseif ($input instanceof Document) {
+            $this->bson = $input;
+        } elseif (is_array($input) || is_object($input)) {
+            $this->bson = Document::fromPHP($input);
+        } else {
+            throw InvalidArgumentException::invalidType('input', $input, [Document::class, 'array', 'null']);
+        }
+
+        $this->library = $library;
+    }
+
+    /** @return mixed */
+    public function __get(string $property)
+    {
+        $this->ensureKeyRead($property);
+
+        if (isset($this->unset[$property]) || isset($this->notFound[$property])) {
+            trigger_error(sprintf('Undefined property: %s', $property), E_USER_WARNING);
+        }
+
+        return array_key_exists($property, $this->set) ? $this->set[$property] : $this->read[$property];
+    }
+
+    public function __isset(string $name): bool
+    {
+        $this->ensureKeyRead($name);
+
+        return ! isset($this->unset[$name]) && ! isset($this->notFound[$name]);
+    }
+
+    /** @param mixed $value */
+    public function __set(string $property, $value): void
+    {
+        $this->set[$property] = $value;
+        unset($this->unset[$property]);
+        unset($this->notFound[$property]);
+    }
+
+    public function __unset(string $name): void
+    {
+        $this->unset[$name] = true;
+        unset($this->set[$name]);
+    }
+
+    public function bsonSerialize(): object
+    {
+        // Always use LazyBSONDocumentCodec for BSON serialisation
+        $codec = new LazyBSONDocumentCodec();
+        $codec->attachLibrary($this->getLibrary());
+
+        // @psalm-suppress InvalidReturnStatement
+        return $codec->encode($this)->toPHP();
+    }
+
+    /** @return Iterator<string, mixed> */
+    public function getIterator(): Iterator
+    {
+        $itemIterator = new AppendIterator();
+        // Iterate through all fields in the BSON document
+        $itemIterator->append($this->bson->getIterator());
+        // Then iterate over all fields that were set
+        $itemIterator->append(new ArrayIterator($this->set));
+
+        $seen = [];
+
+        return new CallbackIterator(
+            new CallbackFilterIterator(
+                $itemIterator,
+                /** @param mixed $current */
+                function ($current, string $key) use (&$seen): bool {
+                    // Skip keys that were unset or handled in a previous iterator
+                    return ! isset($this->unset[$key]) && ! isset($seen[$key]);
+                }
+            ),
+            /**
+             * @param mixed $value
+             * @return mixed
+             */
+            function ($value, string $key) use (&$seen) {
+                // Mark key as seen, skipping any future occurrences
+                $seen[$key] = true;
+
+                // Return actual value (potentially overridden by __set)
+                return $this->__get($key);
+            }
+        );
+    }
+
+    public function jsonSerialize(): object
+    {
+        return (object) iterator_to_array($this);
+    }
+
+    /** @param mixed $offset */
+    public function offsetExists($offset): bool
+    {
+        return $this->__isset((string) $offset);
+    }
+
+    /**
+     * @param mixed $offset
+     * @return mixed
+     */
+    #[ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->__get((string) $offset);
+    }
+
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value): void
+    {
+        $this->__set((string) $offset, $value);
+    }
+
+    /** @param mixed $offset */
+    public function offsetUnset($offset): void
+    {
+        $this->__unset((string) $offset);
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    private function decodeBSONValue($value)
+    {
+        return $this->getLibrary()->canDecode($value)
+            ? $this->getLibrary()->decode($value)
+            : $value;
+    }
+
+    private function ensureKeyRead(string $key): void
+    {
+        if (isset($this->set[$key]) || isset($this->notFound[$key]) || array_key_exists($key, $this->read)) {
+            return;
+        }
+
+        if (! $this->bson->has($key)) {
+            $this->notFound[$key] = true;
+
+            return;
+        }
+
+        $value = $this->bson->get($key);
+
+        // Decode value using the codec library if a codec exists
+        $this->read[$key] = $this->decodeBSONValue($value);
+    }
+
+    private function getLibrary(): CodecLibrary
+    {
+        return $this->library ?? $this->library = new CodecLibrary(new LazyBSONDocumentCodec(), new LazyBSONArrayCodec());
+    }
+}

--- a/stubs/BSON/BSON.stub.php
+++ b/stubs/BSON/BSON.stub.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace MongoDB\BSON;
+
+interface BSON
+{
+    static public function fromPHP(array $value): BSON {}
+
+    public function getIterator(): Iterator {}
+
+    public function toPHP(?array $typeMap = null): array|object {}
+
+    public function __toString(): string {}
+}

--- a/stubs/BSON/Document.stub.php
+++ b/stubs/BSON/Document.stub.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MongoDB\BSON;
+
+final class Document implements BSON, \IteratorAggregate, \Serializable
+{
+    private function __construct() {}
+
+    final static public function fromBSON(string $bson): Document {}
+
+    final static public function fromJSON(string $json): Document {}
+
+    final static public function fromPHP(array|object $value): Document {}
+
+    final public function get(string $key): mixed {}
+
+    final public function getIterator(): Iterator {}
+
+    final public function has(string $key): bool {}
+
+    final public function toPHP(?array $typeMap = null): array|object {}
+
+    final public function toCanonicalExtendedJSON(): string {}
+
+    final public function toRelaxedExtendedJSON(): string {}
+
+    final public function __toString(): string {}
+
+    final public static function __set_state(array $properties): Document {}
+
+    final public function serialize(): string {}
+
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
+
+    final public function __unserialize(array $data): void {}
+
+    final public function __serialize(): array {}
+}

--- a/stubs/BSON/Iterator.stub.php
+++ b/stubs/BSON/Iterator.stub.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+  * @generate-class-entries static
+  * @generate-function-entries static
+  */
+
+namespace MongoDB\BSON;
+
+final class Iterator implements \Iterator
+{
+    final private function __construct() {}
+
+    final public function current(): mixed {}
+
+    final public function key(): string|int {}
+
+    final public function next(): void {}
+
+    final public function rewind(): void {}
+
+    final public function valid(): bool {}
+
+    final public function __wakeup(): void {}
+}

--- a/stubs/BSON/PackedArray.stub.php
+++ b/stubs/BSON/PackedArray.stub.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MongoDB\BSON;
+
+final class PackedArray implements BSON, \IteratorAggregate, \Serializable
+{
+    private function __construct() {}
+
+    final static public function fromPHP(array $value): PackedArray {}
+
+    final public function get(int $index): mixed {}
+
+    final public function getIterator(): Iterator {}
+
+    final public function has(int $index): bool {}
+
+    final public function toPHP(?array $typeMap = null): array|object {}
+
+    final public function __toString(): string {}
+
+    final public static function __set_state(array $properties): PackedArray {}
+
+    final public function serialize(): string {}
+
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
+
+    final public function __unserialize(array $data): void {}
+
+    final public function __serialize(): array {}
+}

--- a/tests/Codec/CodecLibraryTest.php
+++ b/tests/Codec/CodecLibraryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace MongoDB\Tests\Codec;
+
+use MongoDB\Codec\Codec;
+use MongoDB\Codec\CodecLibrary;
+use MongoDB\Codec\KnowsCodecLibrary;
+use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Tests\TestCase;
+
+class CodecLibraryTest extends TestCase
+{
+    public function testDecode(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertTrue($codec->canDecode('cigam'));
+        $this->assertFalse($codec->canDecode('magic'));
+
+        $this->assertSame('magic', $codec->decode('cigam'));
+    }
+
+    public function testDecodeNull(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertTrue($codec->canDecode(null));
+        $this->assertNull($codec->decode(null));
+    }
+
+    public function testDecodeUnsupportedValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('No decoder found for value of type "string"');
+
+        $this->getCodecLibrary()->decode('foo');
+    }
+
+    public function testEncode(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertTrue($codec->canEncode('magic'));
+        $this->assertFalse($codec->canEncode('cigam'));
+
+        $this->assertSame('cigam', $codec->encode('magic'));
+    }
+
+    public function testEncodeNull(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertTrue($codec->canEncode(null));
+        $this->assertNull($codec->encode(null));
+    }
+
+    public function testEncodeUnsupportedValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('No encoder found for value of type "string"');
+
+        $this->getCodecLibrary()->encode('foo');
+    }
+
+    private function getCodecLibrary(): CodecLibrary
+    {
+        return new CodecLibrary(
+            /** @template-implements Codec<string, string> */
+            new class implements Codec
+            {
+                public function canDecode($value): bool
+                {
+                    return $value === 'cigam';
+                }
+
+                public function canEncode($value): bool
+                {
+                    return $value === 'magic';
+                }
+
+                public function decode($value)
+                {
+                    return 'magic';
+                }
+
+                public function encode($value)
+                {
+                    return 'cigam';
+                }
+            }
+        );
+    }
+
+    public function testLibraryAttachesToCodecs(): void
+    {
+        $codec = $this->getTestCodec();
+        $library = $this->getCodecLibrary();
+
+        $library->attachCodec($codec);
+        $this->assertSame($library, $codec->library);
+    }
+
+    public function testLibraryAttachesToCodecsWhenCreating(): void
+    {
+        $codec = $this->getTestCodec();
+        $library = new CodecLibrary($codec);
+
+        $this->assertSame($library, $codec->library);
+    }
+
+    private function getTestCodec(): Codec
+    {
+        return new class implements Codec, KnowsCodecLibrary {
+            public $library;
+
+            public function attachLibrary(CodecLibrary $library): void
+            {
+                $this->library = $library;
+            }
+
+            public function canDecode($value): bool
+            {
+                return false;
+            }
+
+            public function canEncode($value): bool
+            {
+                return false;
+            }
+
+            public function decode($value)
+            {
+                return null;
+            }
+
+            public function encode($value)
+            {
+                return null;
+            }
+        };
+    }
+}

--- a/tests/Codec/LazyBSONArrayCodecTest.php
+++ b/tests/Codec/LazyBSONArrayCodecTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MongoDB\Tests\Codec;
+
+use MongoDB\BSON\PackedArray;
+use MongoDB\Codec\LazyBSONArrayCodec;
+use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Model\LazyBSONArray;
+use MongoDB\Tests\TestCase;
+
+class LazyBSONArrayCodecTest extends TestCase
+{
+    private const ARRAY = [
+        'bar',
+        ['bar' => 'baz'],
+        [0, 1, 2],
+    ];
+
+    public function testDecode(): void
+    {
+        $array = (new LazyBSONArrayCodec())->decode($this->getTestArray());
+
+        $this->assertInstanceOf(LazyBSONArray::class, $array);
+        $this->assertSame('bar', $array[0]);
+    }
+
+    public function testDecodeWithWrongType(): void
+    {
+        $codec = new LazyBSONArrayCodec();
+
+        $this->expectException(UnexpectedValueException::class);
+        $codec->decode('foo');
+    }
+
+    public function testEncode(): void
+    {
+        $array = new LazyBSONArray($this->getTestArray());
+        $encoded = (new LazyBSONArrayCodec())->encode($array);
+
+        $this->assertEquals(
+            self::ARRAY,
+            $encoded->toPHP(['root' => 'array', 'array' => 'array', 'document' => 'array'])
+        );
+    }
+
+    public function testEncodeWithWrongType(): void
+    {
+        $codec = new LazyBSONArrayCodec();
+
+        $this->expectException(UnexpectedValueException::class);
+        $codec->encode('foo');
+    }
+
+    private function getTestArray(): PackedArray
+    {
+        return PackedArray::fromPHP(self::ARRAY);
+    }
+}

--- a/tests/Codec/LazyBSONDocumentCodecTest.php
+++ b/tests/Codec/LazyBSONDocumentCodecTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MongoDB\Tests\Codec;
+
+use MongoDB\BSON\Document;
+use MongoDB\Codec\LazyBSONDocumentCodec;
+use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Model\LazyBSONDocument;
+use MongoDB\Tests\TestCase;
+
+class LazyBSONDocumentCodecTest extends TestCase
+{
+    private const OBJECT = [
+        'foo' => 'bar',
+        'document' => ['bar' => 'baz'],
+        'array' => [0, 1, 2],
+    ];
+
+    public function testDecode(): void
+    {
+        $document = (new LazyBSONDocumentCodec())->decode($this->getTestDocument());
+
+        $this->assertInstanceOf(LazyBSONDocument::class, $document);
+        $this->assertSame('bar', $document->foo);
+    }
+
+    public function testDecodeWithWrongType(): void
+    {
+        $codec = new LazyBSONDocumentCodec();
+
+        $this->expectException(UnexpectedValueException::class);
+        $codec->decode('foo');
+    }
+
+    public function testEncode(): void
+    {
+        $document = new LazyBSONDocument($this->getTestDocument());
+        $encoded = (new LazyBSONDocumentCodec())->encode($document);
+
+        $this->assertEquals(
+            self::OBJECT,
+            $encoded->toPHP(['root' => 'array', 'array' => 'array', 'document' => 'array'])
+        );
+    }
+
+    public function testEncodeWithWrongType(): void
+    {
+        $codec = new LazyBSONDocumentCodec();
+
+        $this->expectException(UnexpectedValueException::class);
+        $codec->encode('foo');
+    }
+
+    private function getTestDocument(): Document
+    {
+        return Document::fromPHP(self::OBJECT);
+    }
+}

--- a/tests/Collection/CodecCollectionTest.php
+++ b/tests/Collection/CodecCollectionTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace MongoDB\Tests\Collection;
+
+use MongoDB\BSON\Document;
+use MongoDB\Codec\Codec;
+use MongoDB\Collection;
+
+use function iterator_to_array;
+
+class CodecCollectionTest extends FunctionalTestCase
+{
+    /** @var Codec */
+    private $codec;
+
+    /** @var Collection */
+    private $codecCollection;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->codec = $this->createCodec();
+
+        $this->codecCollection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName(), ['codec' => $this->codec]);
+    }
+
+    public function testWithoutCollectionCodec(): void
+    {
+        $document = new CollectionTestModel((object) ['foo' => 'bar']);
+        $this->collection->insertOne($document);
+
+        $this->assertMatchesDocument(
+            ['data' => ['foo' => 'bar']],
+            $this->collection->findOne()
+        );
+    }
+
+    public function testOperationCodecOverridesCollection(): void
+    {
+        $this->collection->insertOne(['_id' => 1, 'foo' => 'bar']);
+
+        $this->assertEquals(
+            new CollectionTestModel((object) ['_id' => 1, 'foo' => 'bar']),
+            $this->collection->findOne(['_id' => 1], ['codec' => $this->createCodec()])
+        );
+    }
+
+    public function testOperationTypeMapOverridesCollectionCodec(): void
+    {
+        $this->createTestFixtures();
+
+        $this->assertIsArray($this->codecCollection->findOne(['_id' => 2], ['typeMap' => ['root' => 'array']]));
+    }
+
+    public function testOperationCodecOverridesCollectionCodec(): void
+    {
+        $this->createTestFixtures();
+
+        $codec = $this->createCodec('operation');
+
+        $this->assertEquals(
+            new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz'], 'operation'),
+            $this->codecCollection->findOne(['_id' => 2], ['codec' => $codec])
+        );
+    }
+
+    public function testOperationCodecTakesPrecedenceOverOperationTypemap(): void
+    {
+        $this->createTestFixtures();
+
+        $codec = $this->createCodec('operation');
+
+        $this->assertEquals(
+            new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz'], 'operation'),
+            $this->codecCollection->findOne(['_id' => 2], ['codec' => $codec, 'typeMap' => ['root' => 'array']])
+        );
+    }
+
+    public function testInsertOne(): void
+    {
+        $document = new CollectionTestModel((object) ['foo' => 'bar']);
+        $this->codecCollection->insertOne($document);
+
+        $this->assertMatchesDocument(
+            ['foo' => 'bar'],
+            $this->collection->findOne()
+        );
+    }
+
+    public function testInsertMany(): void
+    {
+        $document = new CollectionTestModel((object) ['foo' => 'bar']);
+        $this->codecCollection->insertMany([$document, $document]);
+
+        $result = iterator_to_array($this->collection->find());
+        $this->assertCount(2, $result);
+        $this->assertMatchesDocument(
+            ['foo' => 'bar'],
+            $result[0]
+        );
+        $this->assertMatchesDocument(
+            ['foo' => 'bar'],
+            $result[1]
+        );
+    }
+
+    public function testFindOne(): void
+    {
+        $this->createTestFixtures();
+
+        $this->assertEquals(
+            new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz']),
+            $this->codecCollection->findOne(['_id' => 2])
+        );
+    }
+
+    public function testFind(): void
+    {
+        $this->createTestFixtures();
+
+        $this->assertEquals(
+            [
+                new CollectionTestModel((object) ['_id' => 1, 'foo' => 'bar']),
+                new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz']),
+            ],
+            iterator_to_array($this->codecCollection->find(['_id' => ['$lt' => 3]]))
+        );
+    }
+
+    public function testAggregate(): void
+    {
+        $this->createTestFixtures();
+
+        $this->assertEquals(
+            [
+                new CollectionTestModel((object) ['_id' => 1, 'foo' => 'bar']),
+                new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz']),
+            ],
+            iterator_to_array($this->codecCollection->aggregate([['$match' => ['_id' => ['$lt' => 3]]]]))
+        );
+    }
+
+    public function testFindOneAndDelete(): void
+    {
+        $this->createTestFixtures();
+
+        $this->assertEquals(
+            new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz']),
+            $this->codecCollection->findOneAndDelete(['_id' => 2])
+        );
+    }
+
+    public function testFindOneAndReplace(): void
+    {
+        $this->createTestFixtures();
+
+        $this->assertEquals(
+            new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz']),
+            $this->codecCollection->findOneAndReplace(['_id' => 2], new CollectionTestModel((object) ['_id' => 2, 'baz' => 'foo']))
+        );
+    }
+
+    public function testFindOneAndUpdate(): void
+    {
+        $this->createTestFixtures();
+
+        $this->assertEquals(
+            new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz']),
+            $this->codecCollection->findOneAndUpdate(['_id' => 2], ['$set' => ['baz' => 'foo']])
+        );
+    }
+
+    public function testReplaceOne(): void
+    {
+        $this->createTestFixtures();
+
+        $document = new CollectionTestModel((object) ['_id' => 2, 'baz' => 'foo']);
+        $this->codecCollection->replaceOne(['_id' => 2], $document);
+
+        $this->assertSameDocument(
+            ['_id' => 2, 'baz' => 'foo'],
+            $this->collection->findOne(['_id' => 2])
+        );
+    }
+
+    private function createCodec(?string $marker = null): Codec
+    {
+        return new class ($marker) implements Codec {
+            /** @var string|null */
+            private $marker;
+
+            public function __construct(?string $marker = null)
+            {
+                $this->marker = $marker;
+            }
+
+            public function canDecode($value): bool
+            {
+                return $value instanceof Document;
+            }
+
+            public function canEncode($value): bool
+            {
+                return $value instanceof CollectionTestModel;
+            }
+
+            public function decode($value): ?CollectionTestModel
+            {
+                if (! $value instanceof Document) {
+                    return null;
+                }
+
+                return new CollectionTestModel($value->toPHP(), $this->marker);
+            }
+
+            public function encode($value): ?Document
+            {
+                if (! $value instanceof CollectionTestModel) {
+                    return null;
+                }
+
+                return Document::fromPHP($value->data);
+            }
+        };
+    }
+
+    private function createTestFixtures(): void
+    {
+        $this->codecCollection->insertMany([
+            new CollectionTestModel((object) ['_id' => 1, 'foo' => 'bar']),
+            new CollectionTestModel((object) ['_id' => 2, 'bar' => 'baz']),
+        ]);
+    }
+}
+
+/** @phpcsIgnore PSR1.Classes.ClassDeclaration.MultipleClasses */
+class CollectionTestModel
+{
+    public $data;
+    public $marker;
+
+    public function __construct(object $data, ?string $marker = null)
+    {
+        $this->data = $data;
+    }
+}

--- a/tests/Model/LazyBSONArrayTest.php
+++ b/tests/Model/LazyBSONArrayTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace MongoDB\Tests\Model;
+
+use Generator;
+use MongoDB\BSON\PackedArray;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\LazyBSONArray;
+use MongoDB\Model\LazyBSONDocument;
+use MongoDB\Tests\TestCase;
+
+use function iterator_to_array;
+use function json_encode;
+
+class LazyBSONArrayTest extends TestCase
+{
+    private const ARRAY = [
+        'bar',
+        ['bar' => 'baz'],
+        [0, 1, 2],
+    ];
+
+    public static function provideTestArray(): Generator
+    {
+        yield 'array' => [new LazyBSONArray(self::ARRAY)];
+
+        yield 'packedArray' => [new LazyBSONArray(PackedArray::fromPHP(self::ARRAY))];
+    }
+
+    public function testConstructWithoutArgument(): void
+    {
+        $instance = new LazyBSONArray();
+        $this->assertSame([], iterator_to_array($instance));
+    }
+
+    public function testConstructWithWrongType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new LazyBSONArray('foo');
+    }
+
+    public function testClone(): void
+    {
+        $original = new LazyBSONArray();
+        $original[0] = (object) ['foo' => 'bar'];
+
+        $clone = clone $original;
+        $clone[0]->foo = 'baz';
+
+        self::assertSame('bar', $original[0]->foo);
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testOffsetGet(LazyBSONArray $array): void
+    {
+        $this->assertSame('bar', $array[0]);
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testOffsetGetAfterUnset(LazyBSONArray $array): void
+    {
+        $this->assertSame('bar', $array[0]);
+        unset($array[0]);
+
+        $this->expectWarning();
+        $this->expectWarningMessage('Undefined offset: 0');
+        $array[0];
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testOffsetGetForMissingOffset(LazyBSONArray $array): void
+    {
+        $this->expectWarning();
+        $this->expectWarningMessage('Undefined offset: 4');
+        $array[4];
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testGetDocument(LazyBSONArray $array): void
+    {
+        $this->assertInstanceOf(LazyBSONDocument::class, $array[1]);
+        $this->assertInstanceOf(LazyBSONDocument::class, $array[1]);
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testGetArray(LazyBSONArray $array): void
+    {
+        $this->assertInstanceOf(LazyBSONArray::class, $array[2]);
+        $this->assertInstanceOf(LazyBSONArray::class, $array[2]);
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testOffsetExists(LazyBSONArray $array): void
+    {
+        $this->assertTrue(isset($array[0]));
+        $this->assertFalse(isset($array[4]));
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testOffsetSet(LazyBSONArray $array): void
+    {
+        $this->assertFalse(isset($array[4]));
+        $array[4] = 'yay!';
+        $this->assertSame('yay!', $array[4]);
+
+        $this->assertSame('bar', $array[0]);
+        $array[0] = 'baz';
+        $this->assertSame('baz', $array[0]);
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testAppend(LazyBSONArray $array): void
+    {
+        $this->assertFalse(isset($array[3]));
+        $array[] = 'yay!';
+        $this->assertSame('yay!', $array[3]);
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testAppendWithGap(LazyBSONArray $array): void
+    {
+        // Leave offset 3 empty
+        $array[4] = 'yay!';
+
+        $this->assertFalse(isset($array[3]));
+        $array[] = 'bleh';
+
+        // Expect offset 3 to be skipped, offset 5 is used as 4 is already set
+        $this->assertFalse(isset($array[3]));
+        $this->assertSame('bleh', $array[5]);
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testOffsetUnset(LazyBSONArray $array): void
+    {
+        $this->assertFalse(isset($array[4]));
+        $array[4] = 'yay!';
+        unset($array[4]);
+        $this->assertFalse(isset($array[4]));
+
+        unset($array[0]);
+        $this->assertFalse(isset($array[0]));
+
+        // Change value to ensure it is unset for good
+        $array[1] = (object) ['foo' => 'baz'];
+        unset($array[1]);
+        $this->assertFalse(isset($array[1]));
+    }
+
+    /** @dataProvider provideTestArray */
+    public function testIterator(LazyBSONArray $array): void
+    {
+        $items = iterator_to_array($array);
+        $this->assertCount(3, $items);
+        $this->assertSame('bar', $items[0]);
+        $this->assertInstanceOf(LazyBSONDocument::class, $items[1]);
+        $this->assertInstanceOf(LazyBSONArray::class, $items[2]);
+
+        $array[0] = 'baz';
+        $items = iterator_to_array($array);
+        $this->assertCount(3, $items);
+        $this->assertSame('baz', $items[0]);
+        $this->assertInstanceOf(LazyBSONDocument::class, $items[1]);
+        $this->assertInstanceOf(LazyBSONArray::class, $items[2]);
+
+        unset($array[0]);
+        unset($array[2]);
+        $items = iterator_to_array($array);
+        $this->assertCount(1, $items);
+        $this->assertInstanceOf(LazyBSONDocument::class, $items[0]);
+
+        // Leave a gap to ensure we're re-indexing keys
+        $array[5] = 'yay!';
+        $items = iterator_to_array($array);
+        $this->assertCount(2, $items);
+        $this->assertInstanceOf(LazyBSONDocument::class, $items[0]);
+        $this->assertSame('yay!', $items[1]);
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $document = new LazyBSONArray([
+            'bar',
+            new LazyBSONArray([1, 2, 3]),
+            new LazyBSONDocument([1, 2, 3]),
+            new LazyBSONArray([]),
+        ]);
+
+        $expectedJson = '["bar",[1,2,3],{"0":1,"1":2,"2":3},[]]';
+
+        $this->assertSame($expectedJson, json_encode($document));
+    }
+}

--- a/tests/Model/LazyBSONDocumentTest.php
+++ b/tests/Model/LazyBSONDocumentTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace MongoDB\Tests\Model;
+
+use Generator;
+use MongoDB\BSON\Document;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\LazyBSONArray;
+use MongoDB\Model\LazyBSONDocument;
+use MongoDB\Tests\TestCase;
+
+use function iterator_to_array;
+use function json_encode;
+
+class LazyBSONDocumentTest extends TestCase
+{
+    private const OBJECT = [
+        'foo' => 'bar',
+        'document' => ['bar' => 'baz'],
+        'array' => [0, 1, 2],
+    ];
+
+    public static function provideTestDocument(): Generator
+    {
+        yield 'array' => [new LazyBSONDocument(self::OBJECT)];
+
+        yield 'object' => [new LazyBSONDocument((object) self::OBJECT)];
+
+        yield 'document' => [new LazyBSONDocument(Document::fromPHP(self::OBJECT))];
+    }
+
+    public function testConstructWithoutArgument(): void
+    {
+        $instance = new LazyBSONDocument();
+        $this->assertSame([], iterator_to_array($instance));
+    }
+
+    public function testConstructWithWrongType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new LazyBSONDocument('foo');
+    }
+
+    public function testClone(): void
+    {
+        $original = new LazyBSONDocument();
+        $original->object = (object) ['foo' => 'bar'];
+
+        $clone = clone $original;
+        $clone->object->foo = 'baz';
+
+        self::assertSame('bar', $original->object->foo);
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testPropertyGet(LazyBSONDocument $document): void
+    {
+        $this->assertSame('bar', $document->foo);
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testPropertyGetAfterUnset(LazyBSONDocument $document): void
+    {
+        $this->assertSame('bar', $document->foo);
+        unset($document->foo);
+
+        $this->expectWarning();
+        $this->expectWarningMessage('Undefined property: foo');
+        $document->foo;
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testPropertyGetForMissingProperty(LazyBSONDocument $document): void
+    {
+        $this->expectWarning();
+        $this->expectWarningMessage('Undefined property: bar');
+        $document->bar;
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testOffsetGet(LazyBSONDocument $document): void
+    {
+        $this->assertSame('bar', $document['foo']);
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testOffsetGetAfterUnset(LazyBSONDocument $document): void
+    {
+        $this->assertSame('bar', $document['foo']);
+        unset($document['foo']);
+
+        $this->expectWarning();
+        $this->expectWarningMessage('Undefined property: foo');
+        $document['foo'];
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testOffsetGetForMissingOffset(LazyBSONDocument $document): void
+    {
+        $this->expectWarning();
+        $this->expectWarningMessage('Undefined property: bar');
+        $document['bar'];
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testGetDocument(LazyBSONDocument $document): void
+    {
+        $this->assertInstanceOf(LazyBSONDocument::class, $document->document);
+        $this->assertInstanceOf(LazyBSONDocument::class, $document['document']);
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testGetArray(LazyBSONDocument $document): void
+    {
+        $this->assertInstanceOf(LazyBSONArray::class, $document->array);
+        $this->assertInstanceOf(LazyBSONArray::class, $document['array']);
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testPropertyIsset(LazyBSONDocument $document): void
+    {
+        $this->assertTrue(isset($document->foo));
+        $this->assertFalse(isset($document->bar));
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testOffsetExists(LazyBSONDocument $document): void
+    {
+        $this->assertTrue(isset($document['foo']));
+        $this->assertFalse(isset($document['bar']));
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testPropertySet(LazyBSONDocument $document): void
+    {
+        $this->assertFalse(isset($document->new));
+        $document->new = 'yay!';
+        $this->assertSame('yay!', $document->new);
+
+        $this->assertSame('bar', $document->foo);
+        $document->foo = 'baz';
+        $this->assertSame('baz', $document->foo);
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testOffsetSet(LazyBSONDocument $document): void
+    {
+        $this->assertFalse(isset($document['new']));
+        $document['new'] = 'yay!';
+        $this->assertSame('yay!', $document['new']);
+
+        $this->assertSame('bar', $document['foo']);
+        $document['foo'] = 'baz';
+        $this->assertSame('baz', $document['foo']);
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testPropertyUnset(LazyBSONDocument $document): void
+    {
+        $this->assertFalse(isset($document->new));
+        $document->new = 'yay!';
+        unset($document->new);
+        $this->assertFalse(isset($document->new));
+
+        unset($document->foo);
+        $this->assertFalse(isset($document->foo));
+
+        // Change value to ensure it is unset for good
+        $document->document = (object) ['foo' => 'baz'];
+        unset($document->document);
+        $this->assertFalse(isset($document->document));
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testOffsetUnset(LazyBSONDocument $document): void
+    {
+        $this->assertFalse(isset($document['new']));
+        $document['new'] = 'yay!';
+        unset($document['new']);
+        $this->assertFalse(isset($document['new']));
+
+        unset($document['foo']);
+        $this->assertFalse(isset($document['foo']));
+
+        // Change value to ensure it is unset for good
+        $document['document'] = (object) ['foo' => 'baz'];
+        unset($document['document']);
+        $this->assertFalse(isset($document['document']));
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testIterator(LazyBSONDocument $document): void
+    {
+        $items = iterator_to_array($document);
+        $this->assertCount(3, $items);
+        $this->assertSame('bar', $items['foo']);
+        $this->assertInstanceOf(LazyBSONDocument::class, $items['document']);
+        $this->assertInstanceOf(LazyBSONArray::class, $items['array']);
+
+        $document->foo = 'baz';
+        $items = iterator_to_array($document);
+        $this->assertCount(3, $items);
+        $this->assertSame('baz', $items['foo']);
+        $this->assertInstanceOf(LazyBSONDocument::class, $items['document']);
+        $this->assertInstanceOf(LazyBSONArray::class, $items['array']);
+
+        unset($document->foo);
+        unset($document->array);
+        $items = iterator_to_array($document);
+        $this->assertCount(1, $items);
+        $this->assertInstanceOf(LazyBSONDocument::class, $items['document']);
+
+        $document->new = 'yay!';
+        $items = iterator_to_array($document);
+        $this->assertCount(2, $items);
+        $this->assertInstanceOf(LazyBSONDocument::class, $items['document']);
+        $this->assertSame('yay!', $items['new']);
+    }
+
+    /** @dataProvider provideTestDocument */
+    public function testBsonSerializeCastsToObject(LazyBSONDocument $document): void
+    {
+        $expected = (object) self::OBJECT;
+        $expected->document = (object) $expected->document;
+
+        $this->assertEquals($expected, $document->bsonSerialize());
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $document = new LazyBSONDocument([
+            'foo' => 'bar',
+            'array' => new LazyBSONArray([1, 2, 3]),
+            'object' => new LazyBSONDocument([1, 2, 3]),
+            'nested' => new LazyBSONDocument([new LazyBSONDocument([new LazyBSONDocument()])]),
+        ]);
+
+        $expectedJson = '{"foo":"bar","array":[1,2,3],"object":{"0":1,"1":2,"2":3},"nested":{"0":{"0":{}}}}';
+
+        $this->assertSame($expectedJson, json_encode($document));
+    }
+
+    public function testJsonSerializeCastsToObject(): void
+    {
+        $data = [0 => 'foo', 2 => 'bar'];
+
+        $document = new LazyBSONDocument($data);
+        $this->assertEquals((object) [0 => 'foo', 2 => 'bar'], $document->jsonSerialize());
+    }
+}


### PR DESCRIPTION
This pull request adds the concept of codecs to the library. A codec consists of an encoder and decoder (currently separated, but we could consolidate these into a single interface).

A decoder is responsible for decoding BSON data into PHP data, while the encoder converts PHP data into BSON data. This PR comes with two default codecs, `LazyBSONDocumentCodec` and `LazyBSONArrayCodec`. These work with new lazy classes that mimic the existing `BSONArray` and `BSONDocument`, but are backed by the new BSON `Document` and `PackedArray` classes provided in the new extension version. This allows us to defer reading and decoding BSON until data is actually accessed. Furthermore, only accessed fields are ever read, meaning that any BSON data that isn't actively used is never decoded and thus does not have a considerable memory or time impact.

For the time being, the new lazy classes do not extend the existing `BSONArray` and `BSONDocument` classes, but for backward compatibility it might be preferable to do so: this would allow us to enable this lazy behaviour by default. As is, this functionality is opt-in due to the BC break involved in returning classes that don't extend the current classes.

The next step is to change the `Collection` class to take a `codec` option, which would allow said class to decode and encode data in the various methods that would return modelled data. Apart from decoding BSON documents into specific PHP objects lazily, the codec functionality would also allow users to change the way BSON types are returned. For example, a `DateTimeCodec` could decode any `MongoDB\BSON\UTCDateTime` instances to a `DateTime` instance and vice-versa, with the collection class automatically converting those instances to `UTCDateTime`.

This is a first draft, and as such there are a number of items left to do:
- [ ] Figure out naming (`Array` vs. `PackedArray`)
- [x] Support passing a codec to a `Collection` instance
- [ ] (optional, desired) Make lazy document/array classes extend existing classes
- [ ] (optional) Make `Client` aware of a codec library containing codecs that should always be used, e.g. to transform BSON types
- [ ] (optional) Provide a codec map to associate a codec with a specific collection, avoiding the need to pass a `codec` option whenever fetching a `Collection` instance.