### PR TITLE
PHPLIB-722: Ignore writeConcern option for read-only aggregations

### DIFF
--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -228,10 +228,12 @@ class Aggregate implements Executable, Explainable
             unset($options['batchSize']);
         }
 
-        /* Ignore batchSize for writes, since no documents are returned and a
-         * batchSize of zero could prevent the pipeline from executing. */
         if ($this->isWrite) {
+            /* Ignore batchSize for writes, since no documents are returned and
+             * a batchSize of zero could prevent the pipeline from executing. */
             unset($options['batchSize']);
+        } else {
+            unset($options['writeConcern']);
         }
 
         $this->databaseName = $databaseName;
@@ -365,14 +367,10 @@ class Aggregate implements Executable, Explainable
     {
         $options = [];
 
-        foreach (['readConcern', 'readPreference', 'session'] as $option) {
+        foreach (['readConcern', 'readPreference', 'session', 'writeConcern'] as $option) {
             if (isset($this->options[$option])) {
                 $options[$option] = $this->options[$option];
             }
-        }
-
-        if ($this->isWrite && isset($this->options['writeConcern'])) {
-            $options['writeConcern'] = $this->options['writeConcern'];
         }
 
         if (! $this->isWrite) {


### PR DESCRIPTION
Fix PHPLIB-722

This does not change anything functionally, but cleanup `$options` in the constructor instead of picking the `writeOption` conditionally in `executeCommand()`. There is no impact on `getCommandDocument()` which already ignores `writeConcern`.