### PR TITLE
PHPLIB-1008: Test crypt_shared with older server versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -175,7 +175,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          SKIP_LEGACY_SHELL=true MONGODB_VERSION=${MONGODB_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          SKIP_CRYPT_SHARED=${SKIP_CRYPT_SHARED} SKIP_LEGACY_SHELL=true MONGODB_VERSION=${MONGODB_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:
@@ -632,7 +632,7 @@ tasks:
             SSL: "yes"
         # Note: "stop load balancer" will be called from "post"
 
-    - name: "test-skip_crypt_shared"
+    - name: "test-csfle-crypt_shared"
       commands:
         - func: "bootstrap mongo-orchestration"
           vars:
@@ -641,7 +641,18 @@ tasks:
         - func: "set aws temp creds"
         - func: "run tests"
           vars:
+            TESTS: "csfle"
+
+    - name: "test-csfle-mongocryptd"
+      commands:
+        - func: "bootstrap mongo-orchestration"
+          vars:
+            TOPOLOGY: "replica_set"
             SKIP_CRYPT_SHARED: "yes"
+        - func: "start kms servers"
+        - func: "set aws temp creds"
+        - func: "run tests"
+          vars:
             TESTS: "csfle"
 
     - name: "test-without_aws_creds"
@@ -788,6 +799,9 @@ axes:
       - id: rhel90
         display_name: "RHEL 9.0"
         run_on: rhel90-small
+      - id: rhel80
+        display_name: "RHEL 8.0"
+        run_on: rhel80-small
 
       # Ubuntu LTS
       - id: ubuntu2204
@@ -947,14 +961,25 @@ buildvariants:
   tasks:
     - name: "test-loadBalanced"
 
-- matrix_name: "test-csfle-skip_crypt_shared"
-  matrix_spec: { "os": "debian11", "mongodb-versions": "*", "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
-  display_name: "CSFLE skip_crypt_shared - ${mongodb-versions}"
+# CSFLE tests (crypt_shared and mongocryptd) are tested on RHEL 8 as it's the only version that supports
+# 4.2 AND 6.0 (which is required for crypt_shared), as well as a somewhat relevant PHP version.
+# Newer MongoDB version may require adding different operating systems here
+- matrix_name: "test-csfle-crypt_shared"
+  matrix_spec: { "os": "rhel80", "mongodb-versions": "*", "php-versions": "8.0", "driver-versions": "latest-stable" }
+  display_name: "CSFLE crypt_shared - ${mongodb-versions}"
   exclude_spec:
-    # CSFLE crypt_shared is available from MongoDB 6.0+
-    - { "os": "debian11", "mongodb-versions": ["3.6", "4.0", "4.2", "4.4", "5.0"], "php-edge-versions": "latest-stable", "driver-versions": "latest-stable" }
+    # MongoDB < 4.2 does not need to be tested.
+    - { "os": "rhel80", "mongodb-versions": ["3.6", "4.0"], "php-versions": "8.0", "driver-versions": "latest-stable" }
   tasks:
-    - name: "test-skip_crypt_shared"
+    - name: "test-csfle-crypt_shared"
+- matrix_name: "test-csfle-mongocryptd"
+  matrix_spec: { "os": "rhel80", "mongodb-versions": "*", "php-versions": "8.0", "driver-versions": "latest-stable" }
+  display_name: "CSFLE mongocryptd - ${mongodb-versions}"
+  exclude_spec:
+    # MongoDB < 4.2 does not need to be tested.
+    - { "os": "rhel80", "mongodb-versions": ["3.6", "4.0"], "php-versions": "8.0", "driver-versions": "latest-stable" }
+  tasks:
+    - name: "test-csfle-mongocryptd"
 
 # Run CSFLE tests without AWS credentials (for "On-demand AWS Credentials" prose test)
 - matrix_name: "test-csfle-without_aws_creds"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -304,7 +304,6 @@ functions:
           MONGODB_SINGLE_MONGOS_LB_URI="${SINGLE_MONGOS_LB_URI}" \
           MONGODB_MULTI_MONGOS_LB_URI="${MULTI_MONGOS_LB_URI}" \
           PHP_VERSION=${PHP_VERSION} \
-          SKIP_CRYPT_SHARED=${SKIP_CRYPT_SHARED} \
           SSL=${SSL} \
           TESTS=${TESTS} \
           sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
@@ -352,7 +351,6 @@ functions:
 
           CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH} \
           MONGODB_URI="${SERVERLESS_URI}" \
-          SKIP_CRYPT_SHARED=${SKIP_CRYPT_SHARED} \
           TESTS="serverless" \
           sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -10,7 +10,6 @@ MONGODB_URI=${MONGODB_URI:-} # Connection string (including credentials and topo
 MONGODB_SINGLE_MONGOS_LB_URI=${MONGODB_SINGLE_MONGOS_LB_URI:-} # Single-mongos LB connection string
 MONGODB_MULTI_MONGOS_LB_URI=${MONGODB_MULTI_MONGOS_LB_URI:-} # Multi-mongos LB connection string
 MONGODB_VERSION=${MONGODB_VERSION:-} # Required if IS_MATRIX_TESTING is "true"
-SKIP_CRYPT_SHARED="${SKIP_CRYPT_SHARED:-no}" # Specify "yes" to ignore CRYPT_SHARED_LIB_PATH. Defaults to "no"
 SSL=${SSL:-no} # Specify "yes" to enable SSL. Defaults to "no"
 TESTS=${TESTS:-} # Optional test group. Defaults to all tests
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,20 @@
 <?php
 
 use MongoDB\Tests\Comparator\Int64Comparator;
+use MongoDB\Tests\TestCase;
 use SebastianBergmann\Comparator\Factory as ComparatorFactory;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 // Register custom comparators
 ComparatorFactory::getInstance()->register(new Int64Comparator());
+
+/* Ugly workaround for event system changes in PHPUnit
+ * PHPUnit 10 introduces a new event system, and at the same time removes the
+ * event system present in previous versions. This makes it near impossible to
+ * support PHPUnit 8.5 (required for PHP 7.2) and PHPUnit 9 (PHP < 8.1)
+ * alongside PHPUnit 10. For this reason, we use this bootstrap file to print
+ * test configuration summary.
+ * @todo PHP_VERSION_ID >= 80100: Remove this and use an extension
+ */
+TestCase::printConfiguration();


### PR DESCRIPTION
PHPLIB-1008

This changes CSFLE testing to not only test without crypt_shared, but to also test crypt_shared on all server versions, including those that do not ship with the shared library. For those versions, drivers-evergreen-tools downloads crypt_shared for MongoDB 6.0. This requires us to test on a platform that supports MongoDB 4.2 up to 6.0, hence the usage of RHEL 8.0 for that pipeline.

As an aside, I'm not sure if the previous tests properly tested without crypt_shared. After adding the initial commit to output some basic information about the test environment, I noticed that crypt_shared was still available. The `SKIP_CRYPT_SHARED` variable was incorrectly set in the call to "run tests", but needs to be set when starting mongo-orchestration as that function downloads crypt_shared unless asked not to do so.