### PR TITLE
PHPLIB-1031: Test mongocryptd is not spawned when shared library is loaded

### DIFF
--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -1050,7 +1050,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             ],
             'extraOptions' => [
                 'mongocryptdBypassSpawn' => true,
-                'mongocryptdURI' => 'mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000',
+                'mongocryptdURI' => 'mongodb://localhost:27021/?serverSelectionTimeoutMS=1000',
                 'mongocryptdSpawnArgs' => ['--pidfilepath=bypass-spawning-mongocryptd.pid', '--port=27021'],
                 'cryptSharedLibRequired' => true,
             ],
@@ -1092,7 +1092,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             ],
             'extraOptions' => [
                 'mongocryptdBypassSpawn' => true,
-                'mongocryptdURI' => 'mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000',
+                'mongocryptdURI' => 'mongodb://localhost:27021/?serverSelectionTimeoutMS=1000',
                 'mongocryptdSpawnArgs' => ['--pidfilepath=bypass-spawning-mongocryptd.pid', '--port=27021'],
             ],
         ];

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -1060,10 +1060,11 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         $clientEncrypted->selectCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
 
-        $clientMongocryptd = static::createTestClient('mongodb://localhost:27021');
+        $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
         $this->expectException(ConnectionTimeoutException::class);
-        $clientMongocryptd->selectDatabase('db')->command(['ping' => 1]);
+        $this->expectExceptionMessage('No suitable servers found');
+        $clientMongocryptd->getManager()->selectServer();
     }
 
     /**
@@ -1137,10 +1138,11 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         $clientEncrypted->selectCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
 
-        $clientMongocryptd = static::createTestClient('mongodb://localhost:27021');
+        $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
         $this->expectException(ConnectionTimeoutException::class);
-        $clientMongocryptd->selectDatabase('db')->command(['ping' => 1]);
+        $this->expectExceptionMessage('No suitable servers found');
+        $clientMongocryptd->getManager()->selectServer();
     }
 
     /**
@@ -1170,10 +1172,11 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         $clientEncrypted->selectCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
 
-        $clientMongocryptd = static::createTestClient('mongodb://localhost:27021');
+        $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
         $this->expectException(ConnectionTimeoutException::class);
-        $clientMongocryptd->selectDatabase('db')->command(['ping' => 1]);
+        $this->expectExceptionMessage('No suitable servers found');
+        $clientMongocryptd->getManager()->selectServer();
     }
 
     /**

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -1030,6 +1030,43 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     }
 
     /**
+     * Prose test 8: Bypass Spawning mongocryptd (via loading shared library)
+     *
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/#via-loading-shared-library
+     */
+    public function testBypassSpawningMongocryptdViaLoadingSharedLibrary(): void
+    {
+        if (! static::isCryptSharedLibAvailable()) {
+            $this->markTestSkipped('Bypass spawning of mongocryptd cannot be tested when crypt_shared is not available');
+        }
+
+        $autoEncryptionOpts = [
+            'keyVaultNamespace' => 'keyvault.datakeys',
+            'kmsProviders' => [
+                'local' => ['key' => new Binary(base64_decode(self::LOCAL_MASTERKEY), 0)],
+            ],
+            'schemaMap' => [
+                'db.coll' => $this->decodeJson(file_get_contents(__DIR__ . '/client-side-encryption/external/external-schema.json')),
+            ],
+            'extraOptions' => [
+                'mongocryptdBypassSpawn' => true,
+                'mongocryptdURI' => 'mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000',
+                'mongocryptdSpawnArgs' => ['--pidfilepath=bypass-spawning-mongocryptd.pid', '--port=27021'],
+                'cryptSharedLibRequired' => true,
+            ],
+        ];
+
+        $clientEncrypted = static::createTestClient(null, [], ['autoEncryption' => $autoEncryptionOpts]);
+
+        $clientEncrypted->selectCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
+
+        $clientMongocryptd = static::createTestClient('mongodb://localhost:27021');
+
+        $this->expectException(ConnectionTimeoutException::class);
+        $clientMongocryptd->selectDatabase('db')->command(['ping' => 1]);
+    }
+
+    /**
      * Prose test 8: Bypass Spawning mongocryptd (via mongocryptdBypassSpawn)
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#via-mongocryptdbypassspawn

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -1063,7 +1063,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
         $this->expectException(ConnectionTimeoutException::class);
-        $this->expectExceptionMessage('No suitable servers found');
+        $this->expectExceptionMessageMatches('#(No suitable servers found)|(No servers yet eligible for rescan)#');
         $clientMongocryptd->getManager()->selectServer();
     }
 
@@ -1141,7 +1141,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
         $this->expectException(ConnectionTimeoutException::class);
-        $this->expectExceptionMessage('No suitable servers found');
+        $this->expectExceptionMessageMatches('#(No suitable servers found)|(No servers yet eligible for rescan)#');
         $clientMongocryptd->getManager()->selectServer();
     }
 
@@ -1175,7 +1175,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
         $this->expectException(ConnectionTimeoutException::class);
-        $this->expectExceptionMessage('No suitable servers found');
+        $this->expectExceptionMessageMatches('#(No suitable servers found)|(No servers yet eligible for rescan)#');
         $clientMongocryptd->getManager()->selectServer();
     }
 


### PR DESCRIPTION
PHPLIB-1031

This is mostly copy-pasta from previous tests, changing the skip condition at the top to only skip the test when crypt_shared isn't available.