### PR TITLE
PHPLIB-1122: Support Document and PackedArray objects in public APIs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "ext-json": "*",
         "ext-mongodb": "^1.16.0",
         "jean85/pretty-package-versions": "^2.0.1",
-        "symfony/polyfill-php80": "^1.19"
+        "symfony/polyfill-php73": "^1.27",
+        "symfony/polyfill-php80": "^1.27"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,37 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
-  <file src="examples/aggregate.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="examples/bulk.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="examples/changestream.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="examples/command_logger.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
   <file src="examples/typemap.php">
     <PropertyNotSetInConstructor occurrences="5">
       <code>$address</code>
@@ -41,30 +9,12 @@
       <code>$type</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="examples/with_transaction.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>toRelaxedExtendedJSON(fromPHP($document))</code>
-    </MixedReturnStatement>
-  </file>
   <file src="src/Client.php">
     <MixedArgument occurrences="1">
       <code>$driverOptions['driver'] ?? []</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$mergedDriver['platform']</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Collection.php">
-    <MixedArgument occurrences="3">
-      <code>$encryptedFields['eccCollection'] ?? 'enxcol_.' . $this-&gt;collectionName . '.ecc'</code>
-      <code>$encryptedFields['ecocCollection'] ?? 'enxcol_.' . $this-&gt;collectionName . '.ecoc'</code>
-      <code>$encryptedFields['escCollection'] ?? 'enxcol_.' . $this-&gt;collectionName . '.esc'</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$encryptedFields</code>
     </MixedAssignment>
   </file>
   <file src="src/Command/ListCollections.php">
@@ -77,21 +27,6 @@
     <MixedAssignment occurrences="2">
       <code>$cmd[$option]</code>
       <code>$options['session']</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Database.php">
-    <MixedArgument occurrences="6">
-      <code>$encryptedFields['eccCollection'] ?? 'enxcol_.' . $collectionName . '.ecc'</code>
-      <code>$encryptedFields['eccCollection'] ?? 'enxcol_.' . $collectionName . '.ecc'</code>
-      <code>$encryptedFields['ecocCollection'] ?? 'enxcol_.' . $collectionName . '.ecoc'</code>
-      <code>$encryptedFields['ecocCollection'] ?? 'enxcol_.' . $collectionName . '.ecoc'</code>
-      <code>$encryptedFields['escCollection'] ?? 'enxcol_.' . $collectionName . '.esc'</code>
-      <code>$encryptedFields['escCollection'] ?? 'enxcol_.' . $collectionName . '.esc'</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="3">
-      <code>$encryptedFields</code>
-      <code>$encryptedFields</code>
-      <code>$options['encryptedFields']</code>
     </MixedAssignment>
   </file>
   <file src="src/Exception/BadMethodCallException.php">
@@ -139,14 +74,10 @@
       <code>drop</code>
       <code>rename</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$id</code>
+    <MixedArgument occurrences="2">
       <code>$options['revision']</code>
       <code>$options['revision']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$id</code>
-    </MixedAssignment>
   </file>
   <file src="src/GridFS/Exception/CorruptFileException.php">
     <UnsafeInstantiation occurrences="4">
@@ -157,24 +88,12 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Exception/FileNotFoundException.php">
-    <MixedArgument occurrences="1">
-      <code>$json</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$json</code>
-    </MixedAssignment>
     <UnsafeInstantiation occurrences="2">
       <code>new static(sprintf('File "%s" not found in "%s"', $json, $namespace))</code>
       <code>new static(sprintf('File with name "%s" and revision "%d" not found in "%s"', $filename, $revision, $namespace))</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/GridFS/Exception/StreamException.php">
-    <MixedArgument occurrences="1">
-      <code>$idString</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$idString</code>
-    </MixedAssignment>
     <UnsafeInstantiation occurrences="3">
       <code>new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS filename: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $filename))</code>
       <code>new static(sprintf('Downloading file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString))</code>
@@ -384,13 +303,14 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_array($operation)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="11">
+    <MixedArgument occurrences="12">
       <code>$args</code>
       <code>$args</code>
       <code>$args</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
+      <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -629,10 +549,9 @@
       <code>$this-&gt;options['typeMap']</code>
       <code>$this-&gt;options['writeConcern']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$cmd[$option]</code>
       <code>$cmd['new']</code>
-      <code>$cmd['update']</code>
       <code>$cmd['upsert']</code>
       <code>$options['session']</code>
       <code>$options['writeConcern']</code>
@@ -834,11 +753,9 @@
     </MixedAssignment>
   </file>
   <file src="src/functions.php">
-    <DocblockTypeContradiction occurrences="4">
+    <DocblockTypeContradiction occurrences="2">
       <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
       <code>is_array($document)</code>
-      <code>is_array($document)</code>
-      <code>is_array($out)</code>
     </DocblockTypeContradiction>
     <MixedArgument occurrences="1">
       <code>$wireVersionForWriteStageOnSecondary</code>
@@ -853,9 +770,8 @@
       <code>$typeMap['fieldPaths'][$fieldPath]</code>
       <code>$typeMap['fieldPaths'][substr($fieldPath, 0, -2)]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment occurrences="6">
       <code>$element[$key]</code>
-      <code>$lastOp</code>
       <code>$type</code>
       <code>$type</code>
       <code>$typeMap['fieldPaths'][$fieldPath . '.' . $existingFieldPath]</code>

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -32,6 +32,7 @@ use function is_bool;
 use function is_integer;
 use function is_object;
 use function is_string;
+use function MongoDB\document_to_array;
 use function trigger_error;
 
 use const E_USER_DEPRECATED;
@@ -427,7 +428,7 @@ class Find implements Executable, Explainable
             }
         }
 
-        $modifiers = empty($this->options['modifiers']) ? [] : (array) $this->options['modifiers'];
+        $modifiers = empty($this->options['modifiers']) ? [] : document_to_array($this->options['modifiers']);
 
         if (! empty($modifiers)) {
             $options['modifiers'] = $modifiers;

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -429,7 +429,7 @@ class Find implements Executable, Explainable
         }
 
         if (! empty($this->options['modifiers'])) {
-            /** @var array|object */
+            /** @psalm-var array|object */
             $modifiers = $this->options['modifiers'];
             $options['modifiers'] = is_object($modifiers) ? document_to_array($modifiers) : $modifiers;
         }

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -428,10 +428,10 @@ class Find implements Executable, Explainable
             }
         }
 
