### PR TITLE
PHPLIB-802: Send readConcern but not writeConcern to explain commands

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -286,10 +286,11 @@
       <code>$this-&gt;options['typeMap']</code>
       <code>$this-&gt;options['typeMap']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="6">
       <code>$cmdOptions['maxAwaitTimeMS']</code>
       <code>$cmd[$option]</code>
       <code>$cmd['hint']</code>
+      <code>$cmd['readConcern']</code>
       <code>$options[$option]</code>
       <code>$options['writeConcern']</code>
     </MixedAssignment>
@@ -383,9 +384,10 @@
     <DocblockTypeContradiction occurrences="1">
       <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="6">
       <code>$cmd[$option]</code>
       <code>$cmd['hint']</code>
+      <code>$cmd['readConcern']</code>
       <code>$options['readConcern']</code>
       <code>$options['readPreference']</code>
       <code>$options['session']</code>
@@ -468,8 +470,9 @@
     <MixedArgument occurrences="1">
       <code>$this-&gt;options['typeMap']</code>
     </MixedArgument>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="5">
       <code>$cmd[$option]</code>
+      <code>$cmd['readConcern']</code>
       <code>$options['readConcern']</code>
       <code>$options['readPreference']</code>
       <code>$options['session']</code>
@@ -534,7 +537,8 @@
     <MixedArrayAccess occurrences="1">
       <code>$options['modifiers'][$modifier[1]]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="5">
+      <code>$cmd['readConcern']</code>
       <code>$options[$modifier[0]]</code>
       <code>$options[$option]</code>
       <code>$options['readPreference']</code>

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -309,7 +309,14 @@ class Aggregate implements Executable, Explainable
      */
     public function getCommandDocument(Server $server)
     {
-        return $this->createCommandDocument();
+        $cmd = $this->createCommandDocument();
+
+        // Read concern can change the query plan
+        if (isset($this->options['readConcern'])) {
+            $cmd['readConcern'] = $this->options['readConcern'];
+        }
+
+        return $cmd;
     }
 
     /**

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -173,7 +173,14 @@ class Count implements Executable, Explainable
      */
     public function getCommandDocument(Server $server)
     {
-        return $this->createCommandDocument();
+        $cmd = $this->createCommandDocument();
+
+        // Read concern can change the query plan
+        if (isset($this->options['readConcern'])) {
+            $cmd['readConcern'] = $this->options['readConcern'];
+        }
+
+        return $cmd;
     }
 
     /**

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -178,13 +178,7 @@ class Delete implements Executable, Explainable
      */
     public function getCommandDocument(Server $server)
     {
-        $cmd = ['delete' => $this->collectionName, 'deletes' => [['q' => $this->filter] + $this->createDeleteOptions()]];
-
-        if (isset($this->options['writeConcern'])) {
-            $cmd['writeConcern'] = $this->options['writeConcern'];
-        }
-
-        return $cmd;
+        return ['delete' => $this->collectionName, 'deletes' => [['q' => $this->filter] + $this->createDeleteOptions()]];
     }
 
     /**

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -166,7 +166,14 @@ class Distinct implements Executable, Explainable
      */
     public function getCommandDocument(Server $server)
     {
-        return $this->createCommandDocument();
+        $cmd = $this->createCommandDocument();
+
+        // Read concern can change the query plan
+        if (isset($this->options['readConcern'])) {
+            $cmd['readConcern'] = $this->options['readConcern'];
+        }
+
+        return $cmd;
     }
 
     /**

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -331,7 +331,14 @@ class Find implements Executable, Explainable
      */
     public function getCommandDocument(Server $server)
     {
-        return $this->createCommandDocument();
+        $cmd = $this->createCommandDocument();
+
+        // Read concern can change the query plan
+        if (isset($this->options['readConcern'])) {
+            $cmd['readConcern'] = $this->options['readConcern'];
+        }
+
+        return $cmd;
     }
 
     /**

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -228,10 +228,6 @@ class Update implements Executable, Explainable
             $cmd['bypassDocumentValidation'] = $this->options['bypassDocumentValidation'];
         }
 
-        if (isset($this->options['writeConcern'])) {
-            $cmd['writeConcern'] = $this->options['writeConcern'];
-        }
-
         return $cmd;
     }
 


### PR DESCRIPTION
Fix [PHPLIB-802](https://jira.mongodb.org/browse/PHPLIB-802)

`ReadConcern` is relevant for query plan evaluation, not `WriteConcern` ([comment](https://jira.mongodb.org/browse/SERVER-28678?focusedCommentId=3457279&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-3457279))

This should be covered by unit tests PHPLIB-1144.