### PR TITLE
PHPLIB-1133: Enable QEv2 tests on serverless

### DIFF
--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-BypassQueryAnalysis.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-BypassQueryAnalysis.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Compact.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Compact.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-CreateCollection.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-CreateCollection.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-DecryptExistingData.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-DecryptExistingData.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-EncryptedFields-vs-jsonSchema.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-EncryptedFields-vs-jsonSchema.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-EncryptedFieldsMap-defaults.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-EncryptedFieldsMap-defaults.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-InsertFind-Indexed.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-InsertFind-Indexed.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-InsertFind-Unindexed.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-InsertFind-Unindexed.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-MissingKey.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-MissingKey.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-NoEncryption.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-NoEncryption.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset"
       ]

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Aggregate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Correctness.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Delete.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-InsertFind.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-WrongType.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-WrongType.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Update.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-validatorAndPartialFieldExpression.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-validatorAndPartialFieldExpression.json
@@ -2,7 +2,6 @@
   "runOn": [
     {
       "minServerVersion": "7.0.0",
-      "serverless": "forbid",
       "topology": [
         "replicaset",
         "sharded",


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1133

Synced with mongodb/specifications@840e6d49c354656bff11b2622f0d3001b39d9403

Patch build for serverless: https://spruce.mongodb.com/version/648b55a12a60ede96e30eaf9/tasks