-        $modifiers = empty($this->options['modifiers']) ? [] : document_to_array($this->options['modifiers']);
-
-        if (! empty($modifiers)) {
-            $options['modifiers'] = $modifiers;
+        if (! empty($this->options['modifiers'])) {
+            /** @var array|object */
+            $modifiers = $this->options['modifiers'];
+            $options['modifiers'] = is_object($modifiers) ? document_to_array($modifiers) : $modifiers;
         }
 
         return $options;

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -293,9 +293,9 @@ class FindAndModify implements Executable, Explainable
         }
 
         if (isset($this->options['update'])) {
-            $cmd['update'] = is_pipeline($this->options['update'])
-                ? $this->options['update']
-                : (object) $this->options['update'];
+            /** @var array|object */
+            $update = $this->options['update'];
+            $cmd['update'] = is_pipeline($update) ? $update : (object) $update;
         }
 
         foreach (['arrayFilters', 'bypassDocumentValidation', 'comment', 'hint', 'maxTimeMS'] as $option) {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -293,7 +293,7 @@ class FindAndModify implements Executable, Explainable
         }
 
         if (isset($this->options['update'])) {
-            /** @var array|object */
+            /** @psalm-var array|object */
             $update = $this->options['update'];
             $cmd['update'] = is_pipeline($update) ? $update : (object) $update;
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -115,6 +115,7 @@ function document_to_array($document): array
         /* Nested documents and arrays are intentionally left as BSON. We avoid
          * iterator_to_array() since Document and PackedArray iteration returns
          * all values as MongoDB\BSON\Value instances. */
+        /** @var array */
         return $document->toPHP([
             'array' => 'bson',
             'document' => 'bson',
@@ -248,6 +249,7 @@ function is_pipeline($pipeline): bool
         /* Nested documents and arrays are intentionally left as BSON. We avoid
          * iterator_to_array() since Document iteration returns all values as
          * MongoDB\BSON\Value instances. */
+        /** @var array */
         $pipeline = $pipeline->toPHP([
             'array' => 'bson',
             'document' => 'bson',

--- a/src/functions.php
+++ b/src/functions.php
@@ -101,11 +101,9 @@ function apply_type_map_to_document($document, array $typeMap)
  * This is used to facilitate unified access to document fields. It also handles
  * Document, PackedArray, and Serializable objects.
  *
- * PackedArray is intentionally allowed because this function is not used for
- * type checking. Prohibiting PackedArray would only require callers to check
- * for a PackedArray in order to avoid an exception. Furthermore, this function
- * does not distinguish between Serializable::bsonSerialize() return values that
- * might encode as a BSON document or array.
+ * This function is not used for type checking. Therefore, it does not reject
+ * PackedArray objects or Serializable::bsonSerialize() return values that would
+ * encode as BSON arrays.
  *
  * @internal
  * @param array|object $document
@@ -127,6 +125,9 @@ function document_to_array($document): array
     }
 
     if (is_object($document)) {
+        /* Note: this omits all uninitialized properties, whereas BSON encoding
+         * includes untyped, uninitialized properties. This is acceptable given
+         * document_to_array()'s use cases. */
         $document = get_object_vars($document);
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -121,9 +121,7 @@ function document_to_array($document): array
             'document' => 'bson',
             'root' => 'array',
         ]);
-    }
-
-    if ($document instanceof Serializable) {
+    } elseif ($document instanceof Serializable) {
         $document = $document->bsonSerialize();
     }
 
@@ -244,9 +242,7 @@ function is_pipeline($pipeline): bool
             'document' => 'bson',
             'root' => 'array',
         ]);
-    }
-
-    if ($pipeline instanceof Serializable) {
+    } elseif ($pipeline instanceof Serializable) {
         $pipeline = $pipeline->bsonSerialize();
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -228,7 +228,7 @@ function is_first_key_operator($document): bool
         return false;
     }
 
-    return '$' === $firstKey[0] ?? null;
+    return '$' === ($firstKey[0] ?? null);
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -115,7 +115,8 @@ function document_to_array($document): array
         /* Nested documents and arrays are intentionally left as BSON. We avoid
          * iterator_to_array() since Document and PackedArray iteration returns
          * all values as MongoDB\BSON\Value instances. */
