### PR TITLE
PHPLIB-693: Remove early returns for failed tests from tearDown methods

### DIFF
--- a/tests/Collection/FunctionalTestCase.php
+++ b/tests/Collection/FunctionalTestCase.php
@@ -24,11 +24,9 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
 
     public function tearDown(): void
     {
-        if ($this->hasFailed()) {
-            return;
+        if (! $this->hasFailed()) {
+            $this->dropCollection();
         }
-
-        $this->dropCollection();
 
         parent::tearDown();
     }

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -40,11 +40,9 @@ class DocumentationExamplesTest extends FunctionalTestCase
 
     public function tearDown(): void
     {
-        if ($this->hasFailed()) {
-            return;
+        if (! $this->hasFailed()) {
+            $this->dropCollection();
         }
-
-        $this->dropCollection();
 
         parent::tearDown();
     }

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -20,11 +20,9 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
 
     public function tearDown(): void
     {
-        if ($this->hasFailed()) {
-            return;
+        if (! $this->hasFailed()) {
+            $this->collection->drop();
         }
-
-        $this->collection->drop();
 
         parent::tearDown();
     }

--- a/tests/Operation/FunctionalTestCase.php
+++ b/tests/Operation/FunctionalTestCase.php
@@ -20,11 +20,9 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
 
     public function tearDown(): void
     {
-        if ($this->hasFailed()) {
-            return;
+        if (! $this->hasFailed()) {
+            $this->dropCollection();
         }
-
-        $this->dropCollection();
 
         parent::tearDown();
     }

--- a/tests/Operation/RenameCollectionFunctionalTest.php
+++ b/tests/Operation/RenameCollectionFunctionalTest.php
@@ -31,12 +31,10 @@ class RenameCollectionFunctionalTest extends FunctionalTestCase
 
     public function tearDown(): void
     {
-        if ($this->hasFailed()) {
-            return;
+        if (! $this->hasFailed()) {
+            $operation = new DropCollection($this->getDatabaseName(), $this->toCollectionName);
+            $operation->execute($this->getPrimaryServer());
         }
-
-        $operation = new DropCollection($this->getDatabaseName(), $this->toCollectionName);
-        $operation->execute($this->getPrimaryServer());
 
         parent::tearDown();
     }


### PR DESCRIPTION
Fix [PHPLIB-693](https://jira.mongodb.org/browse/PHPLIB-693)

Ensure `parent::tearDown` is always called. The call to `disableFailPoints` in `FunctionalTestCase::tearDown` was not necessary since fail points are not used in the modified test classes.