### PR TITLE
PHPLIB-1157: Limit omitted field assertions to top-level

### DIFF
--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -16,7 +16,6 @@ use function in_array;
 use function json_encode;
 use function MongoDB\BSON\fromJSON;
 use function MongoDB\BSON\toPHP;
-use function property_exists;
 use function sprintf;
 use function version_compare;
 
@@ -97,11 +96,12 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     }
 
     /**
-     * Assert omitted fields in command documents.
+     * Assert omitted top-level fields in command documents.
      *
      * Note: this method may modify the $expected object.
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst#null-values
+     * @see https://github.com/mongodb/specifications/blob/09ee1ebc481f1502e3246971a9419e484d736207/source/command-monitoring/tests/README.rst#additional-values
      */
     protected static function assertCommandOmittedFields(stdClass $expected, stdClass $actual): void
     {
@@ -109,11 +109,6 @@ class FunctionalTestCase extends BaseFunctionalTestCase
             if ($value === null) {
                 static::assertObjectNotHasAttribute($key, $actual);
                 unset($expected->{$key});
-                continue;
-            }
-
-            if ($value instanceof stdClass && property_exists($actual, $key) && $actual->{$key} instanceof stdClass) {
-                static::assertCommandOmittedFields($value, $actual->{$key});
             }
         }
     }

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-CreateCollection-OldServer.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-CreateCollection-OldServer.json
@@ -55,6 +55,38 @@
           "result": {
             "errorContains": "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
           }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
         }
       ]
     }

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-CreateCollection.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-CreateCollection.json
@@ -158,9 +158,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -343,9 +340,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -851,9 +845,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1048,9 +1039,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1367,9 +1355,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1635,9 +1620,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1157
https://jira.mongodb.org/browse/PHPLIB-1071

This reverts previous functionality added in d95e7623390b8f657755f6601859d4649612a40d.

CSFLE tests are synced to mongodb/specifications@e59a0ac6daa19e7605b0a1d2c667a67367d52edd

Also updates fle2v2-CreateCollection-OldServer.json from mongodb/specifications@9e770b54bbb6315aa82a162c42c577a5b3f8037a, which was a late change for PHPLIB-1071