-        /** @var array */
+
+        /** @psalm-var array */
         return $document->toPHP([
             'array' => 'bson',
             'document' => 'bson',
@@ -249,7 +250,7 @@ function is_pipeline($pipeline): bool
         /* Nested documents and arrays are intentionally left as BSON. We avoid
          * iterator_to_array() since Document iteration returns all values as
          * MongoDB\BSON\Value instances. */
-        /** @var array */
+        /** @psalm-var array */
         $pipeline = $pipeline->toPHP([
             'array' => 'bson',
             'document' => 'bson',

--- a/src/functions.php
+++ b/src/functions.php
@@ -234,8 +234,13 @@ function is_first_key_operator($document): bool
 /**
  * Returns whether an update specification is a valid aggregation pipeline.
  *
+ * Note: this method may propagate an InvalidArgumentException from
+ * document_or_array() if a Serializable object within the pipeline array
+ * returns a non-array, non-object value from its bsonSerialize() method.
+ *
  * @internal
- * @param mixed $pipeline
+ * @param array|object $pipeline
+ * @throws InvalidArgumentException
  */
 function is_pipeline($pipeline): bool
 {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -155,6 +155,10 @@ class FunctionsTest extends TestCase
     {
         $this->assertFalse(is_first_key_operator($cast(['y' => 1])));
         $this->assertTrue(is_first_key_operator($cast(['$set' => ['y' => 1]])));
+
+        // Empty and packed arrays are unlikely arguments, but still valid
+        $this->assertFalse(is_first_key_operator($cast([])));
+        $this->assertFalse(is_first_key_operator($cast(['foo'])));
     }
 
     /** @dataProvider provideInvalidDocumentValues */

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -2,6 +2,8 @@
 
 namespace MongoDB\Tests;
 
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
@@ -9,8 +11,10 @@ use MongoDB\Model\BSONDocument;
 
 use function MongoDB\apply_type_map_to_document;
 use function MongoDB\create_field_path_type_map;
+use function MongoDB\document_to_array;
 use function MongoDB\generate_index_name;
 use function MongoDB\is_first_key_operator;
+use function MongoDB\is_last_pipeline_operator_write;
 use function MongoDB\is_mapreduce_output_inline;
 use function MongoDB\is_pipeline;
 use function MongoDB\is_write_concern_acknowledged;
@@ -90,21 +94,53 @@ class FunctionsTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideIndexSpecificationDocumentsAndGeneratedNames */
-    public function testGenerateIndexName($document, $expectedName): void
+    /** @dataProvider provideDocumentsAndExpectedArrays */
+    public function testDocumentToArray($document, array $expectedArray): void
     {
-        $this->assertSame($expectedName, generate_index_name($document));
+        $this->assertSame($expectedArray, document_to_array($document));
     }
 
-    public function provideIndexSpecificationDocumentsAndGeneratedNames()
+    public function provideDocumentsAndExpectedArrays(): array
     {
         return [
-            [ ['x' => 1], 'x_1' ],
-            [ ['x' => -1, 'y' => 1], 'x_-1_y_1' ],
-            [ ['x' => '2dsphere', 'y' => 1 ], 'x_2dsphere_y_1' ],
-            [ (object) ['x' => 1], 'x_1' ],
-            [ new BSONDocument(['x' => 1]), 'x_1' ],
+            'array' => [['x' => 1], ['x' => 1]],
+            'object' => [(object) ['x' => 1], ['x' => 1]],
+            'Serializable' => [new BSONDocument(['x' => 1]), ['x' => 1]],
+            'Document' => [Document::fromPHP(['x' => 1]), ['x' => 1]],
+            // PackedArray and array-returning Serializable are both allowed
+            'PackedArray' => [PackedArray::fromPHP(['foo']), [0 => 'foo']],
+            'Serializable:array' => [new BSONArray(['foo']), [0 => 'foo']],
         ];
+    }
+
+    /** @dataProvider provideInvalidDocumentValues */
+    public function testDocumentToArrayArgumentTypeCheck($document): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected $document to have type "array or object"');
+        document_to_array($document);
+    }
+
+    /** @dataProvider provideDocumentCasts */
+    public function testGenerateIndexName($cast): void
+    {
+        $this->assertSame('x_1', generate_index_name($cast(['x' => 1])));
+        $this->assertSame('x_-1_y_1', generate_index_name($cast(['x' => -1, 'y' => 1])));
+        $this->assertSame('x_2dsphere_y_1', generate_index_name($cast(['x' => '2dsphere', 'y' => 1])));
+    }
+
+    public function provideDocumentCasts(): array
+    {
+        // phpcs:disable SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing
+        // phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration
+        // phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
+        return [
+            'array' => [function ($value) { return $value; }],
+            'object' => [function ($value) { return (object) $value; }],
+            'Serializable' => [function ($value) { return new BSONDocument($value); }],
+            'Document' => [function ($value) { return Document::fromPHP($value); }],
+        ];
+        // phpcs:enable
     }
 
     /** @dataProvider provideInvalidDocumentValues */
@@ -114,22 +150,11 @@ class FunctionsTest extends TestCase
         generate_index_name($document);
     }
 
-    /** @dataProvider provideIsFirstKeyOperatorDocuments */
-    public function testIsFirstKeyOperator($document, $isFirstKeyOperator): void
+    /** @dataProvider provideDocumentCasts */
+    public function testIsFirstKeyOperator(callable $cast): void
     {
-        $this->assertSame($isFirstKeyOperator, is_first_key_operator($document));
-    }
-
-    public function provideIsFirstKeyOperatorDocuments()
-    {
-        return [
-            [ ['y' => 1], false ],
-            [ (object) ['y' => 1], false ],
-            [ new BSONDocument(['y' => 1]), false ],
-            [ ['$set' => ['y' => 1]], true ],
-            [ (object) ['$set' => ['y' => 1]], true ],
-            [ new BSONDocument(['$set' => ['y' => 1]]), true ],
-        ];
+        $this->assertFalse(is_first_key_operator($cast(['y' => 1])));
+        $this->assertTrue(is_first_key_operator($cast(['$set' => ['y' => 1]])));
     }
 
     /** @dataProvider provideInvalidDocumentValues */
@@ -139,20 +164,18 @@ class FunctionsTest extends TestCase
         is_first_key_operator($document);
     }
 
-    /** @dataProvider provideMapReduceOutValues */
-    public function testIsMapReduceOutputInline($out, $isInline): void
+    /** @dataProvider provideDocumentCasts */
+    public function testIsMapReduceOutputInlineWithDocumentValues(callable $cast): void
     {
-        $this->assertSame($isInline, is_mapreduce_output_inline($out));
+        $this->assertTrue(is_mapreduce_output_inline($cast(['inline' => 1])));
+        // Note: only the key is significant
+        $this->assertTrue(is_mapreduce_output_inline($cast(['inline' => 0])));
+        $this->assertFalse(is_mapreduce_output_inline($cast(['replace' => 'collectionName'])));
     }
 
-    public function provideMapReduceOutValues()
+    public function testIsMapReduceOutputInlineWithStringValue(): void
     {
-        return [
-            [ 'collectionName', false ],
-            [ ['inline' => 1], true ],
-            [ ['inline' => 0], true ], // only the key is significant
-            [ ['replace' => 'collectionName'], false ],
-        ];
+        $this->assertFalse(is_mapreduce_output_inline('collectionName'));
     }
 
     /** @dataProvider provideTypeMapValues */
@@ -215,30 +238,80 @@ class FunctionsTest extends TestCase
         ];
     }
 
+    /** @dataProvider provideDocumentCasts */
+    public function testIsLastPipelineOperatorWrite(callable $cast): void
+    {
+        $match = ['$match' => ['x' => 1]];
+        $merge = ['$merge' => ['into' => 'coll']];
+        $out = ['$out' => ['db' => 'db', 'coll' => 'coll']];
+
+        $this->assertTrue(is_last_pipeline_operator_write([$cast($merge)]));
+        $this->assertTrue(is_last_pipeline_operator_write([$cast($out)]));
+        $this->assertTrue(is_last_pipeline_operator_write([$cast($match), $cast($merge)]));
+        $this->assertTrue(is_last_pipeline_operator_write([$cast($match), $cast($out)]));
+        $this->assertFalse(is_last_pipeline_operator_write([$cast($match)]));
+        $this->assertFalse(is_last_pipeline_operator_write([$cast($merge), $cast($match)]));
+        $this->assertFalse(is_last_pipeline_operator_write([$cast($out), $cast($match)]));
+    }
+
     /** @dataProvider providePipelines */
     public function testIsPipeline($expected, $pipeline): void
     {
         $this->assertSame($expected, is_pipeline($pipeline));
     }
 
