### PR TITLE
PHPLIB-1180: Add basic infrastructure for codecs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@ tests export-ignore
 docs export-ignore
 examples export-ignore
 mongo-orchestration export-ignore
+stubs export-ignore
 tools export-ignore
 Makefile export-ignore
 phpcs.xml.dist export-ignore

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -75,6 +75,16 @@
       <code>$mergedDriver['platform']</code>
     </MixedAssignment>
   </file>
+  <file src="src/Codec/DecodeIfSupported.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>($value is BSONType ? NativeType : $value)</code>
+    </MixedInferredReturnType>
+  </file>
+  <file src="src/Codec/EncodeIfSupported.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>($value is NativeType ? BSONType : $value)</code>
+    </MixedInferredReturnType>
+  </file>
   <file src="src/Command/ListCollections.php">
     <MixedAssignment occurrences="2">
       <code>$cmd[$option]</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -15,4 +15,9 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <stubs>
+        <file name="stubs/BSON/Document.stub.php"/>
+        <file name="stubs/BSON/Iterator.stub.php"/>
+        <file name="stubs/BSON/PackedArray.stub.php"/>
+    </stubs>
 </psalm>

--- a/src/Codec/Codec.php
+++ b/src/Codec/Codec.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Codec;
+
+/**
+ * @psalm-template BSONType
+ * @psalm-template NativeType
+ * @template-extends Decoder<BSONType, NativeType>
+ * @template-extends Encoder<BSONType, NativeType>
+ */
+interface Codec extends Decoder, Encoder
+{
+}

