### PR TITLE
PHPLIB-1138: Allows line length to be 120 characters max

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,14 @@
     <!-- Target minimum supported PHP version -->
     <config name="php_version" value="70200"/>
 
+    <!-- Allows line length to be 120 characters max -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="120"/>
+        </properties>
+    </rule>
+
     <!-- ****************************************** -->
     <!-- Import rules from doctrine/coding-standard -->
     <!-- ****************************************** -->


### PR DESCRIPTION
Fix PHPLIB-1138

Gives more space for comments and descriptive names.

120 is the "soft limit" proposed by [PSR-12](https://www.php-fig.org/psr/psr-12/).

> 2.3 Lines
> There MUST NOT be a hard limit on line length.
> 
> The soft limit on line length MUST be 120 characters.

No reformatting of the codebase for now. Just allow longer lines.