-    public function providePipelines()
+    public function providePipelines(): array
     {
+        $valid = [
+            ['$match' => ['foo' => 'bar']],
+            (object) ['$group' => ['_id' => 1]],
+            new BSONDocument(['$skip' => 1]),
+            Document::fromPHP(['$limit' => 1]),
+        ];
+
+        $invalidIndex = [1 => ['$group' => ['_id' => 1]]];
+
+        $invalidStageKey = [['group' => ['_id' => 1]]];
+
+        $dbrefInNumericField = ['0' => ['$ref' => 'foo', '$id' => 'bar']];
+
         return [
-            'Not an array' => [false, (object) []],
-            'Empty array' => [false, []],
-            'Non-sequential indexes in array' => [false, [1 => ['$group' => []]]],
-            'Update document instead of pipeline' => [false, ['$set' => ['foo' => 'bar']]],
-            'Invalid pipeline stage' => [false, [['group' => []]]],
-            'Update with DbRef' => [false, ['x' => ['$ref' => 'foo', '$id' => 'bar']]],
-            'Valid pipeline' => [
-                true,
-                [
-                    ['$match' => ['foo' => 'bar']],
-                    ['$group' => ['_id' => 1]],
-                ],
-            ],
-            'False positive with DbRef in numeric field' => [true, ['0' => ['$ref' => 'foo', '$id' => 'bar']]],
-            'DbRef in numeric field as object' => [false, (object) ['0' => ['$ref' => 'foo', '$id' => 'bar']]],
+            // Valid pipeline in various forms
+            'valid: array' => [true, $valid],
+            'valid: Serializable' => [true, new BSONArray($valid)],
+            'valid: PackedArray' => [true, PackedArray::fromPHP($valid)],
+            // Invalid type for an otherwise valid pipeline
+            'invalid type: stdClass' => [false, (object) $valid],
+            'invalid type: Serializable' => [false, new BSONDocument($valid)],
+            'invalid type: Document' => [false, Document::fromPHP($valid)],
+            // Invalid index in pipeline array
+            'invalid index: array' => [false, $invalidIndex],
+            // Note: PackedArray::fromPHP() requires a list array
+            // Note: BSONArray::bsonSerialize() re-indexes the array
+            'invalid index: array' => [true, new BSONArray($invalidIndex)],
+            // Invalid stage key in pipeline element
+            'invalid stage key: array' => [false, $invalidStageKey],
+            'invalid stage key: Serializable' => [false, new BSONArray($invalidStageKey)],
+            'invalid stage key: PackedArray' => [false, PackedArray::fromPHP($invalidStageKey)],
+            // Invalid pipeline element type
+            'invalid pipeline element type: array' => [false, [[[]]]],
+            'invalid pipeline element type: Serializable' => [false, new BSONArray([new BSONArray([])])],
+            'invalid pipeline element type: PackedArray' => [false, PackedArray::fromPHP([[]])],
+            // Empty array has no pipeline stages
+            'invalid empty: array' => [false, []],
+            'invalid empty: Serializable' => [false, new BSONArray([])],
+            'invalid empty: PackedArray' => [false, PackedArray::fromPHP([])],
+            // False positive: DBRef in numeric field
+            'false positive DBRef: array' => [true, $dbrefInNumericField],
+            'false positive DBRef: Serializable' => [true, new BSONArray($dbrefInNumericField)],
+            'false positive DBRef: PackedArray' => [true, PackedArray::fromPHP($dbrefInNumericField)],
+            // Invalid document containing DBRef in numeric field
+            'invalid DBRef: stdClass' => [false, (object) $dbrefInNumericField],
+            'invalid DBRef: Serializable' => [false, new BSONDocument($dbrefInNumericField)],
+            'invalid DBRef: Document' => [false, Document::fromPHP($dbrefInNumericField)],
+            // Additional invalid cases
+            'Update document' => [false, ['$set' => ['foo' => 'bar']]],
+            'Replacement document with DBRef' => [false, ['x' => ['$ref' => 'foo', '$id' => 'bar']]],
         ];
     }
 

--- a/tests/Operation/CountDocumentsFunctionalTest.php
+++ b/tests/Operation/CountDocumentsFunctionalTest.php
@@ -19,7 +19,7 @@ class CountDocumentsFunctionalTest extends FunctionalTestCase
                 $operation = new CountDocuments(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $filter,
+                    $filter
                 );
 
                 $operation->execute($this->getPrimaryServer());

--- a/tests/Operation/CountFunctionalTest.php
+++ b/tests/Operation/CountFunctionalTest.php
@@ -20,7 +20,7 @@ class CountFunctionalTest extends FunctionalTestCase
                 $operation = new Count(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $filter,
+                    $filter
                 );
 
                 $operation->execute($this->getPrimaryServer());

--- a/tests/Operation/CountFunctionalTest.php
+++ b/tests/Operation/CountFunctionalTest.php
@@ -2,13 +2,47 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Count;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
+use stdClass;
 
 class CountFunctionalTest extends FunctionalTestCase
 {
+    /** @dataProvider provideFilterDocuments */
+    public function testFilterDocuments($filter, stdClass $expectedQuery): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($filter): void {
+                $operation = new Count(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    $filter,
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event) use ($expectedQuery): void {
+                $this->assertEquals($expectedQuery, $event['started']->getCommand()->query ?? null);
+            }
+        );
+    }
+
+    public function provideFilterDocuments(): array
+    {
+        $expectedQuery = (object) ['x' => 1];
+
+        return [
+            'array' => [['x' => 1], $expectedQuery],
+            'object' => [(object) ['x' => 1], $expectedQuery],
+            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
+            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
+        ];
+    }
+
     public function testDefaultReadConcernIsOmitted(): void
     {
         (new CommandObserver())->observe(

--- a/tests/Operation/CreateIndexesTest.php
+++ b/tests/Operation/CreateIndexesTest.php
@@ -2,7 +2,10 @@
 
 namespace MongoDB\Tests\Operation;
 
+use Generator;
+use MongoDB\BSON\Document;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\CreateIndexes;
 use stdClass;
 
@@ -56,11 +59,60 @@ class CreateIndexesTest extends TestCase
     public function testConstructorRequiresIndexSpecificationsToBeAnArray($index): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected $index[0] to have type "array"');
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [$index]);
     }
 
     public function provideInvalidIndexSpecificationTypes()
     {
         return $this->wrapValuesForDataProvider($this->getInvalidArrayValues());
+    }
+
+    public function testConstructorRequiresIndexSpecificationKey(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Required "key" document is missing from index specification');
+        new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [[]]);
+    }
+
+    /** @dataProvider provideInvalidDocumentValues */
+    public function testConstructorRequiresIndexSpecificationKeyToBeADocument($key): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected "key" option to have type "array or object"');
+        new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => $key]]);
+    }
+
+    /** @dataProvider provideKeyDocumentsWithInvalidOrder */
+    public function testConstructorValidatesIndexSpecificationKeyOrder($key): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected order value for "x" field within "key" option to have type "numeric or string"');
+        new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => $key]]);
+    }
+
+    public function provideKeyDocumentsWithInvalidOrder(): Generator
+    {
+        $invalidOrderValues = [true, [], new stdClass(), null];
+
+        foreach ($invalidOrderValues as $order) {
+            yield [['x' => $order]];
+            yield [(object) ['x' => $order]];
+            yield [new BSONDocument(['x' => $order])];
+            yield [Document::fromPHP(['x' => $order])];
+        }
+    }
+
+    /** @dataProvider provideInvalidStringValues */
+    public function testConstructorRequiresIndexSpecificationNameToBeString($name): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected "name" option to have type "string"');
+        new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => ['x' => 1], 'name' => $name]]);
+    }
+
+    public function provideInvalidStringValues()
+    {
+        return $this->wrapValuesForDataProvider($this->getInvalidStringValues());
     }
 }

