### PR TITLE
PHPLIB-1098: Test on supported platforms

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -175,7 +175,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          MONGODB_VERSION=${MONGODB_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          SKIP_LEGACY_SHELL=true MONGODB_VERSION=${MONGODB_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:
@@ -773,27 +773,35 @@ axes:
   - id: os
     display_name: OS
     values:
+      # Debian
       - id: debian11
         display_name: "Debian 11"
-        run_on: debian11
+        run_on: debian11-small
       - id: debian10
         display_name: "Debian 10"
-        run_on: debian10
+        run_on: debian10-small
       - id: debian92
         display_name: "Debian 9.2"
-        run_on: debian92
-      - id: rhel70
-        display_name: "RHEL 7.0"
-        run_on: rhel70
-      - id: rhel71-power8
-        display_name: "RHEL 7.1 Power 8"
-        run_on: rhel71-power8-build
-      - id: rhel72-zseries
-        display_name: "RHEL 7.2 zSeries"
-        run_on: rhel72-zseries-build
-      - id: ubuntu1804-arm64
-        display_name: "Ubuntu 18.04 ARM64"
-        run_on: ubuntu1804-arm64-test
+        run_on: debian92-small
+
+      # RHEL
+      - id: rhel90
+        display_name: "RHEL 9.0"
+        run_on: rhel90-small
+
+      # Ubuntu LTS
+      - id: ubuntu2204
+        display_name: "Ubuntu 22.04 x64"
+        run_on: ubuntu2204-small
+      - id: ubuntu2204-arm64
+        display_name: "Ubuntu 22.04 ARM64"
+        run_on: ubuntu2204-arm64-small
+      - id: ubuntu2004
+        display_name: "Ubuntu 20.04 x64"
+        run_on: ubuntu2004-small
+      - id: ubuntu2004-arm64
+        display_name: "Ubuntu 20.04 ARM64"
+        run_on: ubuntu2204-arm64-small
 
   - id: topology
     display_name: Topology
@@ -860,13 +868,25 @@ axes:
           DEPENDENCIES: "lowest"
 
 buildvariants:
-# Test all PHP versions with latest-stable MongoDB and PHPC on Debian
+# Test all PHP versions with latest-stable MongoDB and PHPC on all platforms
 - matrix_name: "test-php-versions"
-  matrix_spec: { "os": "debian11", "mongodb-edge-versions": "latest-stable", "php-versions": "*", "driver-versions": "latest-stable" }
+  matrix_spec:
+    os:
+      - debian11
+      - debian10
+      - rhel90
+      - ubuntu2204
+      - ubuntu2204-arm64
+      - ubuntu2004
+    mongodb-edge-versions: "latest-stable"
+    php-versions: "*"
+    driver-versions: "latest-stable"
   display_name: "${os}, ${mongodb-edge-versions}, ${php-versions}, ${driver-versions}"
   exclude_spec:
     # Exclude "latest-stable" PHP version for Debian 11 (see: test-mongodb-versions matrix)
     - { "os": "debian11", "mongodb-edge-versions": "latest-stable", "php-versions": "8.2", "driver-versions": "latest-stable" }
+    # Exclude PHP versions older than 8.1 on RHEL 9 and Ubuntu 22.04 (OpenSSL 3 is only supported on PHP 8.1+)
+    - { "os": ["rhel90", "ubuntu2204-arm64", "ubuntu2204"], "php-versions": ["7.2", "7.3", "7.4", "8.0"], "mongodb-edge-versions": "*", "driver-versions": "*" }
   tasks:
     - name: "test-standalone"
     - name: "test-replica_set"


### PR DESCRIPTION
PHPLIB-1098

This PR updates the build pipeline to test on supported platforms:
* Add Ubuntu 22.04 and 20.04
* Add RHEL 9.0, 8.2, 8.1, and 7.6

The main tests are currently disabled for RHEL 7.6 and Ubuntu 20.04. Ubuntu 20.04 has issues with the "Start KMS servers" task due to dependency conflicts that I'll have to investigate separately. RHEL 7.6 has issues installing the extension via PECL as it fails with an SSL error when attempting to connect to pecl.php.net. I suspect a certificate problem but need to investigate further.