### PR TITLE
PHPLIB-1137: Reject PackedArrays when expecting documents

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -196,10 +196,6 @@
     </MixedAssignment>
   </file>
   <file src="src/Model/ChangeStreamIterator.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
-      <code>isset($initialResumeToken) &amp;&amp; ! is_array($initialResumeToken) &amp;&amp; ! is_object($initialResumeToken)</code>
-    </DocblockTypeContradiction>
     <MixedArgument occurrences="2">
       <code>$reply-&gt;cursor-&gt;nextBatch</code>
       <code>$this-&gt;current()</code>
@@ -276,8 +272,9 @@
     </MixedAssignment>
   </file>
   <file src="src/Model/IndexInput.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
       <code>$fieldName</code>
+      <code>$index['key']</code>
     </MixedArgument>
     <MixedAssignment occurrences="2">
       <code>$fieldName</code>
@@ -328,11 +325,13 @@
       <code>$args[1]</code>
       <code>$args[2]</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="28">
+    <MixedArrayAccess occurrences="30">
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
+      <code>$args[0]</code>
+      <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -395,9 +394,6 @@
     </MixedOperand>
   </file>
   <file src="src/Operation/Count.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-    </DocblockTypeContradiction>
     <MixedAssignment occurrences="6">
       <code>$cmd[$option]</code>
       <code>$cmd['hint']</code>
@@ -409,11 +405,6 @@
     <MixedMethodCall occurrences="1">
       <code>isInTransaction</code>
     </MixedMethodCall>
-  </file>
-  <file src="src/Operation/CountDocuments.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-    </DocblockTypeContradiction>
   </file>
   <file src="src/Operation/CreateCollection.php">
     <MixedArgument occurrences="2">
@@ -427,7 +418,8 @@
     </MixedAssignment>
   </file>
   <file src="src/Operation/CreateEncryptedCollection.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
+      <code>$options['encryptedFields']</code>
       <code>$this-&gt;options['encryptedFields']</code>
     </MixedArgument>
   </file>
@@ -446,9 +438,6 @@
     </MixedMethodCall>
   </file>
   <file src="src/Operation/DatabaseCommand.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($command) &amp;&amp; ! is_object($command)</code>
-    </DocblockTypeContradiction>
     <MixedArgument occurrences="1">
       <code>$this-&gt;options['typeMap']</code>
     </MixedArgument>
@@ -458,9 +447,6 @@
     </MixedAssignment>
   </file>
   <file src="src/Operation/Delete.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-    </DocblockTypeContradiction>
     <MixedArgument occurrences="1">
       <code>$this-&gt;options['writeConcern']</code>
     </MixedArgument>
@@ -476,9 +462,6 @@
     </MixedMethodCall>
   </file>
   <file src="src/Operation/Distinct.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-    </DocblockTypeContradiction>
     <MixedArgument occurrences="1">
       <code>$this-&gt;options['typeMap']</code>
     </MixedArgument>
@@ -516,6 +499,11 @@
       <code>$options['writeConcern']</code>
     </MixedAssignment>
   </file>
+  <file src="src/Operation/DropEncryptedCollection.php">
+    <MixedArgument occurrences="1">
+      <code>$options['encryptedFields']</code>
+    </MixedArgument>
+  </file>
   <file src="src/Operation/DropIndexes.php">
     <MixedArgument occurrences="1">
       <code>$this-&gt;options['typeMap']</code>
@@ -540,9 +528,6 @@
     </MixedAssignment>
   </file>
   <file src="src/Operation/Find.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-    </DocblockTypeContradiction>
     <MixedArgument occurrences="1">
       <code>$this-&gt;options['typeMap']</code>
     </MixedArgument>
@@ -583,32 +568,30 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Operation/FindOneAndDelete.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-    </DocblockTypeContradiction>
+    <MixedAssignment occurrences="1">
+      <code>$options['fields']</code>
+    </MixedAssignment>
   </file>
   <file src="src/Operation/FindOneAndReplace.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
-      <code>! is_array($replacement) &amp;&amp; ! is_object($replacement)</code>
-    </DocblockTypeContradiction>
+    <MixedAssignment occurrences="1">
+      <code>$options['fields']</code>
+    </MixedAssignment>
     <MixedOperand occurrences="1">
       <code>$options['returnDocument']</code>
     </MixedOperand>
   </file>
   <file src="src/Operation/FindOneAndUpdate.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>! is_array($update) &amp;&amp; ! is_object($update)</code>
     </DocblockTypeContradiction>
+    <MixedAssignment occurrences="1">
+      <code>$options['fields']</code>
+    </MixedAssignment>
     <MixedOperand occurrences="1">
       <code>$options['returnDocument']</code>
     </MixedOperand>
   </file>
   <file src="src/Operation/InsertMany.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
-    </DocblockTypeContradiction>
     <MixedAssignment occurrences="4">
       <code>$insertedIds[$i]</code>
       <code>$options[$option]</code>
@@ -621,9 +604,6 @@
     </MixedMethodCall>
   </file>
   <file src="src/Operation/InsertOne.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
-    </DocblockTypeContradiction>
     <MixedAssignment occurrences="4">
       <code>$insertedId</code>
       <code>$options[$option]</code>
@@ -692,14 +672,8 @@
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
-  <file src="src/Operation/ReplaceOne.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_array($replacement) &amp;&amp; ! is_object($replacement)</code>
-    </DocblockTypeContradiction>
-  </file>
   <file src="src/Operation/Update.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($filter) &amp;&amp; ! is_object($filter)</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>! is_array($update) &amp;&amp; ! is_object($update)</code>
     </DocblockTypeContradiction>
     <MixedArgument occurrences="1">
@@ -767,11 +741,11 @@
     </MixedAssignment>
   </file>
   <file src="src/functions.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>! is_array($document) &amp;&amp; ! is_object($document)</code>
+    <DocblockTypeContradiction occurrences="1">
       <code>is_array($document)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
+      <code>$stage</code>
       <code>$wireVersionForWriteStageOnSecondary</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion occurrences="1">
@@ -784,8 +758,9 @@
       <code>$typeMap['fieldPaths'][$fieldPath]</code>
       <code>$typeMap['fieldPaths'][substr($fieldPath, 0, -2)]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment occurrences="6">
       <code>$element[$key]</code>