--- a/tests/Operation/DatabaseCommandFunctionalTest.php
+++ b/tests/Operation/DatabaseCommandFunctionalTest.php
@@ -2,11 +2,46 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+use MongoDB\Driver\Command;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\DatabaseCommand;
 use MongoDB\Tests\CommandObserver;
 
 class DatabaseCommandFunctionalTest extends FunctionalTestCase
 {
+    /** @dataProvider provideCommandDocuments */
+    public function testCommandDocuments($command): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($command): void {
+                $operation = new DatabaseCommand(
+                    $this->getDatabaseName(),
+                    $command
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event): void {
+                $this->assertEquals(1, $event['started']->getCommand()->ping ?? null);
+            }
+        );
+    }
+
+    public function provideCommandDocuments(): array
+    {
+        return [
+            'array' => [['ping' => 1]],
+            'object' => [(object) ['ping' => 1]],
+            'Serializable' => [new BSONDocument(['ping' => 1])],
+            'Document' => [Document::fromPHP(['ping' => 1])],
+            'Command:array' => [new Command(['ping' => 1])],
+            'Command:object' => [new Command((object) ['ping' => 1])],
+            'Command:Serializable' => [new Command(new BSONDocument(['ping' => 1]))],
+            'Command:Document' => [new Command(Document::fromPHP(['ping' => 1]))],
+        ];
+    }
+
     public function testSessionOption(): void
     {
         (new CommandObserver())->observe(

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -37,7 +37,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     $filter,
-                    1,
+                    1
                 );
 
                 $operation->execute($this->getPrimaryServer());

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -2,14 +2,17 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
 use MongoDB\Collection;
 use MongoDB\DeleteResult;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Delete;
 use MongoDB\Tests\CommandObserver;
+use stdClass;
 
 use function version_compare;
 
@@ -23,6 +26,38 @@ class DeleteFunctionalTest extends FunctionalTestCase
         parent::setUp();
 
         $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
+    }
+
+    /** @dataProvider provideFilterDocuments */
+    public function testFilterDocuments($filter, stdClass $expectedQuery): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($filter): void {
+                $operation = new Delete(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    $filter,
+                    1,
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event) use ($expectedQuery): void {
+                $this->assertEquals($expectedQuery, $event['started']->getCommand()->deletes[0]->q ?? null);
+            }
+        );
+    }
+
+    public function provideFilterDocuments(): array
+    {
+        $expectedQuery = (object) ['x' => 1];
+
+        return [
+            'array' => [['x' => 1], $expectedQuery],
+            'object' => [(object) ['x' => 1], $expectedQuery],
+            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
+            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
+        ];
     }
 
     public function testDeleteOne(): void

--- a/tests/Operation/DistinctFunctionalTest.php
+++ b/tests/Operation/DistinctFunctionalTest.php
@@ -24,7 +24,7 @@ class DistinctFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     'x',
-                    $filter,
+                    $filter
                 );
 
                 $operation->execute($this->getPrimaryServer());

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -27,7 +27,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['query' => $query, 'remove' => true],
+                    ['query' => $query, 'remove' => true]
                 );
 
                 $operation->execute($this->getPrimaryServer());

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -2,19 +2,115 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindAndModify;
 use MongoDB\Tests\CommandObserver;
+use stdClass;
 
 use function version_compare;
 
 class FindAndModifyFunctionalTest extends FunctionalTestCase
 {
+    /** @dataProvider provideQueryDocuments */
+    public function testQueryDocuments($query, stdClass $expectedQuery): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($query): void {
+                $operation = new FindAndModify(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    ['query' => $query, 'remove' => true],
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event) use ($expectedQuery): void {
+                $this->assertEquals($expectedQuery, $event['started']->getCommand()->query ?? null);
+            }
+        );
+    }
+
+    public function provideQueryDocuments(): array
+    {
+        $expected = (object) ['x' => 1];
+
+        return [
+            'array' => [['x' => 1], $expected],
+            'object' => [(object) ['x' => 1], $expected],
+            'Serializable' => [new BSONDocument(['x' => 1]), $expected],
+            'Document' => [Document::fromPHP(['x' => 1]), $expected],
+        ];
+    }
+
+    /**
+     * @dataProvider provideReplacementDocuments
+     * @dataProvider provideUpdateDocuments
+     * @dataProvider provideUpdatePipelines
+     */
+    public function testUpdateDocuments($update, $expectedUpdate): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($update): void {
+                $operation = new FindAndModify(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    [
+                        'query' => ['x' => 1],
+                        'update' => $update,
+                    ]
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event) use ($expectedUpdate): void {
+                $this->assertEquals($expectedUpdate, $event['started']->getCommand()->update ?? null);
+            }
+        );
+    }
+
+    public function provideReplacementDocuments(): array
+    {
+        $expected = (object) ['x' => 1];
+
+        return [
+            'replacement:array' => [['x' => 1], $expected],
+            'replacement:object' => [(object) ['x' => 1], $expected],
+            'replacement:Serializable' => [new BSONDocument(['x' => 1]), $expected],
+            'replacement:Document' => [Document::fromPHP(['x' => 1]), $expected],
+        ];
+    }
+
+    public function provideUpdateDocuments(): array
+    {
+        $expected = (object) ['$set' => (object) ['x' => 1]];
+
+        return [
+            'update:array' => [['$set' => ['x' => 1]], $expected],
+            'update:object' => [(object) ['$set' => ['x' => 1]], $expected],
+            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]]), $expected],
+            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]]), $expected],
+        ];
+    }
+
+    public function provideUpdatePipelines(): array
+    {
+        $expected = [(object) ['$set' => (object) ['x' => 1]]];
+
+        return [
+            'pipeline:array' => [[['$set' => ['x' => 1]]], $expected],
+            'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]]), $expected],
+            'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]]), $expected],
+        ];
+    }
+
     /** @see https://jira.mongodb.org/browse/PHPLIB-344 */
     public function testManagerReadConcernIsOmitted(): void
     {

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -24,7 +24,7 @@ class FindFunctionalTest extends FunctionalTestCase
                 $operation = new Find(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $filter,
+                    $filter
                 );
 
                 $operation->execute($this->getPrimaryServer());

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -2,17 +2,83 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\ReadPreference;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
+use stdClass;
 
 use function microtime;
 
 class FindFunctionalTest extends FunctionalTestCase
 {
+    /** @dataProvider provideFilterDocuments */
+    public function testFilterDocuments($filter, stdClass $expectedQuery): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($filter): void {
+                $operation = new Find(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    $filter,
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event) use ($expectedQuery): void {
+                $this->assertEquals($expectedQuery, $event['started']->getCommand()->filter ?? null);
+            }
+        );
+    }
+
+    public function provideFilterDocuments(): array
+    {
+        $expectedQuery = (object) ['x' => 1];
+
+        return [
+            'array' => [['x' => 1], $expectedQuery],
+            'object' => [(object) ['x' => 1], $expectedQuery],
+            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
+            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
+        ];
+    }
+
+    /** @dataProvider provideModifierDocuments */
+    public function testModifierDocuments($modifiers, stdClass $expectedSort): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($modifiers): void {
+                $operation = new Find(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    [],
+                    ['modifiers' => $modifiers]
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event) use ($expectedSort): void {
+                $this->assertEquals($expectedSort, $event['started']->getCommand()->sort ?? null);
+            }
+        );
+    }
+
+    public function provideModifierDocuments(): array
+    {
+        $expectedSort = (object) ['x' => 1];
+
+        return [
+            'array' => [['$orderby' => ['x' => 1]], $expectedSort],
+            'object' => [(object) ['$orderby' => ['x' => 1]], $expectedSort],
+            'Serializable' => [new BSONDocument(['$orderby' => ['x' => 1]]), $expectedSort],
+            'Document' => [Document::fromPHP(['$orderby' => ['x' => 1]]), $expectedSort],
+        ];
+    }
+
     public function testDefaultReadConcernIsOmitted(): void
     {
         (new CommandObserver())->observe(

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -2,7 +2,11 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+//use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
+//use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindOneAndReplace;
 
 class FindOneAndReplaceTest extends TestCase
@@ -21,11 +25,29 @@ class FindOneAndReplaceTest extends TestCase
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 
-    public function testConstructorReplacementArgumentRequiresNoOperators(): void
+    /** @dataProvider provideInvalidReplacementValues */
+    public function testConstructorReplacementArgumentRequiresNoOperators($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('First key in $replacement argument is an update operator');
-        new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], ['$set' => ['x' => 1]]);
+        new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
+    }
+
+    public function provideInvalidReplacementValues(): array
+    {
+        return [
+            'update:array' => [['$set' => ['x' => 1]]],
+            'update:object' => [(object) ['$set' => ['x' => 1]]],
+            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]])],
+            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]])],
+            // TODO: Enable the following tests when implementing PHPLIB-1129
+            //'pipeline:array' => [[['$set' => ['x' => 1]]]],
+            //'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]])],
+            //'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]])],
+            //'empty_pipeline:array' => [[]],
+            //'empty_pipeline:Serializable' => [new BSONArray([])],
+            //'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
+        ];
     }
 
     /** @dataProvider provideInvalidConstructorOptions */

