### PR TITLE
PHPLIB-1056: Add missing types in reference doc

### DIFF
--- a/docs/reference/method/MongoDBCollection-count.txt
+++ b/docs/reference/method/MongoDBCollection-count.txt
@@ -21,7 +21,7 @@ Definition
 
    .. code-block:: php
 
-      function count($filter = [], array $options = []): integer
+      function count(array|object $filter = [], array $options = []): integer
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-countDocuments.txt
+++ b/docs/reference/method/MongoDBCollection-countDocuments.txt
@@ -21,7 +21,7 @@ Definition
 
    .. code-block:: php
 
-      function countDocuments($filter = [], array $options = []): integer
+      function countDocuments(array|object $filter = [], array $options = []): integer
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-createIndex.txt
+++ b/docs/reference/method/MongoDBCollection-createIndex.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function createIndex($key, array $options = []): string
+      function createIndex(array|object $key, array $options = []): string
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-deleteMany.txt
+++ b/docs/reference/method/MongoDBCollection-deleteMany.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function deleteMany($filter, array $options = []): MongoDB\DeleteResult
+      function deleteMany(array|object $filter, array $options = []): MongoDB\DeleteResult
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-deleteOne.txt
+++ b/docs/reference/method/MongoDBCollection-deleteOne.txt
@@ -21,7 +21,7 @@ Definition
 
    .. code-block:: php
 
-      function deleteOne($filter, array $options = []): MongoDB\DeleteResult
+      function deleteOne(array|object $filter, array $options = []): MongoDB\DeleteResult
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-distinct.txt
+++ b/docs/reference/method/MongoDBCollection-distinct.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function distinct(string $fieldName, $filter = [], array $options = []): mixed[]
+      function distinct(string $fieldName, array|object $filter = [], array $options = []): mixed[]
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-dropIndex.txt
+++ b/docs/reference/method/MongoDBCollection-dropIndex.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function dropIndex(string|\MongoDB\Model\IndexInfo $indexName, array $options = []): array|object
+      function dropIndex(string|MongoDB\Model\IndexInfo $indexName, array $options = []): array|object
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-dropIndex.txt
+++ b/docs/reference/method/MongoDBCollection-dropIndex.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function dropIndex($indexName, array $options = []): array|object
+      function dropIndex(string|\MongoDB\Model\IndexInfo $indexName, array $options = []): array|object
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-find.txt
+++ b/docs/reference/method/MongoDBCollection-find.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function find($filter = [], array $options = []): MongoDB\Driver\Cursor
+      function find(array|object $filter = [], array $options = []): MongoDB\Driver\Cursor
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-findOne.txt
+++ b/docs/reference/method/MongoDBCollection-findOne.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function findOne($filter = [], array $options = []): array|object|null
+      function findOne(array|object $filter = [], array $options = []): array|object|null
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-findOneAndDelete.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndDelete.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function findOneAndDelete($filter = [], array $options = []): object|null
+      function findOneAndDelete(array|object $filter = [], array $options = []): object|null
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-findOneAndReplace.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndReplace.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function findOneAndReplace($filter, $replacement, array $options = []): object|null
+      function findOneAndReplace(array|object $filter, array|object $replacement, array $options = []): object|null
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-findOneAndUpdate.txt
+++ b/docs/reference/method/MongoDBCollection-findOneAndUpdate.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function findOneAndUpdate($filter, $update, array $options = []): object|null
+      function findOneAndUpdate(array|object $filter, array|object $update, array $options = []): object|null
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-insertOne.txt
+++ b/docs/reference/method/MongoDBCollection-insertOne.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function insertOne($document, array $options = []): MongoDB\InsertOneResult
+      function insertOne(array|object $document, array $options = []): MongoDB\InsertOneResult
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-mapReduce.txt
+++ b/docs/reference/method/MongoDBCollection-mapReduce.txt
@@ -24,7 +24,7 @@ Definition
 
    .. code-block:: php
 
-      function mapReduce($map, $reduce, $out, array $options = []): MongoDB\MapReduceResult
+      function mapReduce(MongoDB\BSON\JavascriptInterface $map, MongoDB\BSON\JavascriptInterface $reduce, string|array|object $out, array $options = []): MongoDB\MapReduceResult
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-replaceOne.txt
+++ b/docs/reference/method/MongoDBCollection-replaceOne.txt
@@ -21,7 +21,7 @@ Definition
 
    .. code-block:: php
 
