### PR TITLE
PHPLIB-1129: Improve pipeline checks for replace operations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -36,8 +36,9 @@
     </UnsafeInstantiation>
   </file>
   <file src="src/Exception/InvalidArgumentException.php">
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation occurrences="2">
       <code>new static(sprintf('Expected %s to have type "%s" but found "%s"', $name, $expectedType, get_debug_type($value)))</code>
+      <code>new static('Expected update operator(s) or non-empty pipeline for ' . $name)</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Exception/ResumeTokenException.php">
@@ -308,13 +309,14 @@
     <DocblockTypeContradiction occurrences="1">
       <code>is_array($operation)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="12">
+    <MixedArgument occurrences="13">
       <code>$args</code>
       <code>$args</code>
       <code>$args</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
+      <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -322,11 +324,14 @@
       <code>$args[1]</code>
       <code>$args[2]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="25">
+    <MixedArrayAccess occurrences="28">
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
+      <code>$args[1]</code>
+      <code>$args[1]</code>
+      <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -349,7 +354,8 @@
       <code>$args[2]['upsert']</code>
       <code>$args[2]['upsert']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="11">
+    <MixedArrayAssignment occurrences="12">
+      <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[2]</code>

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -191,8 +191,17 @@ class BulkWrite implements Executable
                         throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]', $i, $type), $args[1], 'array or object');
                     }
 
+                    // Treat empty arrays as replacement documents for BC
+                    if ($args[1] === []) {
+                        $args[1] = (object) $args[1];
+                    }
+
                     if (is_first_key_operator($args[1])) {
                         throw new InvalidArgumentException(sprintf('First key in $operations[%d]["%s"][1] is an update operator', $i, $type));
+                    }
+
+                    if (is_pipeline($args[1], true /* allowEmpty */)) {
+                        throw new InvalidArgumentException(sprintf('$operations[%d]["%s"][1] is an update pipeline', $i, $type));
                     }
 
                     if (! isset($args[2])) {
@@ -229,7 +238,7 @@ class BulkWrite implements Executable
                     }
 
                     if (! is_first_key_operator($args[1]) && ! is_pipeline($args[1])) {
-                        throw new InvalidArgumentException(sprintf('First key in $operations[%d]["%s"][1] is neither an update operator nor a pipeline', $i, $type));
+                        throw new InvalidArgumentException(sprintf('Expected update operator(s) or non-empty pipeline for $operations[%d]["%s"][1]', $i, $type));
                     }
 
                     if (! isset($args[2])) {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -295,6 +295,14 @@ class FindAndModify implements Executable, Explainable
         if (isset($this->options['update'])) {
             /** @psalm-var array|object */
             $update = $this->options['update'];
+            /* A non-empty pipeline will encode as a BSON array, so leave it
+             * as-is. Cast anything else to an object since a BSON document is
+             * likely expected. This includes empty arrays, which historically
+             * can be used to represent empty replacement documents.
+             *
+             * This also allows an empty pipeline expressed as a PackedArray or
+             * Serializable to still encode as a BSON array, since the object
+             * cast will have no effect. */
             $cmd['update'] = is_pipeline($update) ? $update : (object) $update;
         }
 

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -27,6 +27,7 @@ use function is_array;
 use function is_integer;
 use function is_object;
 use function MongoDB\is_first_key_operator;
+use function MongoDB\is_pipeline;
 
 /**
  * Operation for replacing a document with the findAndModify command.
@@ -109,8 +110,17 @@ class FindOneAndReplace implements Executable, Explainable
             throw InvalidArgumentException::invalidType('$replacement', $replacement, 'array or object');
         }
 
+        // Treat empty arrays as replacement documents for BC
+        if ($replacement === []) {
+            $replacement = (object) $replacement;
+        }
+
         if (is_first_key_operator($replacement)) {
-            throw new InvalidArgumentException('First key in $replacement argument is an update operator');
+            throw new InvalidArgumentException('First key in $replacement is an update operator');
+        }
+
+        if (is_pipeline($replacement, true /* allowEmpty */)) {
+            throw new InvalidArgumentException('$replacement is an update pipeline');
         }
 
         if (isset($options['projection']) && ! is_array($options['projection']) && ! is_object($options['projection'])) {

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -114,7 +114,7 @@ class FindOneAndUpdate implements Executable, Explainable
         }
 
         if (! is_first_key_operator($update) && ! is_pipeline($update)) {
-            throw new InvalidArgumentException('Expected an update document with operator as first key or a pipeline');
+            throw new InvalidArgumentException('Expected update operator(s) or non-empty pipeline for $update');
         }
 
         if (isset($options['projection']) && ! is_array($options['projection']) && ! is_object($options['projection'])) {

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -85,12 +85,17 @@ class ReplaceOne implements Executable
             throw InvalidArgumentException::invalidType('$replacement', $replacement, 'array or object');
         }
 