--- a/tests/Operation/FindOneAndUpdateTest.php
+++ b/tests/Operation/FindOneAndUpdateTest.php
@@ -2,7 +2,11 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindOneAndUpdate;
 
 class FindOneAndUpdateTest extends TestCase
@@ -21,11 +25,25 @@ class FindOneAndUpdateTest extends TestCase
         new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], $update);
     }
 
-    public function testConstructorUpdateArgumentRequiresOperatorsOrPipeline(): void
+    /** @dataProvider provideInvalidUpdateValues */
+    public function testConstructorUpdateArgumentRequiresOperatorsOrPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected an update document with operator as first key or a pipeline');
-        new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], []);
+        new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], $update);
+    }
+
+    public function provideInvalidUpdateValues(): array
+    {
+        return [
+            'replacement:array' => [['x' => 1]],
+            'replacement:object' => [(object) ['x' => 1]],
+            'replacement:Serializable' => [new BSONDocument(['x' => 1])],
+            'replacement:Document' => [Document::fromPHP(['x' => 1])],
+            'empty_pipeline:array' => [[]],
+            'empty_pipeline:Serializable' => [new BSONArray([])],
+            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
+        ];
     }
 
     /** @dataProvider provideInvalidConstructorOptions */

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\WriteConcern;
@@ -10,6 +11,7 @@ use MongoDB\InsertOneResult;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Tests\CommandObserver;
+use stdClass;
 
 class InsertOneFunctionalTest extends FunctionalTestCase
 {
@@ -23,36 +25,76 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
     }
 
-    /** @dataProvider provideDocumentWithExistingId */
-    public function testInsertOneWithExistingId($document): void
+    /**
+     * @dataProvider provideDocumentsWithIds
+     * @dataProvider provideDocumentsWithoutIds
+     */
+    public function testDocumentEncoding($document, stdClass $expectedDocument): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($document, $expectedDocument): void {
+                $operation = new InsertOne(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    $document,
+                );
+
+                $result = $operation->execute($this->getPrimaryServer());
+
+                // Replace _id placeholder if necessary
+                if ($expectedDocument->_id === null) {
+                    $expectedDocument->_id = $result->getInsertedId();
+                }
+            },
+            function (array $event) use ($expectedDocument): void {
+                $this->assertEquals($expectedDocument, $event['started']->getCommand()->documents[0] ?? null);
+            }
+        );
+    }
+
+    public function provideDocumentsWithIds(): array
+    {
+        $expectedDocument = (object) ['_id' => 1];
+
+        return [
+            'with_id:array' => [['_id' => 1], $expectedDocument],
+            'with_id:object' => [(object) ['_id' => 1], $expectedDocument],
+            'with_id:Serializable' => [new BSONDocument(['_id' => 1]), $expectedDocument],
+            'with_id:Document' => [Document::fromPHP(['_id' => 1]), $expectedDocument],
+        ];
+    }
+
+    public function provideDocumentsWithoutIds(): array
+    {
+        /* Note: _id placeholders must be replaced with generated ObjectIds. We
+         * also clone the value for each data set since tests will may modify
+         * the object. */
+        $expectedDocument = (object) ['_id' => null, 'x' => 1];
+
+        return [
+            'without_id:array' => [['x' => 1], clone $expectedDocument],
+            'without_id:object' => [(object) ['x' => 1], clone $expectedDocument],
+            'without_id:Serializable' => [new BSONDocument(['x' => 1]), clone $expectedDocument],
+            'without_id:Document' => [Document::fromPHP(['x' => 1]), clone $expectedDocument],
+        ];
+    }
+
+    /** @dataProvider provideDocumentsWithIds */
+    public function testInsertOneWithExistingId($document, stdClass $expectedDocument): void
     {
         $operation = new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
         $result = $operation->execute($this->getPrimaryServer());
 
         $this->assertInstanceOf(InsertOneResult::class, $result);
         $this->assertSame(1, $result->getInsertedCount());
-        $this->assertSame('foo', $result->getInsertedId());
+        $this->assertSame($expectedDocument->_id, $result->getInsertedId());
 
-        $expected = [
-            ['_id' => 'foo', 'x' => 11],
-        ];
-
-        $this->assertSameDocuments($expected, $this->collection->find());
+        $this->assertSameDocuments([$expectedDocument], $this->collection->find());
     }
 
