### PR TITLE
PHPLIB-1232: Run timeseries createCollection tests on MongoDB 6.3

### DIFF
--- a/tests/UnifiedSpecTests/collection-management/timeseries-collection.json
+++ b/tests/UnifiedSpecTests/collection-management/timeseries-collection.json
@@ -255,7 +255,7 @@
       "description": "createCollection with bucketing options",
       "runOnRequirements": [
         {
-          "minServerVersion": "7.0"
+          "minServerVersion": "6.3"
         }
       ],
       "operations": [


### PR DESCRIPTION
PHPLIB-1232

This syncs the file with commit https://github.com/mongodb/specifications/commit/b7792587a6600d07a0e26d65283c67c7418d0b28