-        if (is_first_key_operator($replacement)) {
-            throw new InvalidArgumentException('First key in $replacement argument is an update operator');
+        // Treat empty arrays as replacement documents for BC
+        if ($replacement === []) {
+            $replacement = (object) $replacement;
         }
 
-        if (is_pipeline($replacement)) {
-            throw new InvalidArgumentException('$replacement argument is a pipeline');
+        if (is_first_key_operator($replacement)) {
+            throw new InvalidArgumentException('First key in $replacement is an update operator');
+        }
+
+        if (is_pipeline($replacement, true /* allowEmpty */)) {
+            throw new InvalidArgumentException('$replacement is an update pipeline');
         }
 
         $this->update = new Update(

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -148,7 +148,7 @@ class Update implements Executable, Explainable
         }
 
         if ($options['multi'] && ! is_first_key_operator($update) && ! is_pipeline($update)) {
-            throw new InvalidArgumentException('"multi" option cannot be true if $update is a replacement document');
+            throw new InvalidArgumentException('"multi" option cannot be true unless $update has update operator(s) or non-empty pipeline');
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -89,7 +89,7 @@ class UpdateMany implements Executable, Explainable
         }
 
         if (! is_first_key_operator($update) && ! is_pipeline($update)) {
-            throw new InvalidArgumentException('Expected an update document with operator as first key or a pipeline');
+            throw new InvalidArgumentException('Expected update operator(s) or non-empty pipeline for $update');
         }
 
         $this->update = new Update(

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -89,7 +89,7 @@ class UpdateOne implements Executable, Explainable
         }
 
         if (! is_first_key_operator($update) && ! is_pipeline($update)) {
-            throw new InvalidArgumentException('Expected an update document with operator as first key or a pipeline');
+            throw new InvalidArgumentException('Expected update operator(s) or non-empty pipeline for $update');
         }
 
         $this->update = new Update(

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -4,13 +4,11 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectId;
-use MongoDB\BSON\PackedArray;
 use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite as Bulk;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
-use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\BulkWrite;
 use MongoDB\Tests\CommandObserver;
@@ -177,18 +175,6 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideFilterDocuments(): array
-    {
-        $expectedQuery = (object) ['x' => 1];
-
-        return [
-            'array' => [['x' => 1], $expectedQuery],
-            'object' => [(object) ['x' => 1], $expectedQuery],
-            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
-            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
-        ];
-    }
-
     /** @dataProvider provideReplacementDocuments */
     public function testReplacementDocuments($replacement, stdClass $expectedReplacement): void
     {
@@ -206,18 +192,6 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedReplacement, $event['started']->getCommand()->updates[0]->u ?? null);
             }
         );
-    }
-
-    public function provideReplacementDocuments(): array
-    {
-        $expected = (object) ['x' => 1];
-
-        return [
-            'replacement:array' => [['x' => 1], $expected],
-            'replacement:object' => [(object) ['x' => 1], $expected],
-            'replacement:Serializable' => [new BSONDocument(['x' => 1]), $expected],
-            'replacement:Document' => [Document::fromPHP(['x' => 1]), $expected],
-        ];
     }
 
     /**
@@ -248,29 +222,6 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->updates[1]->u ?? null);
             }
         );
-    }
-
-    public function provideUpdateDocuments(): array
-    {
-        $expected = (object) ['$set' => (object) ['x' => 1]];
-
-        return [
-            'update:array' => [['$set' => ['x' => 1]], $expected],
-            'update:object' => [(object) ['$set' => ['x' => 1]], $expected],
-            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]]), $expected],
-            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]]), $expected],
-        ];
-    }
-
-    public function provideUpdatePipelines(): array
-    {
-        $expected = [(object) ['$set' => (object) ['x' => 1]]];
-
-        return [
-            'pipeline:array' => [[['$set' => ['x' => 1]]], $expected],
-            'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]]), $expected],
-            'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]]), $expected],
-        ];
     }
 
     public function testDeletes(): void

--- a/tests/Operation/CountDocumentsFunctionalTest.php
+++ b/tests/Operation/CountDocumentsFunctionalTest.php
@@ -2,8 +2,6 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\CountDocuments;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
@@ -28,18 +26,6 @@ class CountDocumentsFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedMatchStage, $event['started']->getCommand()->pipeline[0]->{'$match'} ?? null);
             }
         );
-    }
-
-    public function provideFilterDocuments(): array
-    {
-        $expectedQuery = (object) ['x' => 1];
-
-        return [
-            'array' => [['x' => 1], $expectedQuery],
-            'object' => [(object) ['x' => 1], $expectedQuery],
-            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
-            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
-        ];
     }
 
     public function testEmptyCollection(): void

--- a/tests/Operation/CountFunctionalTest.php
+++ b/tests/Operation/CountFunctionalTest.php
@@ -2,8 +2,6 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Count;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\InsertMany;
@@ -29,18 +27,6 @@ class CountFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->query ?? null);
             }
         );
-    }
-
-    public function provideFilterDocuments(): array
-    {
-        $expectedQuery = (object) ['x' => 1];
-
-        return [
-            'array' => [['x' => 1], $expectedQuery],
-            'object' => [(object) ['x' => 1], $expectedQuery],
-            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
-            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
-        ];
     }
 
     public function testDefaultReadConcernIsOmitted(): void

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -2,14 +2,12 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
 use MongoDB\Collection;
 use MongoDB\DeleteResult;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Exception\UnsupportedException;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Delete;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
@@ -46,18 +44,6 @@ class DeleteFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->deletes[0]->q ?? null);
             }
         );
-    }
-
-    public function provideFilterDocuments(): array
-    {
-        $expectedQuery = (object) ['x' => 1];
-
-        return [
-            'array' => [['x' => 1], $expectedQuery],
-            'object' => [(object) ['x' => 1], $expectedQuery],
-            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
-            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
-        ];
     }
 
     public function testDeleteOne(): void

--- a/tests/Operation/DistinctFunctionalTest.php
+++ b/tests/Operation/DistinctFunctionalTest.php
@@ -2,9 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
 use MongoDB\Driver\BulkWrite;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Distinct;
 use MongoDB\Tests\CommandObserver;
 use stdClass;
@@ -33,18 +31,6 @@ class DistinctFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->query ?? null);
             }
         );
-    }
-
-    public function provideFilterDocuments(): array
-    {
-        $expectedQuery = (object) ['x' => 1];
-
-        return [
-            'array' => [['x' => 1], $expectedQuery],
-            'object' => [(object) ['x' => 1], $expectedQuery],
-            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
-            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
-        ];
     }
 
     public function testDefaultReadConcernIsOmitted(): void

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -51,6 +51,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
      * @dataProvider provideReplacementDocuments
      * @dataProvider provideUpdateDocuments
      * @dataProvider provideUpdatePipelines
+     * @dataProvider provideReplacementDocumentLikePipeline
      */
     public function testUpdateDocuments($update, $expectedUpdate): void
     {
@@ -71,6 +72,19 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->update ?? null);
             }
         );
