### PR TITLE
PHPLIB-1122: Additional support for BSON objects

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -422,6 +422,9 @@
       <code>! is_array($encryptedFields['fields'])</code>
       <code>! is_array($field) &amp;&amp; ! is_object($field)</code>
     </DocblockTypeContradiction>
+    <MixedArgument occurrences="1">
+      <code>$this-&gt;options['encryptedFields']</code>
+    </MixedArgument>
   </file>
   <file src="src/Operation/CreateIndexes.php">
     <DocblockTypeContradiction occurrences="1">

--- a/src/Operation/CreateEncryptedCollection.php
+++ b/src/Operation/CreateEncryptedCollection.php
@@ -18,6 +18,8 @@
 namespace MongoDB\Operation;
 
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\PackedArray;
+use MongoDB\BSON\Serializable;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
@@ -27,6 +29,7 @@ use MongoDB\Exception\UnsupportedException;
 use function array_key_exists;
 use function is_array;
 use function is_object;
+use function MongoDB\document_to_array;
 use function MongoDB\server_supports_feature;
 
 /**
@@ -87,7 +90,7 @@ class CreateEncryptedCollection implements Executable
         $this->createCollection = new CreateCollection($databaseName, $collectionName, $options);
 
         /** @psalm-var array{ecocCollection?: ?string, escCollection?: ?string} */
