### PR TITLE
PHPLIB-1128: Move generate_index_name() to private method within IndexInput

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -274,9 +274,13 @@
     <MixedArgument occurrences="1">
       <code>$fieldName</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment occurrences="2">
       <code>$fieldName</code>
+      <code>$type</code>
     </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$type</code>
+    </MixedOperand>
     <MixedReturnStatement occurrences="1">
       <code>$this-&gt;index['name']</code>
     </MixedReturnStatement>
@@ -774,9 +778,8 @@
       <code>$typeMap['fieldPaths'][$fieldPath]</code>
       <code>$typeMap['fieldPaths'][substr($fieldPath, 0, -2)]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="6">
+    <MixedAssignment occurrences="5">
       <code>$element[$key]</code>
-      <code>$type</code>
       <code>$type</code>
       <code>$typeMap['fieldPaths'][$fieldPath . '.' . $existingFieldPath]</code>
       <code>$typeMap['fieldPaths'][$fieldPath]</code>

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -25,7 +25,7 @@ use function is_float;
 use function is_int;
 use function is_object;
 use function is_string;
-use function MongoDB\generate_index_name;
+use function MongoDB\document_to_array;
 use function sprintf;
 
 /**
@@ -64,7 +64,7 @@ class IndexInput implements Serializable
         }
 
         if (! isset($index['name'])) {
-            $index['name'] = generate_index_name($index['key']);
+            $index['name'] = $this->generateIndexName($index['key']);
         }
 
         if (! is_string($index['name'])) {
@@ -91,5 +91,25 @@ class IndexInput implements Serializable
     public function bsonSerialize(): array
     {
         return $this->index;
+    }
+
+    /**
+     * Generate an index name from a key specification.
+     *
+     * @param array|object $document Document containing fields mapped to values,
+     *                               which denote order or an index type
+     * @throws InvalidArgumentException if $document is not an array or object
+     */
+    private function generateIndexName($document): string
+    {
+        $document = document_to_array($document);
+
+        $name = '';
+
+        foreach ($document as $field => $type) {
+            $name .= ($name !== '' ? '_' : '') . $field . '_' . $type;
+        }
+
+        return $name;
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -141,27 +141,6 @@ function document_to_array($document): array
 }
 
 /**
- * Generate an index name from a key specification.
- *
- * @internal
- * @param array|object $document Document containing fields mapped to values,
- *                               which denote order or an index type
- * @throws InvalidArgumentException if $document is not an array or object
- */
-function generate_index_name($document): string
-{
-    $document = document_to_array($document);
-
-    $name = '';
-
-    foreach ($document as $field => $type) {
-        $name .= ($name != '' ? '_' : '') . $field . '_' . $type;
-    }
-
-    return $name;
-}
-
-/**
  * Return a collection's encryptedFields from the encryptedFieldsMap
  * autoEncryption driver option (if available).
  *

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -12,7 +12,6 @@ use MongoDB\Model\BSONDocument;
 use function MongoDB\apply_type_map_to_document;
 use function MongoDB\create_field_path_type_map;
 use function MongoDB\document_to_array;
-use function MongoDB\generate_index_name;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_last_pipeline_operator_write;
 use function MongoDB\is_mapreduce_output_inline;
@@ -121,14 +120,6 @@ class FunctionsTest extends TestCase
         document_to_array($document);
     }
 
-    /** @dataProvider provideDocumentCasts */
-    public function testGenerateIndexName($cast): void
-    {
-        $this->assertSame('x_1', generate_index_name($cast(['x' => 1])));
-        $this->assertSame('x_-1_y_1', generate_index_name($cast(['x' => -1, 'y' => 1])));
-        $this->assertSame('x_2dsphere_y_1', generate_index_name($cast(['x' => '2dsphere', 'y' => 1])));
-    }
-
     public function provideDocumentCasts(): array
     {
         // phpcs:disable SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing
@@ -141,13 +132,6 @@ class FunctionsTest extends TestCase
             'Document' => [function ($value) { return Document::fromPHP($value); }],
         ];
         // phpcs:enable
-    }
-
-    /** @dataProvider provideInvalidDocumentValues */
-    public function testGenerateIndexNameArgumentTypeCheck($document): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        generate_index_name($document);
     }
 
     /** @dataProvider provideDocumentCasts */

--- a/tests/Model/IndexInputTest.php
+++ b/tests/Model/IndexInputTest.php
@@ -2,8 +2,10 @@
 
 namespace MongoDB\Tests\Model;
 
+use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Model\IndexInput;
 use MongoDB\Tests\TestCase;
 use stdClass;
@@ -40,16 +42,22 @@ class IndexInputTest extends TestCase
         new IndexInput(['key' => ['x' => 1], 'name' => 1]);
     }
 
-    /** @dataProvider provideExpectedNameAndKey */
-    public function testNameGeneration($expectedName, array $key): void
+    /**
+     * @dataProvider provideExpectedNameAndKey
+     * @param array|object $key
+     */
+    public function testNameGeneration($expectedName, $key): void
     {
         $this->assertSame($expectedName, (string) new IndexInput(['key' => $key]));
     }
 
-    public function provideExpectedNameAndKey()
+    public function provideExpectedNameAndKey(): array
     {
         return [
             ['x_1', ['x' => 1]],
+            ['x_1', (object) ['x' => 1]],
+            ['x_1', new BSONDocument(['x' => 1])],
+            ['x_1', Document::fromPHP(['x' => 1])],
             ['x_1_y_-1', ['x' => 1, 'y' => -1]],
             ['loc_2dsphere', ['loc' => '2dsphere']],
             ['loc_2dsphere_x_1', ['loc' => '2dsphere', 'x' => 1]],


### PR DESCRIPTION
Fix PHPLIB-1128

`generate_index_name()` was originally made a utility function in [bc65629](https://github.com/mongodb/mongo-php-library/commit/bc65629c772a53c57b4f5debad6aae5b76c9a01c) because it was shared by both the CreateIndexes (via IndexInput) and Count operations. It was later removed from Count in [PHPLIB-285](https://jira.mongodb.org/browse/PHPLIB-285).