### PR TITLE
PHPLIB-1113: Update to psalm 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "squizlabs/php_codesniffer": "^3.7",
         "doctrine/coding-standard": "^11.1",
         "symfony/phpunit-bridge": "^5.2",
-        "vimeo/psalm": "^4.28"
+        "vimeo/psalm": "^5"
     },
     "autoload": {
         "psr-4": { "MongoDB\\": "src/" },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,39 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
-  <file src="examples/aggregate.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="examples/bulk.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="examples/changestream.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="examples/command_logger.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
+<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
   <file src="examples/typemap.php">
-    <PropertyNotSetInConstructor occurrences="5">
+    <PropertyNotSetInConstructor>
       <code>$address</code>
       <code>$emails</code>
       <code>$id</code>
@@ -41,350 +9,345 @@
       <code>$type</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="examples/with_transaction.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
+  <file src="src/ChangeStream.php">
+    <MissingTemplateParam>
+      <code>Iterator</code>
+    </MissingTemplateParam>
   </file>
   <file src="src/Client.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$driverOptions['driver'] ?? []</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$mergedDriver['platform']</code>
     </MixedAssignment>
   </file>
-  <file src="src/Collection.php">
-    <MixedArgument occurrences="3">
-      <code>$encryptedFields['eccCollection'] ?? 'enxcol_.' . $this-&gt;collectionName . '.ecc'</code>
-      <code>$encryptedFields['ecocCollection'] ?? 'enxcol_.' . $this-&gt;collectionName . '.ecoc'</code>
-      <code>$encryptedFields['escCollection'] ?? 'enxcol_.' . $this-&gt;collectionName . '.esc'</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$encryptedFields</code>
-    </MixedAssignment>
-  </file>
   <file src="src/Command/ListCollections.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['session']</code>
     </MixedAssignment>
   </file>
   <file src="src/Command/ListDatabases.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['session']</code>
     </MixedAssignment>
   </file>
-  <file src="src/Database.php">
-    <MixedArgument occurrences="6">
-      <code>$encryptedFields['eccCollection'] ?? 'enxcol_.' . $collectionName . '.ecc'</code>
-      <code>$encryptedFields['eccCollection'] ?? 'enxcol_.' . $collectionName . '.ecc'</code>
-      <code>$encryptedFields['ecocCollection'] ?? 'enxcol_.' . $collectionName . '.ecoc'</code>
-      <code>$encryptedFields['ecocCollection'] ?? 'enxcol_.' . $collectionName . '.ecoc'</code>
-      <code>$encryptedFields['escCollection'] ?? 'enxcol_.' . $collectionName . '.esc'</code>
-      <code>$encryptedFields['escCollection'] ?? 'enxcol_.' . $collectionName . '.esc'</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$encryptedFields</code>
-      <code>$encryptedFields</code>
-      <code>$options['encryptedFields']</code>
-    </MixedAssignment>
-  </file>
   <file src="src/Exception/BadMethodCallException.php">
-    <UnsafeInstantiation occurrences="2">
+    <UnsafeInstantiation>
       <code>new static(sprintf('%s is immutable', $class))</code>
       <code>new static(sprintf('%s should not be called for an unacknowledged write result', $method))</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Exception/InvalidArgumentException.php">
-    <UnsafeInstantiation occurrences="1">
-      <code>new static(sprintf('Expected %s to have type "%s" but found "%s"', $name, $expectedType, get_debug_type($value)))</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static(sprintf('Expected %s to have type "%s" but found "%s"', $name, $expectedType, get_debug_type($value)))]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Exception/ResumeTokenException.php">
-    <UnsafeInstantiation occurrences="2">
+    <UnsafeInstantiation>
       <code>new static('Resume token not found in change document')</code>
