### PR TITLE
PHPLIB-1147, PHPLIB-1148: Int64 improvements

### DIFF
--- a/phpunit.evergreen.xml
+++ b/phpunit.evergreen.xml
@@ -6,7 +6,7 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          defaultTestSuite="Default Test Suite"
 >
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          defaultTestSuite="Default Test Suite"
 >
 

--- a/tests/Comparator/Int64Comparator.php
+++ b/tests/Comparator/Int64Comparator.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MongoDB\Tests\Comparator;
+
+use MongoDB\BSON\Int64;
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+use function is_int;
+use function is_numeric;
+use function is_string;
+use function sprintf;
+
+use const PHP_INT_SIZE;
+
+class Int64Comparator extends Comparator
+{
+    public function accepts($expected, $actual)
+    {
+        // Only compare if either value is an Int64
+        return ($expected instanceof Int64 && $this->isComparable($actual))
+            || ($actual instanceof Int64 && $this->isComparable($expected));
+    }
+
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
+    {
+        if (PHP_INT_SIZE == 8) {
+            // On 64-bit systems, compare integers directly
+            $expectedValue = (int) $expected;
+            $actualValue = (int) $actual;
+        } else {
+            // On 32-bit systems, compare integers as strings
+            $expectedValue = (string) $expected;
+            $actualValue = (string) $actual;
+        }
+
+        if ($expectedValue === $actualValue) {
+            return;
+        }
+
+        throw new ComparisonFailure(
+            $expected,
+            $actual,
+            '',
+            '',
+            false,
+            sprintf(
+                'Failed asserting that %s matches expected %s.',
+                $this->exporter->export($actual),
+                $this->exporter->export($expected)
+            )
+        );
+    }
+
+    private function isComparable($value): bool
+    {
+        return $value instanceof Int64 // Int64 instances
+            || is_int($value) // Integer values
+            || (is_string($value) && is_numeric($value)); // Numeric strings (is_numeric accepts floats)
+    }
+}

--- a/tests/Comparator/Int64Comparator.php
+++ b/tests/Comparator/Int64Comparator.php
@@ -6,35 +6,21 @@ use MongoDB\BSON\Int64;
 use SebastianBergmann\Comparator\Comparator;
 use SebastianBergmann\Comparator\ComparisonFailure;
 
-use function is_int;
 use function is_numeric;
-use function is_string;
 use function sprintf;
-
-use const PHP_INT_SIZE;
 
 class Int64Comparator extends Comparator
 {
     public function accepts($expected, $actual)
     {
-        // Only compare if either value is an Int64
+        // Only compare if either value is an Int64 and the other value is numeric
         return ($expected instanceof Int64 && $this->isComparable($actual))
             || ($actual instanceof Int64 && $this->isComparable($expected));
     }
 
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false): void
     {
-        if (PHP_INT_SIZE == 8) {
-            // On 64-bit systems, compare integers directly
-            $expectedValue = (int) $expected;
-            $actualValue = (int) $actual;
-        } else {
-            // On 32-bit systems, compare integers as strings
-            $expectedValue = (string) $expected;
-            $actualValue = (string) $actual;
-        }
-
-        if ($expectedValue === $actualValue) {
+        if ($expected == $actual) {
             return;
         }
 
@@ -54,8 +40,6 @@ class Int64Comparator extends Comparator
 
     private function isComparable($value): bool
     {
-        return $value instanceof Int64 // Int64 instances
-            || is_int($value) // Integer values
-            || (is_string($value) && is_numeric($value)); // Numeric strings (is_numeric accepts floats)
+        return $value instanceof Int64 || is_numeric($value);
     }
 }

--- a/tests/Comparator/Int64ComparatorTest.php
+++ b/tests/Comparator/Int64ComparatorTest.php
@@ -29,16 +29,28 @@ class Int64ComparatorTest extends TestCase
             'actualValue' => 123,
         ];
 
