### PR TITLE
PHPLIB-1167: Fix `CachingIterator::count()` on empty `Cursor`

### DIFF
--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -110,8 +110,6 @@ class CachingIterator implements Countable, Iterator
             $this->iterator->next();
 
             $this->storeCurrentItem();
-
-            $this->iteratorExhausted = ! $this->iterator->valid();
         }
 
         next($this->items);
@@ -152,6 +150,8 @@ class CachingIterator implements Countable, Iterator
     private function storeCurrentItem(): void
     {
         if (! $this->iterator->valid()) {
+            $this->iteratorExhausted = true;
+
             return;
         }
 

--- a/tests/Model/CachingIteratorFunctionalTest.php
+++ b/tests/Model/CachingIteratorFunctionalTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace MongoDB\Tests\Model;
+
+use MongoDB\Model\CachingIterator;
+use MongoDB\Tests\FunctionalTestCase;
+
+class CachingIteratorFunctionalTest extends FunctionalTestCase
+{
+    /** @see https://jira.mongodb.org/browse/PHPLIB-1167 */
+    public function testEmptyCursor(): void
+    {
+        $collection = $this->dropCollection($this->getDatabaseName(), $this->getCollectionName());
+        $cursor = $collection->find();
+        $iterator = new CachingIterator($cursor);
+
+        $this->assertSame(0, $iterator->count());
+        $iterator->rewind();
+        $this->assertFalse($iterator->valid());
+        $this->assertFalse($iterator->current());
+        $this->assertNull($iterator->key());
+    }
+
+    public function testCursor(): void
+    {
+        $collection = $this->dropCollection($this->getDatabaseName(), $this->getCollectionName());
+        $collection->insertOne(['_id' => 1]);
+        $collection->insertOne(['_id' => 2]);
+        $cursor = $collection->find();
+        $iterator = new CachingIterator($cursor);
+
+        $this->assertSame(2, $iterator->count());
+
+        $iterator->rewind();
+        $this->assertTrue($iterator->valid());
+        $this->assertNotNull($iterator->current());
+        $this->assertSame(0, $iterator->key());
+
+        $iterator->next();
+        $this->assertTrue($iterator->valid());
+        $this->assertNotNull($iterator->current());
+        $this->assertSame(1, $iterator->key());
+
+        $iterator->next();
+        $this->assertFalse($iterator->valid());
+        $this->assertFalse($iterator->current());
+        $this->assertNull($iterator->key());
+    }
+}


### PR DESCRIPTION
Fix PHPLIB-1167 from https://github.com/mongodb/mongo-php-library/pull/1097#discussion_r1237178573

Previous error when calling `CachingIterator::count()` on an empty Cursor (no result).
> Cannot advance a completed or failed cursor.

When `Iterator::valid()` is `false` after a `rewind()`, this means it's empty. The property `$this->iteratorExhausted` is set to `true` so `next()` is not called.