-      <code>new static(sprintf('Expected resume token to have type "array or object" but found "%s"', get_debug_type($value)))</code>
+      <code><![CDATA[new static(sprintf('Expected resume token to have type "array or object" but found "%s"', get_debug_type($value)))]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Exception/UnsupportedException.php">
-    <UnsafeInstantiation occurrences="10">
+    <UnsafeInstantiation>
       <code>new static('Array filters are not supported by the server executing this operation')</code>
       <code>new static('Collations are not supported by the server executing this operation')</code>
       <code>new static('Explain is not supported by the server executing this operation')</code>
       <code>new static('Hint is not supported by the server executing this operation')</code>
       <code>new static('Read concern is not supported by the server executing this command')</code>
-      <code>new static('The "allowDiskUse" option is not supported by the server executing this operation')</code>
-      <code>new static('The "commitQuorum" option is not supported by the server executing this operation')</code>
-      <code>new static('The "readConcern" option cannot be specified within a transaction. Instead, specify it when starting the transaction.')</code>
-      <code>new static('The "writeConcern" option cannot be specified within a transaction. Instead, specify it when starting the transaction.')</code>
+      <code><![CDATA[new static('The "allowDiskUse" option is not supported by the server executing this operation')]]></code>
+      <code><![CDATA[new static('The "commitQuorum" option is not supported by the server executing this operation')]]></code>
+      <code><![CDATA[new static('The "readConcern" option cannot be specified within a transaction. Instead, specify it when starting the transaction.')]]></code>
+      <code><![CDATA[new static('The "writeConcern" option cannot be specified within a transaction. Instead, specify it when starting the transaction.')]]></code>
       <code>new static('Write concern is not supported by the server executing this command')</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Bucket.php">
-    <DocblockTypeContradiction occurrences="4">
+    <DocblockTypeContradiction>
       <code>! is_resource($destination)</code>
       <code>! is_resource($destination)</code>
       <code>! is_resource($source)</code>
       <code>! is_resource($stream)</code>
     </DocblockTypeContradiction>
-    <MissingReturnType occurrences="5">
+    <MissingReturnType>
       <code>delete</code>
       <code>downloadToStream</code>
       <code>downloadToStreamByName</code>
       <code>drop</code>
       <code>rename</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$id</code>
+    <MixedArgument>
       <code>$options['revision']</code>
       <code>$options['revision']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$id</code>
-    </MixedAssignment>
   </file>
   <file src="src/GridFS/Exception/CorruptFileException.php">
-    <UnsafeInstantiation occurrences="4">
-      <code>new static(sprintf('Chunk not found for index "%d"', $expectedIndex))</code>
-      <code>new static(sprintf('Expected chunk to have index "%d" but found "%d"', $expectedIndex, $index))</code>
-      <code>new static(sprintf('Expected chunk to have size "%d" but found "%d"', $expectedSize, $size))</code>
-      <code>new static(sprintf('Invalid data found for index "%d"', $chunkIndex))</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static(sprintf('Chunk not found for index "%d"', $expectedIndex))]]></code>
+      <code><![CDATA[new static(sprintf('Expected chunk to have index "%d" but found "%d"', $expectedIndex, $index))]]></code>
+      <code><![CDATA[new static(sprintf('Expected chunk to have size "%d" but found "%d"', $expectedSize, $size))]]></code>
+      <code><![CDATA[new static(sprintf('Invalid data found for index "%d"', $chunkIndex))]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Exception/FileNotFoundException.php">
-    <MixedArgument occurrences="1">
-      <code>$json</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$json</code>
-    </MixedAssignment>
-    <UnsafeInstantiation occurrences="2">
-      <code>new static(sprintf('File "%s" not found in "%s"', $json, $namespace))</code>
-      <code>new static(sprintf('File with name "%s" and revision "%d" not found in "%s"', $filename, $revision, $namespace))</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static(sprintf('File "%s" not found in "%s"', $json, $namespace))]]></code>
+      <code><![CDATA[new static(sprintf('File with name "%s" and revision "%d" not found in "%s"', $filename, $revision, $namespace))]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Exception/StreamException.php">
-    <MixedArgument occurrences="1">
-      <code>$idString</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$idString</code>
-    </MixedAssignment>
-    <UnsafeInstantiation occurrences="3">
-      <code>new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $filename))</code>
-      <code>new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString))</code>
-      <code>new static(sprintf('Uploading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationUri, $filename))</code>
+    <UnsafeInstantiation>
+      <code><![CDATA[new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $filename))]]></code>
+      <code><![CDATA[new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString))]]></code>
+      <code><![CDATA[new static(sprintf('Uploading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationUri, $filename))]]></code>
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/ReadableStream.php">
-    <MixedArgument occurrences="2">
-      <code>$currentChunk-&gt;n</code>
-      <code>$this-&gt;file-&gt;length</code>
+    <MixedArgument>
+      <code><![CDATA[$currentChunk->n]]></code>
+      <code><![CDATA[$this->file->length]]></code>
     </MixedArgument>
   </file>
   <file src="src/GridFS/StreamWrapper.php">
-    <MixedArgument occurrences="5">
-      <code>$context[$this-&gt;protocol]['collectionWrapper']</code>
-      <code>$context[$this-&gt;protocol]['collectionWrapper']</code>
-      <code>$context[$this-&gt;protocol]['file']</code>
-      <code>$context[$this-&gt;protocol]['filename']</code>
-      <code>$context[$this-&gt;protocol]['options']</code>
+    <MixedArgument>
+      <code><![CDATA[$context[$this->protocol]['collectionWrapper']]]></code>
+      <code><![CDATA[$context[$this->protocol]['collectionWrapper']]]></code>
+      <code><![CDATA[$context[$this->protocol]['file']]]></code>
+      <code><![CDATA[$context[$this->protocol]['filename']]]></code>
+      <code><![CDATA[$context[$this->protocol]['options']]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="5">
-      <code>$context[$this-&gt;protocol]['collectionWrapper']</code>
-      <code>$context[$this-&gt;protocol]['collectionWrapper']</code>
-      <code>$context[$this-&gt;protocol]['file']</code>
-      <code>$context[$this-&gt;protocol]['filename']</code>
-      <code>$context[$this-&gt;protocol]['options']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$context[$this->protocol]['collectionWrapper']]]></code>
+      <code><![CDATA[$context[$this->protocol]['collectionWrapper']]]></code>
+      <code><![CDATA[$context[$this->protocol]['file']]]></code>
+      <code><![CDATA[$context[$this->protocol]['filename']]]></code>
+      <code><![CDATA[$context[$this->protocol]['options']]]></code>
     </MixedArrayAccess>
-    <UnusedFunctionCall occurrences="1">
-      <code>stream_wrapper_unregister</code>
-    </UnusedFunctionCall>
-  </file>
-  <file src="src/GridFS/WritableStream.php">
-    <UnusedFunctionCall occurrences="1">
-      <code>hash_update</code>
-    </UnusedFunctionCall>
   </file>
   <file src="src/MapReduceResult.php">
-    <MixedInferredReturnType occurrences="1">
+    <MissingTemplateParam>
+      <code>IteratorAggregate</code>
+    </MissingTemplateParam>
+    <MixedInferredReturnType>
       <code>Traversable</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>call_user_func($this-&gt;getIterator)</code>
+    <MixedReturnStatement>
+      <code><![CDATA[call_user_func($this->getIterator)]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Model/BSONArray.php">
-    <MixedArrayOffset occurrences="1">
+    <MissingTemplateParam>
+      <code>BSONArray</code>
+    </MissingTemplateParam>
+    <MixedArrayOffset>
       <code>$this[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$key</code>
       <code>$this[$key]</code>
       <code>$value</code>
     </MixedAssignment>
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation>
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Model/BSONDocument.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$iteratorClass</code>
     </ArgumentTypeCoercion>
-    <MixedArrayOffset occurrences="1">
+    <MissingTemplateParam>
+      <code>BSONDocument</code>
+    </MissingTemplateParam>
+    <MixedArrayOffset>
       <code>$this[$key]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$key</code>
       <code>$this[$key]</code>
       <code>$value</code>
     </MixedAssignment>
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation>
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Model/BSONIterator.php">
-    <MixedArgument occurrences="3">
+    <MissingTemplateParam>
+      <code>Iterator</code>
+    </MissingTemplateParam>
+    <MixedArgument>
       <code>$documentLength</code>
       <code>$documentLength</code>
-      <code>$this-&gt;options['typeMap']</code>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$this-&gt;position</code>
+    <MixedAssignment>
+      <code><![CDATA[$this->position]]></code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$documentLength</code>
     </MixedOperand>
   </file>
   <file src="src/Model/CachingIterator.php">
-    <MixedArrayAccess occurrences="2">
+    <MissingTemplateParam>
+      <code>Iterator</code>
+    </MissingTemplateParam>
+    <MixedArrayAccess>
       <code>$currentItem[self::FIELD_KEY]</code>
       <code>$currentItem[self::FIELD_VALUE]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$currentItem</code>
       <code>$currentItem</code>
     </MixedAssignment>
+  </file>
+  <file src="src/Model/CallbackIterator.php">
+    <MissingTemplateParam>
+      <code>Iterator</code>
+    </MissingTemplateParam>
   </file>
   <file src="src/Model/ChangeStreamIterator.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
-      <code>isset($initialResumeToken) &amp;&amp; ! is_array($initialResumeToken) &amp;&amp; ! is_object($initialResumeToken)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($document) && ! is_object($document)]]></code>
+      <code><![CDATA[isset($initialResumeToken) && ! is_array($initialResumeToken) && ! is_object($initialResumeToken)]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="2">
-      <code>$reply-&gt;cursor-&gt;nextBatch</code>
-      <code>$this-&gt;current()</code>
+    <MissingTemplateParam>
+      <code>ChangeStreamIterator</code>
+    </MissingTemplateParam>
+    <MixedArgument>
+      <code><![CDATA[$reply->cursor->nextBatch]]></code>
+      <code><![CDATA[$this->current()]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$this-&gt;postBatchResumeToken</code>
+    <MixedAssignment>
+      <code><![CDATA[$this->postBatchResumeToken]]></code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="2">
-      <code>$reply-&gt;cursor-&gt;nextBatch</code>
-      <code>$reply-&gt;cursor-&gt;postBatchResumeToken</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$reply->cursor->nextBatch]]></code>
+      <code><![CDATA[$reply->cursor->postBatchResumeToken]]></code>
     </MixedPropertyFetch>
-    <UnusedFunctionCall occurrences="2">
-      <code>addSubscriber</code>
-      <code>removeSubscriber</code>
-    </UnusedFunctionCall>
   </file>
   <file src="src/Model/CollectionInfo.php">
-    <MixedArgument occurrences="1">
+    <MissingTemplateParam>
+      <code>ArrayAccess</code>
+    </MissingTemplateParam>
+    <MixedArgument>
       <code>$key</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;info[$key]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->info[$key]]]></code>
     </MixedArrayOffset>
   </file>
   <file src="src/Model/CollectionInfoCommandIterator.php">
-    <MixedArgument occurrences="1">
+    <MissingTemplateParam>
+      <code>CollectionInfoCommandIterator</code>
+    </MissingTemplateParam>
+    <MixedArgument>
       <code>$info</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
+    <MixedArrayAssignment>
       <code>$info['idIndex']['ns']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$info</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$info['name']</code>
     </MixedOperand>
   </file>
+  <file src="src/Model/CollectionInfoIterator.php">
+    <MissingTemplateParam>
+      <code>Iterator</code>
+    </MissingTemplateParam>
+  </file>
   <file src="src/Model/DatabaseInfo.php">
-    <MixedArgument occurrences="1">
+    <MissingTemplateParam>
+      <code>ArrayAccess</code>
+    </MissingTemplateParam>
+    <MixedArgument>
       <code>$key</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;info[$key]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->info[$key]]]></code>
     </MixedArrayOffset>
   </file>
