### PR TITLE
PHPLIB-1117: Remove @api annotation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,17 @@ possible it can be added to the baseline using `set-baseline`:
 $ vendor/bin/psalm --set-baseline=psalm-baseline.xml
 ```
 
+## Automatic code refactoring
+
+The library uses [rector](https://getrector.com/) to refactor the code for new features.
+To run automatic refactoring, use the `rector` command:
+
+```
+$ vendor/bin/rector
+```
+
+New rules can be added to the `rector.php` configuration file.
+
 ## Documentation
 
 Documentation for the library lives in the `docs/` directory and is built with

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,9 @@
         "symfony/polyfill-php80": "^1.27"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.7",
         "doctrine/coding-standard": "^11.1",
+        "rector/rector": "^0.16.0",
+        "squizlabs/php_codesniffer": "^3.7",
         "symfony/phpunit-bridge": "^5.2",
         "vimeo/psalm": "^4.28"
     },
@@ -39,6 +40,7 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        },
+        "sort-packages": true
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/examples',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/tools',
+    ]);
+
+    /**
+     * All classes are public API by default, unless marked with @internal.
+     */
+    $rectorConfig->ruleWithConfiguration(RemoveAnnotationRector::class, ['api']);
+
+    // define sets of rules
+    //    $rectorConfig->sets([
+    //        LevelSetList::UP_TO_PHP_72
+    //    ]);
+};

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -33,11 +33,10 @@ use function in_array;
 /**
  * Iterator for a change stream.
  *
- * @psalm-type ResumeCallable = callable(array|object|null, bool): ChangeStreamIterator
- *
- * @api
  * @see \MongoDB\Collection::watch()
  * @see https://mongodb.com/docs/manual/reference/method/db.watch/#mongodb-method-db.watch
+ *
+ * @psalm-type ResumeCallable = callable(array|object|null, bool): ChangeStreamIterator
  */
 class ChangeStream implements Iterator
 {

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -59,8 +59,6 @@ use function urlencode;
 /**
  * Bucket provides a public API for interacting with the GridFS files and chunks
  * collections.
- *
- * @api
  */
 class Bucket
 {

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -31,7 +31,6 @@ use function call_user_func;
  * output method (e.g. inline, collection) via the IteratorAggregate interface.
  * It also provides access to command statistics.
  *
- * @api
  * @see \MongoDB\Collection::mapReduce()
  * @see https://mongodb.com/docs/manual/reference/command/mapReduce/
  */

--- a/src/Model/BSONArray.php
+++ b/src/Model/BSONArray.php
@@ -31,8 +31,6 @@ use function MongoDB\recursive_copy;
  *
  * The internal data will be filtered through array_values() during BSON
  * serialization to ensure that it becomes a BSON array.
- *
- * @api
  */
 class BSONArray extends ArrayObject implements JsonSerializable, Serializable, Unserializable
 {

--- a/src/Model/BSONDocument.php
+++ b/src/Model/BSONDocument.php
@@ -30,8 +30,6 @@ use function MongoDB\recursive_copy;
  *
  * The internal data will be cast to an object during BSON serialization to
  * ensure that it becomes a BSON document.
- *
- * @api
  */
 class BSONDocument extends ArrayObject implements JsonSerializable, Serializable, Unserializable
 {

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -30,7 +30,6 @@ use function array_key_exists;
  * command or, for legacy servers, queries on the "system.namespaces"
  * collection. It provides methods to access options for the collection.
  *
- * @api
  * @see \MongoDB\Database::listCollections()
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-collections.rst
  */

--- a/src/Model/CollectionInfoIterator.php
+++ b/src/Model/CollectionInfoIterator.php
@@ -25,7 +25,6 @@ use ReturnTypeWillChange;
  *
  * This iterator is used for enumerating collections in a database.
  *
- * @api
  * @see \MongoDB\Database::listCollections()
  */
 interface CollectionInfoIterator extends Iterator

--- a/src/Model/DatabaseInfo.php
+++ b/src/Model/DatabaseInfo.php
@@ -29,7 +29,6 @@ use function array_key_exists;
  * This class models the database information returned by the listDatabases
  * command. It provides methods to access common database properties.
  *
- * @api
  * @see \MongoDB\Client::listDatabases()
  * @see https://mongodb.com/docs/manual/reference/command/listDatabases/
  */

--- a/src/Model/DatabaseInfoIterator.php
+++ b/src/Model/DatabaseInfoIterator.php
@@ -25,7 +25,6 @@ use ReturnTypeWillChange;
  *
  * This iterator is used for enumerating databases on a server.
  *
- * @api
  * @see \MongoDB\Client::listDatabases()
  */
 interface DatabaseInfoIterator extends Iterator

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -34,7 +34,6 @@ use function array_search;
  * For information on keys and index options, see the referenced
  * db.collection.createIndex() documentation.
  *
- * @api
  * @see \MongoDB\Collection::listIndexes()
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst
  * @see https://mongodb.com/docs/manual/reference/method/db.collection.createIndex/

--- a/src/Model/IndexInfoIterator.php
+++ b/src/Model/IndexInfoIterator.php
@@ -25,7 +25,6 @@ use ReturnTypeWillChange;
  *
  * This iterator is used for enumerating indexes in a collection.
  *
- * @api
  * @see \MongoDB\Collection::listIndexes()
  */
 interface IndexInfoIterator extends Iterator

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -44,7 +44,6 @@ use function sprintf;
 /**
  * Operation for the aggregate command.
  *
- * @api
  * @see \MongoDB\Collection::aggregate()
  * @see https://mongodb.com/docs/manual/reference/command/aggregate/
  */

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -40,7 +40,6 @@ use function sprintf;
 /**
  * Operation for executing multiple write operations.
  *
- * @api
  * @see \MongoDB\Collection::bulkWrite()
  */
 class BulkWrite implements Executable

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -37,7 +37,6 @@ use function is_string;
 /**
  * Operation for the count command.
  *
- * @api
  * @see \MongoDB\Collection::count()
  * @see https://mongodb.com/docs/manual/reference/command/count/
  */

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -36,7 +36,6 @@ use function is_object;
 /**
  * Operation for obtaining an exact count of documents in a collection
  *
- * @api
  * @see \MongoDB\Collection::countDocuments()
  * @see https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#countdocuments
  */

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -38,7 +38,6 @@ use const E_USER_DEPRECATED;
 /**
  * Operation for the create command.
  *
- * @api
  * @see \MongoDB\Database::createCollection()
  * @see https://mongodb.com/docs/manual/reference/command/create/
  */

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -36,7 +36,6 @@ use function sprintf;
 /**
  * Operation for the createIndexes command.
  *
- * @api
  * @see \MongoDB\Collection::createIndex()
  * @see \MongoDB\Collection::createIndexes()
  * @see https://mongodb.com/docs/manual/reference/command/createIndexes/

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -30,7 +30,6 @@ use function is_object;
 /**
  * Operation for executing a database command.
  *
- * @api
  * @see \MongoDB\Database::command()
  */
 class DatabaseCommand implements Executable

--- a/src/Operation/DeleteMany.php
+++ b/src/Operation/DeleteMany.php
@@ -26,7 +26,6 @@ use MongoDB\Exception\UnsupportedException;
 /**
  * Operation for deleting multiple document with the delete command.
  *
- * @api
  * @see \MongoDB\Collection::deleteOne()
  * @see https://mongodb.com/docs/manual/reference/command/delete/
  */

--- a/src/Operation/DeleteOne.php
+++ b/src/Operation/DeleteOne.php
@@ -26,7 +26,6 @@ use MongoDB\Exception\UnsupportedException;
 /**
  * Operation for deleting a single document with the delete command.
  *
- * @api
  * @see \MongoDB\Collection::deleteOne()
  * @see https://mongodb.com/docs/manual/reference/command/delete/
  */

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -36,7 +36,6 @@ use function MongoDB\create_field_path_type_map;
 /**
  * Operation for the distinct command.
  *
- * @api
  * @see \MongoDB\Collection::distinct()
  * @see https://mongodb.com/docs/manual/reference/command/distinct/
  */

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -32,7 +32,6 @@ use function is_array;
 /**
  * Operation for the drop command.
  *
- * @api
  * @see \MongoDB\Collection::drop()
  * @see \MongoDB\Database::dropCollection()
  * @see https://mongodb.com/docs/manual/reference/command/drop/

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -30,7 +30,6 @@ use function is_array;
 /**
  * Operation for the dropDatabase command.
  *
- * @api
  * @see \MongoDB\Client::dropDatabase()
  * @see \MongoDB\Database::drop()
  * @see https://mongodb.com/docs/manual/reference/command/dropDatabase/

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -32,7 +32,6 @@ use function is_integer;
 /**
  * Operation for the dropIndexes command.
  *
- * @api
  * @see \MongoDB\Collection::dropIndexes()
  * @see https://mongodb.com/docs/manual/reference/command/dropIndexes/
  */

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -32,7 +32,6 @@ use function is_integer;
 /**
  * Operation for obtaining an estimated count of documents in a collection
  *
- * @api
  * @see \MongoDB\Collection::estimatedDocumentCount()
  * @see https://mongodb.com/docs/manual/reference/command/count/
  */

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -33,7 +33,6 @@ use function MongoDB\server_supports_feature;
 /**
  * Operation for the explain command.
  *
- * @api
  * @see \MongoDB\Collection::explain()
  * @see https://mongodb.com/docs/manual/reference/command/explain/
  */

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -40,7 +40,6 @@ use const E_USER_DEPRECATED;
 /**
  * Operation for the find command.
  *
- * @api
  * @see \MongoDB\Collection::find()
  * @see https://mongodb.com/docs/manual/tutorial/query-documents/
  * @see https://mongodb.com/docs/manual/reference/operator/query-modifier/

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -27,7 +27,6 @@ use function current;
 /**
  * Operation for finding a single document with the find command.
  *
- * @api
  * @see \MongoDB\Collection::findOne()
  * @see https://mongodb.com/docs/manual/tutorial/query-documents/
  * @see https://mongodb.com/docs/manual/reference/operator/query-modifier/

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -28,7 +28,6 @@ use function is_object;
 /**
  * Operation for deleting a document with the findAndModify command.
  *
- * @api
  * @see \MongoDB\Collection::findOneAndDelete()
  * @see https://mongodb.com/docs/manual/reference/command/findAndModify/
  */

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -31,7 +31,6 @@ use function MongoDB\is_first_key_operator;
 /**
  * Operation for replacing a document with the findAndModify command.
  *
- * @api
  * @see \MongoDB\Collection::findOneAndReplace()
  * @see https://mongodb.com/docs/manual/reference/command/findAndModify/
  */

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -32,7 +32,6 @@ use function MongoDB\is_pipeline;
 /**
  * Operation for updating a document with the findAndModify command.
  *
- * @api
  * @see \MongoDB\Collection::findOneAndUpdate()
  * @see https://mongodb.com/docs/manual/reference/command/findAndModify/
  */

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -34,7 +34,6 @@ use function sprintf;
 /**
  * Operation for inserting multiple documents with the insert command.
  *
- * @api
  * @see \MongoDB\Collection::insertMany()
  * @see https://mongodb.com/docs/manual/reference/command/insert/
  */

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -33,7 +33,6 @@ use function is_object;
 /**
  * Operation for inserting a single document with the insert command.
  *
- * @api
  * @see \MongoDB\Collection::insertOne()
  * @see https://mongodb.com/docs/manual/reference/command/insert/
  */

--- a/src/Operation/ListCollectionNames.php
+++ b/src/Operation/ListCollectionNames.php
@@ -27,7 +27,6 @@ use MongoDB\Model\CallbackIterator;
 /**
  * Operation for the listCollectionNames helper.
  *
- * @api
  * @see \MongoDB\Database::listCollectionNames()
  * @see https://mongodb.com/docs/manual/reference/command/listCollections/
  */

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -27,7 +27,6 @@ use MongoDB\Model\CollectionInfoIterator;
 /**
  * Operation for the listCollections command.
  *
- * @api
  * @see \MongoDB\Database::listCollections()
  * @see https://mongodb.com/docs/manual/reference/command/listCollections/
  */

--- a/src/Operation/ListDatabaseNames.php
+++ b/src/Operation/ListDatabaseNames.php
@@ -30,7 +30,6 @@ use function array_column;
 /**
  * Operation for the ListDatabases command, returning only database names.
  *
- * @api
  * @see \MongoDB\Client::listDatabaseNames()
  * @see https://mongodb.com/docs/manual/reference/command/listDatabases/#mongodb-dbcommand-dbcmd.listDatabases
  */

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -28,7 +28,6 @@ use MongoDB\Model\DatabaseInfoLegacyIterator;
 /**
  * Operation for the ListDatabases command.
  *
- * @api
  * @see \MongoDB\Client::listDatabases()
  * @see https://mongodb.com/docs/manual/reference/command/listDatabases/#mongodb-dbcommand-dbcmd.listDatabases`
  */

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -33,7 +33,6 @@ use function is_integer;
 /**
  * Operation for the listIndexes command.
  *
- * @api
  * @see \MongoDB\Collection::listIndexes()
  * @see https://mongodb.com/docs/manual/reference/command/listIndexes/
  */

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -48,7 +48,6 @@ use const E_USER_DEPRECATED;
 /**
  * Operation for the mapReduce command.
  *
- * @api
  * @see \MongoDB\Collection::mapReduce()
  * @see https://mongodb.com/docs/manual/reference/command/mapReduce/
  */

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -30,7 +30,6 @@ use function is_array;
 /**
  * Operation for the collMod command.
  *
- * @api
  * @see \MongoDB\Database::modifyCollection()
  * @see https://mongodb.com/docs/manual/reference/command/collMod/
  */

