### PR TITLE
PHPLIB-1175: Use Python 2.7 container for building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,8 @@ jobs:
   giza:
     name: "Build Docs"
     runs-on: "ubuntu-20.04"
+    container:
+      image: python:2.7.18-buster
 
     steps:
       - name: "Checkout library"
@@ -35,10 +37,9 @@ jobs:
           path: docs
           fetch-depth: 2
 
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
+      # python:2.7.18-buster does not include rsync
+      - name: "Install rsync"
+        run: "apt-get update && apt-get -y install rsync"
 
       # The requirements file installs urllib3 with an incompatible version; we replace it with one that works
       - name: "Install giza"


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1175

Based on a workaround suggsested in https://github.com/actions/setup-python/issues/672

Note: the docs build didn't trigger because this PR doesn't change anything in `docs/`, but I did test manually in an earlier iteration of this PR: https://github.com/mongodb/mongo-php-library/actions/runs/5448375068/jobs/9911480696