+  <file src="src/Model/DatabaseInfoIterator.php">
+    <MissingTemplateParam>
+      <code>Iterator</code>
+    </MissingTemplateParam>
+  </file>
   <file src="src/Model/DatabaseInfoLegacyIterator.php">
-    <MixedArgument occurrences="1">
-      <code>current($this-&gt;databases)</code>
+    <MixedArgument>
+      <code><![CDATA[current($this->databases)]]></code>
     </MixedArgument>
-    <MixedReturnTypeCoercion occurrences="2">
+    <MixedReturnTypeCoercion>
       <code>int</code>
-      <code>key($this-&gt;databases)</code>
+      <code><![CDATA[key($this->databases)]]></code>
     </MixedReturnTypeCoercion>
   </file>
   <file src="src/Model/IndexInfo.php">
-    <MixedArgument occurrences="1">
+    <MissingTemplateParam>
+      <code>ArrayAccess</code>
+    </MissingTemplateParam>
+    <MixedArgument>
       <code>$key</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;info[$key]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->info[$key]]]></code>
     </MixedArrayOffset>
   </file>
+  <file src="src/Model/IndexInfoIterator.php">
+    <MissingTemplateParam>
+      <code>Iterator</code>
+    </MissingTemplateParam>
+  </file>
   <file src="src/Model/IndexInfoIteratorIterator.php">