-        $encryptedFields = (array) $options['encryptedFields'];
+        $encryptedFields = document_to_array($options['encryptedFields']);
         $enxcolOptions = ['clusteredIndex' => ['key' => ['_id' => 1], 'unique' => true]];
 
         $this->createMetadataCollections = [
@@ -118,12 +121,28 @@ class CreateEncryptedCollection implements Executable
      */
     public function createDataKeys(ClientEncryption $clientEncryption, string $kmsProvider, ?array $masterKey, ?array &$encryptedFields = null): void
     {
-        /** @psalm-var array{fields: list<array{keyId: ?Binary}|object{keyId: ?Binary}>} */
-        $encryptedFields = (array) $this->options['encryptedFields'];
+        /** @psalm-var array{fields: list<array{keyId: ?Binary}|object{keyId: ?Binary}>|Serializable|PackedArray} */
+        $encryptedFields = document_to_array($this->options['encryptedFields']);
 
-        /* NOP if there are no fields to examine. If the type is invalid, defer
-         * to the server to raise an error in execute(). */
-        if (! isset($encryptedFields['fields']) || ! is_array($encryptedFields['fields'])) {
+        // NOP if there are no fields to examine
+        if (! isset($encryptedFields['fields'])) {
+            return;
+        }
+
+        // Allow PackedArray or Serializable object for the fields array
+        if ($encryptedFields['fields'] instanceof PackedArray) {
+            /** @psalm-var array */
+            $encryptedFields['fields'] = $encryptedFields['fields']->toPHP([
+                'array' => 'array',
+                'document' => 'object',
+                'root' => 'array',
+            ]);
+        } elseif ($encryptedFields['fields'] instanceof Serializable) {
+            $encryptedFields['fields'] = $encryptedFields['fields']->bsonSerialize();
+        }
+
+        // Skip invalid types and defer to the server to raise an error
+        if (! is_array($encryptedFields['fields'])) {
             return;
         }
 
@@ -138,7 +157,7 @@ class CreateEncryptedCollection implements Executable
                 continue;
             }
 
-            $field = (array) $field;
+            $field = document_to_array($field);
 
             if (array_key_exists('keyId', $field) && $field['keyId'] === null) {
                 $field['keyId'] = $clientEncryption->createDataKey(...$createDataKeyArgs);

--- a/src/Operation/DropEncryptedCollection.php
+++ b/src/Operation/DropEncryptedCollection.php
@@ -23,6 +23,7 @@ use MongoDB\Exception\InvalidArgumentException;
 
 use function is_array;
 use function is_object;
+use function MongoDB\document_to_array;
 
 /**
  * Drop an encrypted collection.
@@ -72,7 +73,7 @@ class DropEncryptedCollection implements Executable
         }
 
         /** @psalm-var array{ecocCollection?: ?string, escCollection?: ?string} */
-        $encryptedFields = (array) $options['encryptedFields'];
+        $encryptedFields = document_to_array($options['encryptedFields']);
 
         $this->dropMetadataCollections = [
             new DropCollection($databaseName, $encryptedFields['escCollection'] ?? 'enxcol_.' . $collectionName . '.esc'),

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -40,6 +40,7 @@ use function is_integer;
 use function is_object;
 use function is_string;
 use function MongoDB\create_field_path_type_map;
+use function MongoDB\document_to_array;
 use function MongoDB\is_mapreduce_output_inline;
 use function trigger_error;
 
@@ -315,7 +316,7 @@ class MapReduce implements Executable
             return;
         }
 
-        $out = (array) $out;
+        $out = document_to_array($out);
 
         if (isset($out['nonAtomic']) && ! $out['nonAtomic']) {
             @trigger_error('Specifying false for "out.nonAtomic" is deprecated.', E_USER_DEPRECATED);

--- a/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
+++ b/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
@@ -3,9 +3,12 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\Document;
 use MongoDB\Client;
 use MongoDB\ClientEncryption;
 use MongoDB\Driver\WriteConcern;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\CreateEncryptedCollection;
 
 use function base64_decode;
@@ -61,61 +64,100 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         ]);
     }
 
-    public function testCreateDataKeysNopIfFieldsArrayIsMissing(): void
+    /** @dataProvider provideEncryptedFieldsAndFieldsIsMissing */
+    public function testCreateDataKeysNopIfFieldsIsMissing($input, array $expectedOutput): void
     {
         $operation = new CreateEncryptedCollection(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['encryptedFields' => []]
+            ['encryptedFields' => $input]
         );
 
         $operation->createDataKeys(
             $this->clientEncryption,
             'local',
             null,
-            $encryptedFields
+            $encryptedFieldsOutput
         );
 
-        $this->assertSame([], $encryptedFields);
+        $this->assertSame($expectedOutput, $encryptedFieldsOutput);
     }
 
-    public function testCreateDataKeysNopIfFieldsArrayIsInvalid(): void
+    public function provideEncryptedFieldsAndFieldsIsMissing(): array
+    {
+        $ef = [];
+
+        return [
+            'array' => [$ef, $ef],
+            'object' => [(object) $ef, $ef],
+            'Serializable' => [new BSONDocument($ef), $ef],
+            'Document' => [Document::fromPHP($ef), $ef],
+        ];
+    }
+
+    /** @dataProvider provideEncryptedFieldsAndFieldsHasInvalidType */
+    public function testCreateDataKeysNopIfFieldsHasInvalidType($input, array $expectedOutput): void
     {
         $operation = new CreateEncryptedCollection(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['encryptedFields' => ['fields' => 'not-an-array']]
+            ['encryptedFields' => $input]
         );
 
         $operation->createDataKeys(
             $this->clientEncryption,
             'local',
             null,
-            $encryptedFields
+            $encryptedFieldsOutput
         );
 
-        $this->assertSame(['fields' => 'not-an-array'], $encryptedFields);
+        $this->assertSame($expectedOutput, $encryptedFieldsOutput);
     }
 
-    public function testCreateDataKeysSkipsNonDocumentFields(): void
+    public function provideEncryptedFieldsAndFieldsHasInvalidType(): array
+    {
+        $ef = ['fields' => 'not-an-array'];
+
+        return [
+            'array' => [$ef, $ef],
+            'object' => [(object) $ef, $ef],
+            'Serializable' => [new BSONDocument($ef), $ef],
+            'Document' => [Document::fromPHP($ef), $ef],
+        ];
+    }
+
+    /** @dataProvider provideEncryptedFieldsElementHasInvalidType */
+    public function testCreateDataKeysSkipsNonDocumentFields($input, array $expectedOutput): void
     {
         $operation = new CreateEncryptedCollection(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['encryptedFields' => ['fields' => ['not-an-array-or-object']]]
+            ['encryptedFields' => $input]
         );
 
         $operation->createDataKeys(
             $this->clientEncryption,
             'local',
             null,
-            $encryptedFields
+            $encryptedFieldsOutput
         );
 
-        $this->assertSame(['fields' => ['not-an-array-or-object']], $encryptedFields);
+        $this->assertSame($expectedOutput, $encryptedFieldsOutput);
     }
 
-    public function testCreateDataKeysDoesNotModifyEncryptedFieldsObjectOption(): void
+    public function provideEncryptedFieldsElementHasInvalidType(): array
+    {
+        $ef = ['fields' => ['not-an-array-or-object']];
+
+        return [
+            'array' => [$ef, $ef],
+            'object' => [(object) $ef, $ef],
+            'Serializable' => [new BSONDocument(['fields' => new BSONArray(['not-an-array-or-object'])]), $ef],
+            'Document' => [Document::fromPHP($ef), $ef],
+        ];
+    }
+
+    public function testCreateDataKeysDoesNotModifyOriginalEncryptedFieldsOption(): void
     {
         $originalField = (object) ['path' => 'ssn', 'bsonType' => 'string', 'keyId' => null];
         $originalEncryptedFields = (object) ['fields' => [$originalField]];
@@ -137,6 +179,37 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $this->assertNull($originalField->keyId);
 
         $this->assertInstanceOf(Binary::class, $modifiedEncryptedFields['fields'][0]['keyId'] ?? null);
+    }
+
+    /** @dataProvider provideEncryptedFields */
+    public function testEncryptedFieldsDocuments($input): void
+    {
+        $operation = new CreateEncryptedCollection(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            ['encryptedFields' => $input]
+        );
+
+        $operation->createDataKeys(
+            $this->clientEncryption,
+            'local',
+            null,
+            $modifiedEncryptedFields
+        );
+
+        $this->assertInstanceOf(Binary::class, $modifiedEncryptedFields['fields'][0]['keyId'] ?? null);
+    }
+
+    public function provideEncryptedFields(): array
+    {
+        $ef = ['fields' => [['path' => 'ssn', 'bsonType' => 'string', 'keyId' => null]]];
+
+        return [
+            'array' => [$ef],
+            'object' => [(object) $ef],
+            'Serializable' => [new BSONDocument(['fields' => new BSONArray([new BSONDocument($ef['fields'][0])])])],
+            'Document' => [Document::fromPHP($ef)],
+        ];
     }
 
     public static function createTestClient(?string $uri = null, array $options = [], array $driverOptions = []): Client

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -67,7 +67,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
     public function provideDocumentsWithoutIds(): array
     {
         /* Note: _id placeholders must be replaced with generated ObjectIds. We
-         * also clone the value for each data set since tests will may modify
+         * also clone the value for each data set since tests may need to modify
          * the object. */
         $expectedDocument = (object) ['_id' => null, 'x' => 1];
 

--- a/tests/Operation/MapReduceTest.php
+++ b/tests/Operation/MapReduceTest.php
@@ -2,9 +2,11 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
 use MongoDB\BSON\Javascript;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\MapReduce;
 use stdClass;
 
@@ -23,6 +25,31 @@ class MapReduceTest extends TestCase
     public function provideInvalidOutValues()
     {
         return $this->wrapValuesForDataProvider([123, 3.14, true]);
+    }
+
+    /** @dataProvider provideDeprecatedOutValues */
+    public function testConstructorOutArgumentDeprecations($out): void
+    {
+        $map = new Javascript('function() { emit(this.x, this.y); }');
+        $reduce = new Javascript('function(key, values) { return Array.sum(values); }');
+
+        $this->assertDeprecated(function () use ($map, $reduce, $out): void {
+            new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out);
+        });
+    }
+
+    public function provideDeprecatedOutValues(): array
+    {
+        return [
+            'nonAtomic:array' => [['nonAtomic' => false]],
+            'nonAtomic:object' => [(object) ['nonAtomic' => false]],
+            'nonAtomic:Serializable' => [new BSONDocument(['nonAtomic' => false])],
+            'nonAtomic:Document' => [Document::fromPHP(['nonAtomic' => false])],
+            'sharded:array' => [['sharded' => false]],
+            'sharded:object' => [(object) ['sharded' => false]],
+            'sharded:Serializable' => [new BSONDocument(['sharded' => false])],
+            'sharded:Document' => [Document::fromPHP(['sharded' => false])],
+        ];
     }
 
     /** @dataProvider provideInvalidConstructorOptions */


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1122

Adds support for BSON objects with:

 * MapReduce `$out` parameter
 * CreateEncryptedCollection and DropEncryptedCollection `encryptedFields` option

Adds test coverage for BulkWrite operations.