### PR TITLE
PHPLIB-1184: Improve CallbackIterator

### DIFF
--- a/src/Model/CallbackIterator.php
+++ b/src/Model/CallbackIterator.php
@@ -17,11 +17,12 @@
 
 namespace MongoDB\Model;
 
-use Closure;
 use Iterator;
 use IteratorIterator;
 use ReturnTypeWillChange;
 use Traversable;
+
+use function call_user_func;
 
 /**
  * Iterator to apply a callback before returning an element
@@ -35,20 +36,20 @@ use Traversable;
  */
 class CallbackIterator implements Iterator
 {
-    /** @var Closure(TValue, TKey): TCallbackValue */
-    private $callback;
+    /** @var callable(TValue, TKey): TCallbackValue */
+    private $callable;
 
     /** @var Iterator<TKey, TValue> */
     private $iterator;
 
     /**
-     * @param Traversable<TKey, TValue>             $traversable
-     * @param Closure(TValue, TKey): TCallbackValue $callback
+     * @param Traversable<TKey, TValue>              $traversable
+     * @param callable(TValue, TKey): TCallbackValue $callable
      */
-    public function __construct(Traversable $traversable, Closure $callback)
+    public function __construct(Traversable $traversable, callable $callable)
     {
         $this->iterator = $traversable instanceof Iterator ? $traversable : new IteratorIterator($traversable);
-        $this->callback = $callback;
+        $this->callable = $callable;
     }
 
     /**
@@ -58,7 +59,7 @@ class CallbackIterator implements Iterator
     #[ReturnTypeWillChange]
     public function current()
     {
-        return ($this->callback)($this->iterator->current(), $this->iterator->key());
+        return call_user_func($this->callable, $this->iterator->current(), $this->iterator->key());
     }
 
     /**

--- a/src/Model/CallbackIterator.php
+++ b/src/Model/CallbackIterator.php
@@ -37,19 +37,19 @@ use function call_user_func;
 class CallbackIterator implements Iterator
 {
     /** @var callable(TValue, TKey): TCallbackValue */
-    private $callable;
+    private $callback;
 
     /** @var Iterator<TKey, TValue> */
     private $iterator;
 
     /**
      * @param Traversable<TKey, TValue>              $traversable
-     * @param callable(TValue, TKey): TCallbackValue $callable
+     * @param callable(TValue, TKey): TCallbackValue $callback
      */
-    public function __construct(Traversable $traversable, callable $callable)
+    public function __construct(Traversable $traversable, callable $callback)
     {
         $this->iterator = $traversable instanceof Iterator ? $traversable : new IteratorIterator($traversable);
-        $this->callable = $callable;
+        $this->callback = $callback;
     }
 
     /**
@@ -59,7 +59,7 @@ class CallbackIterator implements Iterator
     #[ReturnTypeWillChange]
     public function current()
     {
-        return call_user_func($this->callable, $this->iterator->current(), $this->iterator->key());
+        return call_user_func($this->callback, $this->iterator->current(), $this->iterator->key());
     }
 
     /**

--- a/src/Model/CallbackIterator.php
+++ b/src/Model/CallbackIterator.php
@@ -49,7 +49,7 @@ class CallbackIterator implements Iterator
     #[ReturnTypeWillChange]
     public function current()
     {
-        return ($this->callback)($this->iterator->current());
+        return ($this->callback)($this->iterator->current(), $this->iterator->key());
     }
 
     /**

--- a/src/Model/CallbackIterator.php
+++ b/src/Model/CallbackIterator.php
@@ -27,15 +27,24 @@ use Traversable;
  * Iterator to apply a callback before returning an element
  *
  * @internal
+ *
+ * @template TKey
+ * @template TValue
+ * @template TCallbackValue
+ * @template-implements Iterator<TKey, TCallbackValue>
  */
 class CallbackIterator implements Iterator
 {
-    /** @var Closure */
+    /** @var Closure(TValue, TKey): TCallbackValue */
     private $callback;
 
-    /** @var Iterator */
+    /** @var Iterator<TKey, TValue> */
     private $iterator;
 
+    /**
+     * @param Traversable<TKey, TValue>             $traversable
+     * @param Closure(TValue, TKey): TCallbackValue $callback
+     */
     public function __construct(Traversable $traversable, Closure $callback)
     {
         $this->iterator = $traversable instanceof Iterator ? $traversable : new IteratorIterator($traversable);
@@ -44,7 +53,7 @@ class CallbackIterator implements Iterator
 
     /**
      * @see https://php.net/iterator.current
-     * @return mixed
+     * @return TCallbackValue
      */
     #[ReturnTypeWillChange]
     public function current()
@@ -54,7 +63,7 @@ class CallbackIterator implements Iterator
 
     /**
      * @see https://php.net/iterator.key
-     * @return mixed
+     * @return TKey
      */
     #[ReturnTypeWillChange]
     public function key()

--- a/tests/Model/CallbackIteratorTest.php
+++ b/tests/Model/CallbackIteratorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace MongoDB\Tests\Model;
+
+use ArrayIterator;
+use MongoDB\Model\CallbackIterator;
+use MongoDB\Tests\TestCase;
+
+use function array_keys;
+use function iterator_to_array;
+
+class CallbackIteratorTest extends TestCase
+{
+    public function testArrayIteration(): void
+    {
+        $expectedKey = 0;
+
+        $original = [1, 2, 3];
+
+        $callbackIterator = new CallbackIterator(
+            new ArrayIterator($original),
+            function ($value, $key) use (&$expectedKey) {
+                $this->assertSame($expectedKey, $key);
+                $expectedKey++;
+
+                return $value * 2;
+            }
+        );
+
+        $this->assertSame([2, 4, 6], iterator_to_array($callbackIterator));
+    }
+
+    public function testHashIteration(): void
+    {
+        $expectedKey = 0;
+
+        $original = ['a' => 1, 'b' => 2, 'c' => 3];
+        $expectedKeys = array_keys($original);
+
+        $callbackIterator = new CallbackIterator(
+            new ArrayIterator($original),
+            function ($value, $key) use (&$expectedKey, $expectedKeys) {
+                $this->assertSame($expectedKeys[$expectedKey], $key);
+                $expectedKey++;
+
+                return $value * 2;
+            }
+        );
+
+        $this->assertSame(['a' => 2, 'b' => 4, 'c' => 6], iterator_to_array($callbackIterator));
+    }
+}

--- a/tests/Model/CallbackIteratorTest.php
+++ b/tests/Model/CallbackIteratorTest.php
@@ -8,6 +8,7 @@ use MongoDB\Tests\TestCase;
 
 use function array_keys;
 use function iterator_to_array;
+use function strrev;
 
 class CallbackIteratorTest extends TestCase
 {
@@ -48,5 +49,22 @@ class CallbackIteratorTest extends TestCase
         );
 
         $this->assertSame(['a' => 2, 'b' => 4, 'c' => 6], iterator_to_array($callbackIterator));
+    }
+
+    public function testWithCallable(): void
+    {
+        $original = ['foo', 'bar', 'baz'];
+
+        $callbackIterator = new CallbackIterator(
+            new ArrayIterator($original),
+            [self::class, 'reverseValue']
+        );
+
+        $this->assertSame(['oof', 'rab', 'zab'], iterator_to_array($callbackIterator));
+    }
+
+    public static function reverseValue($value, $key)
+    {
+        return strrev($value);
     }
 }


### PR DESCRIPTION
PHPLIB-1184

#1059 contained some improvements to the `CallbackIterator`. These have been extracted here:

* Pass element key to the callback
* Define template for types in CallbackIterator
* Declare the expected type for the callback
* Accept any callable as callback instead of only accepting a `Closure` instance