-    <MixedArgument occurrences="2">
+    <MissingTemplateParam>
+      <code>IndexInfoIteratorIterator</code>
+    </MissingTemplateParam>
+    <MixedArgument>
       <code>$info</code>
       <code>$info</code>
     </MixedArgument>
-    <MixedArrayAssignment occurrences="1">
+    <MixedArrayAssignment>
       <code>$info['ns']</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$info</code>
     </MixedAssignment>
   </file>
   <file src="src/Model/IndexInput.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$fieldName</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$fieldName</code>
     </MixedAssignment>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;index['name']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->index['name']]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Operation/Aggregate.php">
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;options['typeMap']</code>
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$cmdOptions['maxAwaitTimeMS']</code>
       <code>$cmd[$option]</code>
       <code>$cmd['hint']</code>
       <code>$options[$option]</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
-      <code>isDefault</code>
-      <code>isDefault</code>
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/BulkWrite.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_array($operation)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="11">
+    <MixedArgument>
       <code>$args</code>
       <code>$args</code>
       <code>$args</code>
@@ -397,7 +360,7 @@
       <code>$args[1]</code>
       <code>$args[2]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="25">
+    <MixedArrayAccess>
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
@@ -424,20 +387,23 @@
       <code>$args[2]['upsert']</code>
       <code>$args[2]['upsert']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="11">
