### PR TITLE
PHPLIB-1142: Use `disableMD5` when provided to GridFS Bucket constructor

### DIFF
--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -198,6 +198,7 @@ class Bucket
         return [
             'bucketName' => $this->bucketName,
             'databaseName' => $this->databaseName,
+            'disableMD5' => $this->disableMD5,
             'manager' => $this->manager,
             'chunkSizeBytes' => $this->chunkSizeBytes,
             'readConcern' => $this->readConcern,
@@ -547,7 +548,10 @@ class Bucket
      */
     public function openUploadStream(string $filename, array $options = [])
     {
-        $options += ['chunkSizeBytes' => $this->chunkSizeBytes];
+        $options += [
+            'chunkSizeBytes' => $this->chunkSizeBytes,
+            'disableMD5' => $this->disableMD5,
+        ];
 
         $path = $this->createPathForUpload();
         $context = stream_context_create([

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -53,6 +53,7 @@ class BucketFunctionalTest extends FunctionalTestCase
             'readConcern' => new ReadConcern(ReadConcern::LOCAL),
             'readPreference' => new ReadPreference(ReadPreference::PRIMARY),
             'writeConcern' => new WriteConcern(WriteConcern::MAJORITY, 1000),
+            'disableMD5' => true,
         ]);
     }
 
@@ -667,6 +668,19 @@ class BucketFunctionalTest extends FunctionalTestCase
         ];
 
         $this->assertSameDocument($expected, $fileDocument);
+    }
+
+    public function testDisableMD5(): void
+    {
+        $options = ['disableMD5' => true];
+        $id = $this->bucket->uploadFromStream('filename', $this->createStream('data'), $options);
+        $this->assertCollectionCount($this->filesCollection, 1);
+
+        $fileDocument = $this->filesCollection->findOne(
+            ['_id' => $id]
+        );
+
+        $this->assertArrayNotHasKey('md5', $fileDocument);
     }
 
     public function testUploadingFirstFileCreatesIndexes(): void

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -674,7 +674,20 @@ class BucketFunctionalTest extends FunctionalTestCase
     {
         $options = ['disableMD5' => true];
         $id = $this->bucket->uploadFromStream('filename', $this->createStream('data'), $options);
-        $this->assertCollectionCount($this->filesCollection, 1);
+
+        $fileDocument = $this->filesCollection->findOne(
+            ['_id' => $id]
+        );
+
+        $this->assertArrayNotHasKey('md5', $fileDocument);
+    }
+
+    public function testDisableMD5OptionInConstructor(): void
+    {
+        $options = ['disableMD5' => true];
+
+        $this->bucket = new Bucket($this->manager, $this->getDatabaseName(), $options);
+        $id = $this->bucket->uploadFromStream('filename', $this->createStream('data'));
 
         $fileDocument = $this->filesCollection->findOne(
             ['_id' => $id]

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -33,8 +33,8 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         $this->bucket = new Bucket($this->manager, $this->getDatabaseName());
         $this->bucket->drop();
 
-        $this->chunksCollection = new Collection($this->manager, $this->getDatabaseName(), 'fs.chunks');
-        $this->filesCollection = new Collection($this->manager, $this->getDatabaseName(), 'fs.files');
+        $this->chunksCollection = $this->createCollection($this->getDatabaseName(), 'fs.chunks');
+        $this->filesCollection = $this->createCollection($this->getDatabaseName(), 'fs.files');
     }
 
     /**


### PR DESCRIPTION
Fix PHPLIB-1142

Bugfix, the option value set to the constructor was ignored. The only way to disable md5 was to  set the option when calling `Bucket::uploadFromStream`.

Added a functional test to ensure this option works. But it does not cover this specific bug.