### PR TITLE
Remove phpcs:ignore comments for unused use statements

### DIFF
--- a/src/Operation/CreateEncryptedCollection.php
+++ b/src/Operation/CreateEncryptedCollection.php
@@ -17,7 +17,6 @@
 
 namespace MongoDB\Operation;
 
-// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use MongoDB\BSON\Binary;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;

--- a/src/Operation/DropEncryptedCollection.php
+++ b/src/Operation/DropEncryptedCollection.php
@@ -17,8 +17,6 @@
 
 namespace MongoDB\Operation;
 
-// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
-use MongoDB\BSON\Binary;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;


### PR DESCRIPTION
The line in DropEncryptedCollection was never necessary. The line in CreateEncryptedCollection may have been used at one point since Binary is only referenced in a psalm-var annotation, but phpcs no longer complains.