+    <MixedArrayAssignment>
       <code>$args[1]</code>
       <code>$args[1]</code>
+      <code>$args[1]['limit']</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
+      <code>$args[2]['multi']</code>
+      <code>$args[2]['multi']</code>
       <code>$operations[$i][$type][1]</code>
       <code>$operations[$i][$type][2]</code>
       <code>$operations[$i][$type][2]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="11">
+    <MixedAssignment>
       <code>$args</code>
       <code>$args</code>
       <code>$args[2]</code>
@@ -450,186 +416,184 @@
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
-      <code>isDefault</code>
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="2">
+    <MixedOperand>
       <code>$args[2]</code>
       <code>$args[2]</code>
     </MixedOperand>
   </file>
   <file src="src/Operation/Count.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$cmd['hint']</code>
       <code>$options['readConcern']</code>
       <code>$options['readPreference']</code>
       <code>$options['session']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/CountDocuments.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Operation/CreateCollection.php">
-    <MixedArgument occurrences="3">
-      <code>$i</code>
-      <code>$i</code>
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
   </file>
   <file src="src/Operation/CreateEncryptedCollection.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>! is_array($encryptedFields['fields'])</code>
-      <code>! is_array($field) &amp;&amp; ! is_object($field)</code>
+      <code><![CDATA[! is_array($field) && ! is_object($field)]]></code>
+      <code>! isset($encryptedFields['fields']) || ! is_array($encryptedFields['fields'])</code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Operation/CreateIndexes.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_array($index)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$cmd['commitQuorum']</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/DatabaseCommand.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($command) &amp;&amp; ! is_object($command)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($command) && ! is_object($command)]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$options['readPreference']</code>
       <code>$options['session']</code>
     </MixedAssignment>
   </file>
   <file src="src/Operation/Delete.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['writeConcern']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['writeConcern']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$cmd['writeConcern']</code>
       <code>$deleteOptions['hint']</code>
       <code>$options['comment']</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/Distinct.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['readConcern']</code>
       <code>$options['readPreference']</code>
       <code>$options['session']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/DropCollection.php">
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$cmd['comment']</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/DropDatabase.php">
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$cmd['comment']</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
   </file>
   <file src="src/Operation/DropIndexes.php">
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/Explain.php">
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['readPreference']</code>
       <code>$options['session']</code>
     </MixedAssignment>
   </file>
   <file src="src/Operation/Find.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$options['modifiers'][$modifier[1]]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$options[$modifier[0]]</code>
       <code>$options[$option]</code>
       <code>$options['readPreference']</code>
       <code>$options['session']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/FindAndModify.php">