-        yield 'Expects Int64, Actual string' => [
+        yield 'Expects Int64, Actual int string' => [
             'expectedResult' => true,
             'expectedValue' => new Int64(123),
             'actualValue' => '123',
         ];
 
         yield 'Expects Int64, Actual float' => [
-            'expectedResult' => false,
+            'expectedResult' => true,
             'expectedValue' => new Int64(123),
             'actualValue' => 123.0,
+        ];
+
+        yield 'Expects Int64, Actual float string' => [
+            'expectedResult' => true,
+            'expectedValue' => new Int64(123),
+            'actualValue' => '123.0',
+        ];
+
+        yield 'Expects Int64, Actual non-numeric string' => [
+            'expectedResult' => false,
+            'expectedValue' => new Int64(123),
+            'actualValue' => 'foo',
         ];
 
         yield 'Expects int, Actual Int64' => [
@@ -47,15 +59,27 @@ class Int64ComparatorTest extends TestCase
             'actualValue' => new Int64(123),
         ];
 
-        yield 'Expects string, Actual Int64' => [
+        yield 'Expects int string, Actual Int64' => [
             'expectedResult' => true,
             'expectedValue' => '123',
             'actualValue' => new Int64(123),
         ];
 
         yield 'Expects float, Actual Int64' => [
-            'expectedResult' => false,
+            'expectedResult' => true,
             'expectedValue' => 123.0,
+            'actualValue' => new Int64(123),
+        ];
+
+        yield 'Expects float string, Actual Int64' => [
+            'expectedResult' => true,
+            'expectedValue' => '123.0',
+            'actualValue' => new Int64(123),
+        ];
+
+        yield 'Expects non-numeric string, Actual Int64' => [
+            'expectedResult' => false,
+            'expectedValue' => 'foo',
             'actualValue' => new Int64(123),
         ];
 
@@ -65,7 +89,7 @@ class Int64ComparatorTest extends TestCase
             'actualValue' => 123.0,
         ];
 
-        yield 'Expects string, Actual string' => [
+        yield 'Expects numeric string, Actual numeric string' => [
             'expectedResult' => false,
             'expectedValue' => '123',
             'actualValue' => '123',
@@ -84,28 +108,48 @@ class Int64ComparatorTest extends TestCase
     public static function provideMatchingAssertions(): Generator
     {
         yield 'Expected Int64, Actual Int64' => [
-            'expected' => new Int64(123),
-            'actual' => new Int64(123),
+            'expected' => new Int64(8589934592),
+            'actual' => new Int64(8589934592),
         ];
 
         yield 'Expected Int64, Actual int' => [
-            'expected' => new Int64(123),
-            'actual' => 123,
+            'expected' => new Int64(8589934592),
+            'actual' => 8589934592,
         ];
 
-        yield 'Expected Int64, Actual string' => [
-            'expected' => new Int64(123),
-            'actual' => '123',
+        yield 'Expected Int64, Actual int string' => [
+            'expected' => new Int64(8589934592),
+            'actual' => '8589934592',
+        ];
+
+        yield 'Expected Int64, Actual float' => [
+            'expected' => new Int64(8589934592),
+            'actual' => 8589934592.0,
+        ];
+
+        yield 'Expected Int64, Actual float string' => [
+            'expected' => new Int64(8589934592),
+            'actual' => '8589934592.0',
         ];
 
         yield 'Expected int, Actual Int64' => [
-            'expected' => 123,
-            'actual' => new Int64(123),
+            'expected' => 8589934592,
+            'actual' => new Int64(8589934592),
         ];
 
-        yield 'Expected string, Actual Int64' => [
-            'expected' => '123',
-            'actual' => new Int64(123),
+        yield 'Expected int string, Actual Int64' => [
+            'expected' => '8589934592',
+            'actual' => new Int64(8589934592),
+        ];
+
+        yield 'Expected float, Actual Int64' => [
+            'expected' => 8589934592.0,
+            'actual' => new Int64(8589934592),
+        ];
+
+        yield 'Expected float string, Actual Int64' => [
+            'expected' => '8589934592.0',
+            'actual' => new Int64(8589934592),
         ];
     }
 
@@ -120,27 +164,47 @@ class Int64ComparatorTest extends TestCase
     public static function provideFailingValues(): Generator
     {
         yield 'Expected Int64, Actual Int64' => [
-            'expected' => new Int64(123),
+            'expected' => new Int64(8589934592),
             'actual' => new Int64(456),
         ];
 
         yield 'Expected Int64, Actual int' => [
-            'expected' => new Int64(123),
+            'expected' => new Int64(8589934592),
             'actual' => 456,
         ];
 
-        yield 'Expected Int64, Actual string' => [
-            'expected' => new Int64(123),
+        yield 'Expected Int64, Actual int string' => [
+            'expected' => new Int64(8589934592),
             'actual' => '456',
         ];
 
+        yield 'Expected Int64, Actual float' => [
+            'expected' => new Int64(8589934592),
+            'actual' => 8589934592.1,
+        ];
+
+        yield 'Expected Int64, Actual float string' => [
+            'expected' => new Int64(8589934592),
+            'actual' => '8589934592.1',
+        ];
+
         yield 'Expected int, Actual Int64' => [
-            'expected' => 123,
+            'expected' => 8589934592,
             'actual' => new Int64(456),
         ];
 
-        yield 'Expected string, Actual Int64' => [
-            'expected' => '123',
+        yield 'Expected int string, Actual Int64' => [
+            'expected' => '8589934592',
+            'actual' => new Int64(456),
+        ];
+
+        yield 'Expected float, Actual Int64' => [
+            'expected' => 8589934592.1,
+            'actual' => new Int64(456),
+        ];
+
+        yield 'Expected float string, Actual Int64' => [
+            'expected' => '8589934592.1',
             'actual' => new Int64(456),
         ];
     }

--- a/tests/Comparator/Int64ComparatorTest.php
+++ b/tests/Comparator/Int64ComparatorTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace MongoDB\Tests\Comparator;
+
+use Generator;
+use MongoDB\BSON\Int64;
+use PHPUnit\Framework\TestCase;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+class Int64ComparatorTest extends TestCase
+{
+    /** @dataProvider provideAcceptsValues */
+    public function testAccepts(bool $expectedResult, $expectedValue, $actualValue): void
+    {
+        $this->assertSame($expectedResult, (new Int64Comparator())->accepts($expectedValue, $actualValue));
+    }
+
+    public static function provideAcceptsValues(): Generator
+    {
+        yield 'Expects Int64, Actual Int64' => [
+            'expectedResult' => true,
+            'expectedValue' => new Int64(123),
+            'actualValue' => new Int64(123),
+        ];
+
+        yield 'Expects Int64, Actual int' => [
+            'expectedResult' => true,
+            'expectedValue' => new Int64(123),
+            'actualValue' => 123,
+        ];
+
+        yield 'Expects Int64, Actual string' => [
+            'expectedResult' => true,
+            'expectedValue' => new Int64(123),
+            'actualValue' => '123',
+        ];
+
+        yield 'Expects Int64, Actual float' => [
+            'expectedResult' => false,
+            'expectedValue' => new Int64(123),
+            'actualValue' => 123.0,
+        ];
+
+        yield 'Expects int, Actual Int64' => [
+            'expectedResult' => true,
+            'expectedValue' => 123,
+            'actualValue' => new Int64(123),
+        ];
+
+        yield 'Expects string, Actual Int64' => [
+            'expectedResult' => true,
+            'expectedValue' => '123',
+            'actualValue' => new Int64(123),
+        ];
+
+        yield 'Expects float, Actual Int64' => [
+            'expectedResult' => false,
+            'expectedValue' => 123.0,
+            'actualValue' => new Int64(123),
+        ];
+
+        yield 'Expects float, Actual float' => [
+            'expectedResult' => false,
+            'expectedValue' => 123.0,
+            'actualValue' => 123.0,
+        ];
+
+        yield 'Expects string, Actual string' => [
+            'expectedResult' => false,
+            'expectedValue' => '123',
+            'actualValue' => '123',
+        ];
+    }
+
+    /**
+     * @dataProvider provideMatchingAssertions
+     * @doesNotPerformAssertions
+     */
+    public function testMatchingAssertions($expected, $actual): void
+    {
+        (new Int64Comparator())->assertEquals($expected, $actual);
+    }
+
+    public static function provideMatchingAssertions(): Generator
+    {
+        yield 'Expected Int64, Actual Int64' => [
+            'expected' => new Int64(123),
+            'actual' => new Int64(123),
+        ];
+
+        yield 'Expected Int64, Actual int' => [
+            'expected' => new Int64(123),
+            'actual' => 123,
+        ];
+
+        yield 'Expected Int64, Actual string' => [
+            'expected' => new Int64(123),
+            'actual' => '123',
+        ];
+
+        yield 'Expected int, Actual Int64' => [
+            'expected' => 123,
+            'actual' => new Int64(123),
+        ];
+
+        yield 'Expected string, Actual Int64' => [
+            'expected' => '123',
+            'actual' => new Int64(123),
+        ];
+    }
+
+    /** @dataProvider provideFailingValues */
+    public function testFailingAssertions($expected, $actual): void
+    {
+        $this->expectException(ComparisonFailure::class);
+
+        (new Int64Comparator())->assertEquals($expected, $actual);
+    }
+
+    public static function provideFailingValues(): Generator
+    {
+        yield 'Expected Int64, Actual Int64' => [
+            'expected' => new Int64(123),
+            'actual' => new Int64(456),
+        ];
+
+        yield 'Expected Int64, Actual int' => [
+            'expected' => new Int64(123),
+            'actual' => 456,
+        ];
+
+        yield 'Expected Int64, Actual string' => [
+            'expected' => new Int64(123),
+            'actual' => '456',
+        ];
+
+        yield 'Expected int, Actual Int64' => [
+            'expected' => 123,
+            'actual' => new Int64(456),
+        ];
+
+        yield 'Expected string, Actual Int64' => [
+            'expected' => '123',
+            'actual' => new Int64(456),
+        ];
+    }
+}

--- a/tests/SpecTests/ClientSideEncryption/FunctionalTestCase.php
+++ b/tests/SpecTests/ClientSideEncryption/FunctionalTestCase.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Tests\SpecTests\ClientSideEncryption;
 
-use MongoDB\BSON\Int64;
 use MongoDB\Client;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Tests\SpecTests\FunctionalTestCase as BaseFunctionalTestCase;
@@ -14,8 +13,6 @@ use function getenv;
 use function is_executable;
 use function is_readable;
 use function sprintf;
-use function strlen;
-use function unserialize;
 
 use const DIRECTORY_SEPARATOR;
 use const PATH_SEPARATOR;
@@ -67,14 +64,6 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         }
 
         $collection->insertMany($keyVaultData);
-    }
-
-    protected static function createInt64(string $value): Int64
-    {
-        $array = sprintf('a:1:{s:7:"integer";s:%d:"%s";}', strlen($value), $value);
-        $int64 = sprintf('C:%d:"%s":%d:{%s}', strlen(Int64::class), Int64::class, strlen($array), $array);
-
-        return unserialize($int64);
     }
 
     private function createTestCollection(?stdClass $encryptedFields = null, ?stdClass $jsonSchema = null): void

--- a/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\EncryptionException;
@@ -168,8 +169,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         yield 'Long' => [
             'Long',
             [
-                'min' => self::createInt64('0'),
-                'max' => self::createInt64('200'),
+                'min' => new Int64(0),
+                'max' => new Int64(200),
                 'sparsity' => 1,
             ],
         ];
@@ -467,7 +468,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
 
             case 'Long':
                 return function (int $value) {
-                    return self::createInt64((string) $value);
+                    return new Int64($value);
                 };
 
             default:

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -43,9 +43,7 @@ use function iterator_to_array;
 use function json_decode;
 use function sprintf;
 use function str_repeat;
-use function strlen;
 use function substr;
-use function unserialize;
 
 use const DIRECTORY_SEPARATOR;
 use const PATH_SEPARATOR;
@@ -1862,14 +1860,6 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         }
     }
 
-    private function createInt64(string $value): Int64
-    {
-        $array = sprintf('a:1:{s:7:"integer";s:%d:"%s";}', strlen($value), $value);
-        $int64 = sprintf('C:%d:"%s":%d:{%s}', strlen(Int64::class), Int64::class, strlen($array), $array);
-
-        return unserialize($int64);
-    }
-
     private function createTestCollection(?stdClass $encryptedFields = null, ?stdClass $jsonSchema = null): void
     {
         $context = $this->getContext();
@@ -1936,7 +1926,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                 /* Note: workaround issue where mongocryptd refuses to encrypt
                  * 32-bit integers if schemaMap defines a "long" BSON type. */
                 $value = $data->type === 'long' && ! $data->value instanceof Int64
-                    ? $this->createInt64($data->value)
+                    ? new Int64($data->value)
                     : $data->value;
 
                 $encrypted = $clientEncryption->encrypt($value, $encryptionOptions);
@@ -1987,7 +1977,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             /* Note: workaround issue where mongocryptd refuses to encrypt
              * 32-bit integers if schemaMap defines a "long" BSON type. */
             if ($data->type === 'long' && ! $data->value instanceof Int64) {
-                $data->value = $this->createInt64($data->value);
+                $data->value = new Int64($data->value);
             }
 
             return $data;

--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -30,8 +30,6 @@ use function PHPUnit\Framework\logicalAnd;
 use function PHPUnit\Framework\logicalOr;
 use function sprintf;
 
-use const PHP_INT_SIZE;
-
 /**
  * Constraint that checks if one document matches another.
  *
@@ -307,12 +305,6 @@ class DocumentsMatchConstraint extends Constraint
             if ($value instanceof BSONDocument || $value instanceof stdClass || is_array($value)) {
                 $bson[$key] = $this->prepareBSON($value, false, $sortKeys);
                 continue;
-            }
-
-            /* Convert Int64 objects to integers on 64-bit platforms for
-             * compatibility reasons. */
-            if ($value instanceof Int64 && PHP_INT_SIZE != 4) {
-                $bson[$key] = (int) ((string) $value);
             }
         }
 

--- a/tests/SpecTests/DocumentsMatchConstraintTest.php
+++ b/tests/SpecTests/DocumentsMatchConstraintTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\SpecTests;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\Javascript;
 use MongoDB\BSON\MaxKey;
 use MongoDB\BSON\MinKey;
@@ -18,7 +19,6 @@ use PHPUnit\Framework\ExpectationFailedException;
 
 use function MongoDB\BSON\fromJSON;
 use function MongoDB\BSON\toPHP;
-use function unserialize;
 
 use const PHP_INT_SIZE;
 
@@ -85,8 +85,8 @@ class DocumentsMatchConstraintTest extends TestCase
         $undefined = toPHP(fromJSON('{ "x": {"$undefined": true} }'))->x;
         $symbol = toPHP(fromJSON('{ "x": {"$symbol": "test"} }'))->x;
         $dbPointer = toPHP(fromJSON('{ "x": {"$dbPointer": {"$ref": "db.coll", "$id" : { "$oid" : "5a2e78accd485d55b405ac12" }  }} }'))->x;
-        $int64 = unserialize('C:18:"MongoDB\BSON\Int64":28:{a:1:{s:7:"integer";s:1:"1";}}');
-        $long = PHP_INT_SIZE == 4 ? unserialize('C:18:"MongoDB\BSON\Int64":38:{a:1:{s:7:"integer";s:10:"4294967296";}}') : 4294967296;
+        $int64 = new Int64(1);
+        $long = PHP_INT_SIZE == 4 ? new Int64('4294967296') : 4294967296;
 
         return [
             'double' => ['double', 1.4],

--- a/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
+++ b/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\UnifiedSpecTests\Constraint;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\Javascript;
 use MongoDB\BSON\MaxKey;
 use MongoDB\BSON\MinKey;
@@ -22,7 +23,6 @@ use stdClass;
 use function fopen;
 use function MongoDB\BSON\fromJSON;
 use function MongoDB\BSON\toPHP;
-use function unserialize;
 
 use const PHP_INT_SIZE;
 
@@ -39,8 +39,8 @@ class IsBsonTypeTest extends TestCase
         $undefined = toPHP(fromJSON('{ "x": {"$undefined": true} }'))->x;
         $symbol = toPHP(fromJSON('{ "x": {"$symbol": "test"} }'))->x;
         $dbPointer = toPHP(fromJSON('{ "x": {"$dbPointer": {"$ref": "db.coll", "$id" : { "$oid" : "5a2e78accd485d55b405ac12" }  }} }'))->x;
-        $int64 = unserialize('C:18:"MongoDB\BSON\Int64":28:{a:1:{s:7:"integer";s:1:"1";}}');
-        $long = PHP_INT_SIZE == 4 ? unserialize('C:18:"MongoDB\BSON\Int64":38:{a:1:{s:7:"integer";s:10:"4294967296";}}') : 4294967296;
+        $int64 = new Int64(1);
+        $long = PHP_INT_SIZE == 4 ? new Int64('4294967296') : 4294967296;
 
         return [
             'double' => ['double', 1.4],

--- a/tests/UnifiedSpecTests/Constraint/Matches.php
+++ b/tests/UnifiedSpecTests/Constraint/Matches.php
@@ -40,8 +40,6 @@ use function sprintf;
 use function strpos;
 use function strrchr;
 
-use const PHP_INT_SIZE;
-
 /**
  * Constraint that checks if one value matches another.
  *
@@ -424,17 +422,6 @@ class Matches extends Constraint
         if (! is_array($bson) && ! is_object($bson)) {
             return $bson;
         }
-
-        /* Convert Int64 objects to integers on 64-bit platforms for
-         * compatibility reasons. */
-        if ($bson instanceof Int64 && PHP_INT_SIZE != 4) {
-            return (int) ((string) $bson);
-        }
-
-        /* TODO: Convert Int64 objects to integers on 32-bit platforms if they
-         * can be expressed as such. This is necessary to handle flexible
-         * numeric comparisons if the server returns 32-bit value as a 64-bit
-         * integer (e.g. cursor ID). */
 
         // Serializable can produce an array or object, so recurse on its output
         if ($bson instanceof Serializable) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+use MongoDB\Tests\Comparator\Int64Comparator;
+use SebastianBergmann\Comparator\Factory as ComparatorFactory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// Register custom comparators
+ComparatorFactory::getInstance()->register(new Int64Comparator());


### PR DESCRIPTION
PHPLIB-1147
PHPLIB-1148

This PR removes the previous workarounds for creating Int64 instances through `unserialise` and adds a comparator for Int64 values. Using this comparator renders other workarounds for comparing Int64 instances obsolete.

I've built the comparator to only become active if at least one value is an Int64 instance and the other value is an int or numeric string. On 64-bit platforms we're comparing int values directly, whereas we compare string representations on 32-bit platforms to ensure correct behaviour for 64-bit values.

A note to contributors: if you have your own `phpunit.xml` file, make sure to update the `bootstrap` configuration as seen in `phpunit.xml.dist`. This is necessary to ensure that the new comparator is loaded.