+    }
+
+    public function provideReplacementDocumentLikePipeline(): array
+    {
+        /* Note: this expected value differs from UpdateFunctionalTest because
+         * FindAndModify is not affected by libmongoc's pipeline detection for
+         * update commands (see: CDRIVER-4658). */
+        return [
+            'replacement_like_pipeline' => [
+                (object) ['0' => ['$set' => ['x' => 1]]],
+                (object) ['0' => (object) ['$set' => (object) ['x' => 1]]],
+            ],
+        ];
     }
 
     /** @see https://jira.mongodb.org/browse/PHPLIB-344 */

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -3,12 +3,10 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\BSON\Document;
-use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\UnsupportedException;
-use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindAndModify;
 use MongoDB\Tests\CommandObserver;
@@ -73,41 +71,6 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->update ?? null);
             }
         );
-    }
-
-    public function provideReplacementDocuments(): array
-    {
-        $expected = (object) ['x' => 1];
-
-        return [
-            'replacement:array' => [['x' => 1], $expected],
-            'replacement:object' => [(object) ['x' => 1], $expected],
-            'replacement:Serializable' => [new BSONDocument(['x' => 1]), $expected],
-            'replacement:Document' => [Document::fromPHP(['x' => 1]), $expected],
-        ];
-    }
-
-    public function provideUpdateDocuments(): array
-    {
-        $expected = (object) ['$set' => (object) ['x' => 1]];
-
-        return [
-            'update:array' => [['$set' => ['x' => 1]], $expected],
-            'update:object' => [(object) ['$set' => ['x' => 1]], $expected],
-            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]]), $expected],
-            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]]), $expected],
-        ];
-    }
-
-    public function provideUpdatePipelines(): array
-    {
-        $expected = [(object) ['$set' => (object) ['x' => 1]]];
-
-        return [
-            'pipeline:array' => [[['$set' => ['x' => 1]]], $expected],
-            'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]]), $expected],
-            'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]]), $expected],
-        ];
     }
 
     /** @see https://jira.mongodb.org/browse/PHPLIB-344 */

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -34,18 +34,6 @@ class FindFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideFilterDocuments(): array
-    {
-        $expectedQuery = (object) ['x' => 1];
-
-        return [
-            'array' => [['x' => 1], $expectedQuery],
-            'object' => [(object) ['x' => 1], $expectedQuery],
-            'Serializable' => [new BSONDocument(['x' => 1]), $expectedQuery],
-            'Document' => [Document::fromPHP(['x' => 1]), $expectedQuery],
-        ];
-    }
-
     /** @dataProvider provideModifierDocuments */
     public function testModifierDocuments($modifiers, stdClass $expectedSort): void
     {

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -2,11 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
-//use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
-//use MongoDB\Model\BSONArray;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindOneAndReplace;
 
 class FindOneAndReplaceTest extends TestCase
@@ -25,29 +21,32 @@ class FindOneAndReplaceTest extends TestCase
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 
-    /** @dataProvider provideInvalidReplacementValues */
-    public function testConstructorReplacementArgumentRequiresNoOperators($replacement): void
+    /**
+     * @dataProvider provideReplacementDocuments
+     * @doesNotPerformAssertions
+     */
+    public function testConstructorReplacementArgument($replacement): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('First key in $replacement argument is an update operator');
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 
-    public function provideInvalidReplacementValues(): array
+    /** @dataProvider provideUpdateDocuments */
+    public function testConstructorReplacementArgumentProhibitsUpdateDocument($replacement): void
     {
-        return [
-            'update:array' => [['$set' => ['x' => 1]]],
-            'update:object' => [(object) ['$set' => ['x' => 1]]],
-            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]])],
-            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]])],
-            // TODO: Enable the following tests when implementing PHPLIB-1129
-            //'pipeline:array' => [[['$set' => ['x' => 1]]]],
-            //'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]])],
-            //'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]])],
-            //'empty_pipeline:array' => [[]],
-            //'empty_pipeline:Serializable' => [new BSONArray([])],
-            //'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
-        ];
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('First key in $replacement is an update operator');
+        new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
+    }
+
+    /**
+     * @dataProvider provideUpdatePipelines
+     * @dataProvider provideEmptyUpdatePipelinesExcludingArray
+     */
+    public function testConstructorReplacementArgumentProhibitsUpdatePipeline($replacement): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$replacement is an update pipeline');
+        new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 
     /** @dataProvider provideInvalidConstructorOptions */