-    <MixedArgument occurrences="2">
-      <code>$this-&gt;options['typeMap']</code>
-      <code>$this-&gt;options['writeConcern']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
+      <code><![CDATA[$this->options['writeConcern']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$cmd['new']</code>
       <code>$cmd['update']</code>
@@ -637,141 +601,130 @@
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array|object|null</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
-      <code>isDefault</code>
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>is_object($result) ? ($result-&gt;value ?? null) : null</code>
+    <MixedReturnStatement>
+      <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
+      <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Operation/FindOneAndDelete.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Operation/FindOneAndReplace.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-      <code>! is_array($replacement) &amp;&amp; ! is_object($replacement)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
+      <code><![CDATA[! is_array($replacement) && ! is_object($replacement)]]></code>
     </DocblockTypeContradiction>
-    <MixedOperand occurrences="1">
-      <code>$options['returnDocument']</code>
-    </MixedOperand>
   </file>
   <file src="src/Operation/FindOneAndUpdate.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-      <code>! is_array($update) &amp;&amp; ! is_object($update)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
+      <code><![CDATA[! is_array($update) && ! is_object($update)]]></code>
     </DocblockTypeContradiction>
-    <MixedOperand occurrences="1">
-      <code>$options['returnDocument']</code>
-    </MixedOperand>
   </file>
   <file src="src/Operation/InsertMany.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($document) && ! is_object($document)]]></code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$insertedIds[$i]</code>
       <code>$options[$option]</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
-      <code>isDefault</code>
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/InsertOne.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($document) && ! is_object($document)]]></code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$insertedId</code>
       <code>$options[$option]</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
-      <code>isDefault</code>
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/ListCollectionNames.php">
-    <MissingClosureReturnType occurrences="1">
+    <MissingClosureReturnType>
       <code>function (array $collectionInfo) {</code>
     </MissingClosureReturnType>
   </file>
   <file src="src/Operation/ListIndexes.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['session']</code>
     </MixedAssignment>
   </file>
   <file src="src/Operation/MapReduce.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_string($out) &amp;&amp; ! is_array($out) &amp;&amp; ! is_object($out)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_string($out) && ! is_array($out) && ! is_object($out)]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="3">
-      <code>$result-&gt;result-&gt;collection</code>
-      <code>$result-&gt;result-&gt;db</code>
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$result->result->collection]]></code>
+      <code><![CDATA[$result->result->db]]></code>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['readConcern']</code>
       <code>$options['readPreference']</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="4">
-      <code>getScope</code>
-      <code>isDefault</code>
-      <code>isDefault</code>
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/ModifyCollection.php">
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$cmd['comment']</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
   </file>
   <file src="src/Operation/RenameCollection.php">
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['typeMap']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$cmd[$option]</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/ReplaceOne.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($replacement) &amp;&amp; ! is_object($replacement)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($replacement) && ! is_object($replacement)]]></code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Operation/Update.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-      <code>! is_array($update) &amp;&amp; ! is_object($update)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($filter) && ! is_object($filter)]]></code>
+      <code><![CDATA[! is_array($update) && ! is_object($update)]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;options['writeConcern']</code>
+    <MixedArgument>
+      <code><![CDATA[$this->options['writeConcern']]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment>
       <code>$cmd['bypassDocumentValidation']</code>
       <code>$cmd['writeConcern']</code>
       <code>$options[$option]</code>
@@ -779,81 +732,76 @@
       <code>$options['writeConcern']</code>
       <code>$updateOptions[$option]</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
-      <code>isDefault</code>
+    <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/UpdateMany.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($update) &amp;&amp; ! is_object($update)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($update) && ! is_object($update)]]></code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Operation/UpdateOne.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($update) &amp;&amp; ! is_object($update)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($update) && ! is_object($update)]]></code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Operation/Watch.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>isset($resumeToken) &amp;&amp; ! is_array($resumeToken) &amp;&amp; ! is_object($resumeToken)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[isset($resumeToken) && ! is_array($resumeToken) && ! is_object($resumeToken)]]></code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
-      <code>$reply-&gt;cursor-&gt;firstBatch</code>
+    <MixedArgument>
+      <code><![CDATA[$reply->cursor->firstBatch]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$this-&gt;postBatchResumeToken</code>
+    <MixedAssignment>
+      <code><![CDATA[$this->postBatchResumeToken]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array|object|null</code>
     </MixedInferredReturnType>
-    <MixedPropertyFetch occurrences="2">
-      <code>$reply-&gt;cursor-&gt;firstBatch</code>
-      <code>$reply-&gt;cursor-&gt;postBatchResumeToken</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$reply->cursor->firstBatch]]></code>
+      <code><![CDATA[$reply->cursor->postBatchResumeToken]]></code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;changeStreamOptions['resumeAfter']</code>
-      <code>$this-&gt;changeStreamOptions['startAfter']</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->changeStreamOptions['resumeAfter']]]></code>
+      <code><![CDATA[$this->changeStreamOptions['startAfter']]]></code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>$firstBatchSize</code>
       <code>$operationTime</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>$resumeToken === null &amp;&amp; $this-&gt;operationTime !== null</code>
