### PR TITLE
PHPLIB-1152: replace `private static` with `private const`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9,6 +9,11 @@
       <code>$type</code>
     </PropertyNotSetInConstructor>
   </file>
+  <file src="src/ChangeStream.php">
+    <DeprecatedConstant occurrences="1">
+      <code>self::CURSOR_NOT_FOUND</code>
+    </DeprecatedConstant>
+  </file>
   <file src="src/Client.php">
     <MixedArgument occurrences="1">
       <code>$driverOptions['driver'] ?? []</code>

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -42,15 +42,11 @@ class ChangeStream implements Iterator
 {
     /**
      * @deprecated 1.4
-     * @todo Remove this in 2.0 (see: PHPLIB-360)
+     * @todo make this constant private in 2.0 (see: PHPLIB-360)
      */
     public const CURSOR_NOT_FOUND = 43;
 
-    /** @var int */
-    private static $cursorNotFound = 43;
-
-    /** @var int[] */
-    private static $resumableErrorCodes = [
+    private const RESUMABLE_ERROR_CODES = [
         6, // HostUnreachable
         7, // HostNotFound
         89, // NetworkTimeout
@@ -70,8 +66,7 @@ class ChangeStream implements Iterator
         133, // FailedToSatisfyReadPreference
     ];
 
-    /** @var int */
-    private static $wireVersionForResumableChangeStreamError = 9;
+    private const WIRE_VERSION_FOR_RESUMABLE_CHANGE_STREAM_ERROR = 9;
 
     /** @var ResumeCallable|null */
     private $resumeCallable;
@@ -205,15 +200,15 @@ class ChangeStream implements Iterator
             return false;
         }
 
-        if ($exception->getCode() === self::$cursorNotFound) {
+        if ($exception->getCode() === self::CURSOR_NOT_FOUND) {
             return true;
         }
 
-        if (server_supports_feature($this->iterator->getServer(), self::$wireVersionForResumableChangeStreamError)) {
+        if (server_supports_feature($this->iterator->getServer(), self::WIRE_VERSION_FOR_RESUMABLE_CHANGE_STREAM_ERROR)) {
             return $exception->hasErrorLabel('ResumableChangeStreamError');
         }
 
-        return in_array($exception->getCode(), self::$resumableErrorCodes);
+        return in_array($exception->getCode(), self::RESUMABLE_ERROR_CODES);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -46,15 +46,13 @@ class Client
 {
     public const DEFAULT_URI = 'mongodb://127.0.0.1/';
 
-    /** @var array */
-    private static $defaultTypeMap = [
+    private const DEFAULT_TYPE_MAP = [
         'array' => BSONArray::class,
         'document' => BSONDocument::class,
         'root' => BSONDocument::class,
     ];
 
-    /** @var string */
-    private static $handshakeSeparator = ' / ';
+    private const HANDSHAKE_SEPARATOR = '/';
 
     /** @var string|null */
     private static $version;
@@ -102,7 +100,7 @@ class Client
      */
     public function __construct(?string $uri = null, array $uriOptions = [], array $driverOptions = [])
     {
-        $driverOptions += ['typeMap' => self::$defaultTypeMap];
+        $driverOptions += ['typeMap' => self::DEFAULT_TYPE_MAP];
 
         if (! is_array($driverOptions['typeMap'])) {
             throw InvalidArgumentException::invalidType('"typeMap" driver option', $driverOptions['typeMap'], 'array');
@@ -405,7 +403,7 @@ class Client
                 throw InvalidArgumentException::invalidType('"name" handshake option', $driver['name'], 'string');
             }
 
-            $mergedDriver['name'] .= self::$handshakeSeparator . $driver['name'];
+            $mergedDriver['name'] .= self::HANDSHAKE_SEPARATOR . $driver['name'];
         }
 
         if (isset($driver['version'])) {
@@ -413,7 +411,7 @@ class Client
                 throw InvalidArgumentException::invalidType('"version" handshake option', $driver['version'], 'string');
             }
 
-            $mergedDriver['version'] .= self::$handshakeSeparator . $driver['version'];
+            $mergedDriver['version'] .= self::HANDSHAKE_SEPARATOR . $driver['version'];
         }
 
         if (isset($driver['platform'])) {

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -69,15 +69,13 @@ use function strlen;
 
 class Collection
 {
-    /** @var array */
-    private static $defaultTypeMap = [
+    private const DEFAULT_TYPE_MAP = [
         'array' => BSONArray::class,
         'document' => BSONDocument::class,
         'root' => BSONDocument::class,
     ];
 
-    /** @var integer */
-    private static $wireVersionForReadConcernWithWriteStage = 8;
+    private const WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE = 8;
 
     /** @var string */
     private $collectionName;
@@ -158,7 +156,7 @@ class Collection
         $this->collectionName = $collectionName;
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
-        $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;
+        $this->typeMap = $options['typeMap'] ?? self::DEFAULT_TYPE_MAP;
         $this->writeConcern = $options['writeConcern'] ?? $this->manager->getWriteConcern();
     }
 
@@ -229,7 +227,7 @@ class Collection
         if (
             ! isset($options['readConcern']) &&
             ! is_in_transaction($options) &&
-            ( ! $hasWriteStage || server_supports_feature($server, self::$wireVersionForReadConcernWithWriteStage))
+            ( ! $hasWriteStage || server_supports_feature($server, self::WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE))
         ) {
             $options['readConcern'] = $this->readConcern;
         }

--- a/src/Database.php
+++ b/src/Database.php
@@ -53,15 +53,13 @@ use function strlen;
 
 class Database
 {
-    /** @var array */
-    private static $defaultTypeMap = [
+    private const DEFAULT_TYPE_MAP = [
         'array' => BSONArray::class,
         'document' => BSONDocument::class,
         'root' => BSONDocument::class,
     ];
 
-    /** @var integer */
-    private static $wireVersionForReadConcernWithWriteStage = 8;
+    private const WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE = 8;
 
     /** @var string */
     private $databaseName;
@@ -134,7 +132,7 @@ class Database
         $this->databaseName = $databaseName;
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
-        $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;
+        $this->typeMap = $options['typeMap'] ?? self::DEFAULT_TYPE_MAP;
         $this->writeConcern = $options['writeConcern'] ?? $this->manager->getWriteConcern();
     }
 
@@ -217,7 +215,7 @@ class Database
         if (
             ! isset($options['readConcern']) &&
             ! is_in_transaction($options) &&
-            ( ! $hasWriteStage || server_supports_feature($server, self::$wireVersionForReadConcernWithWriteStage))
+            ( ! $hasWriteStage || server_supports_feature($server, self::WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE))
         ) {
             $options['readConcern'] = $this->readConcern;
         }

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -62,21 +62,17 @@ use function urlencode;
  */
 class Bucket
 {
-    /** @var string */
-    private static $defaultBucketName = 'fs';
+    private const DEFAULT_BUCKET_NAME = 'fs';
 
-    /** @var integer */
-    private static $defaultChunkSizeBytes = 261120;
+    private const DEFAULT_CHUNK_SIZE_BYTES = 261120;
 
-    /** @var array */
-    private static $defaultTypeMap = [
+    private const DEFAULT_TYPE_MAP = [
         'array' => BSONArray::class,
         'document' => BSONDocument::class,
         'root' => BSONDocument::class,
     ];
 
-    /** @var string */
-    private static $streamWrapperProtocol = 'gridfs';
+    private const STREAM_WRAPPER_PROTOCOL = 'gridfs';
 
     /** @var CollectionWrapper */
     private $collectionWrapper;
@@ -138,8 +134,8 @@ class Bucket
     public function __construct(Manager $manager, string $databaseName, array $options = [])
     {
         $options += [
-            'bucketName' => self::$defaultBucketName,
-            'chunkSizeBytes' => self::$defaultChunkSizeBytes,
+            'bucketName' => self::DEFAULT_BUCKET_NAME,
+            'chunkSizeBytes' => self::DEFAULT_CHUNK_SIZE_BYTES,
             'disableMD5' => false,
         ];
 
@@ -182,7 +178,7 @@ class Bucket
         $this->disableMD5 = $options['disableMD5'];
         $this->readConcern = $options['readConcern'] ?? $this->manager->getReadConcern();
         $this->readPreference = $options['readPreference'] ?? $this->manager->getReadPreference();
-        $this->typeMap = $options['typeMap'] ?? self::$defaultTypeMap;
+        $this->typeMap = $options['typeMap'] ?? self::DEFAULT_TYPE_MAP;
         $this->writeConcern = $options['writeConcern'] ?? $this->manager->getWriteConcern();
 
         $collectionOptions = array_intersect_key($options, ['readConcern' => 1, 'readPreference' => 1, 'typeMap' => 1, 'writeConcern' => 1]);
@@ -555,7 +551,7 @@ class Bucket
 
         $path = $this->createPathForUpload();
         $context = stream_context_create([
-            self::$streamWrapperProtocol => [
+            self::STREAM_WRAPPER_PROTOCOL => [
                 'collectionWrapper' => $this->collectionWrapper,
                 'filename' => $filename,
                 'options' => $options,
@@ -651,7 +647,7 @@ class Bucket
 
         return sprintf(
             '%s://%s/%s.files/%s',
-            self::$streamWrapperProtocol,
+            self::STREAM_WRAPPER_PROTOCOL,
             urlencode($this->databaseName),
             urlencode($this->bucketName),
             urlencode($id)
@@ -665,7 +661,7 @@ class Bucket
     {
         return sprintf(
             '%s://%s/%s.files',
-            self::$streamWrapperProtocol,
+            self::STREAM_WRAPPER_PROTOCOL,
             urlencode($this->databaseName),
             urlencode($this->bucketName)
         );
@@ -713,7 +709,7 @@ class Bucket
     {
         $path = $this->createPathForFile($file);
         $context = stream_context_create([
-            self::$streamWrapperProtocol => [
+            self::STREAM_WRAPPER_PROTOCOL => [
                 'collectionWrapper' => $this->collectionWrapper,
                 'file' => $file,
             ],
@@ -727,10 +723,10 @@ class Bucket
      */
     private function registerStreamWrapper(): void
     {
-        if (in_array(self::$streamWrapperProtocol, stream_get_wrappers())) {
+        if (in_array(self::STREAM_WRAPPER_PROTOCOL, stream_get_wrappers())) {
             return;
         }
 
-        StreamWrapper::register(self::$streamWrapperProtocol);
+        StreamWrapper::register(self::STREAM_WRAPPER_PROTOCOL);
     }
 }

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -45,8 +45,7 @@ use function substr;
  */
 class WritableStream
 {
-    /** @var integer */
-    private static $defaultChunkSizeBytes = 261120;
+    private const DEFAULT_CHUNK_SIZE_BYTES = 261120;
 
     /** @var string */
     private $buffer = '';
@@ -107,7 +106,7 @@ class WritableStream
     {
         $options += [
             '_id' => new ObjectId(),
-            'chunkSizeBytes' => self::$defaultChunkSizeBytes,
+            'chunkSizeBytes' => self::DEFAULT_CHUNK_SIZE_BYTES,
             'disableMD5' => false,
         ];
 

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -34,8 +34,7 @@ use function unpack;
  */
 class BSONIterator implements Iterator
 {
-    /** @var integer */
-    private static $bsonSize = 4;
+    private const BSON_SIZE = 4;
 
     /** @var string */
     private $buffer;
@@ -141,11 +140,11 @@ class BSONIterator implements Iterator
             return;
         }
 
-        if ($this->bufferLength - $this->position < self::$bsonSize) {
-            throw new UnexpectedValueException(sprintf('Expected at least %d bytes; %d remaining', self::$bsonSize, $this->bufferLength - $this->position));
+        if ($this->bufferLength - $this->position < self::BSON_SIZE) {
+            throw new UnexpectedValueException(sprintf('Expected at least %d bytes; %d remaining', self::BSON_SIZE, $this->bufferLength - $this->position));
         }
 
-        [, $documentLength] = unpack('V', substr($this->buffer, $this->position, self::$bsonSize));
+        [, $documentLength] = unpack('V', substr($this->buffer, $this->position, self::BSON_SIZE));
 
         if ($this->bufferLength - $this->position < $documentLength) {
             throw new UnexpectedValueException(sprintf('Expected %d bytes; %d remaining', $documentLength, $this->bufferLength - $this->position));

--- a/src/Operation/CreateEncryptedCollection.php
+++ b/src/Operation/CreateEncryptedCollection.php
@@ -46,8 +46,7 @@ use function MongoDB\server_supports_feature;
  */
 class CreateEncryptedCollection implements Executable
 {
-    /** @var integer */
-    private static $wireVersionForQueryableEncryptionV2 = 21;
+    private const WIRE_VERSION_FOR_QUERYABLE_ENCRYPTION_V2 = 21;
 
     /** @var CreateCollection */
     private $createCollection;
@@ -158,7 +157,7 @@ class CreateEncryptedCollection implements Executable
      */
     public function execute(Server $server)
     {
-        if (! server_supports_feature($server, self::$wireVersionForQueryableEncryptionV2)) {
+        if (! server_supports_feature($server, self::WIRE_VERSION_FOR_QUERYABLE_ENCRYPTION_V2)) {
             throw new UnsupportedException('Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption.');
         }
 

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -42,8 +42,7 @@ use function sprintf;
  */
 class CreateIndexes implements Executable
 {
-    /** @var integer */
-    private static $wireVersionForCommitQuorum = 9;
+    private const WIRE_VERSION_FOR_COMMIT_QUORUM = 9;
 
     /** @var string */
     private $databaseName;
@@ -188,7 +187,7 @@ class CreateIndexes implements Executable
         if (isset($this->options['commitQuorum'])) {
             /* Drivers MUST manually raise an error if this option is specified
              * when creating an index on a pre 4.4 server. */
-            if (! server_supports_feature($server, self::$wireVersionForCommitQuorum)) {
+            if (! server_supports_feature($server, self::WIRE_VERSION_FOR_COMMIT_QUORUM)) {
                 throw UnsupportedException::commitQuorumNotSupported();
             }
 

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -43,7 +43,7 @@ use function MongoDB\server_supports_feature;
  */
 class Delete implements Executable, Explainable
 {
-    private const WIRE_VERSION_FOR_HINT = 5;
+    private const WIRE_VERSION_FOR_HINT = 9;
 
     /** @var string */
     private $databaseName;

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -43,8 +43,7 @@ use function MongoDB\server_supports_feature;
  */
 class Delete implements Executable, Explainable
 {
-    /** @var integer */
-    private static $wireVersionForHint = 9;
+    private const WIRE_VERSION_FOR_HINT = 5;
 
     /** @var string */
     private $databaseName;
@@ -152,7 +151,7 @@ class Delete implements Executable, Explainable
          * unacknowledged write concern on an unsupported server. */
         if (
             isset($this->options['writeConcern']) && ! is_write_concern_acknowledged($this->options['writeConcern']) &&
-            isset($this->options['hint']) && ! server_supports_feature($server, self::$wireVersionForHint)
+            isset($this->options['hint']) && ! server_supports_feature($server, self::WIRE_VERSION_FOR_HINT)
         ) {
             throw UnsupportedException::hintNotSupported();
         }

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -38,8 +38,7 @@ use function is_array;
  */
 class DropCollection implements Executable
 {
-    /** @var integer */
-    private static $errorCodeNamespaceNotFound = 26;
+    private const ERROR_CODE_NAMESPACE_NOT_FOUND = 26;
 
     /** @var string */
     private $databaseName;
@@ -115,7 +114,7 @@ class DropCollection implements Executable
             /* The server may return an error if the collection does not exist.
              * Check for an error code and return the command reply instead of
              * throwing. */
-            if ($e->getCode() === self::$errorCodeNamespaceNotFound) {
+            if ($e->getCode() === self::ERROR_CODE_NAMESPACE_NOT_FOUND) {
                 return $e->getResultDocument();
             }
 

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -42,8 +42,7 @@ class Explain implements Executable
     public const VERBOSITY_EXEC_STATS = 'executionStats';
     public const VERBOSITY_QUERY = 'queryPlanner';
 
-    /** @var integer */
-    private static $wireVersionForAggregate = 7;
+    private const WIRE_VERSION_FOR_AGGREGATE = 7;
 
     /** @var string */
     private $databaseName;
@@ -110,7 +109,7 @@ class Explain implements Executable
      */
     public function execute(Server $server)
     {
-        if ($this->explainable instanceof Aggregate && ! server_supports_feature($server, self::$wireVersionForAggregate)) {
+        if ($this->explainable instanceof Aggregate && ! server_supports_feature($server, self::WIRE_VERSION_FOR_AGGREGATE)) {
             throw UnsupportedException::explainNotSupported();
         }
 

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -49,11 +49,9 @@ use function MongoDB\server_supports_feature;
  */
 class FindAndModify implements Executable, Explainable
 {
-    /** @var integer */
-    private static $wireVersionForHint = 9;
+    private const WIRE_VERSION_FOR_HINT = 9;
 
-    /** @var integer */
-    private static $wireVersionForUnsupportedOptionServerSideError = 8;
+    private const WIRE_VERSION_FOR_UNSUPPORTED_OPTION_SERVER_SIDE_ERROR = 8;
 
     /** @var string */
     private $databaseName;
@@ -227,7 +225,7 @@ class FindAndModify implements Executable, Explainable
     {
         /* Server versions >= 4.2.0 raise errors for unsupported update options.
          * For previous versions, the CRUD spec requires a client-side error. */
-        if (isset($this->options['hint']) && ! server_supports_feature($server, self::$wireVersionForUnsupportedOptionServerSideError)) {
+        if (isset($this->options['hint']) && ! server_supports_feature($server, self::WIRE_VERSION_FOR_UNSUPPORTED_OPTION_SERVER_SIDE_ERROR)) {
             throw UnsupportedException::hintNotSupported();
         }
 
@@ -235,7 +233,7 @@ class FindAndModify implements Executable, Explainable
          * unacknowledged write concern on an unsupported server. */
         if (
             isset($this->options['writeConcern']) && ! is_write_concern_acknowledged($this->options['writeConcern']) &&
-            isset($this->options['hint']) && ! server_supports_feature($server, self::$wireVersionForHint)
+            isset($this->options['hint']) && ! server_supports_feature($server, self::WIRE_VERSION_FOR_HINT)
         ) {
             throw UnsupportedException::hintNotSupported();
         }

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -38,11 +38,8 @@ use function is_integer;
  */
 class ListIndexes implements Executable
 {
-    /** @var integer */
-    private static $errorCodeDatabaseNotFound = 60;
-
-    /** @var integer */
-    private static $errorCodeNamespaceNotFound = 26;
+    private const ERROR_CODE_DATABASE_NOT_FOUND = 60;
+    private const ERROR_CODE_NAMESPACE_NOT_FOUND = 26;
 
     /** @var string */
     private $databaseName;
@@ -141,7 +138,7 @@ class ListIndexes implements Executable
              * Check for possible error codes (see: SERVER-20463) and return an
              * empty iterator instead of throwing.
              */
-            if ($e->getCode() === self::$errorCodeNamespaceNotFound || $e->getCode() === self::$errorCodeDatabaseNotFound) {
+            if ($e->getCode() === self::ERROR_CODE_NAMESPACE_NOT_FOUND || $e->getCode() === self::ERROR_CODE_DATABASE_NOT_FOUND) {
                 return new IndexInfoIteratorIterator(new EmptyIterator());
             }
 

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -46,8 +46,7 @@ use function MongoDB\server_supports_feature;
  */
 class Update implements Executable, Explainable
 {
-    /** @var integer */
-    private static $wireVersionForHint = 8;
+    private const WIRE_VERSION_FOR_HINT = 8;
 
     /** @var string */
     private $databaseName;
@@ -196,7 +195,7 @@ class Update implements Executable, Explainable
          * unacknowledged write concern on an unsupported server. */
         if (
             isset($this->options['writeConcern']) && ! is_write_concern_acknowledged($this->options['writeConcern']) &&
-            isset($this->options['hint']) && ! server_supports_feature($server, self::$wireVersionForHint)
+            isset($this->options['hint']) && ! server_supports_feature($server, self::WIRE_VERSION_FOR_HINT)
         ) {
             throw UnsupportedException::hintNotSupported();
         }

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -67,8 +67,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
     public const FULL_DOCUMENT_BEFORE_CHANGE_WHEN_AVAILABLE = 'whenAvailable';
     public const FULL_DOCUMENT_BEFORE_CHANGE_REQUIRED = 'required';
 
-    /** @var integer */
-    private static $wireVersionForStartAtOperationTime = 7;
+    private const WIRE_VERSION_FOR_START_AT_OPERATION_TIME = 7;
 
     /** @var Aggregate */
     private $aggregate;
@@ -468,7 +467,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
             return false;
         }
 
-        if (! server_supports_feature($server, self::$wireVersionForStartAtOperationTime)) {
+        if (! server_supports_feature($server, self::WIRE_VERSION_FOR_START_AT_OPERATION_TIME)) {
             return false;
         }
 


### PR DESCRIPTION
Fix PHPLIB-1152

`Client::$version` is the only one left because it is initialised from composer install.