--- a/tests/Operation/FindOneAndUpdateTest.php
+++ b/tests/Operation/FindOneAndUpdateTest.php
@@ -2,11 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\Model\BSONArray;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindOneAndUpdate;
 
 class FindOneAndUpdateTest extends TestCase
@@ -25,25 +21,15 @@ class FindOneAndUpdateTest extends TestCase
         new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], $update);
     }
 
-    /** @dataProvider provideInvalidUpdateValues */
-    public function testConstructorUpdateArgumentRequiresOperatorsOrPipeline($update): void
+    /**
+     * @dataProvider provideReplacementDocuments
+     * @dataProvider provideEmptyUpdatePipelines
+     */
+    public function testConstructorUpdateArgumentProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected an update document with operator as first key or a pipeline');
+        $this->expectExceptionMessage('Expected update operator(s) or non-empty pipeline for $update');
         new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], $update);
-    }
-
-    public function provideInvalidUpdateValues(): array
-    {
-        return [
-            'replacement:array' => [['x' => 1]],
-            'replacement:object' => [(object) ['x' => 1]],
-            'replacement:Serializable' => [new BSONDocument(['x' => 1])],
-            'replacement:Document' => [Document::fromPHP(['x' => 1])],
-            'empty_pipeline:array' => [[]],
-            'empty_pipeline:Serializable' => [new BSONArray([])],
-            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
-        ];
     }
 
     /** @dataProvider provideInvalidConstructorOptions */

