### PR TITLE
Refactor psalm and phpcs workflows to get static names

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -16,17 +16,14 @@ on:
     paths-ignore:
       - "docs/**"
 
+env:
+  PHP_VERSION: "8.2"
+  DRIVER_VERSION: "stable"
+
 jobs:
   phpcs:
     name: "phpcs"
     runs-on: "ubuntu-22.04"
-
-    strategy:
-      matrix:
-        php-version:
-          - "8.2"
-        driver-version:
-          - "stable"
 
     steps:
       - name: "Checkout"
@@ -36,8 +33,8 @@ jobs:
         id: extcache
         uses: shivammathur/cache-extensions@v1
         with:
-          php-version: ${{ matrix.php-version }}
-          extensions: "mongodb-${{ matrix.driver-version }}"
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: "mongodb-${{ env.DRIVER_VERSION }}"
           key: "extcache-v1"
 
       - name: Cache extensions
@@ -51,8 +48,8 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          extensions: "mongodb-${{ matrix.driver-version }}"
-          php-version: "${{ matrix.php-version }}"
+          extensions: "mongodb-${{ env.DRIVER_VERSION }}"
+          php-version: "${{ env.PHP_VERSION }}"
           tools: "cs2pr"
 
       - name: "Show driver information"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,17 +16,14 @@ on:
     paths-ignore:
       - "docs/**"
 
+env:
+  PHP_VERSION: "8.2"
+  DRIVER_VERSION: "stable"
+
 jobs:
   psalm:
     name: "Psalm"
     runs-on: "ubuntu-22.04"
-
-    strategy:
-      matrix:
-        php-version:
-          - "8.2"
-        driver-version:
-          - "stable"
 
     steps:
       - name: "Checkout"
@@ -36,8 +33,8 @@ jobs:
         id: extcache
         uses: shivammathur/cache-extensions@v1
         with:
-          php-version: ${{ matrix.php-version }}
-          extensions: "mongodb-${{ matrix.driver-version }}"
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: "mongodb-${{ ENV.DRIVER_VERSION }}"
           key: "extcache-v1"
 
       - name: Cache extensions
@@ -51,8 +48,8 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          extensions: "mongodb-${{ matrix.driver-version }}"
-          php-version: "${{ matrix.php-version }}"
+          extensions: "mongodb-${{ ENV.DRIVER_VERSION }}"
+          php-version: "${{ env.PHP_VERSION }}"
           tools: "cs2pr"
 
       - name: "Show driver information"


### PR DESCRIPTION
Using a matrix strategy results in changing names whenever we change the driver or PHP version, requiring an update to protected branch settings. Moving this configuration to env variables prevents this issue.