--- a/src/Codec/Codec.php
+++ b/src/Codec/Codec.php
@@ -18,6 +18,9 @@
 namespace MongoDB\Codec;
 
 /**
+ * The Codec interface allows decoding BSON data to native PHP types and back
+ * to BSON.
+ *
  * @psalm-template BSONType
  * @psalm-template NativeType
  * @template-extends Decoder<BSONType, NativeType>

--- a/src/Codec/CodecLibrary.php
+++ b/src/Codec/CodecLibrary.php
@@ -18,10 +18,7 @@
 namespace MongoDB\Codec;
 
 use MongoDB\Exception\InvalidArgumentException;
-use MongoDB\Exception\UnexpectedValueException;
-
-use function get_debug_type;
-use function sprintf;
+use MongoDB\Exception\UnsupportedValueException;
 
 class CodecLibrary implements Codec
 {
@@ -129,7 +126,7 @@ class CodecLibrary implements Codec
             }
         }
 
-        throw new UnexpectedValueException(sprintf('No decoder found for value of type "%s"', get_debug_type($value)));
+        throw UnsupportedValueException::invalidDecodableValue($value);
     }
 
     /**
@@ -144,6 +141,6 @@ class CodecLibrary implements Codec
             }
         }
 
-        throw new UnexpectedValueException(sprintf('No encoder found for value of type "%s"', get_debug_type($value)));
+        throw UnsupportedValueException::invalidEncodableValue($value);
     }
 }

--- a/src/Codec/CodecLibrary.php
+++ b/src/Codec/CodecLibrary.php
@@ -1,0 +1,149 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Codec;
+
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnexpectedValueException;
+
+use function get_debug_type;
+use function sprintf;
+
+class CodecLibrary implements Codec
+{
+    use DecodeIfSupported;
+    use EncodeIfSupported;
+
+    /** @var array<Decoder> */
+    private $decoders = [];
+
+    /** @var array<Encoder> */
+    private $encoders = [];
+
+    /** @param Decoder|Encoder $items */
+    public function __construct(...$items)
+    {
+        foreach ($items as $item) {
+            if (! $item instanceof Decoder && ! $item instanceof Encoder) {
+                throw InvalidArgumentException::invalidType('$items', $item, [Decoder::class, Encoder::class]);
+            }
+
+            if ($item instanceof Codec) {
+                // Use attachCodec to avoid multiple calls to attachLibrary
+                $this->attachCodec($item);
+
+                continue;
+            }
+
+            if ($item instanceof Decoder) {
+                $this->attachDecoder($item);
+            }
+
+            if ($item instanceof Encoder) {
+                $this->attachEncoder($item);
+            }
+        }
+    }
+
+    /** @return static */
+    final public function attachCodec(Codec $codec): self
+    {
+        $this->decoders[] = $codec;
+        $this->encoders[] = $codec;
+        if ($codec instanceof KnowsCodecLibrary) {
+            $codec->attachLibrary($this);
+        }
+
+        return $this;
+    }
+
+    /** @return static */
+    final public function attachDecoder(Decoder $decoder): self
+    {
+        $this->decoders[] = $decoder;
+        if ($decoder instanceof KnowsCodecLibrary) {
+            $decoder->attachLibrary($this);
+        }
+
+        return $this;
+    }
+
+    /** @return static */
+    final public function attachEncoder(Encoder $encoder): self
+    {
+        $this->encoders[] = $encoder;
+        if ($encoder instanceof KnowsCodecLibrary) {
+            $encoder->attachLibrary($this);
+        }
+
+        return $this;
+    }
+
+    /** @param mixed $value */
+    final public function canDecode($value): bool
+    {
+        foreach ($this->decoders as $decoder) {
+            if ($decoder->canDecode($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param mixed $value */
+    final public function canEncode($value): bool
+    {
+        foreach ($this->encoders as $encoder) {
+            if ($encoder->canEncode($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    final public function decode($value)
+    {
+        foreach ($this->decoders as $decoder) {
+            if ($decoder->canDecode($value)) {
+                return $decoder->decode($value);
+            }
+        }
+
+        throw new UnexpectedValueException(sprintf('No decoder found for value of type "%s"', get_debug_type($value)));
+    }
+
+    /**
+     * @param mixed $value
+     * @return mixed
+     */
+    final public function encode($value)
+    {
+        foreach ($this->encoders as $encoder) {
+            if ($encoder->canEncode($value)) {
+                return $encoder->encode($value);
+            }
+        }
+
+        throw new UnexpectedValueException(sprintf('No encoder found for value of type "%s"', get_debug_type($value)));
+    }
+}

--- a/src/Codec/CodecLibrary.php
+++ b/src/Codec/CodecLibrary.php
@@ -65,7 +65,7 @@ class CodecLibrary implements Codec
         $this->decoders[] = $codec;
         $this->encoders[] = $codec;
         if ($codec instanceof KnowsCodecLibrary) {
-            $codec->attachLibrary($this);
+            $codec->attachCodecLibrary($this);
         }
 
         return $this;
@@ -76,7 +76,7 @@ class CodecLibrary implements Codec
     {
         $this->decoders[] = $decoder;
         if ($decoder instanceof KnowsCodecLibrary) {
-            $decoder->attachLibrary($this);
+            $decoder->attachCodecLibrary($this);
         }
 
         return $this;
@@ -87,7 +87,7 @@ class CodecLibrary implements Codec
     {
         $this->encoders[] = $encoder;
         if ($encoder instanceof KnowsCodecLibrary) {
-            $encoder->attachLibrary($this);
+            $encoder->attachCodecLibrary($this);
         }
 
         return $this;

--- a/src/Codec/DecodeIfSupported.php
+++ b/src/Codec/DecodeIfSupported.php
@@ -39,7 +39,6 @@ trait DecodeIfSupported
 
     /**
      * @param mixed $value
-     * @psalm-param mixed $value
      * @return mixed
      * @psalm-return ($value is BSONType ? NativeType : $value)
      */

--- a/src/Codec/DecodeIfSupported.php
+++ b/src/Codec/DecodeIfSupported.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Codec;
+
+/**
+ * @psalm-template BSONType
+ * @psalm-template NativeType
+ */
+trait DecodeIfSupported
+{
+    /**
+     * @param mixed $value
+     * @psalm-assert-if-true BSONType $value
+     */
+    abstract public function canDecode($value): bool;
+
+    /**
+     * @param mixed $value
+     * @psalm-param BSONType $value
+     * @return mixed
+     * @psalm-return NativeType
+     */
+    abstract public function decode($value);
+
+    /**
+     * @param mixed $value
+     * @psalm-param mixed $value
+     * @return mixed
+     * @psalm-return ($value is BSONType ? NativeType : $value)
+     */
+    public function decodeIfSupported($value)
+    {
+        return $this->canDecode($value) ? $this->decode($value) : $value;
+    }
+}

--- a/src/Codec/DecodeIfSupported.php
+++ b/src/Codec/DecodeIfSupported.php
@@ -17,6 +17,8 @@
 
 namespace MongoDB\Codec;
 
+use MongoDB\Exception\UnsupportedValueException;
+
 /**
  * @psalm-template BSONType
  * @psalm-template NativeType
@@ -34,6 +36,7 @@ trait DecodeIfSupported
      * @psalm-param BSONType $value
      * @return mixed
      * @psalm-return NativeType
+     * @throws UnsupportedValueException if the decoder does not support the value
      */
     abstract public function decode($value);
 

--- a/src/Codec/Decoder.php
+++ b/src/Codec/Decoder.php
@@ -17,6 +17,8 @@
 
 namespace MongoDB\Codec;
 
+use MongoDB\Exception\InvalidArgumentException;
+
 /**
  * @internal
  * @psalm-template BSONType
@@ -25,20 +27,31 @@ namespace MongoDB\Codec;
 interface Decoder
 {
     /**
+     * Checks if the decoder supports a given value.
+     *
      * @param mixed $value
      * @psalm-assert-if-true BSONType $value
      */
     public function canDecode($value): bool;
 
     /**
+     * Decodes a given value. If the decoder does not support the value, it
+     * should throw an exception.
+     *
      * @param mixed $value
      * @psalm-param BSONType $value
      * @return mixed
      * @psalm-return NativeType
+     * @throws InvalidArgumentException if the decoder does not support the value
      */
     public function decode($value);
 
     /**
+     * Decodes a given value if supported, otherwise returns the value as-is.
+     *
+     * The DecodeIfSupported trait provides a default implementation of this
+     * method.
+     *
      * @param mixed $value
      * @psalm-param mixed $value
      * @return mixed

--- a/src/Codec/Decoder.php
+++ b/src/Codec/Decoder.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Codec;
+
+/**
+ * @internal
+ * @psalm-template BSONType
+ * @psalm-template NativeType
+ */
+interface Decoder
+{
+    /**
+     * @param mixed $value
+     * @psalm-assert-if-true BSONType $value
+     */
+    public function canDecode($value): bool;
+
+    /**
+     * @param mixed $value
+     * @psalm-param BSONType $value
+     * @return mixed
+     * @psalm-return NativeType
+     */
+    public function decode($value);
+
+    /**
+     * @param mixed $value
+     * @psalm-param mixed $value
+     * @return mixed
+     * @psalm-return ($value is BSONType ? NativeType : $value)
+     */
+    public function decodeIfSupported($value);
+}

--- a/src/Codec/Decoder.php
+++ b/src/Codec/Decoder.php
@@ -17,7 +17,7 @@
 
 namespace MongoDB\Codec;
 
-use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedValueException;
 
 /**
  * @psalm-template BSONType
@@ -41,7 +41,7 @@ interface Decoder
      * @psalm-param BSONType $value
      * @return mixed
      * @psalm-return NativeType
-     * @throws InvalidArgumentException if the decoder does not support the value
+     * @throws UnsupportedValueException if the decoder does not support the value
      */
     public function decode($value);
 

--- a/src/Codec/Decoder.php
+++ b/src/Codec/Decoder.php
@@ -52,7 +52,6 @@ interface Decoder
      * method.
      *
      * @param mixed $value
-     * @psalm-param mixed $value
      * @return mixed
      * @psalm-return ($value is BSONType ? NativeType : $value)
      */

--- a/src/Codec/Decoder.php
+++ b/src/Codec/Decoder.php
@@ -20,7 +20,6 @@ namespace MongoDB\Codec;
 use MongoDB\Exception\InvalidArgumentException;
 
 /**
- * @internal
  * @psalm-template BSONType
  * @psalm-template NativeType
  */

--- a/src/Codec/DocumentCodec.php
+++ b/src/Codec/DocumentCodec.php
@@ -25,4 +25,16 @@ use MongoDB\BSON\Document;
  */
 interface DocumentCodec extends Codec
 {
+    /**
+     * @param mixed $value
+     * @psalm-param Document $value
+     * @psalm-return ObjectType
+     */
+    public function decode($value): object;
+
+    /**
+     * @param mixed $value
+     * @psalm-param ObjectType $value
+     */
+    public function encode($value): Document;
 }

--- a/src/Codec/DocumentCodec.php
+++ b/src/Codec/DocumentCodec.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Codec;
+
+use MongoDB\BSON\Document;
+
+/**
+ * @psalm-template ObjectType of object
+ * @template-extends Codec<Document, ObjectType>
+ */
+interface DocumentCodec extends Codec
+{
+}

--- a/src/Codec/DocumentCodec.php
+++ b/src/Codec/DocumentCodec.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Codec;
 
 use MongoDB\BSON\Document;
+use MongoDB\Exception\UnsupportedValueException;
 
 /**
  * The DocumentCodec interface allows decoding BSON document data to native PHP
@@ -32,12 +33,14 @@ interface DocumentCodec extends Codec
      * @param mixed $value
      * @psalm-param Document $value
      * @psalm-return ObjectType
+     * @throws UnsupportedValueException if the decoder does not support the value
      */
     public function decode($value): object;
 
     /**
      * @param mixed $value
      * @psalm-param ObjectType $value
+     * @throws UnsupportedValueException if the encoder does not support the value
      */
     public function encode($value): Document;
 }

--- a/src/Codec/DocumentCodec.php
+++ b/src/Codec/DocumentCodec.php
@@ -20,6 +20,9 @@ namespace MongoDB\Codec;
 use MongoDB\BSON\Document;
 
 /**
+ * The DocumentCodec interface allows decoding BSON document data to native PHP
+ * objects and back to BSON documents.
+ *
  * @psalm-template ObjectType of object
  * @template-extends Codec<Document, ObjectType>
  */

--- a/src/Codec/EncodeIfSupported.php
+++ b/src/Codec/EncodeIfSupported.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Codec;
+
+/**
+ * @psalm-template BSONType
+ * @psalm-template NativeType
+ */
+trait EncodeIfSupported
+{
+    /**
+     * @param mixed $value
+     * @psalm-assert-if-true NativeType $value
+     */
+    abstract public function canEncode($value): bool;
+
+    /**
+     * @param mixed $value
+     * @psalm-param NativeType $value
+     * @return mixed
+     * @psalm-return BSONType
+     */
+    abstract public function encode($value);
+
+    /**
+     * @param mixed $value
+     * @psalm-param mixed $value
+     * @return mixed
+     * @psalm-return ($value is NativeType ? BSONType : $value)
+     */
+    public function encodeIfSupported($value)
+    {
+        return $this->canEncode($value) ? $this->encode($value) : $value;
+    }
+}

--- a/src/Codec/EncodeIfSupported.php
+++ b/src/Codec/EncodeIfSupported.php
@@ -17,6 +17,8 @@
 
 namespace MongoDB\Codec;
 
+use MongoDB\Exception\UnsupportedValueException;
+
 /**
  * @psalm-template BSONType
  * @psalm-template NativeType
@@ -34,6 +36,7 @@ trait EncodeIfSupported
      * @psalm-param NativeType $value
      * @return mixed
      * @psalm-return BSONType
+     * @throws UnsupportedValueException if the encoder does not support the value
      */
     abstract public function encode($value);
 

--- a/src/Codec/EncodeIfSupported.php
+++ b/src/Codec/EncodeIfSupported.php
@@ -39,7 +39,6 @@ trait EncodeIfSupported
 
     /**
      * @param mixed $value
-     * @psalm-param mixed $value
      * @return mixed
      * @psalm-return ($value is NativeType ? BSONType : $value)
      */

--- a/src/Codec/Encoder.php
+++ b/src/Codec/Encoder.php
@@ -17,7 +17,7 @@
 
 namespace MongoDB\Codec;
 
-use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedValueException;
 
 /**
  * @psalm-template BSONType
@@ -41,7 +41,7 @@ interface Encoder
      * @psalm-param NativeType $value
      * @return mixed
      * @psalm-return BSONType
-     * @throws InvalidArgumentException if the decoder does not support the value
+     * @throws UnsupportedValueException if the encoder does not support the value
      */
     public function encode($value);
 

--- a/src/Codec/Encoder.php
+++ b/src/Codec/Encoder.php
@@ -17,6 +17,8 @@
 
 namespace MongoDB\Codec;
 
+use MongoDB\Exception\InvalidArgumentException;
+
 /**
  * @internal
  * @psalm-template BSONType
@@ -25,20 +27,31 @@ namespace MongoDB\Codec;
 interface Encoder
 {
     /**
+     * Checks if the encoder supports a given value.
+     *
      * @param mixed $value
      * @psalm-assert-if-true NativeType $value
      */
     public function canEncode($value): bool;
 
     /**
+     * Encodes a given value. If the encoder does not support the value, it
+     * should throw an exception.
+     *
      * @param mixed $value
      * @psalm-param NativeType $value
      * @return mixed
      * @psalm-return BSONType
+     * @throws InvalidArgumentException if the decoder does not support the value
      */
     public function encode($value);
 
     /**
+     * Encodes a given value if supported, otherwise returns the value as-is.
+     *
+     * The EncodeIfSupported trait provides a default implementation of this
+     * method.
+     *
      * @param mixed $value
      * @psalm-param mixed $value
      * @return mixed

--- a/src/Codec/Encoder.php
+++ b/src/Codec/Encoder.php
@@ -20,7 +20,6 @@ namespace MongoDB\Codec;
 use MongoDB\Exception\InvalidArgumentException;
 
 /**
- * @internal
  * @psalm-template BSONType
  * @psalm-template NativeType
  */

--- a/src/Codec/Encoder.php
+++ b/src/Codec/Encoder.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Codec;
+
+/**
+ * @internal
+ * @psalm-template BSONType
+ * @psalm-template NativeType
+ */
+interface Encoder
+{
+    /**
+     * @param mixed $value
+     * @psalm-assert-if-true NativeType $value
+     */
+    public function canEncode($value): bool;
+
+    /**
+     * @param mixed $value
+     * @psalm-param NativeType $value
+     * @return mixed
+     * @psalm-return BSONType
+     */
+    public function encode($value);
+
+    /**
+     * @param mixed $value
+     * @psalm-param mixed $value
+     * @return mixed
+     * @psalm-return ($value is NativeType ? BSONType : $value)
+     */
+    public function encodeIfSupported($value);
+}

--- a/src/Codec/Encoder.php
+++ b/src/Codec/Encoder.php
@@ -52,7 +52,6 @@ interface Encoder
      * method.
      *
      * @param mixed $value
-     * @psalm-param mixed $value
      * @return mixed
      * @psalm-return ($value is NativeType ? BSONType : $value)
      */

--- a/src/Codec/KnowsCodecLibrary.php
+++ b/src/Codec/KnowsCodecLibrary.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Codec;
+
+interface KnowsCodecLibrary
+{
+    public function attachLibrary(CodecLibrary $library): void;
+}

--- a/src/Codec/KnowsCodecLibrary.php
+++ b/src/Codec/KnowsCodecLibrary.php
@@ -24,5 +24,5 @@ namespace MongoDB\Codec;
  */
 interface KnowsCodecLibrary
 {
-    public function attachLibrary(CodecLibrary $library): void;
+    public function attachCodecLibrary(CodecLibrary $library): void;
 }

--- a/src/Codec/KnowsCodecLibrary.php
+++ b/src/Codec/KnowsCodecLibrary.php
@@ -17,6 +17,11 @@
 
 namespace MongoDB\Codec;
 
+/**
+ * This interface is used to indicate that a class is aware of the CodecLibrary
+ * it was added to. The library will be injected when the codec is added to the
+ * library. This allows codecs to recursively encode its nested values.
+ */
 interface KnowsCodecLibrary
 {
     public function attachLibrary(CodecLibrary $library): void;

--- a/src/Codec/architecture.md
+++ b/src/Codec/architecture.md
@@ -1,0 +1,99 @@
+# Converting BSON data through codecs
+
+The codec system is a more advanced way to convert BSON data to native types and back, designed for libraries with more
+advanced use cases, e.g. object mappers. It is designed to decouple the serialisation logic from the data model,
+allowing for more flexible implementations.
+
+## Encoders and Decoders
+
+The codec interface is split into two smaller interfaces: encoders and decoders. Both interfaces are marked as internal,
+as users are only expected to interact with the Codec interface. The interfaces are typed using Psalm generics, allowing
+for better type checking when they are used. Without type annotations, the interfaces are equivalent to the following:
+
+```php
+namespace MongoDB\Codec;
+
+interface Decoder
+{
+    public function canDecode(mixed $value): bool;
+
+    public function decode(mixed $value): mixed;
+
+    public function decodeIfSupported(mixed $value): mixed;
+}
+
+interface Encoder
+{
+    public function canEncode(mixed $value): bool;
+
+    public function encode(mixed $value): mixed;
+
+    public function encodeIfSupported(mixed $value): mixed;
+}
+```
+
+## Codec interface
+
+The `Codec` interface combines decoding and encoding into a single interface. This will be used for most values except
+for documents where a more specific `DocumentCodec` is provided.
+
+The base interface supports encoding from a `NativeType` to a `BSONType` and back. Helper methods to determine whether a
+value is supported are provided. The `decodeIfSupported` and `encodeIfSupported` methods are useful to have a codec
+encode or decode a value only if it is supported. If it is not supported, the original value is returned.
+
+```php
+namespace MongoDB\Codec;
+
+/**
+ * @psalm-template BSONType
+ * @psalm-template NativeType
+ * @template-extends Decoder<BSONType, NativeType>
+ * @template-extends Encoder<BSONType, NativeType>
+ */
+interface Codec extends Decoder, Encoder
+{
+}
+```
+
+## Document codec
+
+The document codec is special as it is guaranteed to always encode to a BSON document instance and decode to a PHP
+object. Document codecs can be provided to a `MongoDB\Collection` instance to have it automatically decode data read
+from the database. Likewise, any supported value is encoded before writing to the database in `insert` and `replace`
+operations.
+
+```php
+namespace MongoDB\Codec;
+
+use MongoDB\BSON\Document;
+
+/** 
+ * @template ObjectType of object
+ * @extends Codec<ObjectType, Document> 
+ */
+interface DocumentCodec extends Codec
+{
+}
+```
+
+## Using codecs
+
+The `MongoDB\Collection` class and all operations that work with documents now take a `codec` option. This can be
+an instance of a `DocumentCodec` that will be used to encode documents (for insert and replace operations) and decode
+them into PHP objects when reading data.
+
+### Codecs and type maps
+
+When providing a value for the `codec` option, it takes precedence over the `typeMap` option. An exception is made
+when the `codec` option was specified on the collection level, but an operation is given a `typeMap` option. In
+this case, the type map is used. The precedence order is as follows:
+
+* operation-level `codec` option
+* operation-level `typeMap` option
+* collection-level `codec` option
+* collection-level `typeMap` option
+
+Codecs are not inherited from the client or the database object, as they are purely used for operations that return
+documents. However, database- or client-level aggregation commands will take an operation-level codec option to
+decode the resulting documents.
+

--- a/src/Exception/UnsupportedValueException.php
+++ b/src/Exception/UnsupportedValueException.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Exception;
+
+use InvalidArgumentException;
+
+use function get_debug_type;
+use function sprintf;
+
+class UnsupportedValueException extends InvalidArgumentException implements Exception
+{
+    /** @var mixed */
+    private $value;
+
+    /** @return mixed */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /** @param mixed $value */
+    public static function invalidDecodableValue($value): self
+    {
+        return new self(sprintf('Could not decode value of type "%s".', get_debug_type($value)), $value);
+    }
+
+    /** @param mixed $value */
+    public static function invalidEncodableValue($value): self
+    {
+        return new self(sprintf('Could not encode value of type "%s".', get_debug_type($value)), $value);
+    }
+
+    /** @param mixed $value */
+    private function __construct(string $message, $value)
+    {
+        parent::__construct($message);
+
+        $this->value = $value;
+    }
+}

--- a/stubs/BSON/Document.stub.php
+++ b/stubs/BSON/Document.stub.php
@@ -3,6 +3,8 @@
 namespace MongoDB\BSON;
 
 /**
+ * This stub file is temporary and can be removed when using Psalm 5
+ *
  * @template TValue
  * @template-implements \IteratorAggregate<string, TValue>
  */

--- a/stubs/BSON/Document.stub.php
+++ b/stubs/BSON/Document.stub.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace MongoDB\BSON;
+
+/**
+ * @template TValue
+ * @template-implements \IteratorAggregate<string, TValue>
+ */
+final class Document implements \IteratorAggregate, \Serializable
+{
+    private function __construct() {}
+
+    final static public function fromBSON(string $bson): Document {}
+
+    final static public function fromJSON(string $json): Document {}
+
+    /** @param array|object $value */
+    final static public function fromPHP($value): Document {}
+
+    /** @return TValue */
+    final public function get(string $key) {}
+
+    /** @return Iterator<string, TValue> */
+    final public function getIterator(): Iterator {}
+
+    final public function has(string $key): bool {}
+
+    /** @return array|object */
+    final public function toPHP(?array $typeMap = null) {}
+
+    final public function toCanonicalExtendedJSON(): string {}
+
+    final public function toRelaxedExtendedJSON(): string {}
+
+    final public function __toString(): string {}
+
+    final public static function __set_state(array $properties): Document {}
+
+    final public function serialize(): string {}
+
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
+
+    final public function __unserialize(array $data): void {}
+
+    final public function __serialize(): array {}
+}

--- a/stubs/BSON/Iterator.stub.php
+++ b/stubs/BSON/Iterator.stub.php
@@ -1,13 +1,10 @@
 <?php
 
-/**
-  * @generate-class-entries static
-  * @generate-function-entries static
-  */
-
 namespace MongoDB\BSON;
 
 /**
+ * This stub file is temporary and can be removed when using Psalm 5
+ *
  * @psalm-template TKey of int|string
  * @psalm-template TValue
  * $psalm-implements \Iterator<TKey, TValue>

--- a/stubs/BSON/Iterator.stub.php
+++ b/stubs/BSON/Iterator.stub.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+  * @generate-class-entries static
+  * @generate-function-entries static
+  */
+
+namespace MongoDB\BSON;
+
+/**
+ * @psalm-template TKey of int|string
+ * @psalm-template TValue
+ * $psalm-implements \Iterator<TKey, TValue>
+ */
+final class Iterator implements \Iterator
+{
+    final private function __construct() {}
+
+    /** @return TValue */
+    final public function current() {}
+
+    /** @return TKey */
+    final public function key() {}
+
+    final public function next(): void {}
+
+    final public function rewind(): void {}
+
+    final public function valid(): bool {}
+
+    final public function __wakeup(): void {}
+}

--- a/stubs/BSON/PackedArray.stub.php
+++ b/stubs/BSON/PackedArray.stub.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MongoDB\BSON;
+
+/**
+ * @template TValue
+ * @template-implements \IteratorAggregate<int, TValue>
+ */
+final class PackedArray implements \IteratorAggregate, \Serializable
+{
+    private function __construct() {}
+
+    final static public function fromPHP(array $value): PackedArray {}
+
+    /** @return TValue */
+    final public function get(int $index) {}
+
+    /** @return Iterator<int, TValue> */
+    final public function getIterator(): Iterator {}
+
+    final public function has(int $index): bool {}
+
+    /** @return array|object */
+    final public function toPHP(?array $typeMap = null) {}
+
+    final public function __toString(): string {}
+
+    final public static function __set_state(array $properties): PackedArray {}
+
+    final public function serialize(): string {}
+
+    /** @param string $serialized */
+    final public function unserialize($serialized): void {}
+
+    final public function __unserialize(array $data): void {}
+
+    final public function __serialize(): array {}
+}

--- a/stubs/BSON/PackedArray.stub.php
+++ b/stubs/BSON/PackedArray.stub.php
@@ -3,6 +3,8 @@
 namespace MongoDB\BSON;
 
 /**
+ * This stub file is temporary and can be removed when using Psalm 5
+ *
  * @template TValue
  * @template-implements \IteratorAggregate<int, TValue>
  */

--- a/tests/Codec/CodecLibraryTest.php
+++ b/tests/Codec/CodecLibraryTest.php
@@ -7,7 +7,7 @@ use MongoDB\Codec\CodecLibrary;
 use MongoDB\Codec\DecodeIfSupported;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Codec\KnowsCodecLibrary;
-use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Tests\TestCase;
 
 class CodecLibraryTest extends TestCase
@@ -36,17 +36,13 @@ class CodecLibraryTest extends TestCase
 
         $this->assertFalse($codec->canDecode(null));
 
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('No decoder found for value of type "null"');
-
-        $this->assertNull($codec->decode(null));
+        $this->expectExceptionObject(UnsupportedValueException::invalidDecodableValue(null));
+        $codec->decode(null);
     }
 
     public function testDecodeUnsupportedValue(): void
     {
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('No decoder found for value of type "string"');
-
+        $this->expectExceptionObject(UnsupportedValueException::invalidDecodableValue('foo'));
         $this->getCodecLibrary()->decode('foo');
     }
 
@@ -74,17 +70,13 @@ class CodecLibraryTest extends TestCase
 
         $this->assertFalse($codec->canEncode(null));
 
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('No encoder found for value of type "null"');
-
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue(null));
         $codec->encode(null);
     }
 
     public function testEncodeUnsupportedValue(): void
     {
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('No encoder found for value of type "string"');
-
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue('foo'));
         $this->getCodecLibrary()->encode('foo');
     }
 

--- a/tests/Codec/CodecLibraryTest.php
+++ b/tests/Codec/CodecLibraryTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace MongoDB\Tests\Codec;
+
+use MongoDB\Codec\Codec;
+use MongoDB\Codec\CodecLibrary;
+use MongoDB\Codec\DecodeIfSupported;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Codec\KnowsCodecLibrary;
+use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Tests\TestCase;
+
+class CodecLibraryTest extends TestCase
+{
+    public function testDecode(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertTrue($codec->canDecode('cigam'));
+        $this->assertFalse($codec->canDecode('magic'));
+
+        $this->assertSame('magic', $codec->decode('cigam'));
+    }
+
+    public function testDecodeIfSupported(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertSame('magic', $codec->decodeIfSupported('cigam'));
+        $this->assertSame('magic', $codec->decodeIfSupported('magic'));
+    }
+
+    public function testDecodeNull(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertFalse($codec->canDecode(null));
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('No decoder found for value of type "null"');
+
+        $this->assertNull($codec->decode(null));
+    }
+
+    public function testDecodeUnsupportedValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('No decoder found for value of type "string"');
+
+        $this->getCodecLibrary()->decode('foo');
+    }
+
+    public function testEncode(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertTrue($codec->canEncode('magic'));
+        $this->assertFalse($codec->canEncode('cigam'));
+
+        $this->assertSame('cigam', $codec->encode('magic'));
+    }
+
+    public function testEncodeIfSupported(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertSame('cigam', $codec->encodeIfSupported('magic'));
+        $this->assertSame('cigam', $codec->encodeIfSupported('cigam'));
+    }
+
+    public function testEncodeNull(): void
+    {
+        $codec = $this->getCodecLibrary();
+
+        $this->assertFalse($codec->canEncode(null));
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('No encoder found for value of type "null"');
+
+        $codec->encode(null);
+    }
+
+    public function testEncodeUnsupportedValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('No encoder found for value of type "string"');
+
+        $this->getCodecLibrary()->encode('foo');
+    }
+
+    public function testLibraryAttachesToCodecs(): void
+    {
+        $codec = $this->getTestCodec();
+        $library = $this->getCodecLibrary();
+
+        $library->attachCodec($codec);
+        $this->assertSame($library, $codec->library);
+    }
+
+    public function testLibraryAttachesToCodecsWhenCreating(): void
+    {
+        $codec = $this->getTestCodec();
+        $library = new CodecLibrary($codec);
+
+        $this->assertSame($library, $codec->library);
+    }
+
+    private function getCodecLibrary(): CodecLibrary
+    {
+        return new CodecLibrary(
+            /** @template-implements Codec<string, string> */
+            new class implements Codec
+            {
+                use DecodeIfSupported;
+                use EncodeIfSupported;
+
+                public function canDecode($value): bool
+                {
+                    return $value === 'cigam';
+                }
+
+                public function canEncode($value): bool
+                {
+                    return $value === 'magic';
+                }
+
+                public function decode($value)
+                {
+                    return 'magic';
+                }
+
+                public function encode($value)
+                {
+                    return 'cigam';
+                }
+            }
+        );
+    }
+
+    private function getTestCodec(): Codec
+    {
+        return new class implements Codec, KnowsCodecLibrary {
+            use DecodeIfSupported;
+            use EncodeIfSupported;
+
+            public $library;
+
+            public function attachLibrary(CodecLibrary $library): void
+            {
+                $this->library = $library;
+            }
+
+            public function canDecode($value): bool
+            {
+                return false;
+            }
+
+            public function canEncode($value): bool
+            {
+                return false;
+            }
+
+            public function decode($value)
+            {
+                return null;
+            }
+
+            public function encode($value)
+            {
+                return null;
+            }
+        };
+    }
+}

--- a/tests/Codec/CodecLibraryTest.php
+++ b/tests/Codec/CodecLibraryTest.php
@@ -90,6 +90,7 @@ class CodecLibraryTest extends TestCase
 
     public function testLibraryAttachesToCodecs(): void
     {
+        // TODO PHPUnit >= 10: use createMockForIntersectionOfInterfaces instead
         $codec = $this->getTestCodec();
         $library = $this->getCodecLibrary();
 

--- a/tests/Codec/CodecLibraryTest.php
+++ b/tests/Codec/CodecLibraryTest.php
@@ -16,18 +16,18 @@ class CodecLibraryTest extends TestCase
     {
         $codec = $this->getCodecLibrary();
 
-        $this->assertTrue($codec->canDecode('cigam'));
-        $this->assertFalse($codec->canDecode('magic'));
+        $this->assertTrue($codec->canDecode('encoded'));
+        $this->assertFalse($codec->canDecode('decoded'));
 
-        $this->assertSame('magic', $codec->decode('cigam'));
+        $this->assertSame('decoded', $codec->decode('encoded'));
     }
 
     public function testDecodeIfSupported(): void
     {
         $codec = $this->getCodecLibrary();
 
-        $this->assertSame('magic', $codec->decodeIfSupported('cigam'));
-        $this->assertSame('magic', $codec->decodeIfSupported('magic'));
+        $this->assertSame('decoded', $codec->decodeIfSupported('encoded'));
+        $this->assertSame('decoded', $codec->decodeIfSupported('decoded'));
     }
 
     public function testDecodeNull(): void
@@ -54,18 +54,18 @@ class CodecLibraryTest extends TestCase
     {
         $codec = $this->getCodecLibrary();
 
-        $this->assertTrue($codec->canEncode('magic'));
-        $this->assertFalse($codec->canEncode('cigam'));
+        $this->assertTrue($codec->canEncode('decoded'));
+        $this->assertFalse($codec->canEncode('encoded'));
 
-        $this->assertSame('cigam', $codec->encode('magic'));
+        $this->assertSame('encoded', $codec->encode('decoded'));
     }
 
     public function testEncodeIfSupported(): void
     {
         $codec = $this->getCodecLibrary();
 
-        $this->assertSame('cigam', $codec->encodeIfSupported('magic'));
-        $this->assertSame('cigam', $codec->encodeIfSupported('cigam'));
+        $this->assertSame('encoded', $codec->encodeIfSupported('decoded'));
+        $this->assertSame('encoded', $codec->encodeIfSupported('encoded'));
     }
 
     public function testEncodeNull(): void
@@ -116,22 +116,22 @@ class CodecLibraryTest extends TestCase
 
                 public function canDecode($value): bool
                 {
-                    return $value === 'cigam';
+                    return $value === 'encoded';
                 }
 
                 public function canEncode($value): bool
                 {
-                    return $value === 'magic';
+                    return $value === 'decoded';
                 }
 
                 public function decode($value)
                 {
-                    return 'magic';
+                    return 'decoded';
                 }
 
                 public function encode($value)
                 {
-                    return 'cigam';
+                    return 'encoded';
                 }
             }
         );

--- a/tests/Codec/CodecLibraryTest.php
+++ b/tests/Codec/CodecLibraryTest.php
@@ -145,7 +145,7 @@ class CodecLibraryTest extends TestCase
 
             public $library;
 
-            public function attachLibrary(CodecLibrary $library): void
+            public function attachCodecLibrary(CodecLibrary $library): void
             {
                 $this->library = $library;
             }

--- a/tests/PedantryTest.php
+++ b/tests/PedantryTest.php
@@ -33,7 +33,8 @@ class PedantryTest extends TestCase
         $methods = array_filter(
             $methods,
             function (ReflectionMethod $method) use ($class) {
-                return $method->getDeclaringClass() == $class;
+                return $method->getDeclaringClass() == $class // Exclude inherited methods
+                    && $method->getFileName() === $class->getFileName(); // Exclude methods inherited from traits
             }
         );
 
@@ -86,7 +87,8 @@ class PedantryTest extends TestCase
                 continue;
             }
 
-            $classNames[][] = 'MongoDB\\' . str_replace(DIRECTORY_SEPARATOR, '\\', substr($file->getRealPath(), strlen($srcDir) + 1, -4));
+            $className = 'MongoDB\\' . str_replace(DIRECTORY_SEPARATOR, '\\', substr($file->getRealPath(), strlen($srcDir) + 1, -4));
+            $classNames[$className][] = $className;
         }
 
         return $classNames;


### PR DESCRIPTION
PHPLIB-1180

This follows the prototyping work done in #1059.

This PR only introduces the codec interfaces and two standard codecs to traverse arrays and objects. Support for lazy BSON deserialisation will be added in a separate PR.

Compared to the prototype PR, the following changes have been made to the codecs:
* Introduced `encodeIfSupported` and `decodeIfSupported` methods (suggested during review)
* Special treatment for `null` in CodecLibrary has been removed

Other comments in the prototype PR concerned other areas (such as lazy BSON structures), those will be worked into future pull requests.