--- a/tests/Operation/FunctionalTestCase.php
+++ b/tests/Operation/FunctionalTestCase.php
@@ -2,8 +2,12 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\WriteConcern;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
 
 /**
@@ -16,6 +20,64 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         parent::setUp();
 
         $this->dropCollection($this->getDatabaseName(), $this->getCollectionName());
+    }
+
+    public function provideFilterDocuments(): array
+    {
+        $expected = (object) ['x' => 1];
+
+        return [
+            'filter:array' => [['x' => 1], $expected],
+            'filter:object' => [(object) ['x' => 1], $expected],
+            'filter:Serializable' => [new BSONDocument(['x' => 1]), $expected],
+            'filter:Document' => [Document::fromPHP(['x' => 1]), $expected],
+        ];
+    }
+
+    public function provideReplacementDocuments(): array
+    {
+        $expected = (object) ['x' => 1];
+        $expectedEmpty = (object) [];
+
+        return [
+            'replacement:array' => [['x' => 1], $expected],
+            'replacement:object' => [(object) ['x' => 1], $expected],
+            'replacement:Serializable' => [new BSONDocument(['x' => 1]), $expected],
+            'replacement:Document' => [Document::fromPHP(['x' => 1]), $expected],
+            /* Note: empty arrays could also express an empty pipeline, but we
+             * should interpret them as an empty replacement document for BC. */
+            'empty_replacement:array' => [[], $expectedEmpty],
+            'empty_replacement:object' => [(object) [], $expectedEmpty],
+            'empty_replacement:Serializable' => [new BSONDocument([]), $expectedEmpty],
+            'empty_replacement:Document' => [Document::fromPHP([]), $expectedEmpty],
+        ];
+    }
+
+    public function provideUpdateDocuments(): array
+    {
+        $expected = (object) ['$set' => (object) ['x' => 1]];
+
+        return [
+            'update:array' => [['$set' => ['x' => 1]], $expected],
+            'update:object' => [(object) ['$set' => ['x' => 1]], $expected],
+            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]]), $expected],
+            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]]), $expected],
+        ];
+    }
+
+    public function provideUpdatePipelines(): array
+    {
+        $expected = [(object) ['$set' => (object) ['x' => 1]]];
+
+        return [
+            'pipeline:array' => [[['$set' => ['x' => 1]]], $expected],
+            'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]]), $expected],
+            'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]]), $expected],
+            /* Note: although empty pipelines are valid NOPs for update and
+             * findAndModify commands, they are not supported for updates in
+             * libmongoc since they are indistinguishable from empty replacement
+             * documents (both are empty bson_t structs). */
+        ];
     }
 
     protected function createDefaultReadConcern()

--- a/tests/Operation/ReplaceOneTest.php
+++ b/tests/Operation/ReplaceOneTest.php
@@ -2,11 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
-//use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
-//use MongoDB\Model\BSONArray;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\ReplaceOne;
 
 class ReplaceOneTest extends TestCase
@@ -34,37 +30,22 @@ class ReplaceOneTest extends TestCase
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 
-    public function provideReplacementDocuments()
-    {
-        return $this->wrapValuesForDataProvider([
-            ['y' => 1],
-            (object) ['y' => 1],
-            new BSONDocument(['y' => 1]),
-        ]);
-    }
-
-    /** @dataProvider provideInvalidReplacementValues */
-    public function testConstructorReplacementArgumentRequiresNoOperators($replacement): void
+    /** @dataProvider provideUpdateDocuments */
+    public function testConstructorReplacementArgumentProhibitsUpdateDocument($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('First key in $replacement argument is an update operator');
+        $this->expectExceptionMessage('First key in $replacement is an update operator');
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 
-    public function provideInvalidReplacementValues(): array
+    /**
+     * @dataProvider provideUpdatePipelines
+     * @dataProvider provideEmptyUpdatePipelinesExcludingArray
+     */
+    public function testConstructorReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
-        return [
-            'update:array' => [['$set' => ['x' => 1]]],
-            'update:object' => [(object) ['$set' => ['x' => 1]]],
-            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]])],
-            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]])],
-            // TODO: Enable the following tests when implementing PHPLIB-1129
-            //'pipeline:array' => [[['$set' => ['x' => 1]]]],
-            //'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]])],
-            //'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]])],
-            //'empty_pipeline:array' => [[]],
-            //'empty_pipeline:Serializable' => [new BSONArray([])],
-            //'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
-        ];
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$replacement is an update pipeline');
+        new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 }