-      <code>$this-&gt;operationTime !== null</code>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$resumeToken === null && $this->operationTime !== null]]></code>
+      <code><![CDATA[$this->operationTime !== null]]></code>
     </RedundantConditionGivenDocblockType>
-    <UnusedFunctionCall occurrences="2">
-      <code>addSubscriber</code>
-      <code>removeSubscriber</code>
-    </UnusedFunctionCall>
   </file>
   <file src="src/UpdateResult.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$id</code>
     </MixedAssignment>
   </file>
   <file src="src/functions.php">
-    <DocblockTypeContradiction occurrences="4">
-      <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[! is_array($document) && ! is_object($document)]]></code>
       <code>is_array($document)</code>
       <code>is_array($document)</code>
       <code>is_array($out)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$wireVersionForWriteStageOnSecondary</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$manager-&gt;getServers()</code>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$manager->getServers()]]></code>
     </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess>
       <code>$collectionInfo['options']['encryptedFields']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="2">
+    <MixedArrayAssignment>
       <code>$typeMap['fieldPaths'][$fieldPath]</code>
       <code>$typeMap['fieldPaths'][substr($fieldPath, 0, -2)]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment>
       <code>$element[$key]</code>
       <code>$lastOp</code>
       <code>$type</code>
@@ -862,16 +810,18 @@
       <code>$typeMap['fieldPaths'][$fieldPath]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="3">
+    <MixedInferredReturnType>
       <code>array|object</code>
       <code>array|object|null</code>
       <code>array|object|null</code>
     </MixedInferredReturnType>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$type</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
+    <MixedReturnStatement>
       <code>$collectionInfo['options']['encryptedFields'] ?? null</code>
+      <code>$collectionInfo['options']['encryptedFields'] ?? null</code>
+      <code>$encryptedFieldsMap[$databaseName . '.' . $collectionName] ?? null</code>
       <code>$encryptedFieldsMap[$databaseName . '.' . $collectionName] ?? null</code>
       <code>toPHP(fromPHP($document), $typeMap)</code>
     </MixedReturnStatement>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="1"
     errorBaseline="psalm-baseline.xml"
+    findUnusedBaselineEntry="false"
+    findUnusedCode="false"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/Model/BSONArray.php
+++ b/src/Model/BSONArray.php
@@ -85,6 +85,7 @@ class BSONArray extends ArrayObject implements JsonSerializable, Serializable, U
     #[ReturnTypeWillChange]
     public function bsonUnserialize(array $data)
     {
+        /** @psalm-suppress DirectConstructorCall */
         self::__construct($data);
     }
 

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -74,9 +74,7 @@ class IndexInput implements Serializable
         $this->index = $index;
     }
 
-    /**
-     * Return the index name.
-     */
+    /** Return the index name. */
     public function __toString(): string
     {
         return $this->index['name'];

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -230,7 +230,7 @@ class Aggregate implements Executable, Explainable
             unset($options['writeConcern']);
         }
 
-        $this->isExplain = ! empty($options['explain']);
+        $this->isExplain = $options['explain'] ?? false;
         $this->isWrite = is_last_pipeline_operator_write($pipeline) && ! $this->isExplain;
 
         // Explain does not use a cursor


### PR DESCRIPTION
PHPLIB-1113

This is necessary to better support array/object shapes for the codec pull request, and is necessary to get updated stub maps when we add stubs for new BSON classes to the map for ext-mongodb.

I have fixed the easy-to-fix errors, and a number of template errors (mostly relating to iterators) have been added to the baseline. The additional config values for `findUnusedBaselineEntry` and `findUnusedCode` are set to the current default value (`false`) in anticipation of those defaults changing to `true` in psalm 6. All of these issues can be revisited separately at a later date.