+      <code>$stage</code>
       <code>$type</code>
       <code>$typeMap['fieldPaths'][$fieldPath . '.' . $existingFieldPath]</code>
       <code>$typeMap['fieldPaths'][$fieldPath]</code>

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -79,7 +79,7 @@ class ListCollections implements Executable
         }
 
         if (isset($options['filter']) && ! is_document($options['filter'])) {
-            throw InvalidArgumentException::invalidType('"filter" option', $options['filter'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"filter" option', $options['filter']);
         }
 
         if (isset($options['maxTimeMS']) && ! is_integer($options['maxTimeMS'])) {

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -25,10 +25,9 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\CachingIterator;
 use MongoDB\Operation\Executable;
 
-use function is_array;
 use function is_bool;
 use function is_integer;
-use function is_object;
+use function MongoDB\is_document;
 
 /**
  * Wrapper for the listCollections command.
@@ -79,8 +78,8 @@ class ListCollections implements Executable
             throw InvalidArgumentException::invalidType('"authorizedCollections" option', $options['authorizedCollections'], 'boolean');
         }
 
-        if (isset($options['filter']) && ! is_array($options['filter']) && ! is_object($options['filter'])) {
-            throw InvalidArgumentException::invalidType('"filter" option', $options['filter'], 'array or object');
+        if (isset($options['filter']) && ! is_document($options['filter'])) {
+            throw InvalidArgumentException::invalidType('"filter" option', $options['filter'], 'document');
         }
 
         if (isset($options['maxTimeMS']) && ! is_integer($options['maxTimeMS'])) {

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -77,7 +77,7 @@ class ListDatabases implements Executable
         }
 
         if (isset($options['filter']) && ! is_document($options['filter'])) {
-            throw InvalidArgumentException::invalidType('"filter" option', $options['filter'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"filter" option', $options['filter']);
         }
 
         if (isset($options['maxTimeMS']) && ! is_integer($options['maxTimeMS'])) {

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -29,7 +29,7 @@ use function current;
 use function is_array;
 use function is_bool;
 use function is_integer;
-use function is_object;
+use function MongoDB\is_document;
 
 /**
  * Wrapper for the ListDatabases command.
@@ -76,8 +76,8 @@ class ListDatabases implements Executable
             throw InvalidArgumentException::invalidType('"authorizedDatabases" option', $options['authorizedDatabases'], 'boolean');
         }
 
-        if (isset($options['filter']) && ! is_array($options['filter']) && ! is_object($options['filter'])) {
-            throw InvalidArgumentException::invalidType('"filter" option', $options['filter'], ['array', 'object']);
+        if (isset($options['filter']) && ! is_document($options['filter'])) {
+            throw InvalidArgumentException::invalidType('"filter" option', $options['filter'], 'document');
         }
 
         if (isset($options['maxTimeMS']) && ! is_integer($options['maxTimeMS'])) {

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -30,6 +30,17 @@ use function sprintf;
 class InvalidArgumentException extends DriverInvalidArgumentException implements Exception
 {
     /**
+     * Thrown when an argument or option is expected to be a document.
+     *
+     * @param string $name  Name of the argument or option
+     * @param mixed  $value Actual value (used to derive the type)
+     */
+    public static function expectedDocumentType(string $name, $value): self
+    {
+        return new self(sprintf('Expected %s to have type "document" (array or object) but found "%s"', $name, get_debug_type($value)));
+    }
+
+    /**
      * Thrown when an argument or option has an invalid type.
      *
      * @param string              $name         Name of the argument or option

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -28,11 +28,10 @@ use function array_intersect_key;
 use function hash_final;
 use function hash_init;
 use function hash_update;
-use function is_array;
 use function is_bool;
 use function is_integer;
-use function is_object;
 use function is_string;
+use function MongoDB\is_document;
 use function MongoDB\is_string_array;
 use function sprintf;
 use function strlen;
@@ -130,8 +129,8 @@ class WritableStream
             throw InvalidArgumentException::invalidType('"contentType" option', $options['contentType'], 'string');
         }
 
-        if (isset($options['metadata']) && ! is_array($options['metadata']) && ! is_object($options['metadata'])) {
-            throw InvalidArgumentException::invalidType('"metadata" option', $options['metadata'], 'array or object');
+        if (isset($options['metadata']) && ! is_document($options['metadata'])) {
+            throw InvalidArgumentException::invalidType('"metadata" option', $options['metadata'], 'document');
         }
 
         $this->chunkSize = $options['chunkSizeBytes'];

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -130,7 +130,7 @@ class WritableStream
         }
 
         if (isset($options['metadata']) && ! is_document($options['metadata'])) {
-            throw InvalidArgumentException::invalidType('"metadata" option', $options['metadata'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"metadata" option', $options['metadata']);
         }
 
         $this->chunkSize = $options['chunkSizeBytes'];

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -77,7 +77,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
     public function __construct(Cursor $cursor, int $firstBatchSize, $initialResumeToken, ?object $postBatchResumeToken)
     {
         if (isset($initialResumeToken) && ! is_document($initialResumeToken)) {
-            throw InvalidArgumentException::invalidType('$initialResumeToken', $initialResumeToken, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$initialResumeToken', $initialResumeToken);
         }
 
         parent::__construct($cursor);
@@ -236,7 +236,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
     private function extractResumeToken($document)
     {
         if (! is_document($document)) {
-            throw InvalidArgumentException::invalidType('$document', $document, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$document', $document);
         }
 
         if ($document instanceof Serializable) {

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -36,6 +36,7 @@ use function is_array;
 use function is_object;
 use function MongoDB\Driver\Monitoring\addSubscriber;
 use function MongoDB\Driver\Monitoring\removeSubscriber;
+use function MongoDB\is_document;
 
 /**
  * ChangeStreamIterator wraps a change stream's tailable cursor.
@@ -75,8 +76,8 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      */
     public function __construct(Cursor $cursor, int $firstBatchSize, $initialResumeToken, ?object $postBatchResumeToken)
     {
-        if (isset($initialResumeToken) && ! is_array($initialResumeToken) && ! is_object($initialResumeToken)) {
-            throw InvalidArgumentException::invalidType('$initialResumeToken', $initialResumeToken, 'array or object');
+        if (isset($initialResumeToken) && ! is_document($initialResumeToken)) {
+            throw InvalidArgumentException::invalidType('$initialResumeToken', $initialResumeToken, 'document');
         }
 
         parent::__construct($cursor);
@@ -234,8 +235,8 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      */
     private function extractResumeToken($document)
     {
-        if (! is_array($document) && ! is_object($document)) {
-            throw InvalidArgumentException::invalidType('$document', $document, 'array or object');
+        if (! is_document($document)) {
+            throw InvalidArgumentException::invalidType('$document', $document, 'document');
         }
 
         if ($document instanceof Serializable) {

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -20,12 +20,11 @@ namespace MongoDB\Model;
 use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
 
-use function is_array;
 use function is_float;
 use function is_int;
-use function is_object;
 use function is_string;
 use function MongoDB\document_to_array;
+use function MongoDB\is_document;
 use function sprintf;
 
 /**
@@ -53,8 +52,8 @@ class IndexInput implements Serializable
             throw new InvalidArgumentException('Required "key" document is missing from index specification');
         }
 
-        if (! is_array($index['key']) && ! is_object($index['key'])) {
-            throw InvalidArgumentException::invalidType('"key" option', $index['key'], 'array or object');
+        if (! is_document($index['key'])) {
+            throw InvalidArgumentException::invalidType('"key" option', $index['key'], 'document');
         }
 
         foreach ($index['key'] as $fieldName => $order) {

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -53,7 +53,7 @@ class IndexInput implements Serializable
         }
 
         if (! is_document($index['key'])) {
-            throw InvalidArgumentException::invalidType('"key" option', $index['key'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"key" option', $index['key']);
         }
 
         foreach ($index['key'] as $fieldName => $order) {

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -38,6 +38,7 @@ use function is_integer;
 use function is_object;
 use function is_string;
 use function MongoDB\create_field_path_type_map;
+use function MongoDB\is_document;
 use function MongoDB\is_last_pipeline_operator_write;
 use function MongoDB\is_pipeline;
 
@@ -155,8 +156,8 @@ class Aggregate implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"bypassDocumentValidation" option', $options['bypassDocumentValidation'], 'boolean');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
         if (isset($options['explain']) && ! is_bool($options['explain'])) {
@@ -167,8 +168,8 @@ class Aggregate implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"hint" option', $options['hint'], 'string or array or object');
         }
 
-        if (isset($options['let']) && ! is_array($options['let']) && ! is_object($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], ['array', 'object']);
+        if (isset($options['let']) && ! is_document($options['let'])) {
+            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
         }
 
         if (isset($options['maxAwaitTimeMS']) && ! is_integer($options['maxAwaitTimeMS'])) {

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -157,7 +157,7 @@ class Aggregate implements Executable, Explainable
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['explain']) && ! is_bool($options['explain'])) {
@@ -169,7 +169,7 @@ class Aggregate implements Executable, Explainable
         }
 
         if (isset($options['let']) && ! is_document($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"let" option', $options['let']);
         }
 
         if (isset($options['maxAwaitTimeMS']) && ! is_integer($options['maxAwaitTimeMS'])) {

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -154,7 +154,7 @@ class BulkWrite implements Executable
             }
 
             if (! is_document($args[0])) {
-                throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][0]', $i, $type), $args[0], 'document');
+                throw InvalidArgumentException::expectedDocumentType(sprintf('$operations[%d]["%s"][0]', $i, $type), $args[0]);
             }
 
             switch ($type) {
@@ -174,7 +174,7 @@ class BulkWrite implements Executable
                     $args[1]['limit'] = ($type === self::DELETE_ONE ? 1 : 0);
 
                     if (isset($args[1]['collation']) && ! is_document($args[1]['collation'])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]["collation"]', $i, $type), $args[1]['collation'], 'document');
+                        throw InvalidArgumentException::expectedDocumentType(sprintf('$operations[%d]["%s"][1]["collation"]', $i, $type), $args[1]['collation']);
                     }
 
                     $operations[$i][$type][1] = $args[1];
@@ -187,7 +187,7 @@ class BulkWrite implements Executable
                     }
 
                     if (! is_document($args[1])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]', $i, $type), $args[1], 'document');
+                        throw InvalidArgumentException::expectedDocumentType(sprintf('$operations[%d]["%s"][1]', $i, $type), $args[1]);
                     }
 
                     // Treat empty arrays as replacement documents for BC
@@ -215,7 +215,7 @@ class BulkWrite implements Executable
                     $args[2] += ['upsert' => false];
 
                     if (isset($args[2]['collation']) && ! is_document($args[2]['collation'])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["collation"]', $i, $type), $args[2]['collation'], 'document');
+                        throw InvalidArgumentException::expectedDocumentType(sprintf('$operations[%d]["%s"][2]["collation"]', $i, $type), $args[2]['collation']);
                     }
 
                     if (! is_bool($args[2]['upsert'])) {
@@ -252,7 +252,7 @@ class BulkWrite implements Executable
                     }
 
                     if (isset($args[2]['collation']) && ! is_document($args[2]['collation'])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["collation"]', $i, $type), $args[2]['collation'], 'document');
+                        throw InvalidArgumentException::expectedDocumentType(sprintf('$operations[%d]["%s"][2]["collation"]', $i, $type), $args[2]['collation']);
                     }
 
                     if (! is_bool($args[2]['upsert'])) {
@@ -287,7 +287,7 @@ class BulkWrite implements Executable
         }
 
         if (isset($options['let']) && ! is_document($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"let" option', $options['let']);
         }
 
         if (isset($options['bypassDocumentValidation']) && ! $options['bypassDocumentValidation']) {

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -32,7 +32,6 @@ use function count;
 use function current;
 use function is_array;
 use function is_bool;
-use function is_object;
 use function key;
 use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
@@ -233,11 +232,7 @@ class BulkWrite implements Executable
                         throw new InvalidArgumentException(sprintf('Missing second argument for $operations[%d]["%s"]', $i, $type));
                     }
 
-                    if (! is_array($args[1]) && ! is_object($args[1])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]', $i, $type), $args[1], 'array or object');
-                    }
-
-                    if (! is_first_key_operator($args[1]) && ! is_pipeline($args[1])) {
+                    if ((! is_document($args[1]) || ! is_first_key_operator($args[1])) && ! is_pipeline($args[1])) {
                         throw new InvalidArgumentException(sprintf('Expected update operator(s) or non-empty pipeline for $operations[%d]["%s"][1]', $i, $type));
                     }
 

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -34,6 +34,7 @@ use function is_array;
 use function is_bool;
 use function is_object;
 use function key;
+use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
 use function sprintf;
@@ -153,8 +154,8 @@ class BulkWrite implements Executable
                 throw new InvalidArgumentException(sprintf('Missing first argument for $operations[%d]["%s"]', $i, $type));
             }
 
-            if (! is_array($args[0]) && ! is_object($args[0])) {
-                throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][0]', $i, $type), $args[0], 'array or object');
+            if (! is_document($args[0])) {
+                throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][0]', $i, $type), $args[0], 'document');
             }
 
             switch ($type) {
@@ -173,8 +174,8 @@ class BulkWrite implements Executable
 
                     $args[1]['limit'] = ($type === self::DELETE_ONE ? 1 : 0);
 
-                    if (isset($args[1]['collation']) && ! is_array($args[1]['collation']) && ! is_object($args[1]['collation'])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]["collation"]', $i, $type), $args[1]['collation'], 'array or object');
+                    if (isset($args[1]['collation']) && ! is_document($args[1]['collation'])) {
+                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]["collation"]', $i, $type), $args[1]['collation'], 'document');
                     }
 
                     $operations[$i][$type][1] = $args[1];
@@ -186,8 +187,8 @@ class BulkWrite implements Executable
                         throw new InvalidArgumentException(sprintf('Missing second argument for $operations[%d]["%s"]', $i, $type));
                     }
 
-                    if (! is_array($args[1]) && ! is_object($args[1])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]', $i, $type), $args[1], 'array or object');
+                    if (! is_document($args[1])) {
+                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]', $i, $type), $args[1], 'document');
                     }
 
                     // Treat empty arrays as replacement documents for BC
@@ -214,8 +215,8 @@ class BulkWrite implements Executable
                     $args[2]['multi'] = false;
                     $args[2] += ['upsert' => false];
 
-                    if (isset($args[2]['collation']) && ! is_array($args[2]['collation']) && ! is_object($args[2]['collation'])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["collation"]', $i, $type), $args[2]['collation'], 'array or object');
+                    if (isset($args[2]['collation']) && ! is_document($args[2]['collation'])) {
+                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["collation"]', $i, $type), $args[2]['collation'], 'document');
                     }
 
                     if (! is_bool($args[2]['upsert'])) {
@@ -255,8 +256,8 @@ class BulkWrite implements Executable
                         throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["arrayFilters"]', $i, $type), $args[2]['arrayFilters'], 'array');
                     }
 
-                    if (isset($args[2]['collation']) && ! is_array($args[2]['collation']) && ! is_object($args[2]['collation'])) {
-                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["collation"]', $i, $type), $args[2]['collation'], 'array or object');
+                    if (isset($args[2]['collation']) && ! is_document($args[2]['collation'])) {
+                        throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["collation"]', $i, $type), $args[2]['collation'], 'document');
                     }
 
                     if (! is_bool($args[2]['upsert'])) {
@@ -290,8 +291,8 @@ class BulkWrite implements Executable
             throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
-        if (isset($options['let']) && ! is_array($options['let']) && ! is_object($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'array or object');
+        if (isset($options['let']) && ! is_document($options['let'])) {
+            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
         }
 
         if (isset($options['bypassDocumentValidation']) && ! $options['bypassDocumentValidation']) {

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -93,11 +93,11 @@ class Count implements Executable, Explainable
     public function __construct(string $databaseName, string $collectionName, $filter = [], array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['hint']) && ! is_string($options['hint']) && ! is_array($options['hint']) && ! is_object($options['hint'])) {

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -33,6 +33,7 @@ use function is_float;
 use function is_integer;
 use function is_object;
 use function is_string;
+use function MongoDB\is_document;
 
 /**
  * Operation for the count command.
@@ -91,12 +92,12 @@ class Count implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, $filter = [], array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
         if (isset($options['hint']) && ! is_string($options['hint']) && ! is_array($options['hint']) && ! is_object($options['hint'])) {

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -28,10 +28,10 @@ use function array_intersect_key;
 use function assert;
 use function count;
 use function current;
-use function is_array;
 use function is_float;
 use function is_integer;
 use function is_object;
+use function MongoDB\is_document;
 
 /**
  * Operation for obtaining an exact count of documents in a collection
@@ -96,8 +96,8 @@ class CountDocuments implements Executable
      */
     public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
         if (isset($options['limit']) && ! is_integer($options['limit'])) {

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -97,7 +97,7 @@ class CountDocuments implements Executable
     public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if (isset($options['limit']) && ! is_integer($options['limit'])) {

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -28,8 +28,8 @@ use function current;
 use function is_array;
 use function is_bool;
 use function is_integer;
-use function is_object;
 use function is_string;
+use function MongoDB\is_document;
 use function MongoDB\is_pipeline;
 use function trigger_error;
 
@@ -152,20 +152,20 @@ class CreateCollection implements Executable
             throw InvalidArgumentException::invalidType('"capped" option', $options['capped'], 'boolean');
         }
 
-        if (isset($options['changeStreamPreAndPostImages']) && ! is_array($options['changeStreamPreAndPostImages']) && ! is_object($options['changeStreamPreAndPostImages'])) {
-            throw InvalidArgumentException::invalidType('"changeStreamPreAndPostImages" option', $options['changeStreamPreAndPostImages'], 'array or object');
+        if (isset($options['changeStreamPreAndPostImages']) && ! is_document($options['changeStreamPreAndPostImages'])) {
+            throw InvalidArgumentException::invalidType('"changeStreamPreAndPostImages" option', $options['changeStreamPreAndPostImages'], 'document');
         }
 
-        if (isset($options['clusteredIndex']) && ! is_array($options['clusteredIndex']) && ! is_object($options['clusteredIndex'])) {
-            throw InvalidArgumentException::invalidType('"clusteredIndex" option', $options['clusteredIndex'], 'array or object');
+        if (isset($options['clusteredIndex']) && ! is_document($options['clusteredIndex'])) {
+            throw InvalidArgumentException::invalidType('"clusteredIndex" option', $options['clusteredIndex'], 'document');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
-        if (isset($options['encryptedFields']) && ! is_array($options['encryptedFields']) && ! is_object($options['encryptedFields'])) {
-            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], 'array or object');
+        if (isset($options['encryptedFields']) && ! is_document($options['encryptedFields'])) {
+            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], 'document');
         }
 
         if (isset($options['expireAfterSeconds']) && ! is_integer($options['expireAfterSeconds'])) {
@@ -176,8 +176,8 @@ class CreateCollection implements Executable
             throw InvalidArgumentException::invalidType('"flags" option', $options['flags'], 'integer');
         }
 
-        if (isset($options['indexOptionDefaults']) && ! is_array($options['indexOptionDefaults']) && ! is_object($options['indexOptionDefaults'])) {
-            throw InvalidArgumentException::invalidType('"indexOptionDefaults" option', $options['indexOptionDefaults'], 'array or object');
+        if (isset($options['indexOptionDefaults']) && ! is_document($options['indexOptionDefaults'])) {
+            throw InvalidArgumentException::invalidType('"indexOptionDefaults" option', $options['indexOptionDefaults'], 'document');
         }
 
         if (isset($options['max']) && ! is_integer($options['max'])) {
@@ -200,12 +200,12 @@ class CreateCollection implements Executable
             throw InvalidArgumentException::invalidType('"size" option', $options['size'], 'integer');
         }
 
-        if (isset($options['storageEngine']) && ! is_array($options['storageEngine']) && ! is_object($options['storageEngine'])) {
-            throw InvalidArgumentException::invalidType('"storageEngine" option', $options['storageEngine'], 'array or object');
+        if (isset($options['storageEngine']) && ! is_document($options['storageEngine'])) {
+            throw InvalidArgumentException::invalidType('"storageEngine" option', $options['storageEngine'], 'document');
         }
 
-        if (isset($options['timeseries']) && ! is_array($options['timeseries']) && ! is_object($options['timeseries'])) {
-            throw InvalidArgumentException::invalidType('"timeseries" option', $options['timeseries'], ['array', 'object']);
+        if (isset($options['timeseries']) && ! is_document($options['timeseries'])) {
+            throw InvalidArgumentException::invalidType('"timeseries" option', $options['timeseries'], 'document');
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -220,8 +220,8 @@ class CreateCollection implements Executable
             throw InvalidArgumentException::invalidType('"validationLevel" option', $options['validationLevel'], 'string');
         }
 
-        if (isset($options['validator']) && ! is_array($options['validator']) && ! is_object($options['validator'])) {
-            throw InvalidArgumentException::invalidType('"validator" option', $options['validator'], 'array or object');
+        if (isset($options['validator']) && ! is_document($options['validator'])) {
+            throw InvalidArgumentException::invalidType('"validator" option', $options['validator'], 'document');
         }
 
         if (isset($options['viewOn']) && ! is_string($options['viewOn'])) {

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -153,19 +153,19 @@ class CreateCollection implements Executable
         }
 
         if (isset($options['changeStreamPreAndPostImages']) && ! is_document($options['changeStreamPreAndPostImages'])) {
-            throw InvalidArgumentException::invalidType('"changeStreamPreAndPostImages" option', $options['changeStreamPreAndPostImages'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"changeStreamPreAndPostImages" option', $options['changeStreamPreAndPostImages']);
         }
 
         if (isset($options['clusteredIndex']) && ! is_document($options['clusteredIndex'])) {
-            throw InvalidArgumentException::invalidType('"clusteredIndex" option', $options['clusteredIndex'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"clusteredIndex" option', $options['clusteredIndex']);
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['encryptedFields']) && ! is_document($options['encryptedFields'])) {
-            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"encryptedFields" option', $options['encryptedFields']);
         }
 
         if (isset($options['expireAfterSeconds']) && ! is_integer($options['expireAfterSeconds'])) {
@@ -177,7 +177,7 @@ class CreateCollection implements Executable
         }
 
         if (isset($options['indexOptionDefaults']) && ! is_document($options['indexOptionDefaults'])) {
-            throw InvalidArgumentException::invalidType('"indexOptionDefaults" option', $options['indexOptionDefaults'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"indexOptionDefaults" option', $options['indexOptionDefaults']);
         }
 
         if (isset($options['max']) && ! is_integer($options['max'])) {
@@ -201,11 +201,11 @@ class CreateCollection implements Executable
         }
 
         if (isset($options['storageEngine']) && ! is_document($options['storageEngine'])) {
-            throw InvalidArgumentException::invalidType('"storageEngine" option', $options['storageEngine'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"storageEngine" option', $options['storageEngine']);
         }
 
         if (isset($options['timeseries']) && ! is_document($options['timeseries'])) {
-            throw InvalidArgumentException::invalidType('"timeseries" option', $options['timeseries'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"timeseries" option', $options['timeseries']);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -221,7 +221,7 @@ class CreateCollection implements Executable
         }
 
         if (isset($options['validator']) && ! is_document($options['validator'])) {
-            throw InvalidArgumentException::invalidType('"validator" option', $options['validator'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"validator" option', $options['validator']);
         }
 
         if (isset($options['viewOn']) && ! is_string($options['viewOn'])) {

--- a/src/Operation/CreateEncryptedCollection.php
+++ b/src/Operation/CreateEncryptedCollection.php
@@ -30,6 +30,7 @@ use function array_key_exists;
 use function is_array;
 use function is_object;
 use function MongoDB\document_to_array;
+use function MongoDB\is_document;
 use function MongoDB\server_supports_feature;
 
 /**
@@ -82,8 +83,8 @@ class CreateEncryptedCollection implements Executable
             throw new InvalidArgumentException('"encryptedFields" option is required');
         }
 
-        if (! is_array($options['encryptedFields']) && ! is_object($options['encryptedFields'])) {
-            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], ['array', 'object']);
+        if (! is_document($options['encryptedFields'])) {
+            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], 'document');
         }
 
         $this->createCollection = new CreateCollection($databaseName, $collectionName, $options);

--- a/src/Operation/CreateEncryptedCollection.php
+++ b/src/Operation/CreateEncryptedCollection.php
@@ -84,7 +84,7 @@ class CreateEncryptedCollection implements Executable
         }
 
         if (! is_document($options['encryptedFields'])) {
-            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"encryptedFields" option', $options['encryptedFields']);
         }
 
         $this->createCollection = new CreateCollection($databaseName, $collectionName, $options);

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -25,7 +25,7 @@ use MongoDB\Driver\Session;
 use MongoDB\Exception\InvalidArgumentException;
 
 use function is_array;
-use function is_object;
+use function MongoDB\is_document;
 
 /**
  * Operation for executing a database command.
@@ -66,8 +66,8 @@ class DatabaseCommand implements Executable
      */
     public function __construct(string $databaseName, $command, array $options = [])
     {
-        if (! is_array($command) && ! is_object($command)) {
-            throw InvalidArgumentException::invalidType('$command', $command, 'array or object');
+        if (! is_document($command)) {
+            throw InvalidArgumentException::invalidType('$command', $command, 'document');
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -67,7 +67,7 @@ class DatabaseCommand implements Executable
     public function __construct(string $databaseName, $command, array $options = [])
     {
         if (! is_document($command)) {
-            throw InvalidArgumentException::invalidType('$command', $command, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$command', $command);
         }
 
         if (isset($options['readPreference']) && ! $options['readPreference'] instanceof ReadPreference) {

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -29,6 +29,7 @@ use MongoDB\Exception\UnsupportedException;
 use function is_array;
 use function is_object;
 use function is_string;
+use function MongoDB\is_document;
 use function MongoDB\is_write_concern_acknowledged;
 use function MongoDB\server_supports_feature;
 
@@ -98,16 +99,16 @@ class Delete implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, $filter, int $limit, array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
         if ($limit !== 0 && $limit !== 1) {
             throw new InvalidArgumentException('$limit must be 0 or 1');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
         if (isset($options['hint']) && ! is_string($options['hint']) && ! is_array($options['hint']) && ! is_object($options['hint'])) {
@@ -122,8 +123,8 @@ class Delete implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
-        if (isset($options['let']) && ! is_array($options['let']) && ! is_object($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'array or object');
+        if (isset($options['let']) && ! is_document($options['let'])) {
+            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -100,7 +100,7 @@ class Delete implements Executable, Explainable
     public function __construct(string $databaseName, string $collectionName, $filter, int $limit, array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if ($limit !== 0 && $limit !== 1) {
@@ -108,7 +108,7 @@ class Delete implements Executable, Explainable
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['hint']) && ! is_string($options['hint']) && ! is_array($options['hint']) && ! is_object($options['hint'])) {
@@ -124,7 +124,7 @@ class Delete implements Executable, Explainable
         }
 
         if (isset($options['let']) && ! is_document($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"let" option', $options['let']);
         }
 
         if (isset($options['writeConcern']) && $options['writeConcern']->isDefault()) {

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -89,11 +89,11 @@ class Distinct implements Executable, Explainable
     public function __construct(string $databaseName, string $collectionName, string $fieldName, $filter = [], array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['maxTimeMS']) && ! is_integer($options['maxTimeMS'])) {

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -32,6 +32,7 @@ use function is_array;
 use function is_integer;
 use function is_object;
 use function MongoDB\create_field_path_type_map;
+use function MongoDB\is_document;
 
 /**
  * Operation for the distinct command.
@@ -87,12 +88,12 @@ class Distinct implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, string $fieldName, $filter = [], array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
         if (isset($options['maxTimeMS']) && ! is_integer($options['maxTimeMS'])) {

--- a/src/Operation/DropEncryptedCollection.php
+++ b/src/Operation/DropEncryptedCollection.php
@@ -21,9 +21,8 @@ use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 
-use function is_array;
-use function is_object;
 use function MongoDB\document_to_array;
+use function MongoDB\is_document;
 
 /**
  * Drop an encrypted collection.
@@ -68,8 +67,8 @@ class DropEncryptedCollection implements Executable
             throw new InvalidArgumentException('"encryptedFields" option is required');
         }
 
-        if (! is_array($options['encryptedFields']) && ! is_object($options['encryptedFields'])) {
-            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], ['array', 'object']);
+        if (! is_document($options['encryptedFields'])) {
+            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], 'document');
         }
 
         /** @psalm-var array{ecocCollection?: ?string, escCollection?: ?string} */

--- a/src/Operation/DropEncryptedCollection.php
+++ b/src/Operation/DropEncryptedCollection.php
@@ -68,7 +68,7 @@ class DropEncryptedCollection implements Executable
         }
 
         if (! is_document($options['encryptedFields'])) {
-            throw InvalidArgumentException::invalidType('"encryptedFields" option', $options['encryptedFields'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"encryptedFields" option', $options['encryptedFields']);
         }
 
         /** @psalm-var array{ecocCollection?: ?string, escCollection?: ?string} */

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -164,7 +164,7 @@ class Find implements Executable, Explainable
     public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if (isset($options['allowDiskUse']) && ! is_bool($options['allowDiskUse'])) {
@@ -180,7 +180,7 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['cursorType'])) {
@@ -206,7 +206,7 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['max']) && ! is_document($options['max'])) {
-            throw InvalidArgumentException::invalidType('"max" option', $options['max'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"max" option', $options['max']);
         }
 
         if (isset($options['maxAwaitTimeMS']) && ! is_integer($options['maxAwaitTimeMS'])) {
@@ -222,11 +222,11 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['min']) && ! is_document($options['min'])) {
-            throw InvalidArgumentException::invalidType('"min" option', $options['min'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"min" option', $options['min']);
         }
 
         if (isset($options['modifiers']) && ! is_document($options['modifiers'])) {
-            throw InvalidArgumentException::invalidType('"modifiers" option', $options['modifiers'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"modifiers" option', $options['modifiers']);
         }
 
         if (isset($options['noCursorTimeout']) && ! is_bool($options['noCursorTimeout'])) {
@@ -238,7 +238,7 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['projection']) && ! is_document($options['projection'])) {
-            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"projection" option', $options['projection']);
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
@@ -270,7 +270,7 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['sort']) && ! is_document($options['sort'])) {
-            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"sort" option', $options['sort']);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -278,7 +278,7 @@ class Find implements Executable, Explainable
         }
 
         if (isset($options['let']) && ! is_document($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"let" option', $options['let']);
         }
 
         if (isset($options['readConcern']) && $options['readConcern']->isDefault()) {

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -33,6 +33,7 @@ use function is_integer;
 use function is_object;
 use function is_string;
 use function MongoDB\document_to_array;
+use function MongoDB\is_document;
 use function trigger_error;
 
 use const E_USER_DEPRECATED;
@@ -162,8 +163,8 @@ class Find implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
         if (isset($options['allowDiskUse']) && ! is_bool($options['allowDiskUse'])) {
@@ -178,8 +179,8 @@ class Find implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"batchSize" option', $options['batchSize'], 'integer');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
         if (isset($options['cursorType'])) {
@@ -204,8 +205,8 @@ class Find implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"limit" option', $options['limit'], 'integer');
         }
 
-        if (isset($options['max']) && ! is_array($options['max']) && ! is_object($options['max'])) {
-            throw InvalidArgumentException::invalidType('"max" option', $options['max'], 'array or object');
+        if (isset($options['max']) && ! is_document($options['max'])) {
+            throw InvalidArgumentException::invalidType('"max" option', $options['max'], 'document');
         }
 
         if (isset($options['maxAwaitTimeMS']) && ! is_integer($options['maxAwaitTimeMS'])) {
@@ -220,12 +221,12 @@ class Find implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"maxTimeMS" option', $options['maxTimeMS'], 'integer');
         }
 
-        if (isset($options['min']) && ! is_array($options['min']) && ! is_object($options['min'])) {
-            throw InvalidArgumentException::invalidType('"min" option', $options['min'], 'array or object');
+        if (isset($options['min']) && ! is_document($options['min'])) {
+            throw InvalidArgumentException::invalidType('"min" option', $options['min'], 'document');
         }
 
-        if (isset($options['modifiers']) && ! is_array($options['modifiers']) && ! is_object($options['modifiers'])) {
-            throw InvalidArgumentException::invalidType('"modifiers" option', $options['modifiers'], 'array or object');
+        if (isset($options['modifiers']) && ! is_document($options['modifiers'])) {
+            throw InvalidArgumentException::invalidType('"modifiers" option', $options['modifiers'], 'document');
         }
 
         if (isset($options['noCursorTimeout']) && ! is_bool($options['noCursorTimeout'])) {
@@ -236,8 +237,8 @@ class Find implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"oplogReplay" option', $options['oplogReplay'], 'boolean');
         }
 
-        if (isset($options['projection']) && ! is_array($options['projection']) && ! is_object($options['projection'])) {
-            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'array or object');
+        if (isset($options['projection']) && ! is_document($options['projection'])) {
+            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'document');
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
@@ -268,16 +269,16 @@ class Find implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"snapshot" option', $options['snapshot'], 'boolean');
         }
 
-        if (isset($options['sort']) && ! is_array($options['sort']) && ! is_object($options['sort'])) {
-            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'array or object');
+        if (isset($options['sort']) && ! is_document($options['sort'])) {
+            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'document');
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
             throw InvalidArgumentException::invalidType('"typeMap" option', $options['typeMap'], 'array');
         }
 
-        if (isset($options['let']) && ! is_array($options['let']) && ! is_object($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'array or object');
+        if (isset($options['let']) && ! is_document($options['let'])) {
+            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
         }
 
         if (isset($options['readConcern']) && $options['readConcern']->isDefault()) {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -34,6 +34,7 @@ use function is_integer;
 use function is_object;
 use function is_string;
 use function MongoDB\create_field_path_type_map;
+use function MongoDB\is_document;
 use function MongoDB\is_pipeline;
 use function MongoDB\is_write_concern_acknowledged;
 use function MongoDB\server_supports_feature;
@@ -139,12 +140,12 @@ class FindAndModify implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"bypassDocumentValidation" option', $options['bypassDocumentValidation'], 'boolean');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
-        if (isset($options['fields']) && ! is_array($options['fields']) && ! is_object($options['fields'])) {
-            throw InvalidArgumentException::invalidType('"fields" option', $options['fields'], 'array or object');
+        if (isset($options['fields']) && ! is_document($options['fields'])) {
+            throw InvalidArgumentException::invalidType('"fields" option', $options['fields'], 'document');
         }
 
         if (isset($options['hint']) && ! is_string($options['hint']) && ! is_array($options['hint']) && ! is_object($options['hint'])) {
@@ -159,8 +160,8 @@ class FindAndModify implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"new" option', $options['new'], 'boolean');
         }
 
-        if (isset($options['query']) && ! is_array($options['query']) && ! is_object($options['query'])) {
-            throw InvalidArgumentException::invalidType('"query" option', $options['query'], 'array or object');
+        if (isset($options['query']) && ! is_document($options['query'])) {
+            throw InvalidArgumentException::invalidType('"query" option', $options['query'], 'document');
         }
 
         if (! is_bool($options['remove'])) {
@@ -171,8 +172,8 @@ class FindAndModify implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
-        if (isset($options['sort']) && ! is_array($options['sort']) && ! is_object($options['sort'])) {
-            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'array or object');
+        if (isset($options['sort']) && ! is_document($options['sort'])) {
+            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'document');
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -191,8 +192,8 @@ class FindAndModify implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"upsert" option', $options['upsert'], 'boolean');
         }
 
-        if (isset($options['let']) && ! is_array($options['let']) && ! is_object($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'array or object');
+        if (isset($options['let']) && ! is_document($options['let'])) {
+            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
         }
 
         if (isset($options['bypassDocumentValidation']) && ! $options['bypassDocumentValidation']) {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -141,11 +141,11 @@ class FindAndModify implements Executable, Explainable
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['fields']) && ! is_document($options['fields'])) {
-            throw InvalidArgumentException::invalidType('"fields" option', $options['fields'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"fields" option', $options['fields']);
         }
 
         if (isset($options['hint']) && ! is_string($options['hint']) && ! is_array($options['hint']) && ! is_object($options['hint'])) {
@@ -161,7 +161,7 @@ class FindAndModify implements Executable, Explainable
         }
 
         if (isset($options['query']) && ! is_document($options['query'])) {
-            throw InvalidArgumentException::invalidType('"query" option', $options['query'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"query" option', $options['query']);
         }
 
         if (! is_bool($options['remove'])) {
@@ -173,7 +173,7 @@ class FindAndModify implements Executable, Explainable
         }
 
         if (isset($options['sort']) && ! is_document($options['sort'])) {
-            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"sort" option', $options['sort']);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {
@@ -193,7 +193,7 @@ class FindAndModify implements Executable, Explainable
         }
 
         if (isset($options['let']) && ! is_document($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"let" option', $options['let']);
         }
 
         if (isset($options['bypassDocumentValidation']) && ! $options['bypassDocumentValidation']) {

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -22,8 +22,7 @@ use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 
-use function is_array;
-use function is_object;
+use function MongoDB\is_document;
 
 /**
  * Operation for deleting a document with the findAndModify command.
@@ -82,12 +81,12 @@ class FindOneAndDelete implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
-        if (isset($options['projection']) && ! is_array($options['projection']) && ! is_object($options['projection'])) {
-            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'array or object');
+        if (isset($options['projection']) && ! is_document($options['projection'])) {
+            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'document');
         }
 
         if (isset($options['projection'])) {

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -82,11 +82,11 @@ class FindOneAndDelete implements Executable, Explainable
     public function __construct(string $databaseName, string $collectionName, $filter, array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if (isset($options['projection']) && ! is_document($options['projection'])) {
-            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"projection" option', $options['projection']);
         }
 
         if (isset($options['projection'])) {

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -23,9 +23,8 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 
 use function array_key_exists;
-use function is_array;
 use function is_integer;
-use function is_object;
+use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
 
@@ -102,12 +101,12 @@ class FindOneAndReplace implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, $filter, $replacement, array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
-        if (! is_array($replacement) && ! is_object($replacement)) {
-            throw InvalidArgumentException::invalidType('$replacement', $replacement, 'array or object');
+        if (! is_document($replacement)) {
+            throw InvalidArgumentException::invalidType('$replacement', $replacement, 'document');
         }
 
         // Treat empty arrays as replacement documents for BC
@@ -123,8 +122,8 @@ class FindOneAndReplace implements Executable, Explainable
             throw new InvalidArgumentException('$replacement is an update pipeline');
         }
 
-        if (isset($options['projection']) && ! is_array($options['projection']) && ! is_object($options['projection'])) {
-            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'array or object');
+        if (isset($options['projection']) && ! is_document($options['projection'])) {
+            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'document');
         }
 
         if (array_key_exists('returnDocument', $options) && ! is_integer($options['returnDocument'])) {

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -102,11 +102,11 @@ class FindOneAndReplace implements Executable, Explainable
     public function __construct(string $databaseName, string $collectionName, $filter, $replacement, array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if (! is_document($replacement)) {
-            throw InvalidArgumentException::invalidType('$replacement', $replacement, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$replacement', $replacement);
         }
 
         // Treat empty arrays as replacement documents for BC
@@ -123,7 +123,7 @@ class FindOneAndReplace implements Executable, Explainable
         }
 
         if (isset($options['projection']) && ! is_document($options['projection'])) {
-            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"projection" option', $options['projection']);
         }
 
         if (array_key_exists('returnDocument', $options) && ! is_integer($options['returnDocument'])) {

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -107,7 +107,7 @@ class FindOneAndUpdate implements Executable, Explainable
     public function __construct(string $databaseName, string $collectionName, $filter, $update, array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if (! is_array($update) && ! is_object($update)) {
@@ -119,7 +119,7 @@ class FindOneAndUpdate implements Executable, Explainable
         }
 
         if (isset($options['projection']) && ! is_document($options['projection'])) {
-            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"projection" option', $options['projection']);
         }
 
         if (array_key_exists('returnDocument', $options) && ! is_integer($options['returnDocument'])) {

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -26,6 +26,7 @@ use function array_key_exists;
 use function is_array;
 use function is_integer;
 use function is_object;
+use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
 
@@ -105,8 +106,8 @@ class FindOneAndUpdate implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, $filter, $update, array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
         if (! is_array($update) && ! is_object($update)) {
@@ -117,8 +118,8 @@ class FindOneAndUpdate implements Executable, Explainable
             throw new InvalidArgumentException('Expected update operator(s) or non-empty pipeline for $update');
         }
 
-        if (isset($options['projection']) && ! is_array($options['projection']) && ! is_object($options['projection'])) {
-            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'array or object');
+        if (isset($options['projection']) && ! is_document($options['projection'])) {
+            throw InvalidArgumentException::invalidType('"projection" option', $options['projection'], 'document');
         }
 
         if (array_key_exists('returnDocument', $options) && ! is_integer($options['returnDocument'])) {

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -27,9 +27,8 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\InsertManyResult;
 
 use function array_is_list;
-use function is_array;
 use function is_bool;
-use function is_object;
+use function MongoDB\is_document;
 use function sprintf;
 
 /**
@@ -90,8 +89,8 @@ class InsertMany implements Executable
         }
 
         foreach ($documents as $i => $document) {
-            if (! is_array($document) && ! is_object($document)) {
-                throw InvalidArgumentException::invalidType(sprintf('$documents[%d]', $i), $document, 'array or object');
+            if (! is_document($document)) {
+                throw InvalidArgumentException::invalidType(sprintf('$documents[%d]', $i), $document, 'document');
             }
         }
 

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -90,7 +90,7 @@ class InsertMany implements Executable
 
         foreach ($documents as $i => $document) {
             if (! is_document($document)) {
-                throw InvalidArgumentException::invalidType(sprintf('$documents[%d]', $i), $document, 'document');
+                throw InvalidArgumentException::expectedDocumentType(sprintf('$documents[%d]', $i), $document);
             }
         }
 

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -74,7 +74,7 @@ class InsertOne implements Executable
     public function __construct(string $databaseName, string $collectionName, $document, array $options = [])
     {
         if (! is_document($document)) {
-            throw InvalidArgumentException::invalidType('$document', $document, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$document', $document);
         }
 
         if (isset($options['bypassDocumentValidation']) && ! is_bool($options['bypassDocumentValidation'])) {

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -26,9 +26,8 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\InsertOneResult;
 
-use function is_array;
 use function is_bool;
-use function is_object;
+use function MongoDB\is_document;
 
 /**
  * Operation for inserting a single document with the insert command.
@@ -74,8 +73,8 @@ class InsertOne implements Executable
      */
     public function __construct(string $databaseName, string $collectionName, $document, array $options = [])
     {
-        if (! is_array($document) && ! is_object($document)) {
-            throw InvalidArgumentException::invalidType('$document', $document, 'array or object');
+        if (! is_document($document)) {
+            throw InvalidArgumentException::invalidType('$document', $document, 'document');
         }
 
         if (isset($options['bypassDocumentValidation']) && ! is_bool($options['bypassDocumentValidation'])) {

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -41,6 +41,7 @@ use function is_object;
 use function is_string;
 use function MongoDB\create_field_path_type_map;
 use function MongoDB\document_to_array;
+use function MongoDB\is_document;
 use function MongoDB\is_mapreduce_output_inline;
 use function trigger_error;
 
@@ -169,8 +170,8 @@ class MapReduce implements Executable
             throw InvalidArgumentException::invalidType('"bypassDocumentValidation" option', $options['bypassDocumentValidation'], 'boolean');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
         if (isset($options['finalize']) && ! $options['finalize'] instanceof JavascriptInterface) {
@@ -189,8 +190,8 @@ class MapReduce implements Executable
             throw InvalidArgumentException::invalidType('"maxTimeMS" option', $options['maxTimeMS'], 'integer');
         }
 
-        if (isset($options['query']) && ! is_array($options['query']) && ! is_object($options['query'])) {
-            throw InvalidArgumentException::invalidType('"query" option', $options['query'], 'array or object');
+        if (isset($options['query']) && ! is_document($options['query'])) {
+            throw InvalidArgumentException::invalidType('"query" option', $options['query'], 'document');
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
@@ -201,16 +202,16 @@ class MapReduce implements Executable
             throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
-        if (isset($options['scope']) && ! is_array($options['scope']) && ! is_object($options['scope'])) {
-            throw InvalidArgumentException::invalidType('"scope" option', $options['scope'], 'array or object');
+        if (isset($options['scope']) && ! is_document($options['scope'])) {
+            throw InvalidArgumentException::invalidType('"scope" option', $options['scope'], 'document');
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
             throw InvalidArgumentException::invalidType('"session" option', $options['session'], Session::class);
         }
 
-        if (isset($options['sort']) && ! is_array($options['sort']) && ! is_object($options['sort'])) {
-            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'array or object');
+        if (isset($options['sort']) && ! is_document($options['sort'])) {
+            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'document');
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -171,7 +171,7 @@ class MapReduce implements Executable
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['finalize']) && ! $options['finalize'] instanceof JavascriptInterface) {
@@ -191,7 +191,7 @@ class MapReduce implements Executable
         }
 
         if (isset($options['query']) && ! is_document($options['query'])) {
-            throw InvalidArgumentException::invalidType('"query" option', $options['query'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"query" option', $options['query']);
         }
 
         if (isset($options['readConcern']) && ! $options['readConcern'] instanceof ReadConcern) {
@@ -203,7 +203,7 @@ class MapReduce implements Executable
         }
 
         if (isset($options['scope']) && ! is_document($options['scope'])) {
-            throw InvalidArgumentException::invalidType('"scope" option', $options['scope'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"scope" option', $options['scope']);
         }
 
         if (isset($options['session']) && ! $options['session'] instanceof Session) {
@@ -211,7 +211,7 @@ class MapReduce implements Executable
         }
 
         if (isset($options['sort']) && ! is_document($options['sort'])) {
-            throw InvalidArgumentException::invalidType('"sort" option', $options['sort'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"sort" option', $options['sort']);
         }
 
         if (isset($options['typeMap']) && ! is_array($options['typeMap'])) {

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -81,7 +81,7 @@ class ReplaceOne implements Executable
     public function __construct(string $databaseName, string $collectionName, $filter, $replacement, array $options = [])
     {
         if (! is_document($replacement)) {
-            throw InvalidArgumentException::invalidType('$replacement', $replacement, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$replacement', $replacement);
         }
 
         // Treat empty arrays as replacement documents for BC

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -23,8 +23,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\UpdateResult;
 
-use function is_array;
-use function is_object;
+use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
 
@@ -81,8 +80,8 @@ class ReplaceOne implements Executable
      */
     public function __construct(string $databaseName, string $collectionName, $filter, $replacement, array $options = [])
     {
-        if (! is_array($replacement) && ! is_object($replacement)) {
-            throw InvalidArgumentException::invalidType('$replacement', $replacement, 'array or object');
+        if (! is_document($replacement)) {
+            throw InvalidArgumentException::invalidType('$replacement', $replacement, 'document');
         }
 
         // Treat empty arrays as replacement documents for BC

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -115,7 +115,7 @@ class Update implements Executable, Explainable
     public function __construct(string $databaseName, string $collectionName, $filter, $update, array $options = [])
     {
         if (! is_document($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
+            throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
 
         if (! is_array($update) && ! is_object($update)) {
@@ -136,7 +136,7 @@ class Update implements Executable, Explainable
         }
 
         if (isset($options['collation']) && ! is_document($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"collation" option', $options['collation']);
         }
 
         if (isset($options['hint']) && ! is_string($options['hint']) && ! is_array($options['hint']) && ! is_object($options['hint'])) {
@@ -164,7 +164,7 @@ class Update implements Executable, Explainable
         }
 
         if (isset($options['let']) && ! is_document($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"let" option', $options['let']);
         }
 
         if (isset($options['bypassDocumentValidation']) && ! $options['bypassDocumentValidation']) {

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -30,6 +30,7 @@ use function is_array;
 use function is_bool;
 use function is_object;
 use function is_string;
+use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
 use function MongoDB\is_write_concern_acknowledged;
@@ -113,8 +114,8 @@ class Update implements Executable, Explainable
      */
     public function __construct(string $databaseName, string $collectionName, $filter, $update, array $options = [])
     {
-        if (! is_array($filter) && ! is_object($filter)) {
-            throw InvalidArgumentException::invalidType('$filter', $filter, 'array or object');
+        if (! is_document($filter)) {
+            throw InvalidArgumentException::invalidType('$filter', $filter, 'document');
         }
 
         if (! is_array($update) && ! is_object($update)) {
@@ -134,8 +135,8 @@ class Update implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"bypassDocumentValidation" option', $options['bypassDocumentValidation'], 'boolean');
         }
 
-        if (isset($options['collation']) && ! is_array($options['collation']) && ! is_object($options['collation'])) {
-            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'array or object');
+        if (isset($options['collation']) && ! is_document($options['collation'])) {
+            throw InvalidArgumentException::invalidType('"collation" option', $options['collation'], 'document');
         }
 
         if (isset($options['hint']) && ! is_string($options['hint']) && ! is_array($options['hint']) && ! is_object($options['hint'])) {
@@ -162,8 +163,8 @@ class Update implements Executable, Explainable
             throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
-        if (isset($options['let']) && ! is_array($options['let']) && ! is_object($options['let'])) {
-            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'array or object');
+        if (isset($options['let']) && ! is_document($options['let'])) {
+            throw InvalidArgumentException::invalidType('"let" option', $options['let'], 'document');
         }
 
         if (isset($options['bypassDocumentValidation']) && ! $options['bypassDocumentValidation']) {

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -224,11 +224,11 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
         }
 
         if (isset($options['resumeAfter']) && ! is_document($options['resumeAfter'])) {
-            throw InvalidArgumentException::invalidType('"resumeAfter" option', $options['resumeAfter'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"resumeAfter" option', $options['resumeAfter']);
         }
 
         if (isset($options['startAfter']) && ! is_document($options['startAfter'])) {
-            throw InvalidArgumentException::invalidType('"startAfter" option', $options['startAfter'], 'document');
+            throw InvalidArgumentException::expectedDocumentType('"startAfter" option', $options['startAfter']);
         }
 
         if (isset($options['startAtOperationTime']) && ! $options['startAtOperationTime'] instanceof TimestampInterface) {

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -44,6 +44,7 @@ use function is_object;
 use function is_string;
 use function MongoDB\Driver\Monitoring\addSubscriber;
 use function MongoDB\Driver\Monitoring\removeSubscriber;
+use function MongoDB\is_document;
 use function MongoDB\select_server;
 use function MongoDB\server_supports_feature;
 
@@ -222,12 +223,12 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
             throw InvalidArgumentException::invalidType('"readPreference" option', $options['readPreference'], ReadPreference::class);
         }
 
-        if (isset($options['resumeAfter']) && ! is_array($options['resumeAfter']) && ! is_object($options['resumeAfter'])) {
-            throw InvalidArgumentException::invalidType('"resumeAfter" option', $options['resumeAfter'], 'array or object');
+        if (isset($options['resumeAfter']) && ! is_document($options['resumeAfter'])) {
+            throw InvalidArgumentException::invalidType('"resumeAfter" option', $options['resumeAfter'], 'document');
         }
 
-        if (isset($options['startAfter']) && ! is_array($options['startAfter']) && ! is_object($options['startAfter'])) {
-            throw InvalidArgumentException::invalidType('"startAfter" option', $options['startAfter'], 'array or object');
+        if (isset($options['startAfter']) && ! is_document($options['startAfter'])) {
+            throw InvalidArgumentException::invalidType('"startAfter" option', $options['startAfter'], 'document');
         }
 
         if (isset($options['startAtOperationTime']) && ! $options['startAtOperationTime'] instanceof TimestampInterface) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -88,7 +88,7 @@ function all_servers_support_write_stage_on_secondary(array $servers): bool
 function apply_type_map_to_document($document, array $typeMap)
 {
     if (! is_document($document)) {
-        throw InvalidArgumentException::invalidType('$document', $document, 'document');
+        throw InvalidArgumentException::expectedDocumentType('$document', $document);
     }
 
     return toPHP(fromPHP($document), $typeMap);
@@ -133,7 +133,7 @@ function document_to_array($document): array
     }
 
     if (! is_array($document)) {
-        throw InvalidArgumentException::invalidType('$document', $document, 'document');
+        throw InvalidArgumentException::expectedDocumentType('$document', $document);
     }
 
     return $document;

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -61,27 +61,14 @@ class CollectionFunctionalTest extends FunctionalTestCase
         new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public function provideInvalidConstructorOptions(): void
     {
-        $options = [];
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        $this->createOptionDataProvider([
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     public function testGetManager(): void

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -61,9 +61,9 @@ class CollectionFunctionalTest extends FunctionalTestCase
         new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions(): void
+    public function provideInvalidConstructorOptions(): array
     {
-        $this->createOptionDataProvider([
+        return $this->createOptionDataProvider([
             'readConcern' => $this->getInvalidReadConcernValues(),
             'readPreference' => $this->getInvalidReadPreferenceValues(),
             'typeMap' => $this->getInvalidArrayValues(),

--- a/tests/Command/ListCollectionsTest.php
+++ b/tests/Command/ListCollectionsTest.php
@@ -15,26 +15,13 @@ class ListCollectionsTest extends TestCase
         new ListCollections($this->getDatabaseName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public function provideInvalidConstructorOptions(): void
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['authorizedCollections' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['filter' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        return $options;
+        $this->createOptionDataProvider([
+            'authorizedCollections' => $this->getInvalidBooleanValues(),
+            'filter' => $this->getInvalidDocumentValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'session' => $this->getInvalidSessionValues(),
+        ]);
     }
 }

--- a/tests/Command/ListCollectionsTest.php
+++ b/tests/Command/ListCollectionsTest.php
@@ -15,9 +15,9 @@ class ListCollectionsTest extends TestCase
         new ListCollections($this->getDatabaseName(), $options);
     }
 
-    public function provideInvalidConstructorOptions(): void
+    public function provideInvalidConstructorOptions(): array
     {
-        $this->createOptionDataProvider([
+        return $this->createOptionDataProvider([
             'authorizedCollections' => $this->getInvalidBooleanValues(),
             'filter' => $this->getInvalidDocumentValues(),
             'maxTimeMS' => $this->getInvalidIntegerValues(),

--- a/tests/Command/ListDatabasesTest.php
+++ b/tests/Command/ListDatabasesTest.php
@@ -17,28 +17,12 @@ class ListDatabasesTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['authorizedDatabases' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['filter' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['nameOnly' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'authorizedDatabases' => $this->getInvalidBooleanValues(),
+            'filter' => $this->getInvalidDocumentValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'nameOnly' => $this->getInvalidBooleanValues(),
+            'session' => $this->getInvalidSessionValues(),
+        ]);
     }
 }

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -46,25 +46,12 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     public function testGetManager(): void

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -116,7 +116,7 @@ class FunctionsTest extends TestCase
     public function testDocumentToArrayArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected $document to have type "document"');
+        $this->expectExceptionMessage('Expected $document to have type "document" (array or object)');
         document_to_array($document);
     }
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -112,12 +112,18 @@ class FunctionsTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    /** @dataProvider provideInvalidDocumentValuesForChecks */
     public function testDocumentToArrayArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected $document to have type "array or object"');
+        $this->expectExceptionMessage('Expected $document to have type "document"');
         document_to_array($document);
+    }
+
+    public function provideInvalidDocumentValuesForChecks(): array
+    {
+        // PackedArray is intentionally left out, as document_to_array is used to convert aggregation pipelines
+        return $this->wrapValuesForDataProvider([123, 3.14, 'foo', true]);
     }
 
     public function provideDocumentCasts(): array
@@ -145,7 +151,7 @@ class FunctionsTest extends TestCase
         $this->assertFalse(is_first_key_operator($cast(['foo'])));
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    /** @dataProvider provideInvalidDocumentValuesForChecks */
     public function testIsFirstKeyOperatorArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -66,37 +66,15 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidStringValues(true) as $value) {
-            $options[][] = ['bucketName' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues(true) as $value) {
-            $options[][] = ['chunkSizeBytes' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['disableMD5' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'bucketName' => $this->getInvalidStringValues(true),
+            'chunkSizeBytes' => $this->getInvalidIntegerValues(true),
+            'disableMD5' => $this->getInvalidBooleanValues(true),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     public function testConstructorShouldRequireChunkSizeBytesOptionToBePositive(): void

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -42,21 +42,11 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidIntegerValues(true) as $value) {
-            $options[][] = ['chunkSizeBytes' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['disableMD5' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['metadata' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'chunkSizeBytes' => $this->getInvalidIntegerValues(true),
+            'disableMD5' => $this->getInvalidBooleanValues(true),
+            'metadata' => $this->getInvalidDocumentValues(),
+        ]);
     }
 
     public function testConstructorShouldRequireChunkSizeBytesOptionToBePositive(): void

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -16,7 +16,6 @@ use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\FunctionalTestCase;
 use TypeError;
 
-use function array_merge;
 use function sprintf;
 
 class ChangeStreamIteratorTest extends FunctionalTestCase
@@ -67,7 +66,7 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
 
     public function provideInvalidObjectValues()
     {
-        return $this->wrapValuesForDataProvider(array_merge($this->getInvalidDocumentValues(), [[]]));
+        return $this->wrapValuesForDataProvider([123, 3.14, 'foo', true, []]);
     }
 
     public function testPostBatchResumeTokenIsReturnedForLastElementInFirstBatch(): void

--- a/tests/Operation/AggregateTest.php
+++ b/tests/Operation/AggregateTest.php
@@ -26,69 +26,23 @@ class AggregateTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['allowDiskUse' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['batchSize' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['bypassDocumentValidation' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidHintValues() as $value) {
-            $options[][] = ['hint' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['let' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['explain' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxAwaitTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['useCursor' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'allowDiskUse' => $this->getInvalidBooleanValues(),
+            'batchSize' => $this->getInvalidIntegerValues(),
+            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'collation' => $this->getInvalidDocumentValues(),
+            'hint' => $this->getInvalidHintValues(),
+            'let' => $this->getInvalidDocumentValues(),
+            'explain' => $this->getInvalidBooleanValues(),
+            'maxAwaitTimeMS' => $this->getInvalidIntegerValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'useCursor' => $this->getInvalidBooleanValues(true),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     public function testConstructorBatchSizeOptionRequiresUseCursor(): void
@@ -101,11 +55,6 @@ class AggregateTest extends TestCase
             [['$match' => ['x' => 1]]],
             ['batchSize' => 100, 'useCursor' => false]
         );
-    }
-
-    private function getInvalidHintValues()
-    {
-        return [123, 3.14, true];
     }
 
     public function testExplainableCommandDocument(): void

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -57,7 +57,7 @@ class BulkWriteTest extends TestCase
     public function testInsertOneDocumentArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["insertOne"\]\[0\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["insertOne"\]\[0\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::INSERT_ONE => [$document]],
         ]);
@@ -76,7 +76,7 @@ class BulkWriteTest extends TestCase
     public function testDeleteManyFilterArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteMany"\]\[0\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteMany"\]\[0\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_MANY => [$document]],
         ]);
@@ -86,7 +86,7 @@ class BulkWriteTest extends TestCase
     public function testDeleteManyCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteMany"\]\[1\]\["collation"\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteMany"\]\[1\]\["collation"\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_MANY => [['x' => 1], ['collation' => $collation]]],
         ]);
@@ -110,7 +110,7 @@ class BulkWriteTest extends TestCase
     public function testDeleteOneFilterArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteOne"\]\[0\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteOne"\]\[0\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_ONE => [$document]],
         ]);
@@ -120,7 +120,7 @@ class BulkWriteTest extends TestCase
     public function testDeleteOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteOne"\]\[1\]\["collation"\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteOne"\]\[1\]\["collation"\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_ONE => [['x' => 1], ['collation' => $collation]]],
         ]);
@@ -139,7 +139,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[0\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[0\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [$filter, ['y' => 1]]],
         ]);
@@ -169,7 +169,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneReplacementArgumentTypeCheck($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[1\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[1\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [['x' => 1], $replacement]],
         ]);
@@ -192,7 +192,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('$operations[0]["replaceOne"][1] is an update pipeline');
+        $this->expectExceptionMessageMatches('#(\$operations\[0\]\["replaceOne"\]\[1\] is an update pipeline)|(\$operations\[0\]\["replaceOne"\]\[1\] to have type "document")#');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [['x' => 1], $replacement]],
         ]);
@@ -202,7 +202,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[2\]\["collation"\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[2\]\["collation"\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [['x' => 1], ['y' => 1], ['collation' => $collation]]],
         ]);
@@ -212,7 +212,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneUpsertOptionTypeCheck($upsert): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[2\]\["upsert"\] to have type "boolean" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[2\]\["upsert"\] to have type "boolean" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [['x' => 1], ['y' => 1], ['upsert' => $upsert]]],
         ]);
@@ -236,7 +236,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateManyFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[0\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[0\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [$filter, ['$set' => ['x' => 1]]]],
         ]);
@@ -267,7 +267,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateManyUpdateArgumentTypeCheck($update): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[1\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/(non-empty pipeline for \$operations\[0\]\["updateMany"\]\[1\])|(\$operations\[0\]\["updateMany"\]\[1\] to have type "array or object" but found ".+")/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [['x' => 1], $update]],
         ]);
@@ -290,7 +290,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateManyArrayFiltersOptionTypeCheck($arrayFilters): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[2\]\["arrayFilters"\] to have type "array" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[2\]\["arrayFilters"\] to have type "array" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [['x' => 1], ['$set' => ['x' => 1]], ['arrayFilters' => $arrayFilters]]],
         ]);
@@ -300,7 +300,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateManyCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[2\]\["collation"\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[2\]\["collation"\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [['x' => 1], ['$set' => ['x' => 1]], ['collation' => $collation]]],
         ]);
@@ -310,7 +310,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateManyUpsertOptionTypeCheck($upsert): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[2\]\["upsert"\] to have type "boolean" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[2\]\["upsert"\] to have type "boolean" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [['x' => 1], ['$set' => ['x' => 1]], ['upsert' => $upsert]]],
         ]);
@@ -341,7 +341,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateOneFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[0\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[0\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_ONE => [$filter, ['$set' => ['x' => 1]]]],
         ]);
@@ -360,7 +360,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateOneUpdateArgumentTypeCheck($update): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[1\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/(non-empty pipeline for \$operations\[0\]\["updateOne"\]\[1\])|(\$operations\[0\]\["updateOne"\]\[1\] to have type "array or object" but found ".+")/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_ONE => [['x' => 1], $update]],
         ]);
@@ -383,7 +383,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateOneArrayFiltersOptionTypeCheck($arrayFilters): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[2\]\["arrayFilters"\] to have type "array" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[2\]\["arrayFilters"\] to have type "array" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_ONE => [['x' => 1], ['$set' => ['x' => 1]], ['arrayFilters' => $arrayFilters]]],
         ]);
@@ -393,7 +393,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[2\]\["collation"\] to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[2\]\["collation"\] to have type "document" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_ONE => [['x' => 1], ['$set' => ['x' => 1]], ['collation' => $collation]]],
         ]);
@@ -403,7 +403,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateOneUpsertOptionTypeCheck($upsert): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[2\]\["upsert"\] to have type "boolean" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[2\]\["upsert"\] to have type "boolean" but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_ONE => [['x' => 1], ['$set' => ['x' => 1]], ['upsert' => $upsert]]],
         ]);

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -267,7 +267,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateManyUpdateArgumentTypeCheck($update): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/(non-empty pipeline for \$operations\[0\]\["updateMany"\]\[1\])|(\$operations\[0\]\["updateMany"\]\[1\] to have type "array or object" but found ".+")/');
+        $this->expectExceptionMessage('Expected update operator(s) or non-empty pipeline for $operations[0]["updateMany"][1]');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [['x' => 1], $update]],
         ]);
@@ -360,7 +360,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateOneUpdateArgumentTypeCheck($update): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/(non-empty pipeline for \$operations\[0\]\["updateOne"\]\[1\])|(\$operations\[0\]\["updateOne"\]\[1\] to have type "array or object" but found ".+")/');
+        $this->expectExceptionMessage('Expected update operator(s) or non-empty pipeline for $operations[0]["updateOne"][1]');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_ONE => [['x' => 1], $update]],
         ]);

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -423,24 +423,11 @@ class BulkWriteTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['bypassDocumentValidation' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['ordered' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'ordered' => $this->getInvalidBooleanValues(true),
+            'session' => $this->getInvalidSessionValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 }

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -57,7 +57,7 @@ class BulkWriteTest extends TestCase
     public function testInsertOneDocumentArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["insertOne"\]\[0\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["insertOne"\]\[0\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::INSERT_ONE => [$document]],
         ]);
@@ -76,7 +76,7 @@ class BulkWriteTest extends TestCase
     public function testDeleteManyFilterArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteMany"\]\[0\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteMany"\]\[0\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_MANY => [$document]],
         ]);
@@ -86,7 +86,7 @@ class BulkWriteTest extends TestCase
     public function testDeleteManyCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteMany"\]\[1\]\["collation"\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteMany"\]\[1\]\["collation"\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_MANY => [['x' => 1], ['collation' => $collation]]],
         ]);
@@ -110,7 +110,7 @@ class BulkWriteTest extends TestCase
     public function testDeleteOneFilterArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteOne"\]\[0\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteOne"\]\[0\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_ONE => [$document]],
         ]);
@@ -120,7 +120,7 @@ class BulkWriteTest extends TestCase
     public function testDeleteOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteOne"\]\[1\]\["collation"\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["deleteOne"\]\[1\]\["collation"\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::DELETE_ONE => [['x' => 1], ['collation' => $collation]]],
         ]);
@@ -139,7 +139,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[0\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[0\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [$filter, ['y' => 1]]],
         ]);
@@ -169,7 +169,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneReplacementArgumentTypeCheck($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[1\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[1\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [['x' => 1], $replacement]],
         ]);
@@ -192,7 +192,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#(\$operations\[0\]\["replaceOne"\]\[1\] is an update pipeline)|(\$operations\[0\]\["replaceOne"\]\[1\] to have type "document")#');
+        $this->expectExceptionMessageMatches('#(\$operations\[0\]\["replaceOne"\]\[1\] is an update pipeline)|(\$operations\[0\]\["replaceOne"\]\[1\] to have type "document" \(array or object\))#');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [['x' => 1], $replacement]],
         ]);
@@ -202,7 +202,7 @@ class BulkWriteTest extends TestCase
     public function testReplaceOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[2\]\["collation"\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["replaceOne"\]\[2\]\["collation"\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::REPLACE_ONE => [['x' => 1], ['y' => 1], ['collation' => $collation]]],
         ]);
@@ -236,7 +236,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateManyFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[0\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[0\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [$filter, ['$set' => ['x' => 1]]]],
         ]);
@@ -300,7 +300,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateManyCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[2\]\["collation"\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateMany"\]\[2\]\["collation"\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_MANY => [['x' => 1], ['$set' => ['x' => 1]], ['collation' => $collation]]],
         ]);
@@ -341,7 +341,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateOneFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[0\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[0\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_ONE => [$filter, ['$set' => ['x' => 1]]]],
         ]);
@@ -393,7 +393,7 @@ class BulkWriteTest extends TestCase
     public function testUpdateOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[2\]\["collation"\] to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$operations\[0\]\["updateOne"\]\[2\]\["collation"\] to have type "document" \(array or object\) but found ".+"/');
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::UPDATE_ONE => [['x' => 1], ['$set' => ['x' => 1]], ['collation' => $collation]]],
         ]);

--- a/tests/Operation/CountDocumentsTest.php
+++ b/tests/Operation/CountDocumentsTest.php
@@ -23,45 +23,15 @@ class CountDocumentsTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidHintValues() as $value) {
-            $options[][] = ['hint' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['limit' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['skip' => $value];
-        }
-
-        return $options;
-    }
-
-    private function getInvalidHintValues()
-    {
-        return [123, 3.14, true];
+        return $this->createOptionDataProvider([
+            'collation' => $this->getInvalidDocumentValues(),
+            'hint' => $this->getInvalidHintValues(),
+            'limit' => $this->getInvalidIntegerValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'skip' => $this->getInvalidIntegerValues(),
+        ]);
     }
 }

--- a/tests/Operation/CountTest.php
+++ b/tests/Operation/CountTest.php
@@ -24,46 +24,16 @@ class CountTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidHintValues() as $value) {
-            $options[][] = ['hint' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['limit' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['skip' => $value];
-        }
-
-        return $options;
-    }
-
-    private function getInvalidHintValues()
-    {
-        return [123, 3.14, true];
+        return $this->createOptionDataProvider([
+            'collation' => $this->getInvalidDocumentValues(),
+            'hint' => $this->getInvalidHintValues(),
+            'limit' => $this->getInvalidIntegerValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'skip' => $this->getInvalidIntegerValues(),
+        ]);
     }
 
     public function testExplainableCommandDocument(): void

--- a/tests/Operation/CreateCollectionTest.php
+++ b/tests/Operation/CreateCollectionTest.php
@@ -23,97 +23,30 @@ class CreateCollectionTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['autoIndexId' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['capped' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['changeStreamPreAndPostImages' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['clusteredIndex' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['encryptedFields' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['expireAfterSeconds' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['flags' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['indexOptionDefaults' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['max' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['pipeline' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['size' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['storageEngine' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['timeseries' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidStringValues() as $value) {
-            $options[][] = ['validationAction' => $value];
-        }
-
-        foreach ($this->getInvalidStringValues() as $value) {
-            $options[][] = ['validationLevel' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['validator' => $value];
-        }
-
-        foreach ($this->getInvalidStringValues() as $value) {
-            $options[][] = ['viewOn' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'autoIndexId' => $this->getInvalidBooleanValues(),
+            'capped' => $this->getInvalidBooleanValues(),
+            'changeStreamPreAndPostImages' => $this->getInvalidDocumentValues(),
+            'clusteredIndex' => $this->getInvalidDocumentValues(),
+            'collation' => $this->getInvalidDocumentValues(),
+            'encryptedFields' => $this->getInvalidDocumentValues(),
+            'expireAfterSeconds' => $this->getInvalidIntegerValues(),
+            'flags' => $this->getInvalidIntegerValues(),
+            'indexOptionDefaults' => $this->getInvalidDocumentValues(),
+            'max' => $this->getInvalidIntegerValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'pipeline' => $this->getInvalidArrayValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'size' => $this->getInvalidIntegerValues(),
+            'storageEngine' => $this->getInvalidDocumentValues(),
+            'timeseries' => $this->getInvalidDocumentValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'validationAction' => $this->getInvalidStringValues(),
+            'validationLevel' => $this->getInvalidStringValues(),
+            'validator' => $this->getInvalidDocumentValues(),
+            'viewOn' => $this->getInvalidStringValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     public function testAutoIndexIdOptionIsDeprecated(): void

--- a/tests/Operation/CreateEncryptedCollectionTest.php
+++ b/tests/Operation/CreateEncryptedCollectionTest.php
@@ -6,8 +6,6 @@ use Generator;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateEncryptedCollection;
 
-use function get_debug_type;
-
 class CreateEncryptedCollectionTest extends TestCase
 {
     /** @dataProvider provideInvalidConstructorOptions */
@@ -23,10 +21,8 @@ class CreateEncryptedCollectionTest extends TestCase
             [],
         ];
 
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            yield 'encryptedFields type: ' . get_debug_type($value) => [
-                ['encryptedFields' => $value],
-            ];
-        }
+        yield from $this->createOptionDataProvider([
+            'encryptedFields' => $this->getInvalidDocumentValues(),
+        ]);
     }
 }

--- a/tests/Operation/CreateIndexesTest.php
+++ b/tests/Operation/CreateIndexesTest.php
@@ -27,25 +27,13 @@ class CreateIndexesTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ([3.14, true, [], new stdClass()] as $value) {
-            $options[][] = ['commitQuorum' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            // commitQuorum is int|string, for which no helper exists
+            'commitQuorum' => ['float' => 3.14, 'bool' => true, 'array' => [], 'object' => new stdClass()],
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     public function testConstructorRequiresAtLeastOneIndex(): void

--- a/tests/Operation/CreateIndexesTest.php
+++ b/tests/Operation/CreateIndexesTest.php
@@ -67,7 +67,7 @@ class CreateIndexesTest extends TestCase
     public function testConstructorRequiresIndexSpecificationKeyToBeADocument($key): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected "key" option to have type "document"');
+        $this->expectExceptionMessage('Expected "key" option to have type "document" (array or object)');
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => $key]]);
     }
 

--- a/tests/Operation/CreateIndexesTest.php
+++ b/tests/Operation/CreateIndexesTest.php
@@ -67,7 +67,7 @@ class CreateIndexesTest extends TestCase
     public function testConstructorRequiresIndexSpecificationKeyToBeADocument($key): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Expected "key" option to have type "array or object"');
+        $this->expectExceptionMessage('Expected "key" option to have type "document"');
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => $key]]);
     }
 

--- a/tests/Operation/DatabaseCommandTest.php
+++ b/tests/Operation/DatabaseCommandTest.php
@@ -23,20 +23,10 @@ class DatabaseCommandTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+        ]);
     }
 }

--- a/tests/Operation/DeleteTest.php
+++ b/tests/Operation/DeleteTest.php
@@ -50,21 +50,13 @@ class DeleteTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'collation' => $this->getInvalidDocumentValues(),
+            'hint' => $this->getInvalidHintValues(),
+            'let' => $this->getInvalidDocumentValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     public function testExplainableCommandDocument(): void

--- a/tests/Operation/DistinctTest.php
+++ b/tests/Operation/DistinctTest.php
@@ -25,33 +25,14 @@ class DistinctTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'collation' => $this->getInvalidDocumentValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+        ]);
     }
 
     public function testExplainableCommandDocument(): void

--- a/tests/Operation/DropCollectionTest.php
+++ b/tests/Operation/DropCollectionTest.php
@@ -16,20 +16,10 @@ class DropCollectionTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 }

--- a/tests/Operation/DropDatabaseTest.php
+++ b/tests/Operation/DropDatabaseTest.php
@@ -16,20 +16,10 @@ class DropDatabaseTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 }

--- a/tests/Operation/DropEncryptedCollectionTest.php
+++ b/tests/Operation/DropEncryptedCollectionTest.php
@@ -6,8 +6,6 @@ use Generator;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\DropEncryptedCollection;
 
-use function get_debug_type;
-
 class DropEncryptedCollectionTest extends TestCase
 {
     /** @dataProvider provideInvalidConstructorOptions */
@@ -23,10 +21,8 @@ class DropEncryptedCollectionTest extends TestCase
             [],
         ];
 
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            yield 'encryptedFields type: ' . get_debug_type($value) => [
-                ['encryptedFields' => $value],
-            ];
-        }
+        yield from $this->createOptionDataProvider([
+            'encryptedFields' => $this->getInvalidDocumentValues(),
+        ]);
     }
 }

--- a/tests/Operation/DropIndexesTest.php
+++ b/tests/Operation/DropIndexesTest.php
@@ -22,24 +22,11 @@ class DropIndexesTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 }

--- a/tests/Operation/EstimatedDocumentCountTest.php
+++ b/tests/Operation/EstimatedDocumentCountTest.php
@@ -16,24 +16,11 @@ class EstimatedDocumentCountTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'session' => $this->getInvalidSessionValues(),
+        ]);
     }
 }

--- a/tests/Operation/ExplainTest.php
+++ b/tests/Operation/ExplainTest.php
@@ -18,24 +18,11 @@ class ExplainTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidStringValues() as $value) {
-            $options[][] = ['verbosity' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'verbosity' => $this->getInvalidStringValues(),
+        ]);
     }
 }

--- a/tests/Operation/FindAndModifyTest.php
+++ b/tests/Operation/FindAndModifyTest.php
@@ -29,7 +29,7 @@ class FindAndModifyTest extends TestCase
             'session' => $this->getInvalidSessionValues(),
             'sort' => $this->getInvalidDocumentValues(),
             'typeMap' => $this->getInvalidArrayValues(),
-            'update' => $this->getInvalidDocumentValues(),
+            'update' => $this->getInvalidUpdateValues(),
             'upsert' => $this->getInvalidBooleanValues(),
             'writeConcern' => $this->getInvalidWriteConcernValues(),
         ]);

--- a/tests/Operation/FindAndModifyTest.php
+++ b/tests/Operation/FindAndModifyTest.php
@@ -17,65 +17,22 @@ class FindAndModifyTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['arrayFilters' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['bypassDocumentValidation' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['fields' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['new' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['query' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['remove' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['sort' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['update' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['upsert' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'arrayFilters' => $this->getInvalidArrayValues(),
+            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'collation' => $this->getInvalidDocumentValues(),
+            'fields' => $this->getInvalidDocumentValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'new' => $this->getInvalidBooleanValues(),
+            'query' => $this->getInvalidDocumentValues(),
+            'remove' => $this->getInvalidBooleanValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'sort' => $this->getInvalidDocumentValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'update' => $this->getInvalidDocumentValues(),
+            'upsert' => $this->getInvalidBooleanValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     public function testConstructorUpdateAndRemoveOptionsAreMutuallyExclusive(): void

--- a/tests/Operation/FindOneAndDeleteTest.php
+++ b/tests/Operation/FindOneAndDeleteTest.php
@@ -24,13 +24,9 @@ class FindOneAndDeleteTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['projection' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'projection' => $this->getInvalidDocumentValues(),
+        ]);
     }
 
     public function testExplainableCommandDocument(): void

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -46,7 +46,7 @@ class FindOneAndReplaceTest extends TestCase
     public function testConstructorReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('$replacement is an update pipeline');
+        $this->expectExceptionMessageMatches('#(\$replacement is an update pipeline)|(Expected \$replacement to have type "document")#');
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -59,17 +59,10 @@ class FindOneAndReplaceTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['projection' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues(true) as $value) {
-            $options[][] = ['returnDocument' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'projection' => $this->getInvalidDocumentValues(),
+            'returnDocument' => $this->getInvalidIntegerValues(true),
+        ]);
     }
 
     /** @dataProvider provideInvalidConstructorReturnDocumentOptions */

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -46,7 +46,7 @@ class FindOneAndReplaceTest extends TestCase
     public function testConstructorReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#(\$replacement is an update pipeline)|(Expected \$replacement to have type "document")#');
+        $this->expectExceptionMessageMatches('#(\$replacement is an update pipeline)|(Expected \$replacement to have type "document" \(array or object\))#');
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 

--- a/tests/Operation/FindOneAndUpdateTest.php
+++ b/tests/Operation/FindOneAndUpdateTest.php
@@ -42,17 +42,10 @@ class FindOneAndUpdateTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['projection' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues(true) as $value) {
-            $options[][] = ['returnDocument' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'projection' => $this->getInvalidDocumentValues(),
+            'returnDocument' => $this->getInvalidIntegerValues(),
+        ]);
     }
 
     /** @dataProvider provideInvalidConstructorReturnDocumentOptions */

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -25,101 +25,31 @@ class FindTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['allowPartialResults' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['batchSize' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['cursorType' => $value];
-        }
-
-        foreach ($this->getInvalidHintValues() as $value) {
-            $options[][] = ['hint' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['limit' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['max' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxAwaitTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxScan' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['min' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['modifiers' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['oplogReplay' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['projection' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['returnKey' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['showRecordId' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['skip' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['snapshot' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['sort' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'allowPartialResults' => $this->getInvalidBooleanValues(),
+            'batchSize' => $this->getInvalidIntegerValues(),
+            'collation' => $this->getInvalidDocumentValues(),
+            'cursorType' => $this->getInvalidIntegerValues(),
+            'hint' => $this->getInvalidHintValues(),
+            'limit' => $this->getInvalidIntegerValues(),
+            'max' => $this->getInvalidDocumentValues(),
+            'maxAwaitTimeMS' => $this->getInvalidIntegerValues(),
+            'maxScan' => $this->getInvalidIntegerValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'min' => $this->getInvalidDocumentValues(),
+            'modifiers' => $this->getInvalidDocumentValues(),
+            'oplogReplay' => $this->getInvalidBooleanValues(),
+            'projection' => $this->getInvalidDocumentValues(),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'returnKey' => $this->getInvalidBooleanValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'showRecordId' => $this->getInvalidBooleanValues(),
+            'skip' => $this->getInvalidIntegerValues(),
+            'snapshot' => $this->getInvalidBooleanValues(),
+            'sort' => $this->getInvalidDocumentValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+        ]);
     }
 
     public function testSnapshotOptionIsDeprecated(): void
@@ -138,11 +68,6 @@ class FindTest extends TestCase
         $this->assertDeprecated(function (): void {
             new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['maxScan' => 1]);
         });
-    }
-
-    private function getInvalidHintValues()
-    {
-        return [123, 3.14, true];
     }
 
     /** @dataProvider provideInvalidConstructorCursorTypeOptions */

--- a/tests/Operation/InsertManyTest.php
+++ b/tests/Operation/InsertManyTest.php
@@ -38,24 +38,11 @@ class InsertManyTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['bypassDocumentValidation' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['ordered' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'ordered' => $this->getInvalidBooleanValues(true),
+            'session' => $this->getInvalidSessionValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 }

--- a/tests/Operation/InsertOneTest.php
+++ b/tests/Operation/InsertOneTest.php
@@ -23,20 +23,10 @@ class InsertOneTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['bypassDocumentValidation' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 }

--- a/tests/Operation/ListIndexesTest.php
+++ b/tests/Operation/ListIndexesTest.php
@@ -16,16 +16,9 @@ class ListIndexesTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'session' => $this->getInvalidSessionValues(),
+        ]);
     }
 }

--- a/tests/Operation/MapReduceTest.php
+++ b/tests/Operation/MapReduceTest.php
@@ -65,69 +65,23 @@ class MapReduceTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['bypassDocumentValidation' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidJavascriptValues() as $value) {
-            $options[][] = ['finalize' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['jsMode' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['limit' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['query' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues() as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['scope' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['sort' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['verbose' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'collation' => $this->getInvalidDocumentValues(),
+            'finalize' => $this->getInvalidJavascriptValues(),
+            'jsMode' => $this->getInvalidBooleanValues(),
+            'limit' => $this->getInvalidIntegerValues(),
+            'maxTimeMS' => $this->getInvalidIntegerValues(),
+            'query' => $this->getInvalidDocumentValues(),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(),
+            'scope' => $this->getInvalidDocumentValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'sort' => $this->getInvalidDocumentValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'verbose' => $this->getInvalidBooleanValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     private function getInvalidJavascriptValues()

--- a/tests/Operation/ModifyCollectionTest.php
+++ b/tests/Operation/ModifyCollectionTest.php
@@ -23,20 +23,10 @@ class ModifyCollectionTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 }

--- a/tests/Operation/RenameCollectionTest.php
+++ b/tests/Operation/RenameCollectionTest.php
@@ -22,24 +22,11 @@ class RenameCollectionTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['dropTarget' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'dropTarget' => $this->getInvalidBooleanValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 }

--- a/tests/Operation/ReplaceOneTest.php
+++ b/tests/Operation/ReplaceOneTest.php
@@ -45,7 +45,7 @@ class ReplaceOneTest extends TestCase
     public function testConstructorReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('$replacement is an update pipeline');
+        $this->expectExceptionMessageMatches('#(\$replacement is an update pipeline)|(Expected \$replacement to have type "document")#');
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 }

--- a/tests/Operation/ReplaceOneTest.php
+++ b/tests/Operation/ReplaceOneTest.php
@@ -45,7 +45,7 @@ class ReplaceOneTest extends TestCase
     public function testConstructorReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('#(\$replacement is an update pipeline)|(Expected \$replacement to have type "document")#');
+        $this->expectExceptionMessageMatches('#(\$replacement is an update pipeline)|(Expected \$replacement to have type "document" \(array or object\))#');
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 }

--- a/tests/Operation/TestCase.php
+++ b/tests/Operation/TestCase.php
@@ -74,4 +74,14 @@ abstract class TestCase extends BaseTestCase
             'empty_pipeline:PackedArray' => [PackedArray::fromPHP([])],
         ];
     }
+
+    public function provideInvalidUpdateValues(): array
+    {
+        return $this->wrapValuesForDataProvider($this->getInvalidUpdateValues());
+    }
+
+    protected function getInvalidUpdateValues(): array
+    {
+        return [123, 3.14, 'foo', true];
+    }
 }

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -12,11 +12,11 @@ class UpdateTest extends TestCase
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$filter to have type "array or object" but found "[\w ]+"/');
+        $this->expectExceptionMessageMatches('/Expected \$filter to have type "document" but found ".+"/');
         new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, ['$set' => ['x' => 1]]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    /** @dataProvider provideInvalidUpdateValues */
     public function testConstructorUpdateArgumentTypeCheck($update): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -33,37 +33,16 @@ class UpdateTest extends TestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['arrayFilters' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues() as $value) {
-            $options[][] = ['bypassDocumentValidation' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['multi' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidBooleanValues(true) as $value) {
-            $options[][] = ['upsert' => $value];
-        }
-
-        foreach ($this->getInvalidWriteConcernValues() as $value) {
-            $options[][] = ['writeConcern' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'arrayFilters' => $this->getInvalidArrayValues(),
+            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'collation' => $this->getInvalidDocumentValues(),
+            'hint' => $this->getInvalidHintValues(),
+            'multi' => $this->getInvalidBooleanValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'upsert' => $this->getInvalidBooleanValues(),
+            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        ]);
     }
 
     /**

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -12,7 +12,7 @@ class UpdateTest extends TestCase
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageMatches('/Expected \$filter to have type "document" but found ".+"/');
+        $this->expectExceptionMessageMatches('/Expected \$filter to have type "document" \(array or object\) but found ".+"/');
         new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, ['$set' => ['x' => 1]]);
     }
 

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -50,6 +50,7 @@ class WatchTest extends FunctionalTestCase
             'readPreference' => $this->getInvalidReadPreferenceValues(true),
             'resumeAfter' => $this->getInvalidDocumentValues(),
             'session' => $this->getInvalidSessionValues(),
+            'startAfter' => $this->getInvalidDocumentValues(),
             'startAtOperationTime' => $this->getInvalidTimestampValues(),
             'typeMap' => $this->getInvalidArrayValues(),
         ]);

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -40,53 +40,19 @@ class WatchTest extends FunctionalTestCase
 
     public function provideInvalidConstructorOptions()
     {
-        $options = [];
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['batchSize' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['collation' => $value];
-        }
-
-        foreach ($this->getInvalidStringValues(true) as $value) {
-            $options[][] = ['fullDocument' => $value];
-        }
-
-        foreach ($this->getInvalidStringValues() as $value) {
-            $options[][] = ['fullDocumentBeforeChange' => $value];
-        }
-
-        foreach ($this->getInvalidIntegerValues() as $value) {
-            $options[][] = ['maxAwaitTimeMS' => $value];
-        }
-
-        foreach ($this->getInvalidReadConcernValues() as $value) {
-            $options[][] = ['readConcern' => $value];
-        }
-
-        foreach ($this->getInvalidReadPreferenceValues(true) as $value) {
-            $options[][] = ['readPreference' => $value];
-        }
-
-        foreach ($this->getInvalidDocumentValues() as $value) {
-            $options[][] = ['resumeAfter' => $value];
-        }
-
-        foreach ($this->getInvalidSessionValues() as $value) {
-            $options[][] = ['session' => $value];
-        }
-
-        foreach ($this->getInvalidTimestampValues() as $value) {
-            $options[][] = ['startAtOperationTime' => $value];
-        }
-
-        foreach ($this->getInvalidArrayValues() as $value) {
-            $options[][] = ['typeMap' => $value];
-        }
-
-        return $options;
+        return $this->createOptionDataProvider([
+            'batchSize' => $this->getInvalidIntegerValues(),
+            'collation' => $this->getInvalidDocumentValues(),
+            'fullDocument' => $this->getInvalidStringValues(true),
+            'fullDocumentBeforeChange' => $this->getInvalidStringValues(),
+            'maxAwaitTimeMS' => $this->getInvalidIntegerValues(),
+            'readConcern' => $this->getInvalidReadConcernValues(),
+            'readPreference' => $this->getInvalidReadPreferenceValues(true),
+            'resumeAfter' => $this->getInvalidDocumentValues(),
+            'session' => $this->getInvalidSessionValues(),
+            'startAtOperationTime' => $this->getInvalidTimestampValues(),
+            'typeMap' => $this->getInvalidArrayValues(),
+        ]);
     }
 
     private function getInvalidTimestampValues()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -166,15 +166,14 @@ abstract class TestCase extends BaseTestCase
     {
         $data = [];
 
-        // Loop through each option and get possible values
         foreach ($options as $option => $values) {
-            // Create an option array with a named data provider for each value
             foreach ($values as $key => $value) {
+                $dataKey = $option . '_' . $key;
                 if (is_int($key)) {
-                    $key = get_debug_type($value);
+                    $dataKey .= '_' . get_debug_type($value);
                 }
 
-                $data[$option . '_' . $key] = [[$option => $value]];
+                $data[$dataKey] = [[$option => $value]];
             }
         }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests;
 
 use InvalidArgumentException;
+use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
@@ -139,6 +140,11 @@ abstract class TestCase extends BaseTestCase
         return $this->wrapValuesForDataProvider($this->getInvalidIntegerValues());
     }
 
+    public function provideInvalidUpdateValues()
+    {
+        return $this->wrapValuesForDataProvider($this->getInvalidUpdateValues());
+    }
+
     protected function assertDeprecated(callable $execution): void
     {
         $errors = [];
@@ -214,8 +220,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getInvalidDocumentValues(bool $includeNull = false): array
     {
-        // Note: PackedArray is intentionally omitted here (see: PHPLIB-1137)
-        return array_merge([123, 3.14, 'foo', true], $includeNull ? [null] : []);
+        return array_merge([123, 3.14, 'foo', true, PackedArray::fromPHP([])], $includeNull ? [null] : []);
     }
 
     /**
@@ -301,6 +306,11 @@ abstract class TestCase extends BaseTestCase
     protected function getInvalidStringValues(bool $includeNull = false): array
     {
         return array_merge([123, 3.14, true, [], new stdClass()], $includeNull ? [null] : []);
+    }
+
+    protected function getInvalidUpdateValues(): array
+    {
+        return [123, 3.14, 'foo', true];
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -140,11 +140,6 @@ abstract class TestCase extends BaseTestCase
         return $this->wrapValuesForDataProvider($this->getInvalidIntegerValues());
     }
 
-    public function provideInvalidUpdateValues()
-    {
-        return $this->wrapValuesForDataProvider($this->getInvalidUpdateValues());
-    }
-
     protected function assertDeprecated(callable $execution): void
     {
         $errors = [];
@@ -305,11 +300,6 @@ abstract class TestCase extends BaseTestCase
     protected function getInvalidStringValues(bool $includeNull = false): array
     {
         return array_merge([123, 3.14, true, [], new stdClass()], $includeNull ? [null] : []);
-    }
-
-    protected function getInvalidUpdateValues(): array
-    {
-        return [123, 3.14, 'foo', true];
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,9 +17,11 @@ use function array_map;
 use function array_merge;
 use function array_values;
 use function call_user_func;
+use function get_debug_type;
 use function getenv;
 use function hash;
 use function is_array;
+use function is_int;
 use function is_object;
 use function is_string;
 use function iterator_to_array;
@@ -154,6 +156,25 @@ abstract class TestCase extends BaseTestCase
         $this->assertCount(1, $errors);
     }
 
+    protected function createOptionDataProvider(array $options): array
+    {
+        $data = [];
+
+        // Loop through each option and get possible values
+        foreach ($options as $option => $values) {
+            // Create an option array with a named data provider for each value
+            foreach ($values as $key => $value) {
+                if (is_int($key)) {
+                    $key = get_debug_type($value);
+                }
+
+                $data[$option . '_' . $key] = [[$option => $value]];
+            }
+        }
+
+        return $data;
+    }
+
     /**
      * Return the test collection name.
      */
@@ -198,6 +219,14 @@ abstract class TestCase extends BaseTestCase
     }
 
     /**
+     * Return a list of invalid hint values.
+     */
+    protected function getInvalidHintValues()
+    {
+        return [123, 3.14, true];
+    }
+
+    /**
      * Return a list of invalid integer values.
      */
     protected function getInvalidIntegerValues(bool $includeNull = false): array
@@ -210,7 +239,19 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getInvalidReadConcernValues(bool $includeNull = false): array
     {
-        return array_merge([123, 3.14, 'foo', true, [], new stdClass(), new ReadPreference(ReadPreference::PRIMARY), new WriteConcern(1)], $includeNull ? [null] : []);
+        return array_merge(
+            [
+                123,
+                3.14,
+                'foo',
+                true,
+                [],
+                new stdClass(),
+                new ReadPreference(ReadPreference::PRIMARY),
+                new WriteConcern(1),
+            ],
+            $includeNull ? ['null' => null] : []
+        );
     }
 
     /**
@@ -218,7 +259,19 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getInvalidReadPreferenceValues(bool $includeNull = false): array
     {
-        return array_merge([123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new WriteConcern(1)], $includeNull ? [null] : []);
+        return array_merge(
+            [
+                123,
+                3.14,
+                'foo',
+                true,
+                [],
+                new stdClass(),
+                new ReadConcern(),
+                new WriteConcern(1),
+            ],
+            $includeNull ? ['null' => null] : []
+        );
     }
 
     /**
@@ -226,7 +279,20 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getInvalidSessionValues(bool $includeNull = false): array
     {
-        return array_merge([123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new ReadPreference(ReadPreference::PRIMARY), new WriteConcern(1)], $includeNull ? [null] : []);
+        return array_merge(
+            [
+                123,
+                3.14,
+                'foo',
+                true,
+                [],
+                new stdClass(),
+                new ReadConcern(),
+                new ReadPreference(ReadPreference::PRIMARY),
+                new WriteConcern(1),
+            ],
+            $includeNull ? ['null' => null] : []
+        );
     }
 
     /**
@@ -242,7 +308,19 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getInvalidWriteConcernValues(bool $includeNull = false): array
     {
-        return array_merge([123, 3.14, 'foo', true, [], new stdClass(), new ReadConcern(), new ReadPreference(ReadPreference::PRIMARY)], $includeNull ? [null] : []);
+        return array_merge(
+            [
+                123,
+                3.14,
+                'foo',
+                true,
+                [],
+                new stdClass(),
+                new ReadConcern(),
+                new ReadPreference(ReadPreference::PRIMARY),
+            ],
+            $includeNull ? ['null' => null] : []
+        );
     }
 
     /**


### PR DESCRIPTION
PHPLIB-1137

This PR adds a new `is_document` function that is used to validate input options. While we accept `array|object` for documents, a `PackedArray` instance is one of those objects where we are absolutely sure that it is not a document.

This PR also includes a commit to refactor most data providers that provide options to operation classes. This was done to give the individual data sets a name, making it easier to spot failing tests. Due to the large amount of unrelated changes in that first commit, I suggest reviewing the commits separately.