### PR TITLE
PHPLIB-1116: Add tests for runCommand spec

### DIFF
--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -683,10 +683,16 @@ final class Operation
                 assertArrayHasKey('command', $args);
                 assertInstanceOf(stdClass::class, $args['command']);
 
-                return $database->command(
-                    $args['command'],
-                    array_diff_key($args, ['command' => 1])
-                )->toArray()[0];
+                // Note: commandName is not used by PHP
+                $options = array_diff_key($args, ['command' => 1, 'commandName' => 1]);
+
+                /* runCommand spec tests may execute commands that return a
+                 * cursor (e.g. aggregate). PHPC creates a cursor automatically
+                 * so cannot return the original command result. Existing spec
+                 * tests do not evaluate the result, so we can return null here.
+                 * If that changes down the line, we can use command monitoring
+                 * to capture and return the command result. */
+                return $database->command($args['command'], $options)->toArray()[0] ?? null;
 
             default:
                 Assert::fail('Unsupported database operation: ' . $this->name);

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -168,6 +168,17 @@ class UnifiedSpecTest extends FunctionalTestCase
         return $this->provideTests(__DIR__ . '/load-balancers/*.json');
     }
 
+    /** @dataProvider provideRunCommandTests */
+    public function testRunCommand(UnifiedTestCase $test): void
+    {
+        self::$runner->run($test);
+    }
+
+    public function provideRunCommandTests()
+    {
+        return $this->provideTests(__DIR__ . '/run-command/*.json');
+    }
+
     /** @dataProvider provideSessionsTests */
     public function testSessions(UnifiedTestCase $test): void
     {

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -80,7 +80,7 @@ final class Util
             'listCollections' => ['authorizedCollections', 'filter', 'maxTimeMS', 'session'],
             'modifyCollection' => ['collection', 'changeStreamPreAndPostImages', 'index', 'validator'],
             // Note: commandName is not used by PHP
-            'runCommand' => ['command', 'session', 'commandName'],
+            'runCommand' => ['command', 'commandName', 'readPreference', 'session'],
         ],
         Collection::class => [
             'aggregate' => ['pipeline', 'session', 'useCursor', 'allowDiskUse', 'batchSize', 'bypassDocumentValidation', 'collation', 'comment', 'explain', 'hint', 'let', 'maxAwaitTimeMS', 'maxTimeMS'],

--- a/tests/UnifiedSpecTests/run-command/runCommand.json
+++ b/tests/UnifiedSpecTests/run-command/runCommand.json
@@ -1,0 +1,573 @@
+{
+  "description": "runCommand",
+  "schemaVersion": "1.3",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "db",
+        "client": "client",
+        "databaseName": "db"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "db",
+        "collectionName": "collection"
+      }
+    },
+    {
+      "database": {
+        "id": "dbWithRC",
+        "client": "client",
+        "databaseName": "dbWithRC",
+        "databaseOptions": {
+          "readConcern": {
+            "level": "local"
+          }
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "dbWithWC",
+        "client": "client",
+        "databaseName": "dbWithWC",
+        "databaseOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    },
+    {
+      "session": {
+        "id": "session",
+        "client": "client"
+      }
+    },
+    {
+      "client": {
+        "id": "clientWithStableApi",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "serverApi": {
+          "version": "1",
+          "strict": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "dbWithStableApi",
+        "client": "clientWithStableApi",
+        "databaseName": "dbWithStableApi"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection",
+      "databaseName": "db",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "always attaches $db and implicit lsid to given command and omits default readPreference",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  },
+                  "$readPreference": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "attaches the provided session lsid to given command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "session": "session"
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "attaches the provided $readPreference to given command",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset",
+            "load-balanced",
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "readPreference": {
+              "mode": "nearest"
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$readPreference": {
+                    "mode": "nearest"
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not attach $readPreference to given command on standalone",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "single"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "readPreference": {
+              "mode": "nearest"
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not attach primary $readPreference to given command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "readPreference": {
+              "mode": "primary"
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not inherit readConcern specified at the db level",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "dbWithRC",
+          "arguments": {
+            "commandName": "aggregate",
+            "command": {
+              "aggregate": "collection",
+              "pipeline": [],
+              "cursor": {}
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "$db": "dbWithRC"
+                },
+                "commandName": "aggregate"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not inherit writeConcern specified at the db level",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "dbWithWC",
+          "arguments": {
+            "commandName": "insert",
+            "command": {
+              "insert": "collection",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "$db": "dbWithWC"
+                },
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not retry retryable errors on given command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "ping"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "attaches transaction fields to given command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2",
+          "topologies": [
+            "sharded-replicaset",
+            "load-balanced"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session",
+          "arguments": {
+            "callback": [
+              {
+                "name": "runCommand",
+                "object": "db",
+                "arguments": {
+                  "session": "session",
+                  "commandName": "insert",
+                  "command": {
+                    "insert": "collection",
+                    "documents": [
+                      {
+                        "_id": 2
+                      }
+                    ],
+                    "ordered": true
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "db"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "attaches apiVersion fields to given command when stableApi is configured on the client",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "dbWithStableApi",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "clientWithStableApi",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$db": "dbWithStableApi",
+                  "apiVersion": "1",
+                  "apiStrict": true,
+                  "apiDeprecationErrors": {
+                    "$$unsetOrMatches": false
+                  }
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1116

Opening this PR preemptively as I noticed some test runner changes were necessary to POC https://github.com/mongodb/specifications/pull/1389. This PR will be updated once the spec is merged and we have a final sync commit.