### PR TITLE
PHPLIB-1135: Remove var_dump from tests, use print_r instead

### DIFF
--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -105,5 +105,4 @@ $collection->insertOne($entry);
 
 $foundEntry = $collection->findOne([]);
 
-/** @psalm-suppress ForbiddenCode */
 print_r($foundEntry);

--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -10,7 +10,7 @@ use MongoDB\Model\BSONArray;
 use UnexpectedValueException;
 
 use function getenv;
-use function var_dump;
+use function print_r;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -106,4 +106,4 @@ $collection->insertOne($entry);
 $foundEntry = $collection->findOne([]);
 
 /** @psalm-suppress ForbiddenCode */
-var_dump($foundEntry);
+print_r($foundEntry);

--- a/examples/typemap.php
+++ b/examples/typemap.php
@@ -10,7 +10,7 @@ use UnexpectedValueException;
 
 use function getenv;
 use function is_array;
-use function var_dump;
+use function print_r;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -117,4 +117,4 @@ $typeMap = [
 $entry = $collection->findOne([], ['typeMap' => $typeMap]);
 
 /** @psalm-suppress ForbiddenCode */
-var_dump($entry);
+print_r($entry);

--- a/examples/typemap.php
+++ b/examples/typemap.php
@@ -116,5 +116,4 @@ $typeMap = [
 
 $entry = $collection->findOne([], ['typeMap' => $typeMap]);
 
-/** @psalm-suppress ForbiddenCode */
 print_r($entry);

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -90,32 +90,31 @@ OUTPUT;
         ];
 
         $expectedOutput = <<<'OUTPUT'
-object(MongoDB\Examples\PersistableEntry)#%d (%d) {
-  ["id":"MongoDB\Examples\PersistableEntry":private]=>
-  object(MongoDB\BSON\ObjectId)#%d (%d) {
-    ["oid"]=>
-    string(24) "%s"
-  }
-  ["name"]=>
-  string(7) "alcaeus"
-  ["emails"]=>
-  array(2) {
-    [0]=>
-    object(MongoDB\Examples\PersistableEmail)#%d (%d) {
-      ["type"]=>
-      string(4) "work"
-      ["address"]=>
-      string(19) "alcaeus@example.com"
-    }
-    [1]=>
-    object(MongoDB\Examples\PersistableEmail)#%d (%d) {
-      ["type"]=>
-      string(7) "private"
-      ["address"]=>
-      string(18) "secret@example.com"
-    }
-  }
-}
+MongoDB\Examples\PersistableEntry Object
+(
+    [id:MongoDB\Examples\PersistableEntry:private] => MongoDB\BSON\ObjectId Object
+        (
+            [oid] => %s
+        )
+
+    [name] => alcaeus
+    [emails] => Array
+        (
+            [0] => MongoDB\Examples\PersistableEmail Object
+                (
+                    [type] => work
+                    [address] => alcaeus@example.com
+                )
+
+            [1] => MongoDB\Examples\PersistableEmail Object
+                (
+                    [type] => private
+                    [address] => secret@example.com
+                )
+
+        )
+
+)
 OUTPUT;
 
         yield 'persistable' => [
@@ -124,32 +123,31 @@ OUTPUT;
         ];
 
         $expectedOutput = <<<'OUTPUT'
-object(MongoDB\Examples\TypeMapEntry)#%d (%d) {
-  ["id":"MongoDB\Examples\TypeMapEntry":private]=>
-  object(MongoDB\BSON\ObjectId)#%d (%d) {
-    ["oid"]=>
-    string(24) "%s"
-  }
-  ["name":"MongoDB\Examples\TypeMapEntry":private]=>
-  string(7) "alcaeus"
-  ["emails":"MongoDB\Examples\TypeMapEntry":private]=>
-  array(2) {
-    [0]=>
-    object(MongoDB\Examples\TypeMapEmail)#%d (%d) {
-      ["type":"MongoDB\Examples\TypeMapEmail":private]=>
-      string(4) "work"
-      ["address":"MongoDB\Examples\TypeMapEmail":private]=>
-      string(19) "alcaeus@example.com"
-    }
-    [1]=>
-    object(MongoDB\Examples\TypeMapEmail)#%d (%d) {
-      ["type":"MongoDB\Examples\TypeMapEmail":private]=>
-      string(7) "private"
-      ["address":"MongoDB\Examples\TypeMapEmail":private]=>
-      string(18) "secret@example.com"
-    }
-  }
-}
+MongoDB\Examples\TypeMapEntry Object
+(
+    [id:MongoDB\Examples\TypeMapEntry:private] => MongoDB\BSON\ObjectId Object
+        (
+            [oid] => %s
+        )
+
+    [name:MongoDB\Examples\TypeMapEntry:private] => alcaeus
+    [emails:MongoDB\Examples\TypeMapEntry:private] => Array
+        (
+            [0] => MongoDB\Examples\TypeMapEmail Object
+                (
+                    [type:MongoDB\Examples\TypeMapEmail:private] => work
+                    [address:MongoDB\Examples\TypeMapEmail:private] => alcaeus@example.com
+                )
+
+            [1] => MongoDB\Examples\TypeMapEmail Object
+                (
+                    [type:MongoDB\Examples\TypeMapEmail:private] => private
+                    [address:MongoDB\Examples\TypeMapEmail:private] => secret@example.com
+                )
+
+        )
+
+)
 OUTPUT;
 
         yield 'typemap' => [


### PR DESCRIPTION
`var_dump` output is modified by [xdebug](https://xdebug.org/docs/develop), what causes tests to fail during debug.

I think it's easier to read this way.

There other calls to `var_dump` in `DocumentationExamplesTest`, but they are hidden and not tested.