### PR TITLE
Remove unreachable code

### DIFF
--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -92,9 +92,6 @@ class Bucket
     /** @var string */
     private $bucketName;
 
-    /** @var boolean */
-    private $disableMD5;
-
     /** @var integer */
     private $chunkSizeBytes;
 
@@ -181,7 +178,6 @@ class Bucket
         $this->databaseName = $databaseName;
         $this->bucketName = $options['bucketName'];
         $this->chunkSizeBytes = $options['chunkSizeBytes'];
-        $this->disableMD5 = $options['disableMD5'];
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
         $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -92,6 +92,9 @@ class Bucket
     /** @var string */
     private $bucketName;
 
+    /** @var boolean */
+    private $disableMD5;
+
     /** @var integer */
     private $chunkSizeBytes;
 
@@ -178,6 +181,7 @@ class Bucket
         $this->databaseName = $databaseName;
         $this->bucketName = $options['bucketName'];
         $this->chunkSizeBytes = $options['chunkSizeBytes'];
+        $this->disableMD5 = $options['disableMD5'];
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
         $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -47,9 +47,6 @@ class StreamWrapper
     public $context;
 
     /** @var string|null */
-    private $mode;
-
-    /** @var string|null */
     private $protocol;
 
     /** @var ReadableStream|WritableStream|null */
@@ -127,7 +124,6 @@ class StreamWrapper
     public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
     {
         $this->initProtocol($path);
-        $this->mode = $mode;
 
         if ($mode === 'r') {
             return $this->initReadableStream();

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -255,8 +255,7 @@ class WritableStream
         $this->isClosed = true;
     }
 
-    /** @return mixed */
-    private function fileCollectionInsert()
+    private function fileCollectionInsert(): void
     {
         $this->file['length'] = $this->length;
         $this->file['uploadDate'] = new UTCDateTime();
@@ -272,8 +271,6 @@ class WritableStream
 
             throw $e;
         }
-
-        return $this->file['_id'];
     }
 
     private function insertChunkFromBuffer(): void

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -159,13 +159,4 @@ class Explain implements Executable
 
         return $options;
     }
-
-    private function isFindAndModify(Explainable $explainable): bool
-    {
-        if ($explainable instanceof FindAndModify || $explainable instanceof FindOneAndDelete || $explainable instanceof FindOneAndReplace || $explainable instanceof FindOneAndUpdate) {
-            return true;
-        }
-
-        return false;
-    }
 }


### PR DESCRIPTION
Remove private properties and method never accessed. Found thanks to `./vendor/bin/psalm --find-dead-code`.

This code should be safe to remove, unless it's used for introspection, using reflection or by the C driver.