--- a/tests/Operation/TestCase.php
+++ b/tests/Operation/TestCase.php
@@ -2,6 +2,10 @@
 
 namespace MongoDB\Tests\Operation;
 
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
 use MongoDB\Tests\TestCase as BaseTestCase;
 
 /**
@@ -9,4 +13,65 @@ use MongoDB\Tests\TestCase as BaseTestCase;
  */
 abstract class TestCase extends BaseTestCase
 {
+    public function provideReplacementDocuments(): array
+    {
+        return [
+            'replacement:array' => [['x' => 1]],
+            'replacement:object' => [(object) ['x' => 1]],
+            'replacement:Serializable' => [new BSONDocument(['x' => 1])],
+            'replacement:Document' => [Document::fromPHP(['x' => 1])],
+            /* Note: empty arrays could also express a pipeline, but PHPLIB
+             * interprets them as a replacement document for BC. */
+            'empty_replacement:array' => [[]],
+            'empty_replacement:object' => [(object) []],
+            'empty_replacement:Serializable' => [new BSONDocument([])],
+            'empty_replacement:Document' => [Document::fromPHP([])],
+        ];
+    }
+
+    public function provideUpdateDocuments(): array
+    {
+        return [
+            'update:array' => [['$set' => ['x' => 1]]],
+            'update:object' => [(object) ['$set' => ['x' => 1]]],
+            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]])],
+            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]])],
+        ];
+    }
+
+    public function provideUpdatePipelines(): array
+    {
+        return [
+            'pipeline:array' => [[['$set' => ['x' => 1]]]],
+            'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]])],
+            'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]])],
+        ];
+    }
+
+    public function provideEmptyUpdatePipelines(): array
+    {
+        /* Empty update pipelines are accepted by the update and findAndModify
+         * commands (as NOPs); however, they are not supported for updates in
+         * libmongoc because empty arrays and documents have the same bson_t
+         * representation (libmongoc considers it an empty replacement for BC).
+         * For consistency, PHPLIB rejects empty pipelines for updateOne,
+         * updateMany, and findOneAndUpdate operations. Replace operations
+         * interpret empty arrays as replacement documents for BC, but rejects
+         * other representations. */
+        return [
+            'empty_pipeline:array' => [[]],
+            'empty_pipeline:Serializable' => [new BSONArray([])],
+            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
+        ];
+    }
+
+    public function provideEmptyUpdatePipelinesExcludingArray(): array
+    {
+        /* This data provider is used for replace operations, which accept empty
+         * arrays as replacement documents for BC. */
+        return [
+            'empty_pipeline:Serializable' => [new BSONArray([])],
+            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
+        ];
+    }
 }

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -79,8 +79,8 @@ class UpdateFunctionalTest extends FunctionalTestCase
 
     public function provideReplacementDocumentLikePipeline(): array
     {
-        /* libmongoc encodes this replacement document as a BSON array because
-         * it resembles an update pipeline (see: CDRIVER-4658). */
+        /* Note: libmongoc encodes this replacement document as a BSON array
+         * because it resembles an update pipeline (see: CDRIVER-4658). */
         return [
             'replacement_like_pipeline' => [
                 (object) ['0' => ['$set' => ['x' => 1]]],

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -52,6 +52,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
      * @dataProvider provideReplacementDocuments
      * @dataProvider provideUpdateDocuments
      * @dataProvider provideUpdatePipelines
+     * @dataProvider provideReplacementDocumentLikePipeline
      */
     public function testUpdateDocuments($update, $expectedUpdate): void
     {
@@ -74,6 +75,18 @@ class UpdateFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->updates[0]->u ?? null);
             }
         );
+    }
+
+    public function provideReplacementDocumentLikePipeline(): array
+    {
+        /* libmongoc encodes this replacement document as a BSON array because
+         * it resembles an update pipeline (see: CDRIVER-4658). */
+        return [
+            'replacement_like_pipeline' => [
+                (object) ['0' => ['$set' => ['x' => 1]]],
+                [(object) ['$set' => (object) ['x' => 1]]],
+            ],
+        ];
     }
 
     public function testSessionOption(): void

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -2,16 +2,12 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectId;
-use MongoDB\BSON\PackedArray;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Exception\UnsupportedException;
-use MongoDB\Model\BSONArray;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Update;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\UpdateResult;
@@ -52,18 +48,6 @@ class UpdateFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideFilterDocuments(): array
-    {
-        $expected = (object) ['x' => 1];
-
-        return [
-            'array' => [['x' => 1], $expected],
-            'object' => [(object) ['x' => 1], $expected],
-            'Serializable' => [new BSONDocument(['x' => 1]), $expected],
-            'Document' => [Document::fromPHP(['x' => 1]), $expected],
-        ];
-    }
-
     /**
      * @dataProvider provideReplacementDocuments
      * @dataProvider provideUpdateDocuments
@@ -90,41 +74,6 @@ class UpdateFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->updates[0]->u ?? null);
             }
         );
-    }
-
-    public function provideReplacementDocuments(): array
-    {
-        $expected = (object) ['x' => 1];
-
-        return [
-            'replacement:array' => [['x' => 1], $expected],
-            'replacement:object' => [(object) ['x' => 1], $expected],
-            'replacement:Serializable' => [new BSONDocument(['x' => 1]), $expected],
-            'replacement:Document' => [Document::fromPHP(['x' => 1]), $expected],
-        ];
-    }
-
-    public function provideUpdateDocuments(): array
-    {
-        $expected = (object) ['$set' => (object) ['x' => 1]];
-
-        return [
-            'update:array' => [['$set' => ['x' => 1]], $expected],
-            'update:object' => [(object) ['$set' => ['x' => 1]], $expected],
-            'update:Serializable' => [new BSONDocument(['$set' => ['x' => 1]]), $expected],
-            'update:Document' => [Document::fromPHP(['$set' => ['x' => 1]]), $expected],
-        ];
-    }
-
-    public function provideUpdatePipelines(): array
-    {
-        $expected = [(object) ['$set' => (object) ['x' => 1]]];
-
-        return [
-            'pipeline:array' => [[['$set' => ['x' => 1]]], $expected],
-            'pipeline:Serializable' => [new BSONArray([['$set' => ['x' => 1]]]), $expected],
-            'pipeline:PackedArray' => [PackedArray::fromPHP([['$set' => ['x' => 1]]]), $expected],
-        ];
     }
 
     public function testSessionOption(): void

--- a/tests/Operation/UpdateManyTest.php
+++ b/tests/Operation/UpdateManyTest.php
@@ -2,11 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\Model\BSONArray;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\UpdateMany;
 
 class UpdateManyTest extends TestCase
@@ -27,6 +23,7 @@ class UpdateManyTest extends TestCase
 
     /**
      * @dataProvider provideUpdateDocuments
+     * @dataProvider provideUpdatePipelines
      * @doesNotPerformAssertions
      */
     public function testConstructorUpdateArgument($update): void
