### PR TITLE
PHPLIB-947: Require 7.0+ for explain apiVersion bug fix

### DIFF
--- a/tests/SpecTests/client-side-encryption/tests/explain.json
+++ b/tests/SpecTests/client-side-encryption/tests/explain.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.1.10"
+      "minServerVersion": "7.0.0"
     }
   ],
   "database_name": "default",


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-947

POC for https://github.com/mongodb/specifications/pull/1435

As noted in [DRIVERS-2612](https://jira.mongodb.org/browse/DRIVERS-2612?focusedCommentId=5502676&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-5502676), this is blocked on the release of 7.0.0-rc4 for [BACKPORT-16190](https://jira.mongodb.org/browse/BACKPORT-16190).