### PR TITLE
PHPLIB-1057: Deprecate method IndexInfo::isGeoHaystack()

### DIFF
--- a/docs/reference/method/MongoDBModelIndexInfo-isGeoHaystack.txt
+++ b/docs/reference/method/MongoDBModelIndexInfo-isGeoHaystack.txt
@@ -4,6 +4,9 @@ MongoDB\\Model\\IndexInfo::isGeoHaystack()
 
 .. versionadded:: 1.4
 
+.. deprecated:: 1.16
+   MongoDB 5.0 and later no longer supports geoHaystack indexes.
+
 .. default-domain:: mongodb
 
 .. contents:: On this page
@@ -23,10 +26,6 @@ Definition
    .. code-block:: php
 
       function isGeoHaystack(): boolean
-
-   .. note::
-
-      MongoDB 5.0 and later no longer supports geoHaystack indexes.
 
 Return Values
 -------------

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -124,9 +124,12 @@ class IndexInfo implements ArrayAccess
      * Return whether or not this index is of type geoHaystack.
      *
      * @return boolean
+     * @deprecated Since 1.16: MongoDB 5.0 removes support for geoHaystack indexes.
      */
     public function isGeoHaystack()
     {
+        trigger_error('MongoDB 5.0 removes support for "geoHaystack" indexes, the method "IndexInfo::isGeoHaystack()" will be removed in a future release', E_USER_DEPRECATED);
+
         return array_search('geoHaystack', $this->getKey(), true) !== false;
     }
 

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -23,6 +23,9 @@ use ReturnTypeWillChange;
 
 use function array_key_exists;
 use function array_search;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Index information model class.

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -50,7 +50,9 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
         $index = $result->current();
 
         $this->assertEquals($indexName, $index->getName());
-        $this->assertTrue($index->isGeoHaystack());
+        $this->assertDeprecated(function () use ($index): void {
+            $this->assertTrue($index->isGeoHaystack());
+        });
         $this->assertEquals(5, $index['bucketSize']);
     }
 

--- a/tests/Model/IndexInfoTest.php
+++ b/tests/Model/IndexInfoTest.php
@@ -22,7 +22,9 @@ class IndexInfoTest extends TestCase
         $this->assertSame('x_1', $info->getName());
         $this->assertSame('foo.bar', $info->getNamespace());
         $this->assertFalse($info->is2dSphere());
-        $this->assertFalse($info->isGeoHaystack());
+        $this->assertDeprecated(function () use ($info): void {
+            $this->assertFalse($info->isGeoHaystack());
+        });
         $this->assertFalse($info->isSparse());
         $this->assertFalse($info->isText());
         $this->assertFalse($info->isTtl());
@@ -44,7 +46,9 @@ class IndexInfoTest extends TestCase
         $this->assertSame('y_sparse', $info->getName());
         $this->assertSame('foo.bar', $info->getNamespace());
         $this->assertFalse($info->is2dSphere());
-        $this->assertFalse($info->isGeoHaystack());
+        $this->assertDeprecated(function () use ($info): void {
+            $this->assertFalse($info->isGeoHaystack());
+        });
         $this->assertTrue($info->isSparse());
         $this->assertFalse($info->isText());
         $this->assertFalse($info->isTtl());
@@ -66,7 +70,9 @@ class IndexInfoTest extends TestCase
         $this->assertSame('z_unique', $info->getName());
         $this->assertSame('foo.bar', $info->getNamespace());
         $this->assertFalse($info->is2dSphere());
-        $this->assertFalse($info->isGeoHaystack());
+        $this->assertDeprecated(function () use ($info): void {
+            $this->assertFalse($info->isGeoHaystack());
+        });
         $this->assertFalse($info->isSparse());
         $this->assertFalse($info->isText());
         $this->assertFalse($info->isTtl());
@@ -88,7 +94,9 @@ class IndexInfoTest extends TestCase
         $this->assertSame('z_unique', $info->getName());
         $this->assertSame('foo.bar', $info->getNamespace());
         $this->assertFalse($info->is2dSphere());
-        $this->assertFalse($info->isGeoHaystack());
+        $this->assertDeprecated(function () use ($info): void {
+            $this->assertFalse($info->isGeoHaystack());
+        });
         $this->assertFalse($info->isSparse());
         $this->assertFalse($info->isText());
         $this->assertTrue($info->isTtl());
@@ -166,7 +174,9 @@ class IndexInfoTest extends TestCase
         $this->assertSame('pos_2dsphere', $info->getName());
         $this->assertSame('foo.bar', $info->getNamespace());
         $this->assertTrue($info->is2dSphere());
-        $this->assertFalse($info->isGeoHaystack());
+        $this->assertDeprecated(function () use ($info): void {
+            $this->assertFalse($info->isGeoHaystack());
+        });
         $this->assertFalse($info->isSparse());
         $this->assertFalse($info->isText());
         $this->assertFalse($info->isTtl());
@@ -187,7 +197,9 @@ class IndexInfoTest extends TestCase
         $this->assertSame('pos2_geoHaystack_x_1', $info->getName());
         $this->assertSame('foo.bar', $info->getNamespace());
         $this->assertFalse($info->is2dSphere());
-        $this->assertTrue($info->isGeoHaystack());
+        $this->assertDeprecated(function () use ($info): void {
+            $this->assertTrue($info->isGeoHaystack());
+        });
         $this->assertFalse($info->isSparse());
         $this->assertFalse($info->isText());
         $this->assertFalse($info->isTtl());
@@ -208,7 +220,9 @@ class IndexInfoTest extends TestCase
         $this->assertSame('title_text_description_text', $info->getName());
         $this->assertSame('foo.bar', $info->getNamespace());
         $this->assertFalse($info->is2dSphere());
-        $this->assertFalse($info->isGeoHaystack());
+        $this->assertDeprecated(function () use ($info): void {
+            $this->assertFalse($info->isGeoHaystack());
+        });
         $this->assertFalse($info->isSparse());
         $this->assertTrue($info->isText());
         $this->assertFalse($info->isTtl());


### PR DESCRIPTION
Fix [PHPLIB-1057](https://jira.mongodb.org/browse/PHPLIB-1057)

MongoDB 5.0 removes support for "geoHaystack" indexes, the method "IndexInfo::isGeoHaystack()" will be removed in a future release.