@@ -34,33 +31,14 @@ class UpdateManyTest extends TestCase
         new UpdateMany($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
     }
 
-    public function provideUpdateDocuments()
-    {
-        return $this->wrapValuesForDataProvider([
-            ['$set' => ['y' => 1]],
-            (object) ['$set' => ['y' => 1]],
-            new BSONDocument(['$set' => ['y' => 1]]),
-        ]);
-    }
-
-    /** @dataProvider provideInvalidUpdateValues */
-    public function testConstructorUpdateArgumentRequiresOperators($update): void
+    /**
+     * @dataProvider provideReplacementDocuments
+     * @dataProvider provideEmptyUpdatePipelines
+     */
+    public function testConstructorUpdateArgumentProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected an update document with operator as first key or a pipeline');
+        $this->expectExceptionMessage('Expected update operator(s) or non-empty pipeline for $update');
         new UpdateMany($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
-    }
-
-    public function provideInvalidUpdateValues(): array
-    {
-        return [
-            'replacement:array' => [['x' => 1]],
-            'replacement:object' => [(object) ['x' => 1]],
-            'replacement:Serializable' => [new BSONDocument(['x' => 1])],
-            'replacement:Document' => [Document::fromPHP(['x' => 1])],
-            'empty_pipeline:array' => [[]],
-            'empty_pipeline:Serializable' => [new BSONArray([])],
-            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
-        ];
     }
 }

--- a/tests/Operation/UpdateOneTest.php
+++ b/tests/Operation/UpdateOneTest.php
@@ -2,11 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\Model\BSONArray;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\UpdateOne;
 
 class UpdateOneTest extends TestCase