--- a/src/Operation/RenameCollection.php
+++ b/src/Operation/RenameCollection.php
@@ -32,7 +32,6 @@ use function is_bool;
 /**
  * Operation for the renameCollection command.
  *
- * @api
  * @see \MongoDB\Collection::rename()
  * @see \MongoDB\Database::renameCollection()
  * @see https://mongodb.com/docs/manual/reference/command/renameCollection/

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -31,7 +31,6 @@ use function MongoDB\is_pipeline;
 /**
  * Operation for replacing a single document with the update command.
  *
- * @api
  * @see \MongoDB\Collection::replaceOne()
  * @see https://mongodb.com/docs/manual/reference/command/update/
  */

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -31,7 +31,6 @@ use function MongoDB\is_pipeline;
 /**
  * Operation for updating multiple documents with the update command.
  *
- * @api
  * @see \MongoDB\Collection::updateMany()
  * @see https://mongodb.com/docs/manual/reference/command/update/
  */

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -31,7 +31,6 @@ use function MongoDB\is_pipeline;
 /**
  * Operation for updating a single document with the update command.
  *
- * @api
  * @see \MongoDB\Collection::updateOne()
  * @see https://mongodb.com/docs/manual/reference/command/update/
  */

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -53,7 +53,6 @@ use function MongoDB\server_supports_feature;
  * Note: the implementation of CommandSubscriber is an internal implementation
  * detail and should not be considered part of the public API.
  *
- * @api
  * @see \MongoDB\Collection::watch()
  * @see https://mongodb.com/docs/manual/changeStreams/
  */


### PR DESCRIPTION
Fix PHPLIB-1117

All classes are public API by default, unless marked with `@internal`.

These classes had none of these 2 annotations `@api` or `@internal` and are part of the public api to be consistent with other `*Result` classes.
- `BulkWriteResult`
- `Client`
- `Collection`
- `Database`
- `DeleteResult`
- `InsertManyResult`
- `InsertOneResult`
- `UpdateResult`