### PR TITLE
PHPLIB-1056 Improve type coverage on option arrays

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -196,8 +196,8 @@ class Client
      * Drop a database.
      *
      * @see DropDatabase::__construct() for supported options
-     * @param string $databaseName Database name
-     * @param array  $options      Additional options
+     * @param string                                              $databaseName Database name
+     * @param array{session?: Session, typeMap?: array, writeConcern?: WriteConcern} $options      Additional options
      * @return array|object Command result document
      * @throws UnsupportedException if options are unsupported on the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
@@ -276,6 +276,7 @@ class Client
      * List database names.
      *
      * @see ListDatabaseNames::__construct() for supported options
+     * @param array{authorizedDatabases?: bool, comment?: mixed, filter?: array|object, maxTimeMS?: int, session?: Session} $options Command options
      * @throws UnexpectedValueException if the command response was malformed
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -67,7 +67,7 @@ class ListDatabases implements Executable
      *
      *  * session (MongoDB\Driver\Session): Client session.
      *
-     * @param array $options Command options
+     * @param array{authorizedDatabases?: bool, comment?:mixed, filter?: array|object, maxTimeMS?: int, nameOnly?: bool, session?: Session} $options Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct(array $options = [])

--- a/src/Database.php
+++ b/src/Database.php
@@ -24,6 +24,7 @@ use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\CreateEncryptedCollectionException;
 use MongoDB\Exception\InvalidArgumentException;
@@ -239,8 +240,8 @@ class Database
      * Execute a command on this database.
      *
      * @see DatabaseCommand::__construct() for supported options
-     * @param array|object $command Command document
-     * @param array        $options Options for command execution
+     * @param array|object                                                               $command Command document
+     * @param array{readPreference?: ReadPreference, session?: Session, typeMap?: array} $options Options for command execution
      * @return Cursor
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
@@ -558,8 +559,8 @@ class Database
      * Select a collection within this database.
      *
      * @see Collection::__construct() for supported options
-     * @param string $collectionName Name of the collection to select
-     * @param array  $options        Collection constructor options
+     * @param string                                                                                                          $collectionName Name of the collection to select
+     * @param array{readConcern?: ReadConcern, readPreference?: ReadPreference, typeMap?: array, writeConcern?: WriteConcern} $options        Collection constructor options
      * @return Collection
      * @throws InvalidArgumentException for parameter/option parsing errors
      */

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -64,8 +64,8 @@ class BSONIterator implements Iterator
      *
      * @internal
      * @see https://php.net/manual/en/function.mongodb.bson-tophp.php
-     * @param string $data    Concatenated, valid, BSON-encoded documents
-     * @param array  $options Iterator options
+     * @param string                 $data    Concatenated, valid, BSON-encoded documents
+     * @param array{typeMap?: array} $options Iterator options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct(string $data, array $options = [])

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -130,10 +130,10 @@ class Aggregate implements Executable, Explainable
      * Note: Collection-agnostic commands (e.g. $currentOp) may be executed by
      * specifying null for the collection name.
      *
-     * @param string      $databaseName   Database name
-     * @param string|null $collectionName Collection name
-     * @param array       $pipeline       List of pipeline operations
-     * @param array       $options        Command options
+     * @param string                                                                                                                                                                                                                                                                                                                                                   $databaseName   Database name
+     * @param string|null                                                                                                                                                                                                                                                                                                                                              $collectionName Collection name
+     * @param array                                                                                                                                                                                                                                                                                                                                                    $pipeline       List of pipeline operations
+     * @param array{ allowDiskUse?: bool, batchSize?: int, bypassDocumentValidation?: bool, collation?: array|object, comment?: mixed, explain?: bool, hint?: array|object|string, let?: array|object, maxTimeMS?: int, readConcern?: ReadConcern, readPreference?: ReadPreference, session?: Session, typeMap?: array, useCursor?: bool, writeConcern?: WriteConcern} $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct(string $databaseName, ?string $collectionName, array $pipeline, array $options = [])

--- a/src/Operation/ListDatabaseNames.php
+++ b/src/Operation/ListDatabaseNames.php
@@ -22,6 +22,7 @@ use Iterator;
 use MongoDB\Command\ListDatabases as ListDatabasesCommand;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
+use MongoDB\Driver\Session;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
 
@@ -60,7 +61,7 @@ class ListDatabaseNames implements Executable
      *
      *  * session (MongoDB\Driver\Session): Client session.
      *
-     * @param array $options Command options
+     * @param array{authorizedDatabases?: bool, comment?: mixed, filter?: array|object, maxTimeMS?: int, session?: Session} $options Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct(array $options = [])

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -58,7 +58,7 @@ class ListDatabases implements Executable
      *
      *  * session (MongoDB\Driver\Session): Client session.
      *
-     * @param array $options Command options
+     * @param array{authorizedDatabases?: bool, comment?: mixed, filter?: array|object, maxTimeMS?: int} $options Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct(array $options = [])


### PR DESCRIPTION
Fix [PHPLIB-1056](https://jira.mongodb.org/browse/PHPLIB-1056)

I think I'm going a bit to far by documenting array shapes. This is very useful for code completion. This is very verbose and contagious, and leads to new phpstan errors like this:

```
ERROR: DocblockTypeContradiction - src/Operation/Aggregate.php:209:15 - Docblock-defined type bool for $options['useCursor'] is always bool (see https://psalm.dev/155)
        if (! is_bool($options['useCursor'])) {
```