-      function replaceOne($filter, $replacement, array $options = []): MongoDB\UpdateResult
+      function replaceOne(array|object $filter, array|object $replacement, array $options = []): MongoDB\UpdateResult
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-updateMany.txt
+++ b/docs/reference/method/MongoDBCollection-updateMany.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function updateMany($filter, $update, array $options = []): MongoDB\UpdateResult
+      function updateMany(array|object $filter, array|object $update, array $options = []): MongoDB\UpdateResult
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBCollection-updateOne.txt
+++ b/docs/reference/method/MongoDBCollection-updateOne.txt
@@ -21,7 +21,7 @@ Definition
 
    .. code-block:: php
 
-      function updateOne($filter, $update, array $options = []): MongoDB\UpdateResult
+      function updateOne(array|object $filter, array|object $update, array $options = []): MongoDB\UpdateResult
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBDatabase-command.txt
+++ b/docs/reference/method/MongoDBDatabase-command.txt
@@ -21,7 +21,7 @@ Definition
 
    .. code-block:: php
 
-      function command($command, array $options = []): MongoDB\Driver\Cursor
+      function command(array|object $command, array $options = []): MongoDB\Driver\Cursor
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBDatabase-createCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-createCollection.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function createCollection($collectionName, array $options = []): array|object
+      function createCollection(string $collectionName, array $options = []): array|object
 
    MongoDB creates collections implicitly when you first reference the
    collection in a command, such as when inserting a document into a new

--- a/docs/reference/method/MongoDBDatabase-dropCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-dropCollection.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function dropCollection($collectionName, array $options = []): array|object
+      function dropCollection(string $collectionName, array $options = []): array|object
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBDatabase-modifyCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-modifyCollection.txt
@@ -22,7 +22,7 @@ Definition
 
    .. code-block:: php
 
-      function modifyCollection($collectionName, array $collectionOptions, array $options = []): array|object
+      function modifyCollection(string $collectionName, array $collectionOptions, array $options = []): array|object
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBDatabase-selectCollection.txt
+++ b/docs/reference/method/MongoDBDatabase-selectCollection.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function selectCollection($collectionName, array $options = []): MongoDB\Collection
+      function selectCollection(string $collectionName, array $options = []): MongoDB\Collection
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBDatabase__get.txt
+++ b/docs/reference/method/MongoDBDatabase__get.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function __get($collectionName): MongoDB\Collection
+      function __get(string $collectionName): MongoDB\Collection
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBGridFSBucket-downloadToStreamByName.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-downloadToStreamByName.txt
@@ -20,7 +20,7 @@ Definition
 
    .. code-block:: php
 
-      function downloadToStreamByName(string $filename, $destination, array $options = []): void
+      function downloadToStreamByName(string $filename, resource $destination, array $options = []): void
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBGridFSBucket-find.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-find.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function find($filter = [], array $options = []): MongoDB\Driver\Cursor
+      function find(array|object $filter = [], array $options = []): MongoDB\Driver\Cursor
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBGridFSBucket-findOne.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-findOne.txt
@@ -20,7 +20,7 @@ Definition
 
    .. code-block:: php
 
-      function findOne($filter = [], array $options = []): array|object|null
+      function findOne(array|object $filter = [], array $options = []): array|object|null
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBGridFSBucket-getFileDocumentForStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getFileDocumentForStream.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function getFileDocumentForStream($stream): array|object
+      function getFileDocumentForStream(resource $stream): array|object
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBGridFSBucket-getFileIdForStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-getFileIdForStream.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function getFileIdForStream($stream): mixed
+      function getFileIdForStream(resource $stream): mixed
 
    This method has the following parameters:
 

--- a/docs/reference/method/MongoDBGridFSBucket-uploadFromStream.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-uploadFromStream.txt
@@ -19,7 +19,7 @@ Definition
 
    .. code-block:: php
 
-      function uploadFromStream(string $filename, $source, array $options = []): mixed
+      function uploadFromStream(string $filename, resource $source, array $options = []): mixed
 
    This method has the following parameters:
 


### PR DESCRIPTION
Fix [PHPLIB-1056](https://jira.mongodb.org/browse/PHPLIB-1056)

I checked all the methods to make sure that all the arguments have a defined. I used the syntax of the latest PHP versions but that's not a problem for the doc.