@@ -27,6 +23,7 @@ class UpdateOneTest extends TestCase
 
     /**
      * @dataProvider provideUpdateDocuments
+     * @dataProvider provideUpdatePipelines
      * @doesNotPerformAssertions
      */
     public function testConstructorUpdateArgument($update): void
@@ -34,33 +31,14 @@ class UpdateOneTest extends TestCase
         new UpdateOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
     }
 
-    public function provideUpdateDocuments()
-    {
-        return $this->wrapValuesForDataProvider([
-            ['$set' => ['y' => 1]],
-            (object) ['$set' => ['y' => 1]],
-            new BSONDocument(['$set' => ['y' => 1]]),
-        ]);
-    }
-
-    /** @dataProvider provideInvalidUpdateValues */
-    public function testConstructorUpdateArgumentRequiresOperators($update): void
+    /**
+     * @dataProvider provideReplacementDocuments
+     * @dataProvider provideEmptyUpdatePipelines
+     */
+    public function testConstructorUpdateArgumentProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected an update document with operator as first key or a pipeline');
+        $this->expectExceptionMessage('Expected update operator(s) or non-empty pipeline for $update');
         new UpdateOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
-    }
-
-    public function provideInvalidUpdateValues(): array
-    {
-        return [
-            'replacement:array' => [['x' => 1]],
-            'replacement:object' => [(object) ['x' => 1]],
-            'replacement:Serializable' => [new BSONDocument(['x' => 1])],
-            'replacement:Document' => [Document::fromPHP(['x' => 1])],
-            'empty_pipeline:array' => [[]],
-            'empty_pipeline:Serializable' => [new BSONArray([])],
-            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
-        ];
     }
 }

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -2,11 +2,7 @@
 
 namespace MongoDB\Tests\Operation;
 
-use MongoDB\BSON\Document;
-use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\Model\BSONArray;
-use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Update;
 
 class UpdateTest extends TestCase
@@ -69,24 +65,14 @@ class UpdateTest extends TestCase
         return $options;
     }
 
-    /** @dataProvider provideInvalidUpdateValues */
-    public function testConstructorMultiOptionRequiresOperators($update): void
+    /**
+     * @dataProvider provideReplacementDocuments
+     * @dataProvider provideEmptyUpdatePipelines
+     */
+    public function testConstructorMultiOptionProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('"multi" option cannot be true if $update is a replacement document');
+        $this->expectExceptionMessage('"multi" option cannot be true unless $update has update operator(s) or non-empty pipeline');
         new Update($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update, ['multi' => true]);
-    }
-
-    public function provideInvalidUpdateValues(): array
-    {
-        return [
-            'replacement:array' => [['x' => 1]],
-            'replacement:object' => [(object) ['x' => 1]],
-            'replacement:Serializable' => [new BSONDocument(['x' => 1])],
-            'replacement:Document' => [Document::fromPHP(['x' => 1])],
-            'empty_pipeline:array' => [[]],
-            'empty_pipeline:Serializable' => [new BSONArray([])],
-            'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
-        ];
     }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1129

Consolidates data providers in base TestCase and FunctionalTestCase classes.

Change is_pipeline() to conditionally consider empty arrays as pipelines. This was needed for improvements to replace/update parameter validation, and will prove useful for consolidated pipeline validation in [PHPLIB-881](https://jira.mongodb.org/browse/PHPLIB-881).

Prohibit update documents and pipelines (both empty and non-empty) for replacement operations.

Prohibit replacement documents and empty pipeines for update operations. Empty pipelines must be prohibited because libmongoc does not support them for update commands (they're indistinguishable from empty replacement documents). For consistency, we also prohibit them for FindOneAndUpdate even though PHPLIB could work around that.

Prohibit update pipelines for replace operations (both empty and non-empty). Previously ReplaceOne only prohibited non-empty pipelines and BulkWrite replaceOne and FindOneAndReplace has no validation. A notable exception is empty arrays, which are treated as replacement documents for BC.

Add tests for valid update/replacement arguments for BulkWrite replaceOne, updateMany, and updateOne operations. Also adds more comprehensive tests for valid $update arguments for UpdateMany and UpdateOne operations (update documents and non-empty pipelines).

----

This depends on https://github.com/mongodb/mongo-php-library/pull/1096 and can be rebased after that is merged.