-    public function provideDocumentWithExistingId()
+    /** @dataProvider provideDocumentsWithoutIds */
+    public function testInsertOneWithGeneratedId($document, stdClass $expectedDocument): void
     {
-        return [
-            [['_id' => 'foo', 'x' => 11]],
-            [(object) ['_id' => 'foo', 'x' => 11]],
-            [new BSONDocument(['_id' => 'foo', 'x' => 11])],
-        ];
-    }
-
-    public function testInsertOneWithGeneratedId(): void
-    {
-        $document = ['x' => 11];
-
         $operation = new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
         $result = $operation->execute($this->getPrimaryServer());
 
@@ -60,11 +102,10 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $this->assertSame(1, $result->getInsertedCount());
         $this->assertInstanceOf(ObjectId::class, $result->getInsertedId());
 
-        $expected = [
-            ['_id' => $result->getInsertedId(), 'x' => 11],
-        ];
+        // Replace _id placeholder
+        $expectedDocument->_id = $result->getInsertedId();
 
-        $this->assertSameDocuments($expected, $this->collection->find());
+        $this->assertSameDocuments([$expectedDocument], $this->collection->find());
     }
 
     public function testSessionOption(): void

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -36,7 +36,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
                 $operation = new InsertOne(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $document,
+                    $document
                 );
 
                 $result = $operation->execute($this->getPrimaryServer());

--- a/tests/Operation/ReplaceOneTest.php
+++ b/tests/Operation/ReplaceOneTest.php
@@ -2,7 +2,10 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+//use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
+//use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\ReplaceOne;
 
@@ -31,14 +34,6 @@ class ReplaceOneTest extends TestCase
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 
-    /** @dataProvider provideUpdateDocuments */
-    public function testConstructorReplacementArgumentRequiresNoOperators($replacement): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('First key in $replacement argument is an update operator');
-        new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
-    }
-
     public function provideReplacementDocuments()
     {
         return $this->wrapValuesForDataProvider([
@@ -48,12 +43,28 @@ class ReplaceOneTest extends TestCase
         ]);
     }
 
-    public function provideUpdateDocuments()
+    /** @dataProvider provideInvalidReplacementValues */
+    public function testConstructorReplacementArgumentRequiresNoOperators($replacement): void
     {
-        return $this->wrapValuesForDataProvider([
-            ['$set' => ['y' => 1]],
-            (object) ['$set' => ['y' => 1]],
-            new BSONDocument(['$set' => ['y' => 1]]),
-        ]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('First key in $replacement argument is an update operator');
+        new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
+    }
+
+    public function provideInvalidReplacementValues(): array
+    {
+        return [
+            'update:array' => [['$set' => ['x' => 1]]],
+            'update:object' => [(object) ['$set' => ['x' => 1]]],
+            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]])],
+            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]])],
+            // TODO: Enable the following tests when implementing PHPLIB-1129
+            //'pipeline:array' => [[['$set' => ['x' => 1]]]],
+            //'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]])],
+            //'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]])],
+            //'empty_pipeline:array' => [[]],
+            //'empty_pipeline:Serializable' => [new BSONArray([])],
+            //'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
+        ];
     }
 }

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -2,15 +2,20 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectId;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Update;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\UpdateResult;
+use stdClass;
 
 use function version_compare;
 
@@ -24,6 +29,97 @@ class UpdateFunctionalTest extends FunctionalTestCase
         parent::setUp();
 
         $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
+    }
+
+    /** @dataProvider provideFilterDocuments */
+    public function testFilterDocuments($filter, stdClass $expectedFilter): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($filter): void {
+                $operation = new Update(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    $filter,
+                    ['$set' => ['x' => 1]],
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event) use ($expectedFilter): void {
+                $this->assertEquals($expectedFilter, $event['started']->getCommand()->updates[0]->q ?? null);
+            }
+        );
+    }
+
+    public function provideFilterDocuments(): array
+    {
+        $expected = (object) ['x' => 1];
+
+        return [
+            'array' => [['x' => 1], $expected],
+            'object' => [(object) ['x' => 1], $expected],
+            'Serializable' => [new BSONDocument(['x' => 1]), $expected],
+            'Document' => [Document::fromPHP(['x' => 1]), $expected],
+        ];
+    }
+
+    /**
+     * @dataProvider provideReplacementDocuments
+     * @dataProvider provideUpdateDocuments
+     * @dataProvider provideUpdatePipelines
+     */
+    public function testUpdateDocuments($update, $expectedUpdate): void
+    {
+        (new CommandObserver())->observe(
+            function () use ($update): void {
+                $operation = new Update(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    ['x' => 1],
+                    $update
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event) use ($expectedUpdate): void {
+                $this->assertEquals($expectedUpdate, $event['started']->getCommand()->updates[0]->u ?? null);
+            }
+        );
+    }
+
+    public function provideReplacementDocuments(): array
+    {
+        $expected = (object) ['x' => 1];
+
+        return [
+            'replacement:array' => [['x' => 1], $expected],
+            'replacement:object' => [(object) ['x' => 1], $expected],
+            'replacement:Serializable' => [new BSONDocument(['x' => 1]), $expected],
+            'replacement:Document' => [Document::fromPHP(['x' => 1]), $expected],
+        ];
+    }
+
+    public function provideUpdateDocuments(): array
+    {
+        $expected = (object) ['$set' => (object) ['x' => 1]];
+
+        return [
+            'update:array' => [['$set' => ['x' => 1]], $expected],
+            'update:object' => [(object) ['$set' => ['x' => 1]], $expected],
+            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]]), $expected],
+            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]]), $expected],
+        ];
+    }
+
+    public function provideUpdatePipelines(): array
+    {
+        $expected = [(object) ['$set' => (object) ['x' => 1]]];
+
+        return [
+            'pipeline:array' => [[['$set' => ['x' => 1]]], $expected],
+            'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]]), $expected],
+            'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]]), $expected],
+        ];
     }
 
     public function testSessionOption(): void

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -17,6 +17,7 @@ use MongoDB\Tests\CommandObserver;
 use MongoDB\UpdateResult;
 use stdClass;
 
+use function is_array;
 use function version_compare;
 
 class UpdateFunctionalTest extends FunctionalTestCase
@@ -70,6 +71,10 @@ class UpdateFunctionalTest extends FunctionalTestCase
      */
     public function testUpdateDocuments($update, $expectedUpdate): void
     {
+        if (is_array($expectedUpdate) && version_compare($this->getServerVersion(), '4.2.0', '<')) {
+            $this->markTestSkipped('Pipeline-style updates are not supported');
+        }
+
         (new CommandObserver())->observe(
             function () use ($update): void {
                 $operation = new Update(

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -40,7 +40,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     $filter,
-                    ['$set' => ['x' => 1]],
+                    ['$set' => ['x' => 1]]
                 );
 
                 $operation->execute($this->getPrimaryServer());

--- a/tests/Operation/UpdateManyTest.php
+++ b/tests/Operation/UpdateManyTest.php
@@ -2,7 +2,10 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\UpdateMany;
 
@@ -31,23 +34,6 @@ class UpdateManyTest extends TestCase
         new UpdateMany($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
     }
 
-    /** @dataProvider provideReplacementDocuments */
-    public function testConstructorUpdateArgumentRequiresOperators($replacement): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected an update document with operator as first key or a pipeline');
-        new UpdateMany($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
-    }
-
-    public function provideReplacementDocuments()
-    {
-        return $this->wrapValuesForDataProvider([
-            ['y' => 1],
-            (object) ['y' => 1],
-            new BSONDocument(['y' => 1]),
-        ]);
-    }
-
     public function provideUpdateDocuments()
     {
         return $this->wrapValuesForDataProvider([
@@ -55,5 +41,26 @@ class UpdateManyTest extends TestCase
             (object) ['$set' => ['y' => 1]],
             new BSONDocument(['$set' => ['y' => 1]]),
         ]);
+    }
+
+    /** @dataProvider provideInvalidUpdateValues */
+    public function testConstructorUpdateArgumentRequiresOperators($update): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected an update document with operator as first key or a pipeline');
+        new UpdateMany($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
+    }
+
+    public function provideInvalidUpdateValues(): array
+    {
+        return [
+            'replacement:array' => [['x' => 1]],
+            'replacement:object' => [(object) ['x' => 1]],
+            'replacement:Serializable' => [new BSONDocument(['x' => 1])],
+            'replacement:Document' => [Document::fromPHP(['x' => 1])],
+            'empty_pipeline:array' => [[]],
+            'empty_pipeline:Serializable' => [new BSONArray([])],
+            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
+        ];
     }
 }

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -2,7 +2,11 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Update;
 
 class UpdateTest extends TestCase
@@ -63,5 +67,26 @@ class UpdateTest extends TestCase
         }
 
         return $options;
+    }
+
+    /** @dataProvider provideInvalidUpdateValues */
+    public function testConstructorMultiOptionRequiresOperators($update): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"multi" option cannot be true if $update is a replacement document');
+        new Update($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update, ['multi' => true]);
+    }
+
+    public function provideInvalidUpdateValues(): array
+    {
+        return [
+            'replacement:array' => [['x' => 1]],
+            'replacement:object' => [(object) ['x' => 1]],
+            'replacement:Serializable' => [new BSONDocument(['x' => 1])],
+            'replacement:Document' => [Document::fromPHP(['x' => 1])],
+            'empty_pipeline:array' => [[]],
+            'empty_pipeline:Serializable' => [new BSONArray([])],
+            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
+        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -193,6 +193,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getInvalidDocumentValues(bool $includeNull = false): array
     {
+        // Note: PackedArray is intentionally omitted here (see: PHPLIB-1137)
         return array_merge([123, 3.14, 'foo', true], $includeNull ? [null] : []);
     }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1122

Excluding tests, most changes were concentrated in functions.php. A document_to_array() function was introduced to make it easier to access document values as arrays. This is mainly used by other utility functions (e.g. checking for dollar prefixed keys) but also ended up being used in the Find operation for handling the "modifiers" option.

Adds tests for using Document and PackedArray objects in operations.

Beyond handling of document/array types, this also filled gaps in test coverage for:

 * Validation for IndexInput key/name options
 * Passing a MongoDB\Driver\Command directly to DatabaseCommand
 * is_last_pipeline_operator_write()

----

### Addressed

Most changes were made to internal functions, which are used by many operations/classes. The following is a summary of test coverage changes in FunctionsTest:

* `document_to_array()`: various types for `$document` argument. This is used by many other internal functions and the Find operation.
* `is_first_key_operator()`: various types for `$document` argument. This is used by operations that peform updates (e.g. BulkWrite, FindOneAndUpdate, Update).
* `is_last_pipeline_operator_write()`: testing more inputs and using a variety of types for stage documents. This is used by Aggregate (operation and helpers) and indirectly by the Watch operation.
* `is_mapreduce_output_inline()`: various types for `$out` argument. This is used by MapReduce.
* `is_pipeline()`: various types for `$pipeline` argument and stage documents within. This is used for validating update values for `update` and `findAndModify` commands.

The following is a summary of added test coverage for various operations/classes. When an argument/option is listed without additional details, that means we've added test coverage for expressing the document in various forms (i.e. array, stdClass, Serializable, Document):

* CountFunctionalTest:
  * Count: `$filter`
* CountDocumentsFunctionalTest
  * CountDocuments: `$filter`
* CreateIndexesTest:
  * IndexInput: order validation for `key` option. Additionally filled gaps in test coverage for validating `key` and `name` options (unrelated to documents)
* CreateIndexesFunctionalTest:
  * CreateIndexes: `key` option
  * IndexInput: generating `name` option from `key` option
* DatabaseCommand
  * DatabaseCommand: `$command`. Additionally added test coverage for passing a `MongoDB\Driver\Command` object constructed from various document types.
* DeleteFunctionalTest
  * DeleteMany: `$filter`
  * DeleteOne: `$filter`
* DistinctFunctionalTest
  * Distinct: `$filter`
* FindFunctionalTest
  * Find: `$filter`, `modifiers` option
  * FindOne: `$filter`, `modifiers` option
* FindAndModifyFunctionalTest
  * FindAndModify: `filter` and `query` options
  * FindOneAndDelete: `$filter`
  * FindOneAndReplace: `$filter`, `$replacement`
  * FindOneAndUpdate: `$filter`, `$update`
* FindOneAndReplaceTest
  * FindOneAndReplace: `$replacement` validation
* FindOneAndUpdateTest
  * FindOneAndUpdate: `$update` validation
* InsertManyFunctionalTest
  * InsertMany: encoding `$documents` elements and `_id` generation/access
* InsertOneFunctionalTest
  * InsertOne: encoding `$document` and `_id` generation/access
* ReplaceOneTest
  * ReplaceOneTest: `$replacement` validation
* UpdateTest
  * Update: `$update` validation based on `multi` option
* UpdateFunctionalTest
  * Update: `$filter`, `$update`
  * ReplaceOne: `$filter`, `$replacement`
  * UpdateMany: `$filter`, `$update`
  * UpdateOne: `$filter`, `$update`
* UpdateManyTest
  * UpdateMany: `$update` validation
* UpdateOneTest
  * UpdateOne: `$update` validation

### Omitted

The following are notable parts of PHPLIB that were _not_ touched by this PR:

* `apply_type_map_to_document()`: only used in GridFS on stdClass objects
* GridFS metadata document: not used beyond type validation as an "array or object"