### PR TITLE
PHPLIB-1118: Drop support for PHP 7.2 and 7.3

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -690,14 +690,6 @@ axes:
         display_name: "PHP 7.4"
         variables:
           PHP_VERSION: "7.4"
-      - id: "7.3"
-        display_name: "PHP 7.3"
-        variables:
-          PHP_VERSION: "7.3"
-      - id: "7.2"
-        display_name: "PHP 7.2"
-        variables:
-          PHP_VERSION: "7.2"
 
   - id: php-edge-versions
     display_name: PHP Version
@@ -707,9 +699,9 @@ axes:
         variables:
           PHP_VERSION: "8.2"
       - id: "oldest-supported"
-        display_name: "PHP 7.2"
+        display_name: "PHP 7.4"
         variables:
-          PHP_VERSION: "7.2"
+          PHP_VERSION: "7.4"
 
   - id: mongodb-versions
     display_name: MongoDB Version
@@ -898,7 +890,7 @@ buildvariants:
     # Exclude "latest-stable" PHP version for Debian 11 (see: test-mongodb-versions matrix)
     - { "os": "debian11", "mongodb-edge-versions": "latest-stable", "php-versions": "8.2", "driver-versions": "latest-stable" }
     # Exclude PHP versions older than 8.1 on RHEL 9 and Ubuntu 22.04 (OpenSSL 3 is only supported on PHP 8.1+)
-    - { "os": ["rhel90", "ubuntu2204-arm64", "ubuntu2204"], "php-versions": ["7.2", "7.3", "7.4", "8.0"], "mongodb-edge-versions": "*", "driver-versions": "*" }
+    - { "os": ["rhel90", "ubuntu2204-arm64", "ubuntu2204"], "php-versions": ["7.4", "8.0"], "mongodb-edge-versions": "*", "driver-versions": "*" }
   tasks:
     - name: "test-standalone"
     - name: "test-replica_set"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         { "name": "Jérôme Tamarelle", "email": "jerome.tamarelle@mongodb.com" }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-hash": "*",
         "ext-json": "*",
         "ext-mongodb": "^1.16.0",

--- a/examples/bulk.php
+++ b/examples/bulk.php
@@ -68,7 +68,7 @@ $collection->bulkWrite(
                 ['x' => 10], // Document
             ],
         ],
-    ]
+    ],
 );
 
 $cursor = $collection->find([]);

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -69,7 +69,7 @@ $collection->insertMany([
 
 $collection->updateMany(
     ['x' => ['$gt' => 1]],
-    ['$set' => ['y' => 1]]
+    ['$set' => ['y' => 1]],
 );
 
 $cursor = $collection->find([], ['batchSize' => 2]);

--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -16,14 +16,12 @@ require __DIR__ . '/../vendor/autoload.php';
 
 class PersistableEntry implements Persistable
 {
-    /** @var ObjectId */
-    private $id;
+    private ObjectId $id;
 
-    /** @var string */
-    public $name;
+    public string $name;
 
     /** @var array<PersistableEmail> */
-    public $emails = [];
+    public array $emails = [];
 
     public function __construct(string $name)
     {
@@ -65,11 +63,9 @@ class PersistableEntry implements Persistable
 
 class PersistableEmail implements Persistable
 {
-    /** @var string */
-    public $type;
+    public string $type;
 
-    /** @var string */
-    public $address;
+    public string $address;
 
     public function __construct(string $type, string $address)
     {

--- a/examples/typemap.php
+++ b/examples/typemap.php
@@ -16,14 +16,12 @@ require __DIR__ . '/../vendor/autoload.php';
 
 class TypeMapEntry implements Unserializable
 {
-    /** @var ObjectId */
-    private $id;
+    private ObjectId $id;
 
-    /** @var string */
-    private $name;
+    private string $name;
 
     /** @var array<TypeMapEmail> */
-    private $emails;
+    private array $emails;
 
     private function __construct()
     {
@@ -64,11 +62,9 @@ class TypeMapEntry implements Unserializable
 
 class TypeMapEmail implements Unserializable
 {
-    /** @var string */
-    private $type;
+    private string $type;
 
-    /** @var string */
-    private $address;
+    private string $address;
 
     private function __construct()
     {

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -37,13 +37,13 @@ $insertData = function (Session $session) use ($collection): void {
             ['x' => 2],
             ['x' => 3],
         ],
-        ['session' => $session]
+        ['session' => $session],
     );
 
     $collection->updateMany(
         ['x' => ['$gt' => 1]],
         ['$set' => ['y' => 1]],
-        ['session' => $session]
+        ['session' => $session],
     );
 };
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -152,9 +152,6 @@
     <!-- *********************************************************** -->
     <!-- Require native type hints for all code without a BC promise -->
     <!-- *********************************************************** -->
-    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
-        <exclude-pattern>src</exclude-pattern>
-    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
         <exclude-pattern>src</exclude-pattern>
     </rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,7 +17,7 @@
     <file>rector.php</file>
 
     <!-- Target minimum supported PHP version -->
-    <config name="php_version" value="70200"/>
+    <config name="php_version" value="70400"/>
 
     <!-- ****************************************** -->
     <!-- Import rules from doctrine/coding-standard -->
@@ -112,8 +112,6 @@
 
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
         <properties>
-            <!-- Requires PHP 7.4 -->
-            <property name="enableNativeTypeHint" value="false" />
             <!-- Requires PHP 8.0 -->
             <property name="enableMixedTypeHint" value="false" />
             <!-- Requires PHP 8.0 -->

--- a/rector.php
+++ b/rector.php
@@ -15,7 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     // Modernize code
-    $rectorConfig->sets([LevelSetList::UP_TO_PHP_72]);
+    $rectorConfig->sets([LevelSetList::UP_TO_PHP_74]);
 
     $rectorConfig->skip([
         // Falsely detect unassigned variables in code paths stopped by PHPUnit\Framework\Assert::markTestSkipped()

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -25,6 +26,10 @@ return static function (RectorConfig $rectorConfig): void {
         // @see https://github.com/phpstan/phpstan-src/pull/2429
         RemoveExtraParametersRector::class => [
             __DIR__ . '/src/Operation/',
+        ],
+        // Assigns wrong type due to outdated PHPStan stubs
+        TypedPropertyFromAssignsRector::class => [
+            __DIR__ . '/src/Model/BSONIterator.php',
         ],
     ]);
 

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php56\Rector\FunctionLike\AddDefaultValueForUndefinedVariableRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 
@@ -30,6 +31,10 @@ return static function (RectorConfig $rectorConfig): void {
         // Assigns wrong type due to outdated PHPStan stubs
         TypedPropertyFromAssignsRector::class => [
             __DIR__ . '/src/Model/BSONIterator.php',
+        ],
+        // Not necessary in documentation examples
+        JsonThrowOnErrorRector::class => [
+            __DIR__ . '/tests/DocumentationExamplesTest.php',
         ],
     ]);
 

--- a/src/BulkWriteResult.php
+++ b/src/BulkWriteResult.php
@@ -25,14 +25,11 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class BulkWriteResult
 {
-    /** @var WriteResult */
-    private $writeResult;
+    private WriteResult $writeResult;
 
-    /** @var array */
-    private $insertedIds;
+    private array $insertedIds;
 
-    /** @var boolean */
-    private $isAcknowledged;
+    private bool $isAcknowledged;
 
     public function __construct(WriteResult $writeResult, array $insertedIds)
     {

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -74,16 +74,13 @@ class ChangeStream implements Iterator
     /** @var ChangeStreamIterator */
     private $iterator;
 
-    /** @var integer */
-    private $key = 0;
+    private int $key = 0;
 
     /**
      * Whether the change stream has advanced to its first result. This is used
      * to determine whether $key should be incremented after an iteration event.
-     *
-     * @var boolean
      */
-    private $hasAdvanced = false;
+    private bool $hasAdvanced = false;
 
     /**
      * @internal

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -71,8 +71,7 @@ class ChangeStream implements Iterator
     /** @var ResumeCallable|null */
     private $resumeCallable;
 
-    /** @var ChangeStreamIterator */
-    private $iterator;
+    private ChangeStreamIterator $iterator;
 
     private int $key = 0;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -54,26 +54,19 @@ class Client
 
     private const HANDSHAKE_SEPARATOR = '/';
 
-    /** @var string|null */
-    private static $version;
+    private static ?string $version = null;
 
-    /** @var Manager */
-    private $manager;
+    private Manager $manager;
 
-    /** @var ReadConcern */
-    private $readConcern;
+    private ReadConcern $readConcern;
 
-    /** @var ReadPreference */
-    private $readPreference;
+    private ReadPreference $readPreference;
 
-    /** @var string */
-    private $uri;
+    private string $uri;
 
-    /** @var array */
-    private $typeMap;
+    private array $typeMap;
 
-    /** @var WriteConcern */
-    private $writeConcern;
+    private WriteConcern $writeConcern;
 
     /**
      * Constructs a new Client instance.

--- a/src/Codec/CodecLibrary.php
+++ b/src/Codec/CodecLibrary.php
@@ -25,11 +25,11 @@ class CodecLibrary implements Codec
     use DecodeIfSupported;
     use EncodeIfSupported;
 
-    /** @var array<Decoder> */
-    private $decoders = [];
+    /** @var list<Decoder> */
+    private array $decoders = [];
 
-    /** @var array<Encoder> */
-    private $encoders = [];
+    /** @var list<Encoder> */
+    private array $encoders = [];
 
     /** @param Decoder|Encoder $items */
     public function __construct(...$items)

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -83,17 +83,13 @@ class Collection
 
     private Manager $manager;
 
-    /** @var ReadConcern */
-    private $readConcern;
+    private ReadConcern $readConcern;
 
-    /** @var ReadPreference */
-    private $readPreference;
+    private ReadPreference $readPreference;
 
-    /** @var array */
-    private $typeMap;
+    private array $typeMap;
 
-    /** @var WriteConcern */
-    private $writeConcern;
+    private WriteConcern $writeConcern;
 
     /**
      * Constructs new Collection instance.

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -77,14 +77,11 @@ class Collection
 
     private const WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE = 8;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var Manager */
-    private $manager;
+    private Manager $manager;
 
     /** @var ReadConcern */
     private $readConcern;

--- a/src/Command/ListCollections.php
+++ b/src/Command/ListCollections.php
@@ -37,11 +37,9 @@ use function MongoDB\is_document;
  */
 class ListCollections implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a listCollections command.

--- a/src/Command/ListDatabases.php
+++ b/src/Command/ListDatabases.php
@@ -39,8 +39,7 @@ use function MongoDB\is_document;
  */
 class ListDatabases implements Executable
 {
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a listDatabases command.

--- a/src/Database.php
+++ b/src/Database.php
@@ -65,17 +65,13 @@ class Database
 
     private Manager $manager;
 
-    /** @var ReadConcern */
-    private $readConcern;
+    private ReadConcern $readConcern;
 
-    /** @var ReadPreference */
-    private $readPreference;
+    private ReadPreference $readPreference;
 
-    /** @var array */
-    private $typeMap;
+    private array $typeMap;
 
-    /** @var WriteConcern */
-    private $writeConcern;
+    private WriteConcern $writeConcern;
 
     /**
      * Constructs new Database instance.

--- a/src/Database.php
+++ b/src/Database.php
@@ -61,11 +61,9 @@ class Database
 
     private const WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE = 8;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var Manager */
-    private $manager;
+    private Manager $manager;
 
     /** @var ReadConcern */
     private $readConcern;

--- a/src/DeleteResult.php
+++ b/src/DeleteResult.php
@@ -25,11 +25,9 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class DeleteResult
 {
-    /** @var WriteResult */
-    private $writeResult;
+    private WriteResult $writeResult;
 
-    /** @var boolean */
-    private $isAcknowledged;
+    private bool $isAcknowledged;
 
     public function __construct(WriteResult $writeResult)
     {

--- a/src/Exception/CreateEncryptedCollectionException.php
+++ b/src/Exception/CreateEncryptedCollectionException.php
@@ -28,8 +28,7 @@ use function sprintf;
  */
 final class CreateEncryptedCollectionException extends RuntimeException
 {
-    /** @var array */
-    private $encryptedFields;
+    private array $encryptedFields;
 
     public function __construct(Throwable $previous, array $encryptedFields)
     {

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -74,23 +74,17 @@ class Bucket
 
     private const STREAM_WRAPPER_PROTOCOL = 'gridfs';
 
-    /** @var CollectionWrapper */
-    private $collectionWrapper;
+    private CollectionWrapper $collectionWrapper;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var Manager */
-    private $manager;
+    private Manager $manager;
 
-    /** @var string */
-    private $bucketName;
+    private string $bucketName;
 
-    /** @var boolean */
-    private $disableMD5;
+    private bool $disableMD5;
 
-    /** @var integer */
-    private $chunkSizeBytes;
+    private int $chunkSizeBytes;
 
     /** @var ReadConcern */
     private $readConcern;
@@ -654,7 +648,7 @@ class Bucket
             self::STREAM_WRAPPER_PROTOCOL,
             urlencode($this->databaseName),
             urlencode($this->bucketName),
-            urlencode($id)
+            urlencode($id),
         );
     }
 
@@ -667,7 +661,7 @@ class Bucket
             '%s://%s/%s.files',
             self::STREAM_WRAPPER_PROTOCOL,
             urlencode($this->databaseName),
-            urlencode($this->bucketName)
+            urlencode($this->bucketName),
         );
     }
 

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -86,17 +86,13 @@ class Bucket
 
     private int $chunkSizeBytes;
 
-    /** @var ReadConcern */
-    private $readConcern;
+    private ReadConcern $readConcern;
 
-    /** @var ReadPreference */
-    private $readPreference;
+    private ReadPreference $readPreference;
 
-    /** @var array */
-    private $typeMap;
+    private array $typeMap;
 
-    /** @var WriteConcern */
-    private $writeConcern;
+    private WriteConcern $writeConcern;
 
     /**
      * Constructs a GridFS bucket.

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -40,20 +40,15 @@ use function sprintf;
  */
 class CollectionWrapper
 {
-    /** @var string */
-    private $bucketName;
+    private string $bucketName;
 
-    /** @var Collection */
-    private $chunksCollection;
+    private Collection $chunksCollection;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var boolean */
-    private $checkedIndexes = false;
+    private bool $checkedIndexes = false;
 
-    /** @var Collection */
-    private $filesCollection;
+    private Collection $filesCollection;
 
     /**
      * Constructs a GridFS collection wrapper.
@@ -120,7 +115,7 @@ class CollectionWrapper
             [
                 'sort' => ['n' => 1],
                 'typeMap' => ['root' => 'stdClass'],
-            ]
+            ],
         );
     }
 
@@ -158,7 +153,7 @@ class CollectionWrapper
                 'skip' => $skip,
                 'sort' => ['uploadDate' => $sortOrder],
                 'typeMap' => ['root' => 'stdClass'],
-            ]
+            ],
         );
         assert(is_object($file) || $file === null);
 
@@ -174,7 +169,7 @@ class CollectionWrapper
     {
         $file = $this->filesCollection->findOne(
             ['_id' => $id],
-            ['typeMap' => ['root' => 'stdClass']]
+            ['typeMap' => ['root' => 'stdClass']],
         );
         assert(is_object($file) || $file === null);
 
@@ -265,7 +260,7 @@ class CollectionWrapper
     {
         return $this->filesCollection->updateOne(
             ['_id' => $id],
-            ['$set' => ['filename' => $filename]]
+            ['$set' => ['filename' => $filename]],
         );
     }
 

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -39,35 +39,25 @@ use function substr;
  */
 class ReadableStream
 {
-    /** @var string|null */
-    private $buffer;
+    private ?string $buffer = null;
 
-    /** @var integer */
-    private $bufferOffset = 0;
+    private int $bufferOffset = 0;
 
-    /** @var integer */
-    private $chunkSize;
+    private int $chunkSize;
 
-    /** @var integer */
-    private $chunkOffset = 0;
+    private int $chunkOffset = 0;
 
-    /** @var Cursor|null */
-    private $chunksIterator;
+    private ?Cursor $chunksIterator = null;
 
-    /** @var CollectionWrapper */
-    private $collectionWrapper;
+    private CollectionWrapper $collectionWrapper;
 
-    /** @var integer */
-    private $expectedLastChunkSize = 0;
+    private int $expectedLastChunkSize = 0;
 
-    /** @var object */
-    private $file;
+    private object $file;
 
-    /** @var integer */
-    private $length;
+    private int $length;
 
-    /** @var integer */
-    private $numChunks = 0;
+    private int $numChunks = 0;
 
     /**
      * Constructs a readable GridFS stream.

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -46,8 +46,7 @@ class StreamWrapper
     /** @var resource|null Stream context (set by PHP) */
     public $context;
 
-    /** @var string|null */
-    private $protocol;
+    private ?string $protocol = null;
 
     /** @var ReadableStream|WritableStream|null */
     private $stream;
@@ -298,7 +297,7 @@ class StreamWrapper
         assert($this->protocol !== null);
         $this->stream = new ReadableStream(
             $context[$this->protocol]['collectionWrapper'],
-            $context[$this->protocol]['file']
+            $context[$this->protocol]['file'],
         );
 
         return true;
@@ -318,7 +317,7 @@ class StreamWrapper
         $this->stream = new WritableStream(
             $context[$this->protocol]['collectionWrapper'],
             $context[$this->protocol]['filename'],
-            $context[$this->protocol]['options']
+            $context[$this->protocol]['options'],
         );
 
         return true;

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -46,32 +46,23 @@ class WritableStream
 {
     private const DEFAULT_CHUNK_SIZE_BYTES = 261120;
 
-    /** @var string */
-    private $buffer = '';
+    private string $buffer = '';
 
-    /** @var integer */
-    private $chunkOffset = 0;
+    private int $chunkOffset = 0;
 
-    /** @var integer */
-    private $chunkSize;
+    private int $chunkSize;
 
-    /** @var boolean */
-    private $disableMD5;
+    private bool $disableMD5;
 
-    /** @var CollectionWrapper */
-    private $collectionWrapper;
+    private CollectionWrapper $collectionWrapper;
 
-    /** @var array */
-    private $file;
+    private array $file;
 
-    /** @var HashContext|null */
-    private $hashCtx;
+    private ?HashContext $hashCtx = null;
 
-    /** @var boolean */
-    private $isClosed = false;
+    private bool $isClosed = false;
 
-    /** @var integer */
-    private $length = 0;
+    private int $length = 0;
 
     /**
      * Constructs a writable GridFS stream.

--- a/src/InsertManyResult.php
+++ b/src/InsertManyResult.php
@@ -25,14 +25,11 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class InsertManyResult
 {
-    /** @var WriteResult */
-    private $writeResult;
+    private WriteResult $writeResult;
 
-    /** @var array */
-    private $insertedIds;
+    private array $insertedIds;
 
-    /** @var boolean */
-    private $isAcknowledged;
+    private bool $isAcknowledged;
 
     public function __construct(WriteResult $writeResult, array $insertedIds)
     {

--- a/src/InsertOneResult.php
+++ b/src/InsertOneResult.php
@@ -25,14 +25,12 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class InsertOneResult
 {
-    /** @var WriteResult */
-    private $writeResult;
+    private WriteResult $writeResult;
 
     /** @var mixed */
     private $insertedId;
 
-    /** @var boolean */
-    private $isAcknowledged;
+    private bool $isAcknowledged;
 
     /** @param mixed $insertedId */
     public function __construct(WriteResult $writeResult, $insertedId)

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -41,11 +41,9 @@ class MapReduceResult implements IteratorAggregate
 
     private int $executionTimeMS;
 
-    /** @var array */
-    private $counts;
+    private array $counts;
 
-    /** @var array */
-    private $timing;
+    private array $timing;
 
     /**
      * @internal

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -39,8 +39,7 @@ class MapReduceResult implements IteratorAggregate
     /** @var callable */
     private $getIterator;
 
-    /** @var integer */
-    private $executionTimeMS;
+    private int $executionTimeMS;
 
     /** @var array */
     private $counts;

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -36,23 +36,18 @@ class BSONIterator implements Iterator
 {
     private const BSON_SIZE = 4;
 
-    /** @var string */
-    private $buffer;
+    private string $buffer;
 
-    /** @var integer */
-    private $bufferLength;
+    private int $bufferLength;
 
-    /** @var mixed */
-    private $current;
+    /** @var array|object|null */
+    private $current = null;
 
-    /** @var integer */
-    private $key = 0;
+    private int $key = 0;
 
-    /** @var integer */
-    private $position = 0;
+    private int $position = 0;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a BSON Iterator.

--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -42,17 +42,13 @@ class CachingIterator implements Countable, Iterator
     private const FIELD_KEY = 0;
     private const FIELD_VALUE = 1;
 
-    /** @var array */
-    private $items = [];
+    private array $items = [];
 
-    /** @var Iterator */
-    private $iterator;
+    private Iterator $iterator;
 
-    /** @var boolean */
-    private $iteratorAdvanced = false;
+    private bool $iteratorAdvanced = false;
 
-    /** @var boolean */
-    private $iteratorExhausted = false;
+    private bool $iteratorExhausted = false;
 
     /**
      * Initialize the iterator and stores the first item in the cache. This

--- a/src/Model/CallbackIterator.php
+++ b/src/Model/CallbackIterator.php
@@ -40,7 +40,7 @@ class CallbackIterator implements Iterator
     private $callback;
 
     /** @var Iterator<TKey, TValue> */
-    private $iterator;
+    private Iterator $iterator;
 
     /**
      * @param Traversable<TKey, TValue>              $traversable

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -49,26 +49,20 @@ use function MongoDB\is_document;
  */
 class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 {
-    /** @var integer */
-    private $batchPosition = 0;
+    private int $batchPosition = 0;
 
-    /** @var integer */
-    private $batchSize;
+    private int $batchSize;
 
-    /** @var boolean */
-    private $isRewindNop;
+    private bool $isRewindNop;
 
-    /** @var boolean */
-    private $isValid = false;
+    private bool $isValid = false;
 
-    /** @var object|null */
-    private $postBatchResumeToken;
+    private ?object $postBatchResumeToken = null;
 
     /** @var array|object|null */
     private $resumeToken;
 
-    /** @var Server */
-    private $server;
+    private Server $server;
 
     /**
      * @internal

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -35,8 +35,7 @@ use function array_key_exists;
  */
 class CollectionInfo implements ArrayAccess
 {
-    /** @var array */
-    private $info;
+    private array $info;
 
     /** @param array $info Collection info */
     public function __construct(array $info)

--- a/src/Model/CollectionInfoCommandIterator.php
+++ b/src/Model/CollectionInfoCommandIterator.php
@@ -33,8 +33,7 @@ use Traversable;
  */
 class CollectionInfoCommandIterator extends IteratorIterator implements CollectionInfoIterator
 {
-    /** @var string|null */
-    private $databaseName;
+    private ?string $databaseName = null;
 
     public function __construct(Traversable $iterator, ?string $databaseName = null)
     {

--- a/src/Model/DatabaseInfo.php
+++ b/src/Model/DatabaseInfo.php
@@ -34,8 +34,7 @@ use function array_key_exists;
  */
 class DatabaseInfo implements ArrayAccess
 {
-    /** @var array */
-    private $info;
+    private array $info;
 
     /** @param array $info Database info */
     public function __construct(array $info)

--- a/src/Model/DatabaseInfoLegacyIterator.php
+++ b/src/Model/DatabaseInfoLegacyIterator.php
@@ -34,8 +34,7 @@ use function reset;
  */
 class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
 {
-    /** @var array */
-    private $databases;
+    private array $databases;
 
     public function __construct(array $databases)
     {

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -43,8 +43,7 @@ use const E_USER_DEPRECATED;
  */
 class IndexInfo implements ArrayAccess
 {
-    /** @var array */
-    private $info;
+    private array $info;
 
     /** @param array $info Index info */
     public function __construct(array $info)

--- a/src/Model/IndexInfoIteratorIterator.php
+++ b/src/Model/IndexInfoIteratorIterator.php
@@ -37,8 +37,7 @@ use function array_key_exists;
  */
 class IndexInfoIteratorIterator extends IteratorIterator implements IndexInfoIterator
 {
-    /** @var string|null $ns */
-    private $ns;
+    private ?string $ns = null;
 
     public function __construct(Traversable $iterator, ?string $ns = null)
     {

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -39,8 +39,7 @@ use function sprintf;
  */
 class IndexInput implements Serializable
 {
-    /** @var array */
-    private $index;
+    private array $index;
 
     /**
      * @param array $index Index specification

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -50,23 +50,17 @@ use function MongoDB\is_pipeline;
  */
 class Aggregate implements Executable, Explainable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string|null */
-    private $collectionName;
+    private ?string $collectionName = null;
 
-    /** @var array */
-    private $pipeline;
+    private array $pipeline;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
-    /** @var bool */
-    private $isExplain;
+    private bool $isExplain;
 
-    /** @var bool */
-    private $isWrite;
+    private bool $isWrite;
 
     /**
      * Constructs an aggregate command.
@@ -267,7 +261,7 @@ class Aggregate implements Executable, Explainable
 
         $command = new Command(
             $this->createCommandDocument(),
-            $this->createCommandOptions()
+            $this->createCommandOptions(),
         );
 
         $cursor = $this->executeCommand($server, $command);

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -52,17 +52,14 @@ class BulkWrite implements Executable
     public const UPDATE_MANY = 'updateMany';
     public const UPDATE_ONE  = 'updateOne';
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
     /** @var array[] */
-    private $operations;
+    private array $operations;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a bulk write operation.

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -43,17 +43,14 @@ use function MongoDB\is_document;
  */
 class Count implements Executable, Explainable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
     /** @var array|object */
     private $filter;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a count command.

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -41,23 +41,18 @@ use function MongoDB\is_document;
  */
 class CountDocuments implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
     /** @var array|object */
     private $filter;
 
-    /** @var array */
-    private $aggregateOptions;
+    private array $aggregateOptions;
 
-    /** @var array */
-    private $countOptions;
+    private array $countOptions;
 
-    /** @var Aggregate */
-    private $aggregate;
+    private Aggregate $aggregate;
 
     /**
      * Constructs an aggregate command for counting documents

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -46,14 +46,11 @@ class CreateCollection implements Executable
     public const USE_POWER_OF_2_SIZES = 1;
     public const NO_PADDING = 2;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var array */
-    private $options = [];
+    private array $options = [];
 
     /**
      * Constructs a create command.

--- a/src/Operation/CreateEncryptedCollection.php
+++ b/src/Operation/CreateEncryptedCollection.php
@@ -54,7 +54,7 @@ class CreateEncryptedCollection implements Executable
 
     private CreateCollection $createCollection;
 
-    /** @var CreateCollection[] */
+    /** @var list<CreateCollection> */
     private array $createMetadataCollections;
 
     private CreateIndexes $createSafeContentIndex;

--- a/src/Operation/CreateEncryptedCollection.php
+++ b/src/Operation/CreateEncryptedCollection.php
@@ -52,23 +52,18 @@ class CreateEncryptedCollection implements Executable
 {
     private const WIRE_VERSION_FOR_QUERYABLE_ENCRYPTION_V2 = 21;
 
-    /** @var CreateCollection */
-    private $createCollection;
+    private CreateCollection $createCollection;
 
     /** @var CreateCollection[] */
-    private $createMetadataCollections;
+    private array $createMetadataCollections;
 
-    /** @var CreateIndexes */
-    private $createSafeContentIndex;
+    private CreateIndexes $createSafeContentIndex;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * @see CreateCollection::__construct() for supported options

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -45,17 +45,13 @@ class CreateIndexes implements Executable
 {
     private const WIRE_VERSION_FOR_COMMIT_QUORUM = 9;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var array */
-    private $indexes = [];
+    private array $indexes = [];
 
-    /** @var array */
-    private $options = [];
+    private array $options = [];
 
     /**
      * Constructs a createIndexes command.
@@ -143,9 +139,10 @@ class CreateIndexes implements Executable
 
         $this->executeCommand($server);
 
-        return array_map(function (IndexInput $index) {
-            return (string) $index;
-        }, $this->indexes);
+        return array_map(
+            fn (IndexInput $index): string => (string) $index,
+            $this->indexes,
+        );
     }
 
     /**

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -49,6 +49,7 @@ class CreateIndexes implements Executable
 
     private string $collectionName;
 
+    /** @var list<IndexInput> */
     private array $indexes = [];
 
     private array $options = [];
@@ -140,7 +141,7 @@ class CreateIndexes implements Executable
         $this->executeCommand($server);
 
         return array_map(
-            fn (IndexInput $index): string => (string) $index,
+            'strval',
             $this->indexes,
         );
     }

--- a/src/Operation/DatabaseCommand.php
+++ b/src/Operation/DatabaseCommand.php
@@ -34,14 +34,11 @@ use function MongoDB\is_document;
  */
 class DatabaseCommand implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var Command */
-    private $command;
+    private Command $command;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a command.

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -46,20 +46,16 @@ class Delete implements Executable, Explainable
 {
     private const WIRE_VERSION_FOR_HINT = 9;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
     /** @var array|object */
     private $filter;
 
-    /** @var integer */
-    private $limit;
+    private int $limit;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a delete command.

--- a/src/Operation/DeleteMany.php
+++ b/src/Operation/DeleteMany.php
@@ -31,8 +31,7 @@ use MongoDB\Exception\UnsupportedException;
  */
 class DeleteMany implements Executable, Explainable
 {
-    /** @var Delete */
-    private $delete;
+    private Delete $delete;
 
     /**
      * Constructs a delete command.

--- a/src/Operation/DeleteOne.php
+++ b/src/Operation/DeleteOne.php
@@ -31,8 +31,7 @@ use MongoDB\Exception\UnsupportedException;
  */
 class DeleteOne implements Executable, Explainable
 {
-    /** @var Delete */
-    private $delete;
+    private Delete $delete;
 
     /**
      * Constructs a delete command.

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -42,20 +42,16 @@ use function MongoDB\is_document;
  */
 class Distinct implements Executable, Explainable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var string */
-    private $fieldName;
+    private string $fieldName;
 
     /** @var array|object */
     private $filter;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a distinct command.

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -40,14 +40,11 @@ class DropCollection implements Executable
 {
     private const ERROR_CODE_NAMESPACE_NOT_FOUND = 26;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a drop command.

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -36,11 +36,9 @@ use function is_array;
  */
 class DropDatabase implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a dropDatabase command.

--- a/src/Operation/DropEncryptedCollection.php
+++ b/src/Operation/DropEncryptedCollection.php
@@ -41,7 +41,7 @@ class DropEncryptedCollection implements Executable
 {
     private DropCollection $dropCollection;
 
-    /** @var DropCollection[] */
+    /** @var list<DropCollection> */
     private array $dropMetadataCollections;
 
     /**

--- a/src/Operation/DropEncryptedCollection.php
+++ b/src/Operation/DropEncryptedCollection.php
@@ -39,11 +39,10 @@ use function MongoDB\is_document;
  */
 class DropEncryptedCollection implements Executable
 {
-    /** @var DropCollection */
-    private $dropCollection;
+    private DropCollection $dropCollection;
 
     /** @var DropCollection[] */
-    private $dropMetadataCollections;
+    private array $dropMetadataCollections;
 
     /**
      * Constructs an operation to drop an encrypted collection and its related

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -37,17 +37,13 @@ use function is_integer;
  */
 class DropIndexes implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var string */
-    private $indexName;
+    private string $indexName;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a dropIndexes command.

--- a/src/Operation/EstimatedDocumentCount.php
+++ b/src/Operation/EstimatedDocumentCount.php
@@ -37,14 +37,11 @@ use function is_integer;
  */
 class EstimatedDocumentCount implements Executable, Explainable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a command to get the estimated number of documents in a

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -44,14 +44,11 @@ class Explain implements Executable
 
     private const WIRE_VERSION_FOR_AGGREGATE = 7;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var Explainable */
-    private $explainable;
+    private Explainable $explainable;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs an explain command for explainable operations.

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -51,17 +51,14 @@ class Find implements Executable, Explainable
     public const TAILABLE = 2;
     public const TAILABLE_AWAIT = 3;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
     /** @var array|object */
     private $filter;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a find command.

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -54,14 +54,11 @@ class FindAndModify implements Executable, Explainable
 
     private const WIRE_VERSION_FOR_UNSUPPORTED_OPTION_SERVER_SIDE_ERROR = 8;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a findAndModify command.

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -33,8 +33,7 @@ use function current;
  */
 class FindOne implements Executable, Explainable
 {
-    /** @var Find */
-    private $find;
+    private Find $find;
 
     /**
      * Constructs a find command for finding a single document.
@@ -108,7 +107,7 @@ class FindOne implements Executable, Explainable
             $databaseName,
             $collectionName,
             $filter,
-            ['limit' => 1] + $options
+            ['limit' => 1] + $options,
         );
     }
 

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -32,8 +32,7 @@ use function MongoDB\is_document;
  */
 class FindOneAndDelete implements Executable, Explainable
 {
-    /** @var FindAndModify */
-    private $findAndModify;
+    private FindAndModify $findAndModify;
 
     /**
      * Constructs a findAndModify command for deleting a document.
@@ -98,7 +97,7 @@ class FindOneAndDelete implements Executable, Explainable
         $this->findAndModify = new FindAndModify(
             $databaseName,
             $collectionName,
-            ['query' => $filter, 'remove' => true] + $options
+            ['query' => $filter, 'remove' => true] + $options,
         );
     }
 

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -39,8 +39,7 @@ class FindOneAndReplace implements Executable, Explainable
     public const RETURN_DOCUMENT_BEFORE = 1;
     public const RETURN_DOCUMENT_AFTER = 2;
 
-    /** @var FindAndModify */
-    private $findAndModify;
+    private FindAndModify $findAndModify;
 
     /**
      * Constructs a findAndModify command for replacing a document.
@@ -151,7 +150,7 @@ class FindOneAndReplace implements Executable, Explainable
         $this->findAndModify = new FindAndModify(
             $databaseName,
             $collectionName,
-            ['query' => $filter, 'update' => $replacement] + $options
+            ['query' => $filter, 'update' => $replacement] + $options,
         );
     }
 

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -41,8 +41,7 @@ class FindOneAndUpdate implements Executable, Explainable
     public const RETURN_DOCUMENT_BEFORE = 1;
     public const RETURN_DOCUMENT_AFTER = 2;
 
-    /** @var FindAndModify */
-    private $findAndModify;
+    private FindAndModify $findAndModify;
 
     /**
      * Constructs a findAndModify command for updating a document.
@@ -147,7 +146,7 @@ class FindOneAndUpdate implements Executable, Explainable
         $this->findAndModify = new FindAndModify(
             $databaseName,
             $collectionName,
-            ['query' => $filter, 'update' => $update] + $options
+            ['query' => $filter, 'update' => $update] + $options,
         );
     }
 

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -43,7 +43,7 @@ class InsertMany implements Executable
 
     private string $collectionName;
 
-    /** @var object[]|array[] */
+    /** @var list<object>|list<array> */
     private array $documents;
 
     private array $options;

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -43,7 +43,7 @@ class InsertMany implements Executable
 
     private string $collectionName;
 
-    /** @var list<object>|list<array> */
+    /** @var list<object|array> */
     private array $documents;
 
     private array $options;

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -39,17 +39,14 @@ use function sprintf;
  */
 class InsertMany implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
     /** @var object[]|array[] */
-    private $documents;
+    private array $documents;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs an insert command.

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -37,17 +37,14 @@ use function MongoDB\is_document;
  */
 class InsertOne implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
     /** @var array|object */
     private $document;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs an insert command.

--- a/src/Operation/ListCollectionNames.php
+++ b/src/Operation/ListCollectionNames.php
@@ -32,8 +32,7 @@ use MongoDB\Model\CallbackIterator;
  */
 class ListCollectionNames implements Executable
 {
-    /** @var ListCollectionsCommand */
-    private $listCollections;
+    private ListCollectionsCommand $listCollections;
 
     /**
      * Constructs a listCollections command.
@@ -76,9 +75,7 @@ class ListCollectionNames implements Executable
     {
         return new CallbackIterator(
             $this->listCollections->execute($server),
-            function (array $collectionInfo) {
-                return $collectionInfo['name'];
-            }
+            fn (array $collectionInfo): string => (string) $collectionInfo['name']
         );
     }
 }

--- a/src/Operation/ListCollectionNames.php
+++ b/src/Operation/ListCollectionNames.php
@@ -75,7 +75,7 @@ class ListCollectionNames implements Executable
     {
         return new CallbackIterator(
             $this->listCollections->execute($server),
-            fn (array $collectionInfo): string => (string) $collectionInfo['name']
+            fn (array $collectionInfo): string => (string) $collectionInfo['name'],
         );
     }
 }

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -32,11 +32,9 @@ use MongoDB\Model\CollectionInfoIterator;
  */
 class ListCollections implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var ListCollectionsCommand */
-    private $listCollections;
+    private ListCollectionsCommand $listCollections;
 
     /**
      * Constructs a listCollections command.

--- a/src/Operation/ListDatabaseNames.php
+++ b/src/Operation/ListDatabaseNames.php
@@ -35,8 +35,7 @@ use function array_column;
  */
 class ListDatabaseNames implements Executable
 {
-    /** @var ListDatabasesCommand */
-    private $listDatabases;
+    private ListDatabasesCommand $listDatabases;
 
     /**
      * Constructs a listDatabases command.

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -33,8 +33,7 @@ use MongoDB\Model\DatabaseInfoLegacyIterator;
  */
 class ListDatabases implements Executable
 {
-    /** @var ListDatabasesCommand */
-    private $listDatabases;
+    private ListDatabasesCommand $listDatabases;
 
     /**
      * Constructs a listDatabases command.

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -41,14 +41,11 @@ class ListIndexes implements Executable
     private const ERROR_CODE_DATABASE_NOT_FOUND = 60;
     private const ERROR_CODE_NAMESPACE_NOT_FOUND = 26;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a listIndexes command.

--- a/src/Operation/MapReduce.php
+++ b/src/Operation/MapReduce.php
@@ -55,23 +55,18 @@ use const E_USER_DEPRECATED;
  */
 class MapReduce implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var JavascriptInterface */
-    private $map;
+    private JavascriptInterface $map;
 
-    /** @var JavascriptInterface */
-    private $reduce;
+    private JavascriptInterface $reduce;
 
     /** @var array|object|string */
     private $out;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a mapReduce command.
@@ -366,9 +361,7 @@ class MapReduce implements Executable
         if (isset($result->results) && is_array($result->results)) {
             $results = $result->results;
 
-            return function () use ($results) {
-                return new ArrayIterator($results);
-            };
+            return fn () => new ArrayIterator($results);
         }
 
         if (isset($result->result) && (is_string($result->result) || is_object($result->result))) {
@@ -378,9 +371,7 @@ class MapReduce implements Executable
                 ? new Find($this->databaseName, $result->result, [], $options)
                 : new Find($result->result->db, $result->result->collection, [], $options);
 
-            return function () use ($find, $server) {
-                return $find->execute($server);
-            };
+            return fn () => $find->execute($server);
         }
 
         throw new UnexpectedValueException('mapReduce command did not return inline results or an output collection');

--- a/src/Operation/ModifyCollection.php
+++ b/src/Operation/ModifyCollection.php
@@ -35,17 +35,13 @@ use function is_array;
  */
 class ModifyCollection implements Executable
 {
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var array */
-    private $collectionOptions;
+    private array $collectionOptions;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a collMod command.

--- a/src/Operation/RenameCollection.php
+++ b/src/Operation/RenameCollection.php
@@ -38,14 +38,11 @@ use function is_bool;
  */
 class RenameCollection implements Executable
 {
-    /** @var string */
-    private $fromNamespace;
+    private string $fromNamespace;
 
-    /** @var string */
-    private $toNamespace;
+    private string $toNamespace;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a renameCollection command.

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -35,8 +35,7 @@ use function MongoDB\is_pipeline;
  */
 class ReplaceOne implements Executable
 {
-    /** @var Update */
-    private $update;
+    private Update $update;
 
     /**
      * Constructs an update command.
@@ -102,7 +101,7 @@ class ReplaceOne implements Executable
             $collectionName,
             $filter,
             $replacement,
-            ['multi' => false] + $options
+            ['multi' => false] + $options,
         );
     }
 

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -49,11 +49,9 @@ class Update implements Executable, Explainable
 {
     private const WIRE_VERSION_FOR_HINT = 8;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
     /** @var array|object */
     private $filter;
@@ -61,8 +59,7 @@ class Update implements Executable, Explainable
     /** @var array|object */
     private $update;
 
-    /** @var array */
-    private $options;
+    private array $options;
 
     /**
      * Constructs a update command.

--- a/src/Operation/UpdateMany.php
+++ b/src/Operation/UpdateMany.php
@@ -36,8 +36,7 @@ use function MongoDB\is_pipeline;
  */
 class UpdateMany implements Executable, Explainable
 {
-    /** @var Update */
-    private $update;
+    private Update $update;
 
     /**
      * Constructs an update command.
@@ -97,7 +96,7 @@ class UpdateMany implements Executable, Explainable
             $collectionName,
             $filter,
             $update,
-            ['multi' => true] + $options
+            ['multi' => true] + $options,
         );
     }
 

--- a/src/Operation/UpdateOne.php
+++ b/src/Operation/UpdateOne.php
@@ -36,8 +36,7 @@ use function MongoDB\is_pipeline;
  */
 class UpdateOne implements Executable, Explainable
 {
-    /** @var Update */
-    private $update;
+    private Update $update;
 
     /**
      * Constructs an update command.
@@ -97,7 +96,7 @@ class UpdateOne implements Executable, Explainable
             $collectionName,
             $filter,
             $update,
-            ['multi' => false] + $options
+            ['multi' => false] + $options,
         );
     }
 

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -72,11 +72,9 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
 
     private Aggregate $aggregate;
 
-    /** @var array */
-    private $aggregateOptions;
+    private array $aggregateOptions;
 
-    /** @var array */
-    private $changeStreamOptions;
+    private array $changeStreamOptions;
 
     private ?string $collectionName = null;
 

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -70,8 +70,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
 
     private const WIRE_VERSION_FOR_START_AT_OPERATION_TIME = 7;
 
-    /** @var Aggregate */
-    private $aggregate;
+    private Aggregate $aggregate;
 
     /** @var array */
     private $aggregateOptions;
@@ -79,29 +78,21 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
     /** @var array */
     private $changeStreamOptions;
 
-    /** @var string|null */
-    private $collectionName;
+    private ?string $collectionName = null;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var integer */
-    private $firstBatchSize;
+    private int $firstBatchSize;
 
-    /** @var boolean */
-    private $hasResumed = false;
+    private bool $hasResumed = false;
 
-    /** @var Manager */
-    private $manager;
+    private Manager $manager;
 
-    /** @var TimestampInterface */
-    private $operationTime;
+    private ?TimestampInterface $operationTime = null;
 
-    /** @var array */
-    private $pipeline;
+    private array $pipeline;
 
-    /** @var object|null */
-    private $postBatchResumeToken;
+    private ?object $postBatchResumeToken = null;
 
     /**
      * Constructs an aggregate command for creating a change stream.
@@ -325,9 +316,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
     {
         return new ChangeStream(
             $this->createChangeStreamIterator($server),
-            function ($resumeToken, $hasAdvanced): ChangeStreamIterator {
-                return $this->resume($resumeToken, $hasAdvanced);
-            }
+            fn ($resumeToken, $hasAdvanced): ChangeStreamIterator => $this->resume($resumeToken, $hasAdvanced)
         );
     }
 
@@ -353,7 +342,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
             $this->executeAggregate($server),
             $this->firstBatchSize,
             $this->getInitialResumeToken(),
-            $this->postBatchResumeToken
+            $this->postBatchResumeToken,
         );
     }
 

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -314,7 +314,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
     {
         return new ChangeStream(
             $this->createChangeStreamIterator($server),
-            fn ($resumeToken, $hasAdvanced): ChangeStreamIterator => $this->resume($resumeToken, $hasAdvanced)
+            fn ($resumeToken, $hasAdvanced): ChangeStreamIterator => $this->resume($resumeToken, $hasAdvanced),
         );
     }
 

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -16,8 +16,7 @@ class WithTransaction
     /** @var callable */
     private $callback;
 
-    /** @var array */
-    private $transactionOptions;
+    private array $transactionOptions;
 
     /**
      * @see Session::startTransaction for supported transaction options

--- a/src/UpdateResult.php
+++ b/src/UpdateResult.php
@@ -25,11 +25,9 @@ use MongoDB\Exception\BadMethodCallException;
  */
 class UpdateResult
 {
-    /** @var WriteResult */
-    private $writeResult;
+    private WriteResult $writeResult;
 
-    /** @var boolean */
-    private $isAcknowledged;
+    private bool $isAcknowledged;
 
     public function __construct(WriteResult $writeResult)
     {

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -18,8 +18,7 @@ use function sprintf;
  */
 class ClientFunctionalTest extends FunctionalTestCase
 {
-    /** @var Client */
-    private $client;
+    private Client $client;
 
     public function setUp(): void
     {

--- a/tests/Codec/CodecLibraryTest.php
+++ b/tests/Codec/CodecLibraryTest.php
@@ -126,7 +126,7 @@ class CodecLibraryTest extends TestCase
                 {
                     return 'encoded';
                 }
-            }
+            },
         );
     }
 

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -705,7 +705,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
     {
         return array_filter(
             $this->collectionMethodClosures(),
-            fn ($rw) => str_contains($rw[1], 'r')
+            fn ($rw) => str_contains($rw[1], 'r'),
         );
     }
 
@@ -713,7 +713,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
     {
         return array_filter(
             $this->collectionMethodClosures(),
-            fn ($rw) => str_contains($rw[1], 'w')
+            fn ($rw) => str_contains($rw[1], 'w'),
         );
     }
 

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -25,6 +25,8 @@ use function str_contains;
 use function usort;
 use function version_compare;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * Functional tests for the Collection class.
  */
@@ -111,7 +113,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
             $cursor = $this->collection->aggregate(
                 [['$match' => ['_id' => ['$lt' => 3]]]],
-                ['session' => $session]
+                ['session' => $session],
             );
 
             $expected = [
@@ -139,7 +141,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                         'sparse' => true,
                         'unique' => true,
                         'writeConcern' => new WriteConcern(1),
-                    ]
+                    ],
                 );
             },
             function (array $event): void {
@@ -149,7 +151,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 $this->assertObjectHasAttribute('writeConcern', $command);
                 $this->assertObjectHasAttribute('sparse', $command->indexes[0]);
                 $this->assertObjectHasAttribute('unique', $command->indexes[0]);
-            }
+            },
         );
     }
 
@@ -182,8 +184,8 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     return 1;
                 }
 
-                $a = json_encode($a);
-                $b = json_encode($b);
+                $a = json_encode($a, JSON_THROW_ON_ERROR);
+                $b = json_encode($b, JSON_THROW_ON_ERROR);
             }
 
             return $a < $b ? -1 : 1;
@@ -291,7 +293,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
             $cursor = $this->collection->find(
                 ['_id' => ['$lt' => 3]],
-                ['session' => $session]
+                ['session' => $session],
             );
 
             $expected = [
@@ -438,7 +440,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->aggregate(
                         [['$match' => ['_id' => ['$lt' => 3]]]],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'r',
             ],
@@ -461,7 +463,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->bulkWrite(
                         [['insertOne' => [['test' => 'foo']]]],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -481,7 +483,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->countDocuments(
                         [],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'r',
             ],
@@ -501,7 +503,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->deleteMany(
                         ['test' => 'foo'],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -510,7 +512,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->deleteOne(
                         ['test' => 'foo'],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -520,7 +522,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     $collection->distinct(
                         '_id',
                         [],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'r',
             ],
@@ -569,7 +571,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->find(
                         ['test' => 'foo'],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'r',
             ],
@@ -578,7 +580,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->findOne(
                         ['test' => 'foo'],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'r',
             ],
@@ -587,7 +589,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->findOneAndDelete(
                         ['test' => 'foo'],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -597,7 +599,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     $collection->findOneAndReplace(
                         ['test' => 'foo'],
                         [],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -607,7 +609,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     $collection->findOneAndUpdate(
                         ['test' => 'foo'],
                         ['$set' => ['updated' => 1]],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -619,7 +621,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                             ['test' => 'foo'],
                             ['test' => 'bar'],
                         ],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -628,7 +630,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                 function ($collection, $session, $options = []): void {
                     $collection->insertOne(
                         ['test' => 'foo'],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -661,7 +663,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     $collection->replaceOne(
                         ['test' => 'foo'],
                         [],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -671,7 +673,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     $collection->updateMany(
                         ['test' => 'foo'],
                         ['$set' => ['updated' => 1]],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -681,7 +683,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     $collection->updateOne(
                         ['test' => 'foo'],
                         ['$set' => ['updated' => 1]],
-                        ['session' => $session] + $options
+                        ['session' => $session] + $options,
                     );
                 }, 'w',
             ],
@@ -703,9 +705,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
     {
         return array_filter(
             $this->collectionMethodClosures(),
-            function ($rw) {
-                return str_contains($rw[1], 'r');
-            }
+            fn ($rw) => str_contains($rw[1], 'r')
         );
     }
 
@@ -713,9 +713,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
     {
         return array_filter(
             $this->collectionMethodClosures(),
-            function ($rw) {
-                return str_contains($rw[1], 'w');
-            }
+            fn ($rw) => str_contains($rw[1], 'w')
         );
     }
 
@@ -741,7 +739,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Collection/CrudSpecFunctionalTest.php
+++ b/tests/Collection/CrudSpecFunctionalTest.php
@@ -25,6 +25,8 @@ use function sprintf;
 use function str_replace;
 use function strtolower;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * CRUD spec functional tests.
  *
@@ -39,8 +41,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
     public const SERVERLESS_FORBID = 'forbid';
     public const SERVERLESS_REQUIRE = 'require';
 
-    /** @var Collection */
-    private $expectedCollection;
+    private Collection $expectedCollection;
 
     public function setUp(): void
     {
@@ -87,7 +88,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
         $testArgs = [];
 
         foreach (glob(__DIR__ . '/spec-tests/*/*.json') as $filename) {
-            $json = json_decode(file_get_contents($filename), true);
+            $json = json_decode(file_get_contents($filename), true, 512, JSON_THROW_ON_ERROR);
 
             foreach ($json['tests'] as $test) {
                 $name = str_replace(' ', '_', $test['description']);
@@ -157,13 +158,13 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             case 'aggregate':
                 return $this->collection->aggregate(
                     $operation['arguments']['pipeline'],
-                    array_diff_key($operation['arguments'], ['pipeline' => 1])
+                    array_diff_key($operation['arguments'], ['pipeline' => 1]),
                 );
 
             case 'bulkWrite':
                 return $this->collection->bulkWrite(
                     array_map([$this, 'prepareBulkWriteRequest'], $operation['arguments']['requests']),
-                    $operation['arguments']['options'] ?? []
+                    $operation['arguments']['options'] ?? [],
                 );
 
             case 'count':
@@ -189,7 +190,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 return $this->collection->distinct(
                     $operation['arguments']['fieldName'],
                     $operation['arguments']['filter'] ?? [],
-                    array_diff_key($operation['arguments'], ['fieldName' => 1, 'filter' => 1])
+                    array_diff_key($operation['arguments'], ['fieldName' => 1, 'filter' => 1]),
                 );
 
             case 'findOneAndReplace':
@@ -218,13 +219,13 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             case 'insertMany':
                 return $this->collection->insertMany(
                     $operation['arguments']['documents'],
-                    $operation['arguments']['options'] ?? []
+                    $operation['arguments']['options'] ?? [],
                 );
 
             case 'insertOne':
                 return $this->collection->insertOne(
                     $operation['arguments']['document'],
-                    array_diff_key($operation['arguments'], ['document' => 1])
+                    array_diff_key($operation['arguments'], ['document' => 1]),
                 );
 
             default:
@@ -337,7 +338,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 if (isset($expectedResult['insertedIds'])) {
                     $this->assertSameDocument(
                         ['insertedIds' => $expectedResult['insertedIds']],
-                        ['insertedIds' => $actualResult->getInsertedIds()]
+                        ['insertedIds' => $actualResult->getInsertedIds()],
                     );
                 }
 
@@ -356,7 +357,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 if (isset($expectedResult['upsertedIds'])) {
                     $this->assertSameDocument(
                         ['upsertedIds' => $expectedResult['upsertedIds']],
-                        ['upsertedIds' => $actualResult->getUpsertedIds()]
+                        ['upsertedIds' => $actualResult->getUpsertedIds()],
                     );
                 }
 
@@ -371,7 +372,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             case 'distinct':
                 $this->assertSameDocument(
                     ['values' => $expectedResult],
-                    ['values' => $actualResult]
+                    ['values' => $actualResult],
                 );
                 break;
 
@@ -395,7 +396,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
             case 'findOneAndUpdate':
                 $this->assertSameDocument(
                     ['result' => $expectedResult],
-                    ['result' => $actualResult]
+                    ['result' => $actualResult],
                 );
                 break;
 
@@ -410,7 +411,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 if (isset($expectedResult['insertedIds'])) {
                     $this->assertSameDocument(
                         ['insertedIds' => $expectedResult['insertedIds']],
-                        ['insertedIds' => $actualResult->getInsertedIds()]
+                        ['insertedIds' => $actualResult->getInsertedIds()],
                     );
                 }
 
@@ -427,7 +428,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 if (isset($expectedResult['insertedId'])) {
                     $this->assertSameDocument(
                         ['insertedId' => $expectedResult['insertedId']],
-                        ['insertedId' => $actualResult->getInsertedId()]
+                        ['insertedId' => $actualResult->getInsertedId()],
                     );
                 }
 
@@ -454,7 +455,7 @@ class CrudSpecFunctionalTest extends FunctionalTestCase
                 if (array_key_exists('upsertedId', $expectedResult)) {
                     $this->assertSameDocument(
                         ['upsertedId' => $expectedResult['upsertedId']],
-                        ['upsertedId' => $actualResult->getUpsertedId()]
+                        ['upsertedId' => $actualResult->getUpsertedId()],
                     );
                 }
 

--- a/tests/Collection/FunctionalTestCase.php
+++ b/tests/Collection/FunctionalTestCase.php
@@ -10,8 +10,7 @@ use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    /** @var Collection */
-    protected $collection;
+    protected Collection $collection;
 
     public function setUp(): void
     {

--- a/tests/CommandObserver.php
+++ b/tests/CommandObserver.php
@@ -17,8 +17,7 @@ use function MongoDB\Driver\Monitoring\removeSubscriber;
  */
 class CommandObserver implements CommandSubscriber
 {
-    /** @var array */
-    private $commands = [];
+    private array $commands = [];
 
     public function observe(callable $execution, callable $commandCallback): void
     {

--- a/tests/Comparator/Int64Comparator.php
+++ b/tests/Comparator/Int64Comparator.php
@@ -33,8 +33,8 @@ class Int64Comparator extends Comparator
             sprintf(
                 'Failed asserting that %s matches expected %s.',
                 $this->exporter->export($actual),
-                $this->exporter->export($expected)
-            )
+                $this->exporter->export($expected),
+            ),
         );
     }
 

--- a/tests/Comparator/Int64ComparatorTest.php
+++ b/tests/Comparator/Int64ComparatorTest.php
@@ -108,48 +108,48 @@ class Int64ComparatorTest extends TestCase
     public static function provideMatchingAssertions(): Generator
     {
         yield 'Expected Int64, Actual Int64' => [
-            'expected' => new Int64(8589934592),
-            'actual' => new Int64(8589934592),
+            'expected' => new Int64(8_589_934_592),
+            'actual' => new Int64(8_589_934_592),
         ];
 
         yield 'Expected Int64, Actual int' => [
-            'expected' => new Int64(8589934592),
-            'actual' => 8589934592,
+            'expected' => new Int64(8_589_934_592),
+            'actual' => 8_589_934_592,
         ];
 
         yield 'Expected Int64, Actual int string' => [
-            'expected' => new Int64(8589934592),
+            'expected' => new Int64(8_589_934_592),
             'actual' => '8589934592',
         ];
 
         yield 'Expected Int64, Actual float' => [
-            'expected' => new Int64(8589934592),
-            'actual' => 8589934592.0,
+            'expected' => new Int64(8_589_934_592),
+            'actual' => 8_589_934_592.0,
         ];
 
         yield 'Expected Int64, Actual float string' => [
-            'expected' => new Int64(8589934592),
+            'expected' => new Int64(8_589_934_592),
             'actual' => '8589934592.0',
         ];
 
         yield 'Expected int, Actual Int64' => [
-            'expected' => 8589934592,
-            'actual' => new Int64(8589934592),
+            'expected' => 8_589_934_592,
+            'actual' => new Int64(8_589_934_592),
         ];
 
         yield 'Expected int string, Actual Int64' => [
             'expected' => '8589934592',
-            'actual' => new Int64(8589934592),
+            'actual' => new Int64(8_589_934_592),
         ];
 
         yield 'Expected float, Actual Int64' => [
-            'expected' => 8589934592.0,
-            'actual' => new Int64(8589934592),
+            'expected' => 8_589_934_592.0,
+            'actual' => new Int64(8_589_934_592),
         ];
 
         yield 'Expected float string, Actual Int64' => [
             'expected' => '8589934592.0',
-            'actual' => new Int64(8589934592),
+            'actual' => new Int64(8_589_934_592),
         ];
     }
 
@@ -164,32 +164,32 @@ class Int64ComparatorTest extends TestCase
     public static function provideFailingValues(): Generator
     {
         yield 'Expected Int64, Actual Int64' => [
-            'expected' => new Int64(8589934592),
+            'expected' => new Int64(8_589_934_592),
             'actual' => new Int64(456),
         ];
 
         yield 'Expected Int64, Actual int' => [
-            'expected' => new Int64(8589934592),
+            'expected' => new Int64(8_589_934_592),
             'actual' => 456,
         ];
 
         yield 'Expected Int64, Actual int string' => [
-            'expected' => new Int64(8589934592),
+            'expected' => new Int64(8_589_934_592),
             'actual' => '456',
         ];
 
         yield 'Expected Int64, Actual float' => [
-            'expected' => new Int64(8589934592),
-            'actual' => 8589934592.1,
+            'expected' => new Int64(8_589_934_592),
+            'actual' => 8_589_934_592.1,
         ];
 
         yield 'Expected Int64, Actual float string' => [
-            'expected' => new Int64(8589934592),
+            'expected' => new Int64(8_589_934_592),
             'actual' => '8589934592.1',
         ];
 
         yield 'Expected int, Actual Int64' => [
-            'expected' => 8589934592,
+            'expected' => 8_589_934_592,
             'actual' => new Int64(456),
         ];
 
@@ -199,7 +199,7 @@ class Int64ComparatorTest extends TestCase
         ];
 
         yield 'Expected float, Actual Int64' => [
-            'expected' => 8589934592.1,
+            'expected' => 8_589_934_592.1,
             'actual' => new Int64(456),
         ];
 

--- a/tests/Database/CollectionManagementFunctionalTest.php
+++ b/tests/Database/CollectionManagementFunctionalTest.php
@@ -26,7 +26,7 @@ class CollectionManagementFunctionalTest extends FunctionalTestCase
         $cappedCollectionOptions = [
             'capped' => true,
             'max' => 100,
-            'size' => 1048576,
+            'size' => 1_048_576,
         ];
 
         $commandResult = $this->database->createCollection($cappedCollectionName, $cappedCollectionOptions);
@@ -34,7 +34,7 @@ class CollectionManagementFunctionalTest extends FunctionalTestCase
         $this->assertCollectionExists($cappedCollectionName, null, function (CollectionInfo $info) use ($that): void {
             $that->assertTrue($info->isCapped());
             $that->assertEquals(100, $info->getCappedMax());
-            $that->assertEquals(1048576, $info->getCappedSize());
+            $that->assertEquals(1_048_576, $info->getCappedSize());
         });
     }
 

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -185,7 +185,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $commandResult = $this->database->modifyCollection(
             $this->getCollectionName(),
             ['index' => ['keyPattern' => ['lastAccess' => 1], 'expireAfterSeconds' => 1000]],
-            ['typeMap' => ['root' => 'array', 'document' => 'array']]
+            ['typeMap' => ['root' => 'array', 'document' => 'array']],
         );
         $this->assertCommandSucceeded($commandResult);
 
@@ -222,7 +222,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
             $this->getCollectionName(),
             $toCollectionName,
             null,
-            ['dropTarget' => true]
+            ['dropTarget' => true],
         );
         $this->assertCommandSucceeded($commandResult);
         $this->assertCollectionDoesNotExist($this->getCollectionName());
@@ -258,7 +258,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $commandResult = $this->database->renameCollection(
             $this->getCollectionName(),
             $toCollectionName,
-            $toDatabaseName
+            $toDatabaseName,
         );
         $this->assertCommandSucceeded($commandResult);
         $this->assertCollectionDoesNotExist($this->getCollectionName());

--- a/tests/Database/FunctionalTestCase.php
+++ b/tests/Database/FunctionalTestCase.php
@@ -10,8 +10,7 @@ use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    /** @var Database */
-    protected $database;
+    protected Database $database;
 
     public function setUp(): void
     {

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -1711,7 +1711,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         try {
             $count = $db->sales->count();
         } catch (\MongoDB\Driver\Exception\CommandException $e) {
-            echo json_encode($e->getResultDocument(), \JSON_THROW_ON_ERROR);
+            echo json_encode($e->getResultDocument());
             // { "ok": 0, "errmsg": "Provided apiStrict:true, but the command count is not in API Version 1", "code": 323, "codeName": "APIStrictError" }
         }
 

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -1711,7 +1711,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         try {
             $count = $db->sales->count();
         } catch (\MongoDB\Driver\Exception\CommandException $e) {
-            echo json_encode($e->getResultDocument(), JSON_THROW_ON_ERROR);
+            echo json_encode($e->getResultDocument(), \JSON_THROW_ON_ERROR);
             // { "ok": 0, "errmsg": "Provided apiStrict:true, but the command count is not in API Version 1", "code": 323, "codeName": "APIStrictError" }
         }
 

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -597,7 +597,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 44
         $cursor = $db->inventory->find(
             ['status' => 'A'],
-            ['projection' => ['item' => 1, 'status' => 1]]
+            ['projection' => ['item' => 1, 'status' => 1]],
         );
         // End Example 44
 
@@ -616,7 +616,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 45
         $cursor = $db->inventory->find(
             ['status' => 'A'],
-            ['projection' => ['item' => 1, 'status' => 1, '_id' => 0]]
+            ['projection' => ['item' => 1, 'status' => 1, '_id' => 0]],
         );
         // End Example 45
 
@@ -635,7 +635,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 46
         $cursor = $db->inventory->find(
             ['status' => 'A'],
-            ['projection' => ['status' => 0, 'instock' => 0]]
+            ['projection' => ['status' => 0, 'instock' => 0]],
         );
         // End Example 46
 
@@ -654,7 +654,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 47
         $cursor = $db->inventory->find(
             ['status' => 'A'],
-            ['projection' => ['item' => 1, 'status' => 1, 'size.uom' => 1]]
+            ['projection' => ['item' => 1, 'status' => 1, 'size.uom' => 1]],
         );
         // End Example 47
 
@@ -674,7 +674,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 48
         $cursor = $db->inventory->find(
             ['status' => 'A'],
-            ['projection' => ['size.uom' => 0]]
+            ['projection' => ['size.uom' => 0]],
         );
         // End Example 48
 
@@ -693,7 +693,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 49
         $cursor = $db->inventory->find(
             ['status' => 'A'],
-            ['projection' => ['item' => 1, 'status' => 1, 'instock.qty' => 1]]
+            ['projection' => ['item' => 1, 'status' => 1, 'instock.qty' => 1]],
         );
         // End Example 49
 
@@ -714,7 +714,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Example 50
         $cursor = $db->inventory->find(
             ['status' => 'A'],
-            ['projection' => ['item' => 1, 'status' => 1, 'instock' => ['$slice' => -1]]]
+            ['projection' => ['item' => 1, 'status' => 1, 'instock' => ['$slice' => -1]]],
         );
         // End Example 50
 
@@ -813,7 +813,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
             [
                 '$set' => ['size.uom' => 'cm', 'status' => 'P'],
                 '$currentDate' => ['lastModified' => true],
-            ]
+            ],
         );
         // End Example 52
 
@@ -833,7 +833,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
             [
                 '$set' => ['size.uom' => 'cm', 'status' => 'P'],
                 '$currentDate' => ['lastModified' => true],
-            ]
+            ],
         );
         // End Example 53
 
@@ -856,7 +856,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
                     ['warehouse' => 'A', 'qty' => 60],
                     ['warehouse' => 'B', 'qty' => 40],
                 ],
-            ]
+            ],
         );
         // End Example 54
 
@@ -1205,7 +1205,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // Start Index Example 2
         $indexName = $db->restaurants->createIndex(
             ['cuisine' => 1, 'name' => 1],
-            ['partialFilterExpression' => ['rating' => ['$gt' => 5]]]
+            ['partialFilterExpression' => ['rating' => ['$gt' => 5]]],
         );
         // End Index Example 2
 
@@ -1227,11 +1227,11 @@ class DocumentationExamplesTest extends FunctionalTestCase
             $client->hr->employees->updateOne(
                 ['employee' => 3],
                 ['$set' => ['status' => 'Inactive']],
-                ['session' => $session]
+                ['session' => $session],
             );
             $client->reporting->events->insertOne(
                 ['employee' => 3, 'status' => ['new' => 'Inactive', 'old' => 'Active']],
-                ['session' => $session]
+                ['session' => $session],
             );
         } catch (\MongoDB\Driver\Exception\Exception $error) {
             echo "Caught exception during transaction, aborting.\n";
@@ -1412,11 +1412,11 @@ class DocumentationExamplesTest extends FunctionalTestCase
             $client->hr->employees->updateOne(
                 ['employee' => 3],
                 ['$set' => ['status' => 'Inactive']],
-                ['session' => $session]
+                ['session' => $session],
             );
             $client->reporting->events->insertOne(
                 ['employee' => 3, 'status' => ['new' => 'Inactive', 'old' => 'Active']],
-                ['session' => $session]
+                ['session' => $session],
             );
         } catch (\MongoDB\Driver\Exception\Exception $error) {
             echo "Caught exception during transaction, aborting.\n";
@@ -1472,7 +1472,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $client = static::createTestClient();
         $items = $this->createCollection('test', 'items');
         $items->insertOne(
-            ['sku' => '111', 'name' => 'Peanuts', 'start' => new UTCDateTime()]
+            ['sku' => '111', 'name' => 'Peanuts', 'start' => new UTCDateTime()],
         );
 
         try {
@@ -1492,11 +1492,11 @@ class DocumentationExamplesTest extends FunctionalTestCase
             [
                 'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::MAJORITY),
                 'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY, 1000),
-            ]
+            ],
         )->items;
 
         $s1 = $client->startSession(
-            ['causalConsistency' => true]
+            ['causalConsistency' => true],
         );
 
         $currentDate = new \MongoDB\BSON\UTCDateTime();
@@ -1504,11 +1504,11 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $items->updateOne(
             ['sku' => '111', 'end' => ['$exists' => false]],
             ['$set' => ['end' => $currentDate]],
-            ['session' => $s1]
+            ['session' => $s1],
         );
         $items->insertOne(
             ['sku' => '111-nuts', 'name' => 'Pecans', 'start' => $currentDate],
-            ['session' => $s1]
+            ['session' => $s1],
         );
         // End Causal Consistency Example 1
         // phpcs:enable
@@ -1518,7 +1518,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
         // Start Causal Consistency Example 2
         $s2 = $client->startSession(
-            ['causalConsistency' => true]
+            ['causalConsistency' => true],
         );
         $s2->advanceClusterTime($s1->getClusterTime());
         $s2->advanceOperationTime($s1->getOperationTime());
@@ -1529,12 +1529,12 @@ class DocumentationExamplesTest extends FunctionalTestCase
                 'readPreference' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::SECONDARY),
                 'readConcern' => new \MongoDB\Driver\ReadConcern(\MongoDB\Driver\ReadConcern::MAJORITY),
                 'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY, 1000),
-            ]
+            ],
         )->items;
 
         $result = $items->find(
             ['end' => ['$exists' => false]],
-            ['session' => $s2]
+            ['session' => $s2],
         );
         foreach ($result as $item) {
             var_dump($item);
@@ -1590,7 +1590,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
                 ['$match' => ['adoptable' => true]],
                 ['$count' => 'adoptableCatsCount'],
             ],
-            ['session' => $session]
+            ['session' => $session],
         )->toArray()[0]->adoptableCatsCount;
 
         $adoptablePetsCount += $dogsCollection->aggregate(
@@ -1598,7 +1598,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
                 ['$match' => ['adoptable' => true]],
                 ['$count' => 'adoptableDogsCount'],
             ],
-            ['session' => $session]
+            ['session' => $session],
         )->toArray()[0]->adoptableDogsCount;
 
         var_dump($adoptablePetsCount);
@@ -1642,7 +1642,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
                 ],
                 ['$count' => 'totalDailySales'],
             ],
-            ['session' => $session]
+            ['session' => $session],
         )->toArray()[0]->totalDailySales;
         // End Snapshot Query Example 2
 
@@ -1691,9 +1691,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $db = $client->selectDatabase($this->getDatabaseName());
 
         // Start Versioned API Example 5
-        $strtoutc = function (string $datetime) {
-            return new \MongoDB\BSON\UTCDateTime(new \DateTime($datetime));
-        };
+        $strtoutc = fn (string $datetime) => new \MongoDB\BSON\UTCDateTime(new \DateTime($datetime));
 
         $db->sales->insertMany([
             ['_id' => 1, 'item' => 'abc', 'price' => 10, 'quantity' => 2, 'date' => $strtoutc('2021-01-01T08:00:00Z')],
@@ -1713,7 +1711,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         try {
             $count = $db->sales->count();
         } catch (\MongoDB\Driver\Exception\CommandException $e) {
-            echo json_encode($e->getResultDocument());
+            echo json_encode($e->getResultDocument(), JSON_THROW_ON_ERROR);
             // { "ok": 0, "errmsg": "Provided apiStrict:true, but the command count is not in API Version 1", "code": 323, "codeName": "APIStrictError" }
         }
 
@@ -1762,7 +1760,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
             'foo',
             [
                 'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY, 1000),
-            ]
+            ],
         )->insertOne(['abc' => 0]);
 
         $client->selectCollection(
@@ -1770,7 +1768,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
             'bar',
             [
                 'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY, 1000),
-            ]
+            ],
         )->insertOne(['xyz' => 0]);
 
         // Step 1: Define the callback that specifies the sequence of operations to perform inside the transactions.

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -486,7 +486,7 @@ OUTPUT;
             [
                 'unique' => true,
                 'partialFilterExpression' => ['keyAltNames' => ['$exists' => true]],
-            ]
+            ],
         );
     }
 }

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -54,7 +54,6 @@ abstract class FunctionalTestCase extends TestCase
 {
     protected Manager $manager;
 
-    /** @var array */
     private array $configuredFailPoints = [];
 
     /** @var array{int,{Collection,array}} */

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -52,11 +52,10 @@ use const PATH_SEPARATOR;
 
 abstract class FunctionalTestCase extends TestCase
 {
-    /** @var Manager */
-    protected $manager;
+    protected Manager $manager;
 
     /** @var array */
-    private $configuredFailPoints = [];
+    private array $configuredFailPoints = [];
 
     /** @var array{int,{Collection,array}} */
     private $collectionsToCleanup = [];
@@ -85,7 +84,7 @@ abstract class FunctionalTestCase extends TestCase
         return new Client(
             $uri ?? static::getUri(),
             static::appendAuthenticationOptions($options),
-            static::appendServerApiOption($driverOptions)
+            static::appendServerApiOption($driverOptions),
         );
     }
 
@@ -94,7 +93,7 @@ abstract class FunctionalTestCase extends TestCase
         return new Manager(
             $uri ?? static::getUri(),
             static::appendAuthenticationOptions($options),
-            static::appendServerApiOption($driverOptions)
+            static::appendServerApiOption($driverOptions),
         );
     }
 
@@ -330,7 +329,7 @@ abstract class FunctionalTestCase extends TestCase
         $cursor = $this->manager->executeCommand(
             'admin',
             new Command(['getParameter' => 1, 'featureCompatibilityVersion' => 1]),
-            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY)
+            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY),
         );
 
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);
@@ -353,7 +352,7 @@ abstract class FunctionalTestCase extends TestCase
         $buildInfo = $this->manager->executeCommand(
             $this->getDatabaseName(),
             new Command(['buildInfo' => 1]),
-            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY)
+            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY),
         )->toArray()[0];
 
         if (isset($buildInfo->version) && is_string($buildInfo->version)) {
@@ -368,7 +367,7 @@ abstract class FunctionalTestCase extends TestCase
         $cursor = $this->manager->executeCommand(
             $this->getDatabaseName(),
             new Command(['serverStatus' => 1]),
-            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY)
+            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY),
         );
 
         $result = current($cursor->toArray());
@@ -389,7 +388,7 @@ abstract class FunctionalTestCase extends TestCase
         try {
             $cursor = $this->manager->executeCommand(
                 'admin',
-                new Command(['getParameter' => 1, 'requireApiVersion' => 1])
+                new Command(['getParameter' => 1, 'requireApiVersion' => 1]),
             );
 
             $document = current($cursor->toArray());
@@ -455,7 +454,7 @@ abstract class FunctionalTestCase extends TestCase
 
         $cursor = $this->getPrimaryServer()->executeQuery(
             'config.shards',
-            new Query([], ['limit' => 1])
+            new Query([], ['limit' => 1]),
         );
 
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);
@@ -726,7 +725,7 @@ abstract class FunctionalTestCase extends TestCase
         try {
             $cursor = $this->manager->executeCommand(
                 'admin',
-                new Command(['getParameter' => 1, 'enableTestCommands' => 1])
+                new Command(['getParameter' => 1, 'enableTestCommands' => 1]),
             );
 
             $document = current($cursor->toArray());

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -132,10 +132,10 @@ class FunctionsTest extends TestCase
         // phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration
         // phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
         return [
-            'array' => [function ($value) { return $value; }],
-            'object' => [function ($value) { return (object) $value; }],
-            'Serializable' => [function ($value) { return new BSONDocument($value); }],
-            'Document' => [function ($value) { return Document::fromPHP($value); }],
+            'array' => [fn ($value) => $value],
+            'object' => [fn ($value) => (object) $value],
+            'Serializable' => [fn ($value) => new BSONDocument($value)],
+            'Document' => [fn ($value) => Document::fromPHP($value)],
         ];
         // phpcs:enable
     }

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -37,7 +37,6 @@ use function substr;
 
 use const PHP_EOL;
 use const PHP_OS;
-use const PHP_VERSION_ID;
 
 /**
  * Functional tests for the Bucket class.
@@ -156,7 +155,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $this->chunksCollection->updateOne(
             ['files_id' => $id, 'n' => 0],
-            ['$set' => ['n' => 1]]
+            ['$set' => ['n' => 1]],
         );
 
         $this->expectException(CorruptFileException::class);
@@ -170,7 +169,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $this->chunksCollection->updateOne(
             ['files_id' => $id, 'n' => 0],
-            ['$set' => ['data' => new Binary('fooba')]]
+            ['$set' => ['data' => new Binary('fooba')]],
         );
 
         $this->expectException(CorruptFileException::class);
@@ -297,7 +296,7 @@ class BucketFunctionalTest extends FunctionalTestCase
                     '_id' => 0,
                 ],
                 'sort' => ['length' => -1],
-            ]
+            ],
         );
 
         $expected = [
@@ -333,7 +332,7 @@ class BucketFunctionalTest extends FunctionalTestCase
                     '_id' => 0,
                 ],
                 'sort' => ['length' => -1],
-            ]
+            ],
         );
 
         $this->assertInstanceOf(BSONDocument::class, $fileDocument);
@@ -566,7 +565,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $fileDocument = $this->filesCollection->findOne(
             ['_id' => $id],
-            ['projection' => ['filename' => 1, '_id' => 0]]
+            ['projection' => ['filename' => 1, '_id' => 0]],
         );
 
         $this->assertSameDocument(['filename' => 'b'], $fileDocument);
@@ -580,7 +579,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $fileDocument = $this->filesCollection->findOne(
             ['_id' => $id],
-            ['projection' => ['filename' => 1, '_id' => 0]]
+            ['projection' => ['filename' => 1, '_id' => 0]],
         );
 
         $this->assertSameDocument(['filename' => 'a'], $fileDocument);
@@ -637,7 +636,7 @@ class BucketFunctionalTest extends FunctionalTestCase
                     'md5' => 1,
                     '_id' => 0,
                 ],
-            ]
+            ],
         );
 
         $expected = [
@@ -654,7 +653,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $id = $this->bucket->uploadFromStream('filename', $this->createStream('data'), $options);
 
         $fileDocument = $this->filesCollection->findOne(
-            ['_id' => $id]
+            ['_id' => $id],
         );
 
         $this->assertArrayNotHasKey('md5', $fileDocument);
@@ -668,7 +667,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $id = $this->bucket->uploadFromStream('filename', $this->createStream('data'));
 
         $fileDocument = $this->filesCollection->findOne(
-            ['_id' => $id]
+            ['_id' => $id],
         );
 
         $this->assertArrayNotHasKey('md5', $fileDocument);
@@ -715,10 +714,6 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testUploadFromStreamFails(): void
     {
-        if (PHP_VERSION_ID < 70400) {
-            $this->markTestSkipped('Test only works on PHP 7.4 and newer');
-        }
-
         UnusableStream::register();
         $source = fopen('unusable://temp', 'w');
 
@@ -741,7 +736,7 @@ CMD;
         @exec(
             $command,
             $output,
-            $return
+            $return,
         );
 
         $this->assertSame(0, $return);

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -17,14 +17,11 @@ use function stream_get_contents;
  */
 abstract class FunctionalTestCase extends BaseFunctionalTestCase
 {
-    /** @var Bucket */
-    protected $bucket;
+    protected Bucket $bucket;
 
-    /** @var Collection */
-    protected $chunksCollection;
+    protected Collection $chunksCollection;
 
-    /** @var Collection */
-    protected $filesCollection;
+    protected Collection $filesCollection;
 
     public function setUp(): void
     {

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -115,7 +115,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
     {
         return array_filter(
             $this->provideFileIdAndExpectedBytes(),
-            fn (array $args) => $args[1] > 0
+            fn (array $args) => $args[1] > 0,
         );
     }
 

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -16,8 +16,7 @@ use function array_filter;
  */
 class ReadableStreamFunctionalTest extends FunctionalTestCase
 {
-    /** @var CollectionWrapper */
-    private $collectionWrapper;
+    private CollectionWrapper $collectionWrapper;
 
     public function setUp(): void
     {
@@ -116,9 +115,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
     {
         return array_filter(
             $this->provideFileIdAndExpectedBytes(),
-            function (array $args) {
-                return $args[1] > 0;
-            }
+            fn (array $args) => $args[1] > 0
         );
     }
 
@@ -161,7 +158,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
     {
         $this->chunksCollection->updateOne(
             ['files_id' => 'length-10', 'n' => 2],
-            ['$set' => ['data' => new Binary('i')]]
+            ['$set' => ['data' => new Binary('i')]],
         );
 
         $fileDocument = $this->collectionWrapper->findFileById('length-10');
@@ -218,7 +215,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$commands): void {
                 $commands[] = $event['started']->getCommandName();
-            }
+            },
         );
 
         $this->assertSame(['find'], $commands);
@@ -252,7 +249,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$commands): void {
                 $commands[] = $event['started']->getCommandName();
-            }
+            },
         );
 
         $this->assertSame([], $commands);
@@ -284,7 +281,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$commands): void {
                 $commands[] = $event['started']->getCommandName();
-            }
+            },
         );
 
         $this->assertSame([], $commands);

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -96,10 +96,10 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $this->assertSame(0100444, $stat['mode']);
         $this->assertSame(10, $stat[7]);
         $this->assertSame(10, $stat['size']);
-        $this->assertSame(1484202200, $stat[9]);
-        $this->assertSame(1484202200, $stat['mtime']);
-        $this->assertSame(1484202200, $stat[10]);
-        $this->assertSame(1484202200, $stat['ctime']);
+        $this->assertSame(1_484_202_200, $stat[9]);
+        $this->assertSame(1_484_202_200, $stat['mtime']);
+        $this->assertSame(1_484_202_200, $stat[10]);
+        $this->assertSame(1_484_202_200, $stat['ctime']);
         $this->assertSame(4, $stat[11]);
         $this->assertSame(4, $stat['blksize']);
     }
@@ -190,10 +190,10 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $this->assertSame(0100444, $stat['mode']);
         $this->assertSame(10, $stat[7]);
         $this->assertSame(10, $stat['size']);
-        $this->assertSame(1484202200, $stat[9]);
-        $this->assertSame(1484202200, $stat['mtime']);
-        $this->assertSame(1484202200, $stat[10]);
-        $this->assertSame(1484202200, $stat['ctime']);
+        $this->assertSame(1_484_202_200, $stat[9]);
+        $this->assertSame(1_484_202_200, $stat['mtime']);
+        $this->assertSame(1_484_202_200, $stat[10]);
+        $this->assertSame(1_484_202_200, $stat['ctime']);
         $this->assertSame(4, $stat[11]);
         $this->assertSame(4, $stat['blksize']);
     }

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -13,8 +13,7 @@ use function str_repeat;
  */
 class WritableStreamFunctionalTest extends FunctionalTestCase
 {
-    /** @var CollectionWrapper */
-    private $collectionWrapper;
+    private CollectionWrapper $collectionWrapper;
 
     public function setUp(): void
     {
@@ -81,7 +80,7 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
 
         $fileDocument = $this->filesCollection->findOne(
             ['_id' => $stream->getFile()->_id],
-            ['projection' => ['md5' => 1, '_id' => 0]]
+            ['projection' => ['md5' => 1, '_id' => 0]],
         );
 
         $this->assertSameDocument(['md5' => $expectedMD5], $fileDocument);

--- a/tests/Model/BSONArrayTest.php
+++ b/tests/Model/BSONArrayTest.php
@@ -11,6 +11,8 @@ use stdClass;
 
 use function json_encode;
 
+use const JSON_THROW_ON_ERROR;
+
 class BSONArrayTest extends TestCase
 {
     public function testBsonSerializeReindexesKeys(): void
@@ -88,7 +90,7 @@ class BSONArrayTest extends TestCase
 
         $expectedJson = '["foo",[1,2,3],{"foo":1,"bar":2,"baz":3},[[[]]]]';
 
-        $this->assertSame($expectedJson, json_encode($document));
+        $this->assertSame($expectedJson, json_encode($document, JSON_THROW_ON_ERROR));
     }
 
     public function testJsonSerializeReindexesKeys(): void

--- a/tests/Model/BSONDocumentTest.php
+++ b/tests/Model/BSONDocumentTest.php
@@ -12,6 +12,8 @@ use stdClass;
 
 use function json_encode;
 
+use const JSON_THROW_ON_ERROR;
+
 class BSONDocumentTest extends TestCase
 {
     public function testConstructorDefaultsToPropertyAccess(): void
@@ -96,7 +98,7 @@ class BSONDocumentTest extends TestCase
 
         $expectedJson = '{"foo":"bar","array":[1,2,3],"object":{"0":1,"1":2,"2":3},"nested":{"0":{"0":{}}}}';
 
-        $this->assertSame($expectedJson, json_encode($document));
+        $this->assertSame($expectedJson, json_encode($document, JSON_THROW_ON_ERROR));
     }
 
     public function testJsonSerializeCastsToObject(): void

--- a/tests/Model/BSONIteratorTest.php
+++ b/tests/Model/BSONIteratorTest.php
@@ -34,7 +34,7 @@ class BSONIteratorTest extends TestCase
                     [
                         ['_id' => 1, 'x' => ['foo' => 'bar']],
                         ['_id' => 3, 'x' => ['foo' => 'bar']],
-                    ]
+                    ],
                 )),
                 [
                     (object) ['_id' => 1, 'x' => (object) ['foo' => 'bar']],
@@ -48,7 +48,7 @@ class BSONIteratorTest extends TestCase
                     [
                         ['_id' => 1, 'x' => ['foo' => 'bar']],
                         ['_id' => 3, 'x' => ['foo' => 'bar']],
-                    ]
+                    ],
                 )),
                 [
                     ['_id' => 1, 'x' => ['foo' => 'bar']],
@@ -62,7 +62,7 @@ class BSONIteratorTest extends TestCase
                     [
                         ['_id' => 1, 'x' => ['foo' => 'bar']],
                         ['_id' => 3, 'x' => ['foo' => 'bar']],
-                    ]
+                    ],
                 )),
                 [
                     (object) ['_id' => 1, 'x' => ['foo' => 'bar']],
@@ -76,7 +76,7 @@ class BSONIteratorTest extends TestCase
                     [
                         ['_id' => 1, 'x' => ['foo' => 'bar']],
                         ['_id' => 3, 'x' => ['foo' => 'bar']],
-                    ]
+                    ],
                 )),
                 [
                     ['_id' => 1, 'x' => (object) ['foo' => 'bar']],

--- a/tests/Model/CachingIteratorTest.php
+++ b/tests/Model/CachingIteratorTest.php
@@ -119,8 +119,7 @@ class CachingIteratorTest extends TestCase
     public function testWithWrongIterator(): void
     {
         $nestedIterator = new class implements Iterator {
-            /** @var int */
-            private $i = 0;
+            private int $i = 0;
 
             public function current(): int
             {

--- a/tests/Model/CallbackIteratorTest.php
+++ b/tests/Model/CallbackIteratorTest.php
@@ -28,7 +28,7 @@ class CallbackIteratorTest extends TestCase
 
         $iteratorAggregate = new class ($listIterator) implements IteratorAggregate
         {
-            private $iterator;
+            private Iterator $iterator;
 
             public function __construct(Iterator $iterator)
             {

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -20,8 +20,7 @@ use function sprintf;
 
 class ChangeStreamIteratorTest extends FunctionalTestCase
 {
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
     public function setUp(): void
     {
@@ -144,7 +143,7 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
             $callable,
             function (array $event) use (&$commands): void {
                 $this->fail(sprintf('"%s" command was executed', $event['started']->getCommandName()));
-            }
+            },
         );
 
         $this->assertEmpty($commands);

--- a/tests/Model/CollectionInfoTest.php
+++ b/tests/Model/CollectionInfoTest.php
@@ -13,7 +13,7 @@ class CollectionInfoTest extends TestCase
         $info = new CollectionInfo([
             'name' => 'foo',
             'type' => 'view',
-            'options' => ['capped' => true, 'size' => 1048576],
+            'options' => ['capped' => true, 'size' => 1_048_576],
             'info' => ['readOnly' => true],
             'idIndex' => ['idIndex' => true], // Dummy option
         ]);
@@ -24,8 +24,8 @@ class CollectionInfoTest extends TestCase
         $this->assertSame('view', $info->getType());
         $this->assertSame('view', $info['type']);
 
-        $this->assertSame(['capped' => true, 'size' => 1048576], $info->getOptions());
-        $this->assertSame(['capped' => true, 'size' => 1048576], $info['options']);
+        $this->assertSame(['capped' => true, 'size' => 1_048_576], $info->getOptions());
+        $this->assertSame(['capped' => true, 'size' => 1_048_576], $info['options']);
 
         $this->assertSame(['readOnly' => true], $info->getInfo());
         $this->assertSame(['readOnly' => true], $info['info']);
@@ -58,22 +58,22 @@ class CollectionInfoTest extends TestCase
         $this->assertNull($info->getCappedMax());
         $this->assertNull($info->getCappedSize());
 
-        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576]]);
+        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1_048_576]]);
         $this->assertTrue($info->isCapped());
         $this->assertNull($info->getCappedMax());
-        $this->assertSame(1048576, $info->getCappedSize());
+        $this->assertSame(1_048_576, $info->getCappedSize());
 
-        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576, 'max' => 100]]);
+        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1_048_576, 'max' => 100]]);
         $this->assertTrue($info->isCapped());
         $this->assertSame(100, $info->getCappedMax());
-        $this->assertSame(1048576, $info->getCappedSize());
+        $this->assertSame(1_048_576, $info->getCappedSize());
     }
 
     public function testDebugInfo(): void
     {
         $expectedInfo = [
             'name' => 'foo',
-            'options' => ['capped' => true, 'size' => 1048576],
+            'options' => ['capped' => true, 'size' => 1_048_576],
         ];
 
         $info = new CollectionInfo($expectedInfo);
@@ -90,7 +90,7 @@ class CollectionInfoTest extends TestCase
 
     public function testOffsetSetCannotBeCalled(): void
     {
-        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576]]);
+        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1_048_576]]);
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(CollectionInfo::class . ' is immutable');
         $info['options'] = ['capped' => false];
@@ -98,7 +98,7 @@ class CollectionInfoTest extends TestCase
 
     public function testOffsetUnsetCannotBeCalled(): void
     {
-        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1048576]]);
+        $info = new CollectionInfo(['name' => 'foo', 'options' => ['capped' => true, 'size' => 1_048_576]]);
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(CollectionInfo::class . ' is immutable');
         unset($info['options']);

--- a/tests/Model/DatabaseInfoTest.php
+++ b/tests/Model/DatabaseInfoTest.php
@@ -16,8 +16,8 @@ class DatabaseInfoTest extends TestCase
 
     public function testGetSizeOnDisk(): void
     {
-        $info = new DatabaseInfo(['sizeOnDisk' => 1048576]);
-        $this->assertSame(1048576, $info->getSizeOnDisk());
+        $info = new DatabaseInfo(['sizeOnDisk' => 1_048_576]);
+        $this->assertSame(1_048_576, $info->getSizeOnDisk());
     }
 
     public function testIsEmpty(): void
@@ -33,7 +33,7 @@ class DatabaseInfoTest extends TestCase
     {
         $expectedInfo = [
             'name' => 'foo',
-            'sizeOnDisk' => 1048576,
+            'sizeOnDisk' => 1_048_576,
             'empty' => false,
         ];
 
@@ -51,7 +51,7 @@ class DatabaseInfoTest extends TestCase
 
     public function testOffsetSetCannotBeCalled(): void
     {
-        $info = new DatabaseInfo(['name' => 'foo', 'sizeOnDisk' => 1048576, 'empty' => false]);
+        $info = new DatabaseInfo(['name' => 'foo', 'sizeOnDisk' => 1_048_576, 'empty' => false]);
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(DatabaseInfo::class . ' is immutable');
         $info['empty'] = true;
@@ -59,7 +59,7 @@ class DatabaseInfoTest extends TestCase
 
     public function testOffsetUnsetCannotBeCalled(): void
     {
-        $info = new DatabaseInfo(['name' => 'foo', 'sizeOnDisk' => 1048576, 'empty' => false]);
+        $info = new DatabaseInfo(['name' => 'foo', 'sizeOnDisk' => 1_048_576, 'empty' => false]);
         $this->expectException(BadMethodCallException::class);
         $this->expectExceptionMessage(DatabaseInfo::class . ' is immutable');
         unset($info['empty']);

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -7,8 +7,7 @@ use MongoDB\Tests\FunctionalTestCase;
 
 class IndexInfoFunctionalTest extends FunctionalTestCase
 {
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
     public function setUp(): void
     {

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -23,14 +23,14 @@ class AggregateFunctionalTest extends FunctionalTestCase
                 $operation = new Aggregate(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    [['$match' => ['x' => 1]]]
+                    [['$match' => ['x' => 1]]],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('allowDiskUse', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -42,14 +42,14 @@ class AggregateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['$out' => $this->getCollectionName() . '.output']],
-                    ['batchSize' => 0]
+                    ['batchSize' => 0],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertEquals(new stdClass(), $event['started']->getCommand()->cursor);
-            }
+            },
         );
 
         $outCollection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName() . '.output');
@@ -63,14 +63,14 @@ class AggregateFunctionalTest extends FunctionalTestCase
                 $operation = new Aggregate(
                     'admin',
                     null,
-                    [['$currentOp' => (object) []]]
+                    [['$currentOp' => (object) []]],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertSame(1, $event['started']->getCommand()->aggregate);
-            }
+            },
         );
     }
 
@@ -82,14 +82,14 @@ class AggregateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['$match' => ['x' => 1]]],
-                    ['readConcern' => $this->createDefaultReadConcern()]
+                    ['readConcern' => $this->createDefaultReadConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -101,14 +101,14 @@ class AggregateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['$out' => $this->getCollectionName() . '.output']],
-                    ['writeConcern' => $this->createDefaultWriteConcern()]
+                    ['writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
 
         $outCollection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName() . '.output');
@@ -146,14 +146,14 @@ class AggregateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -184,7 +184,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
          * result in different explain output (see: SERVER-24860) */
         $this->assertThat($results[0], $this->logicalOr(
             $this->arrayHasKey('stages'),
-            $this->arrayHasKey('queryPlanner')
+            $this->arrayHasKey('queryPlanner'),
         ));
     }
 
@@ -214,7 +214,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
 
         $this->assertCollectionCount($this->getCollectionName() . '.output', 0);
@@ -228,7 +228,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['$match' => ['x' => 1]]],
-                    ['bypassDocumentValidation' => true]
+                    ['bypassDocumentValidation' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -236,7 +236,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
-            }
+            },
         );
     }
 
@@ -248,14 +248,14 @@ class AggregateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['$match' => ['x' => 1]]],
-                    ['bypassDocumentValidation' => false]
+                    ['bypassDocumentValidation' => false],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Operation/AggregateTest.php
+++ b/tests/Operation/AggregateTest.php
@@ -53,7 +53,7 @@ class AggregateTest extends TestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             [['$match' => ['x' => 1]]],
-            ['batchSize' => 100, 'useCursor' => false]
+            ['batchSize' => 100, 'useCursor' => false],
         );
     }
 

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -18,8 +18,7 @@ use function is_array;
 
 class BulkWriteFunctionalTest extends FunctionalTestCase
 {
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
     public function setUp(): void
     {
@@ -70,7 +69,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                 $operation = new BulkWrite(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    [['insertOne' => [$document]]]
+                    [['insertOne' => [$document]]],
                 );
 
                 $result = $operation->execute($this->getPrimaryServer());
@@ -82,7 +81,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use ($expectedDocument): void {
                 $this->assertEquals($expectedDocument, $event['started']->getCommand()->documents[0] ?? null);
-            }
+            },
         );
     }
 
@@ -161,7 +160,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                         ['replaceOne' => [$filter, ['x' => 1]]],
                         ['updateOne' => [$filter, ['$set' => ['x' => 1]]]],
                         ['updateMany' => [$filter, ['$set' => ['x' => 1]]]],
-                    ]
+                    ],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -170,7 +169,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                 $this->assertEquals($expectedFilter, $event['started']->getCommand()->updates[0]->q ?? null);
                 $this->assertEquals($expectedFilter, $event['started']->getCommand()->updates[1]->q ?? null);
                 $this->assertEquals($expectedFilter, $event['started']->getCommand()->updates[2]->q ?? null);
-            }
+            },
         );
     }
 
@@ -182,14 +181,14 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                 $operation = new BulkWrite(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    [['replaceOne' => [['x' => 1], $replacement]]]
+                    [['replaceOne' => [['x' => 1], $replacement]]],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedReplacement): void {
                 $this->assertEquals($expectedReplacement, $event['started']->getCommand()->updates[0]->u ?? null);
-            }
+            },
         );
     }
 
@@ -211,7 +210,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                     [
                         ['updateOne' => [['x' => 1], $update]],
                         ['updateMany' => [['x' => 1], $update]],
-                    ]
+                    ],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -219,7 +218,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
             function (array $event) use ($expectedUpdate): void {
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->updates[0]->u ?? null);
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->updates[1]->u ?? null);
-            }
+            },
         );
     }
 
@@ -256,7 +255,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                     [
                         ['deleteOne' => [$filter]],
                         ['deleteMany' => [$filter]],
-                    ]
+                    ],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -264,7 +263,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
             function (array $event) use ($expectedQuery): void {
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->deletes[0]->q ?? null);
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->deletes[1]->q ?? null);
-            }
+            },
         );
     }
 
@@ -372,14 +371,14 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['insertOne' => [['_id' => 1]]]],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -391,7 +390,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['insertOne' => [['_id' => 1]]]],
-                    ['bypassDocumentValidation' => true]
+                    ['bypassDocumentValidation' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -399,7 +398,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
-            }
+            },
         );
     }
 
@@ -411,14 +410,14 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['insertOne' => [['_id' => 1]]]],
-                    ['bypassDocumentValidation' => false]
+                    ['bypassDocumentValidation' => false],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -417,7 +417,7 @@ class BulkWriteTest extends TestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             [[BulkWrite::INSERT_ONE => [['x' => 1]]]],
-            $options
+            $options,
         );
     }
 

--- a/tests/Operation/CountDocumentsFunctionalTest.php
+++ b/tests/Operation/CountDocumentsFunctionalTest.php
@@ -17,14 +17,14 @@ class CountDocumentsFunctionalTest extends FunctionalTestCase
                 $operation = new CountDocuments(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $filter
+                    $filter,
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedMatchStage): void {
                 $this->assertEquals($expectedMatchStage, $event['started']->getCommand()->pipeline[0]->{'$match'} ?? null);
-            }
+            },
         );
     }
 

--- a/tests/Operation/CountFunctionalTest.php
+++ b/tests/Operation/CountFunctionalTest.php
@@ -18,14 +18,14 @@ class CountFunctionalTest extends FunctionalTestCase
                 $operation = new Count(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $filter
+                    $filter,
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedQuery): void {
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->query ?? null);
-            }
+            },
         );
     }
 
@@ -37,14 +37,14 @@ class CountFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [],
-                    ['readConcern' => $this->createDefaultReadConcern()]
+                    ['readConcern' => $this->createDefaultReadConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -93,14 +93,14 @@ class CountFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/CreateCollectionFunctionalTest.php
+++ b/tests/Operation/CreateCollectionFunctionalTest.php
@@ -14,14 +14,14 @@ class CreateCollectionFunctionalTest extends FunctionalTestCase
                 $operation = new CreateCollection(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['writeConcern' => $this->createDefaultWriteConcern()]
+                    ['writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -32,14 +32,14 @@ class CreateCollectionFunctionalTest extends FunctionalTestCase
                 $operation = new CreateCollection(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
+++ b/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
@@ -5,7 +5,7 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Document;
 use MongoDB\Client;
-use MongoDB\ClientEncryption;
+use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
@@ -18,8 +18,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
 {
     public const LOCAL_MASTERKEY = 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk';
 
-    /** @var ClientEncryption */
-    private $clientEncryption;
+    private ClientEncryption $clientEncryption;
 
     public function setUp(): void
     {
@@ -61,14 +60,14 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $operation = new CreateEncryptedCollection(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['encryptedFields' => $input]
+            ['encryptedFields' => $input],
         );
 
         $operation->createDataKeys(
             $this->clientEncryption,
             'local',
             null,
-            $encryptedFieldsOutput
+            $encryptedFieldsOutput,
         );
 
         $this->assertSame($expectedOutput, $encryptedFieldsOutput);
@@ -92,14 +91,14 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $operation = new CreateEncryptedCollection(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['encryptedFields' => $input]
+            ['encryptedFields' => $input],
         );
 
         $operation->createDataKeys(
             $this->clientEncryption,
             'local',
             null,
-            $encryptedFieldsOutput
+            $encryptedFieldsOutput,
         );
 
         $this->assertSame($expectedOutput, $encryptedFieldsOutput);
@@ -123,14 +122,14 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $operation = new CreateEncryptedCollection(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['encryptedFields' => $input]
+            ['encryptedFields' => $input],
         );
 
         $operation->createDataKeys(
             $this->clientEncryption,
             'local',
             null,
-            $encryptedFieldsOutput
+            $encryptedFieldsOutput,
         );
 
         $this->assertSame($expectedOutput, $encryptedFieldsOutput);
@@ -156,14 +155,14 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $operation = new CreateEncryptedCollection(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['encryptedFields' => $originalEncryptedFields]
+            ['encryptedFields' => $originalEncryptedFields],
         );
 
         $operation->createDataKeys(
             $this->clientEncryption,
             'local',
             null,
-            $modifiedEncryptedFields
+            $modifiedEncryptedFields,
         );
 
         $this->assertSame($originalField, $originalEncryptedFields->fields[0]);
@@ -178,14 +177,14 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $operation = new CreateEncryptedCollection(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['encryptedFields' => $input]
+            ['encryptedFields' => $input],
         );
 
         $operation->createDataKeys(
             $this->clientEncryption,
             'local',
             null,
-            $modifiedEncryptedFields
+            $modifiedEncryptedFields,
         );
 
         $this->assertInstanceOf(Binary::class, $modifiedEncryptedFields['fields'][0]['keyId'] ?? null);

--- a/tests/Operation/CreateIndexesFunctionalTest.php
+++ b/tests/Operation/CreateIndexesFunctionalTest.php
@@ -127,10 +127,10 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
         // phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration
         // phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore
         return [
-            'array' => [function ($key) { return $key; }],
-            'object' => [function ($key) { return (object) $key; }],
-            'Serializable' => [function ($key) { return new BSONDocument($key); }],
-            'Document' => [function ($key) { return Document::fromPHP($key); }],
+            'array' => [fn ($key) => $key],
+            'object' => [fn ($key) => (object) $key],
+            'Serializable' => [fn ($key) => new BSONDocument($key)],
+            'Document' => [fn ($key) => Document::fromPHP($key)],
         ];
         // phpcs:enable
     }
@@ -156,14 +156,14 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['key' => ['x' => 1]]],
-                    ['writeConcern' => $this->createDefaultWriteConcern()]
+                    ['writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -175,14 +175,14 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['key' => ['x' => 1]]],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -200,14 +200,14 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['key' => ['x' => 1]]],
-                    ['commitQuorum' => 'majority']
+                    ['commitQuorum' => 'majority'],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('commitQuorum', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -219,7 +219,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             [['key' => ['x' => 1]]],
-            ['commitQuorum' => 'majority']
+            ['commitQuorum' => 'majority'],
         );
 
         $this->expectException(UnsupportedException::class);

--- a/tests/Operation/DatabaseCommandFunctionalTest.php
+++ b/tests/Operation/DatabaseCommandFunctionalTest.php
@@ -17,14 +17,14 @@ class DatabaseCommandFunctionalTest extends FunctionalTestCase
             function () use ($command): void {
                 $operation = new DatabaseCommand(
                     $this->getDatabaseName(),
-                    $command
+                    $command,
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertEquals(1, $event['started']->getCommand()->ping ?? null);
-            }
+            },
         );
     }
 
@@ -49,14 +49,14 @@ class DatabaseCommandFunctionalTest extends FunctionalTestCase
                 $operation = new DatabaseCommand(
                     $this->getDatabaseName(),
                     ['ping' => 1],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -14,8 +14,7 @@ use stdClass;
 
 class DeleteFunctionalTest extends FunctionalTestCase
 {
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
     public function setUp(): void
     {
@@ -33,14 +32,14 @@ class DeleteFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     $filter,
-                    1
+                    1,
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedQuery): void {
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->deletes[0]->q ?? null);
-            }
+            },
         );
     }
 
@@ -92,7 +91,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
             $this->getCollectionName(),
             [],
             0,
-            ['hint' => '_id_', 'writeConcern' => new WriteConcern(0)]
+            ['hint' => '_id_', 'writeConcern' => new WriteConcern(0)],
         );
 
         $this->expectException(UnsupportedException::class);
@@ -110,14 +109,14 @@ class DeleteFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     [],
                     0,
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Operation/DistinctFunctionalTest.php
+++ b/tests/Operation/DistinctFunctionalTest.php
@@ -11,6 +11,8 @@ use function is_scalar;
 use function json_encode;
 use function usort;
 
+use const JSON_THROW_ON_ERROR;
+
 class DistinctFunctionalTest extends FunctionalTestCase
 {
     /** @dataProvider provideFilterDocuments */
@@ -22,14 +24,14 @@ class DistinctFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     'x',
-                    $filter
+                    $filter,
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedQuery): void {
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->query ?? null);
-            }
+            },
         );
     }
 
@@ -42,14 +44,14 @@ class DistinctFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     'x',
                     [],
-                    ['readConcern' => $this->createDefaultReadConcern()]
+                    ['readConcern' => $this->createDefaultReadConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -62,14 +64,14 @@ class DistinctFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     'x',
                     [],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -103,8 +105,8 @@ class DistinctFunctionalTest extends FunctionalTestCase
                     return 1;
                 }
 
-                $a = json_encode($a);
-                $b = json_encode($b);
+                $a = json_encode($a, JSON_THROW_ON_ERROR);
+                $b = json_encode($b, JSON_THROW_ON_ERROR);
             }
 
             return $a < $b ? -1 : 1;

--- a/tests/Operation/DropCollectionFunctionalTest.php
+++ b/tests/Operation/DropCollectionFunctionalTest.php
@@ -15,14 +15,14 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
                 $operation = new DropCollection(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['writeConcern' => $this->createDefaultWriteConcern()]
+                    ['writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -61,14 +61,14 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
                 $operation = new DropCollection(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/DropDatabaseFunctionalTest.php
+++ b/tests/Operation/DropDatabaseFunctionalTest.php
@@ -18,14 +18,14 @@ class DropDatabaseFunctionalTest extends FunctionalTestCase
             function (): void {
                 $operation = new DropDatabase(
                     $this->getDatabaseName(),
-                    ['writeConcern' => $this->createDefaultWriteConcern()]
+                    ['writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -63,14 +63,14 @@ class DropDatabaseFunctionalTest extends FunctionalTestCase
             function (): void {
                 $operation = new DropDatabase(
                     $this->getDatabaseName(),
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Operation/DropIndexesFunctionalTest.php
+++ b/tests/Operation/DropIndexesFunctionalTest.php
@@ -26,14 +26,14 @@ class DropIndexesFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     'x_1',
-                    ['writeConcern' => $this->createDefaultWriteConcern()]
+                    ['writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -131,14 +131,14 @@ class DropIndexesFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     '*',
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Operation/ExplainFunctionalTest.php
+++ b/tests/Operation/ExplainFunctionalTest.php
@@ -131,7 +131,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $cappedCollectionOptions = [
             'capped' => true,
             'max' => 100,
-            'size' => 1048576,
+            'size' => 1_048_576,
         ];
 
         $this->createCollection($databaseName, $cappedCollectionName, $cappedCollectionOptions);
@@ -150,7 +150,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
                 $this->assertObjectNotHasAttribute('maxAwaitTimeMS', $command->explain);
                 $this->assertObjectHasAttribute('tailable', $command->explain);
                 $this->assertObjectHasAttribute('awaitData', $command->explain);
-            }
+            },
         );
     }
 
@@ -162,7 +162,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             [],
-            ['modifiers' => ['$orderby' => ['_id' => 1]]]
+            ['modifiers' => ['$orderby' => ['_id' => 1]]],
         );
 
         (new CommandObserver())->observe(
@@ -174,7 +174,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
                 $command = $event['started']->getCommand();
                 $this->assertObjectHasAttribute('sort', $command->explain);
                 $this->assertObjectNotHasAttribute('modifiers', $command->explain);
-            }
+            },
         );
     }
 
@@ -251,7 +251,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     ['_id' => ['$gt' => 1]],
                     ['$inc' => ['x' => 1]],
-                    ['bypassDocumentValidation' => true]
+                    ['bypassDocumentValidation' => true],
                 );
 
                 $explainOperation = new Explain($this->getDatabaseName(), $operation);
@@ -260,10 +260,10 @@ class ExplainFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute(
                     'bypassDocumentValidation',
-                    $event['started']->getCommand()->explain
+                    $event['started']->getCommand()->explain,
                 );
                 $this->assertEquals(true, $event['started']->getCommand()->explain->bypassDocumentValidation);
-            }
+            },
         );
     }
 
@@ -278,7 +278,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     ['_id' => ['$gt' => 1]],
                     ['$inc' => ['x' => 1]],
-                    ['bypassDocumentValidation' => false]
+                    ['bypassDocumentValidation' => false],
                 );
 
                 $explainOperation = new Explain($this->getDatabaseName(), $operation);
@@ -287,9 +287,9 @@ class ExplainFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectNotHasAttribute(
                     'bypassDocumentValidation',
-                    $event['started']->getCommand()->explain
+                    $event['started']->getCommand()->explain,
                 );
-            }
+            },
         );
     }
 

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -22,14 +22,14 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['query' => $query, 'remove' => true]
+                    ['query' => $query, 'remove' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedQuery): void {
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->query ?? null);
-            }
+            },
         );
     }
 
@@ -61,14 +61,14 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                     [
                         'query' => ['x' => 1],
                         'update' => $update,
-                    ]
+                    ],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedUpdate): void {
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->update ?? null);
-            }
+            },
         );
     }
 
@@ -96,14 +96,14 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['remove' => true]
+                    ['remove' => true],
                 );
 
                 $operation->execute($server);
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -114,14 +114,14 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['remove' => true, 'writeConcern' => $this->createDefaultWriteConcern()]
+                    ['remove' => true, 'writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -132,7 +132,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         $operation = new FindAndModify(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['remove' => true, 'hint' => '_id_']
+            ['remove' => true, 'hint' => '_id_'],
         );
 
         $this->expectException(UnsupportedException::class);
@@ -148,7 +148,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         $operation = new FindAndModify(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['remove' => true, 'hint' => '_id_', 'writeConcern' => new WriteConcern(0)]
+            ['remove' => true, 'hint' => '_id_', 'writeConcern' => new WriteConcern(0)],
         );
 
         $this->expectException(UnsupportedException::class);
@@ -170,7 +170,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         $operation = new FindAndModify(
             $this->getDatabaseName(),
             $this->getCollectionName(),
-            ['remove' => true, 'writeConcern' => new WriteConcern(50)]
+            ['remove' => true, 'writeConcern' => new WriteConcern(50)],
         );
 
         $operation->execute($this->getPrimaryServer());
@@ -183,14 +183,14 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['remove' => true, 'session' => $this->createSession()]
+                    ['remove' => true, 'session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -201,7 +201,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['remove' => true, 'bypassDocumentValidation' => true]
+                    ['remove' => true, 'bypassDocumentValidation' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -209,7 +209,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
-            }
+            },
         );
     }
 
@@ -220,14 +220,14 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 $operation = new FindAndModify(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['remove' => true, 'bypassDocumentValidation' => false]
+                    ['remove' => true, 'bypassDocumentValidation' => false],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -242,7 +242,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
             [
                 'remove' => true,
                 'typeMap' => $typeMap,
-            ]
+            ],
         );
         $document = $operation->execute($this->getPrimaryServer());
 

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -23,14 +23,14 @@ class FindFunctionalTest extends FunctionalTestCase
                 $operation = new Find(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $filter
+                    $filter,
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedQuery): void {
                 $this->assertEquals($expectedQuery, $event['started']->getCommand()->filter ?? null);
-            }
+            },
         );
     }
 
@@ -43,14 +43,14 @@ class FindFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [],
-                    ['modifiers' => $modifiers]
+                    ['modifiers' => $modifiers],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedSort): void {
                 $this->assertEquals($expectedSort, $event['started']->getCommand()->sort ?? null);
-            }
+            },
         );
     }
 
@@ -74,14 +74,14 @@ class FindFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [],
-                    ['readConcern' => $this->createDefaultReadConcern()]
+                    ['readConcern' => $this->createDefaultReadConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -144,14 +144,14 @@ class FindFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -211,7 +211,7 @@ class FindFunctionalTest extends FunctionalTestCase
         $cappedCollectionOptions = [
             'capped' => true,
             'max' => 100,
-            'size' => 1048576,
+            'size' => 1_048_576,
         ];
 
         $this->createCollection($databaseName, $cappedCollectionName, $cappedCollectionOptions);

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -14,8 +14,7 @@ use MongoDB\Tests\CommandObserver;
 
 class InsertManyFunctionalTest extends FunctionalTestCase
 {
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
     public function setUp(): void
     {
@@ -54,7 +53,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
                 $operation = new InsertMany(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $documents
+                    $documents,
                 );
 
                 $result = $operation->execute($this->getPrimaryServer());
@@ -69,7 +68,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use ($expectedDocuments): void {
                 $this->assertEquals($expectedDocuments, $event['started']->getCommand()->documents ?? null);
-            }
+            },
         );
     }
 
@@ -125,14 +124,14 @@ class InsertManyFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['_id' => 1], ['_id' => 2]],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -144,7 +143,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['_id' => 1], ['_id' => 2]],
-                    ['bypassDocumentValidation' => true]
+                    ['bypassDocumentValidation' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -152,7 +151,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
-            }
+            },
         );
     }
 
@@ -164,14 +163,14 @@ class InsertManyFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     [['_id' => 1], ['_id' => 2]],
-                    ['bypassDocumentValidation' => false]
+                    ['bypassDocumentValidation' => false],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -15,8 +15,7 @@ use stdClass;
 
 class InsertOneFunctionalTest extends FunctionalTestCase
 {
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
     public function setUp(): void
     {
@@ -36,7 +35,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
                 $operation = new InsertOne(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    $document
+                    $document,
                 );
 
                 $result = $operation->execute($this->getPrimaryServer());
@@ -48,7 +47,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use ($expectedDocument): void {
                 $this->assertEquals($expectedDocument, $event['started']->getCommand()->documents[0] ?? null);
-            }
+            },
         );
     }
 
@@ -116,14 +115,14 @@ class InsertOneFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     ['_id' => 1],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -135,7 +134,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     ['_id' => 1],
-                    ['bypassDocumentValidation' => true]
+                    ['bypassDocumentValidation' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -143,7 +142,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
-            }
+            },
         );
     }
 
@@ -155,14 +154,14 @@ class InsertOneFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     ['_id' => 1],
-                    ['bypassDocumentValidation' => false]
+                    ['bypassDocumentValidation' => false],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Operation/ListCollectionNamesFunctionalTest.php
+++ b/tests/Operation/ListCollectionNamesFunctionalTest.php
@@ -35,7 +35,7 @@ class ListCollectionNamesFunctionalTest extends FunctionalTestCase
             function (): void {
                 $operation = new ListCollectionNames(
                     $this->getDatabaseName(),
-                    ['authorizedCollections' => true]
+                    ['authorizedCollections' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -43,7 +43,7 @@ class ListCollectionNamesFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('authorizedCollections', $event['started']->getCommand());
                 $this->assertSame(true, $event['started']->getCommand()->authorizedCollections);
-            }
+            },
         );
     }
 
@@ -53,14 +53,14 @@ class ListCollectionNamesFunctionalTest extends FunctionalTestCase
             function (): void {
                 $operation = new ListCollectionNames(
                     $this->getDatabaseName(),
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/ListCollectionsFunctionalTest.php
+++ b/tests/Operation/ListCollectionsFunctionalTest.php
@@ -80,7 +80,7 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
             function (): void {
                 $operation = new ListCollections(
                     $this->getDatabaseName(),
-                    ['authorizedCollections' => true]
+                    ['authorizedCollections' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -88,7 +88,7 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('authorizedCollections', $event['started']->getCommand());
                 $this->assertSame(true, $event['started']->getCommand()->authorizedCollections);
-            }
+            },
         );
     }
 
@@ -98,14 +98,14 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
             function (): void {
                 $operation = new ListCollections(
                     $this->getDatabaseName(),
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/ListDatabaseNamesFunctionalTest.php
+++ b/tests/Operation/ListDatabaseNamesFunctionalTest.php
@@ -26,7 +26,7 @@ class ListDatabaseNamesFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('authorizedDatabases', $event['started']->getCommand());
                 $this->assertSame(true, $event['started']->getCommand()->nameOnly);
-            }
+            },
         );
 
         foreach ($databases as $database) {
@@ -39,7 +39,7 @@ class ListDatabaseNamesFunctionalTest extends FunctionalTestCase
         (new CommandObserver())->observe(
             function (): void {
                 $operation = new ListDatabaseNames(
-                    ['authorizedDatabases' => true]
+                    ['authorizedDatabases' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -47,7 +47,7 @@ class ListDatabaseNamesFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('authorizedDatabases', $event['started']->getCommand());
                 $this->assertSame(true, $event['started']->getCommand()->authorizedDatabases);
-            }
+            },
         );
     }
 
@@ -73,14 +73,14 @@ class ListDatabaseNamesFunctionalTest extends FunctionalTestCase
         (new CommandObserver())->observe(
             function (): void {
                 $operation = new ListDatabaseNames(
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/ListDatabasesFunctionalTest.php
+++ b/tests/Operation/ListDatabasesFunctionalTest.php
@@ -27,7 +27,7 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('authorizedDatabases', $event['started']->getCommand());
-            }
+            },
         );
 
         $this->assertInstanceOf(DatabaseInfoIterator::class, $databases);
@@ -42,7 +42,7 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
         (new CommandObserver())->observe(
             function (): void {
                 $operation = new ListDatabases(
-                    ['authorizedDatabases' => true]
+                    ['authorizedDatabases' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -50,7 +50,7 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('authorizedDatabases', $event['started']->getCommand());
                 $this->assertSame(true, $event['started']->getCommand()->authorizedDatabases);
-            }
+            },
         );
     }
 
@@ -80,14 +80,14 @@ class ListDatabasesFunctionalTest extends FunctionalTestCase
         (new CommandObserver())->observe(
             function (): void {
                 $operation = new ListDatabases(
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/ListIndexesFunctionalTest.php
+++ b/tests/Operation/ListIndexesFunctionalTest.php
@@ -49,14 +49,14 @@ class ListIndexesFunctionalTest extends FunctionalTestCase
                 $operation = new ListIndexes(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -35,14 +35,14 @@ class MapReduceFunctionalTest extends FunctionalTestCase
                     new Javascript('function() { emit(this.x, this.y); }'),
                     new Javascript('function(key, values) { return Array.sum(values); }'),
                     ['inline' => 1],
-                    ['readConcern' => $this->createDefaultReadConcern()]
+                    ['readConcern' => $this->createDefaultReadConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('readConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -60,14 +60,14 @@ class MapReduceFunctionalTest extends FunctionalTestCase
                     new Javascript('function() { emit(this.x, this.y); }'),
                     new Javascript('function(key, values) { return Array.sum(values); }'),
                     $this->getCollectionName() . '.output',
-                    ['writeConcern' => $this->createDefaultWriteConcern()]
+                    ['writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -155,14 +155,14 @@ class MapReduceFunctionalTest extends FunctionalTestCase
                     new Javascript('function() { emit(this.x, this.y); }'),
                     new Javascript('function(key, values) { return Array.sum(values); }'),
                     ['inline' => 1],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -178,7 +178,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
                     new Javascript('function() { emit(this.x, this.y); }'),
                     new Javascript('function(key, values) { return Array.sum(values); }'),
                     ['inline' => 1],
-                    ['bypassDocumentValidation' => true]
+                    ['bypassDocumentValidation' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -186,7 +186,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
-            }
+            },
         );
     }
 
@@ -202,14 +202,14 @@ class MapReduceFunctionalTest extends FunctionalTestCase
                     new Javascript('function() { emit(this.x, this.y); }'),
                     new Javascript('function(key, values) { return Array.sum(values); }'),
                     ['inline' => 1],
-                    ['bypassDocumentValidation' => false]
+                    ['bypassDocumentValidation' => false],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
-            }
+            },
         );
     }
 

--- a/tests/Operation/ModifyCollectionFunctionalTest.php
+++ b/tests/Operation/ModifyCollectionFunctionalTest.php
@@ -28,7 +28,7 @@ class ModifyCollectionFunctionalTest extends FunctionalTestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             ['index' => ['keyPattern' => ['lastAccess' => 1], 'expireAfterSeconds' => 1000]],
-            ['typeMap' => ['root' => 'array', 'document' => 'array']]
+            ['typeMap' => ['root' => 'array', 'document' => 'array']],
         );
         $result = $modifyCollection->execute($this->getPrimaryServer());
 

--- a/tests/Operation/RenameCollectionFunctionalTest.php
+++ b/tests/Operation/RenameCollectionFunctionalTest.php
@@ -10,14 +10,11 @@ use MongoDB\Tests\CommandObserver;
 
 class RenameCollectionFunctionalTest extends FunctionalTestCase
 {
-    /** @var integer */
-    private static $errorCodeNamespaceNotFound = 26;
+    private static int $errorCodeNamespaceNotFound = 26;
 
-    /** @var integer */
-    private static $errorCodeNamespaceExists = 48;
+    private static int $errorCodeNamespaceExists = 48;
 
-    /** @var string */
-    private $toCollectionName;
+    private string $toCollectionName;
 
     public function setUp(): void
     {
@@ -43,14 +40,14 @@ class RenameCollectionFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     $this->getDatabaseName(),
                     $this->toCollectionName,
-                    ['writeConcern' => $this->createDefaultWriteConcern()]
+                    ['writeConcern' => $this->createDefaultWriteConcern()],
                 );
 
                 $operation->execute($server);
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('writeConcern', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -66,7 +63,7 @@ class RenameCollectionFunctionalTest extends FunctionalTestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             $this->getDatabaseName(),
-            $this->toCollectionName
+            $this->toCollectionName,
         );
         $commandResult = $operation->execute($server);
 
@@ -101,7 +98,7 @@ class RenameCollectionFunctionalTest extends FunctionalTestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             $this->getDatabaseName(),
-            $this->toCollectionName
+            $this->toCollectionName,
         );
         $operation->execute($server);
     }
@@ -115,7 +112,7 @@ class RenameCollectionFunctionalTest extends FunctionalTestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             $this->getDatabaseName(),
-            $this->toCollectionName
+            $this->toCollectionName,
         );
         $operation->execute($this->getPrimaryServer());
     }
@@ -135,14 +132,14 @@ class RenameCollectionFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     $this->getDatabaseName(),
                     $this->toCollectionName,
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($server);
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 }

--- a/tests/Operation/RenameCollectionTest.php
+++ b/tests/Operation/RenameCollectionTest.php
@@ -16,7 +16,7 @@ class RenameCollectionTest extends TestCase
             $this->getCollectionName(),
             $this->getDatabaseName(),
             $this->getCollectionName() . '.renamed',
-            $options
+            $options,
         );
     }
 

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -17,8 +17,7 @@ use function is_array;
 
 class UpdateFunctionalTest extends FunctionalTestCase
 {
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
     public function setUp(): void
     {
@@ -36,14 +35,14 @@ class UpdateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     $filter,
-                    ['$set' => ['x' => 1]]
+                    ['$set' => ['x' => 1]],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedFilter): void {
                 $this->assertEquals($expectedFilter, $event['started']->getCommand()->updates[0]->q ?? null);
-            }
+            },
         );
     }
 
@@ -65,14 +64,14 @@ class UpdateFunctionalTest extends FunctionalTestCase
                     $this->getDatabaseName(),
                     $this->getCollectionName(),
                     ['x' => 1],
-                    $update
+                    $update,
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event) use ($expectedUpdate): void {
                 $this->assertEquals($expectedUpdate, $event['started']->getCommand()->updates[0]->u ?? null);
-            }
+            },
         );
     }
 
@@ -97,14 +96,14 @@ class UpdateFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     ['_id' => 1],
                     ['$inc' => ['x' => 1]],
-                    ['session' => $this->createSession()]
+                    ['session' => $this->createSession()],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectHasAttribute('lsid', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -117,7 +116,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     ['_id' => 1],
                     ['$inc' => ['x' => 1]],
-                    ['bypassDocumentValidation' => true]
+                    ['bypassDocumentValidation' => true],
                 );
 
                 $operation->execute($this->getPrimaryServer());
@@ -125,7 +124,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
             function (array $event): void {
                 $this->assertObjectHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
                 $this->assertEquals(true, $event['started']->getCommand()->bypassDocumentValidation);
-            }
+            },
         );
     }
 
@@ -138,14 +137,14 @@ class UpdateFunctionalTest extends FunctionalTestCase
                     $this->getCollectionName(),
                     ['_id' => 1],
                     ['$inc' => ['x' => 1]],
-                    ['bypassDocumentValidation' => false]
+                    ['bypassDocumentValidation' => false],
                 );
 
                 $operation->execute($this->getPrimaryServer());
             },
             function (array $event): void {
                 $this->assertObjectNotHasAttribute('bypassDocumentValidation', $event['started']->getCommand());
-            }
+            },
         );
     }
 
@@ -158,7 +157,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
             $this->getCollectionName(),
             ['_id' => 1],
             ['$inc' => ['x' => 1]],
-            ['hint' => '_id_', 'writeConcern' => new WriteConcern(0)]
+            ['hint' => '_id_', 'writeConcern' => new WriteConcern(0)],
         );
 
         $this->expectException(UnsupportedException::class);

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -40,11 +40,9 @@ class WatchFunctionalTest extends FunctionalTestCase
     public const INTERRUPTED = 11601;
     public const NOT_PRIMARY = 10107;
 
-    /** @var integer */
-    private static $wireVersionForStartAtOperationTime = 7;
+    private static int $wireVersionForStartAtOperationTime = 7;
 
-    /** @var array */
-    private $defaultOptions = ['maxAwaitTimeMS' => 500];
+    private array $defaultOptions = ['maxAwaitTimeMS' => 500];
 
     public function setUp(): void
     {
@@ -117,7 +115,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$events): void {
                 $events[] = $event;
-            }
+            },
         );
 
         $this->assertCount(1, $events);
@@ -139,7 +137,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$lastEvent): void {
                 $lastEvent = $event;
-            }
+            },
         );
 
         $this->assertNotNull($lastEvent);
@@ -174,7 +172,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$commands): void {
                 $commands[] = $event['started']->getCommandName();
-            }
+            },
         );
 
         $expectedCommands = [
@@ -213,7 +211,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$events): void {
                 $events[] = $event;
-            }
+            },
         );
 
         $this->assertCount(1, $events);
@@ -235,7 +233,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$events): void {
                 $events[] = $event;
-            }
+            },
         );
 
         $this->assertCount(3, $events);
@@ -287,7 +285,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$events): void {
                 $events[] = $event;
-            }
+            },
         );
 
         $this->assertCount(1, $events);
@@ -312,7 +310,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$events): void {
                 $events[] = $event;
-            }
+            },
         );
 
         $this->assertCount(3, $events);
@@ -1118,7 +1116,7 @@ class WatchFunctionalTest extends FunctionalTestCase
                 if (isset($command->aggregate)) {
                     $originalSession = bin2hex((string) $command->lsid->id);
                 }
-            }
+            },
         );
 
         $changeStream->rewind();
@@ -1131,7 +1129,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             function (array $event) use (&$sessionAfterResume, &$commands): void {
                 $commands[] = $event['started']->getCommandName();
                 $sessionAfterResume[] = bin2hex((string) $event['started']->getCommand()->lsid->id);
-            }
+            },
         );
 
         $expectedCommands = [
@@ -1213,7 +1211,7 @@ class WatchFunctionalTest extends FunctionalTestCase
                 }
 
                 $aggregateCommands[] = (array) $command;
-            }
+            },
         );
 
         $this->assertCount(2, $aggregateCommands);
@@ -1224,9 +1222,9 @@ class WatchFunctionalTest extends FunctionalTestCase
                 $this->logicalOr(
                     $this->objectHasAttribute('resumeAfter'),
                     $this->objectHasAttribute('startAfter'),
-                    $this->objectHasAttribute('startAtOperationTime')
-                )
-            )
+                    $this->objectHasAttribute('startAtOperationTime'),
+                ),
+            ),
         );
 
         $this->assertThat(
@@ -1234,8 +1232,8 @@ class WatchFunctionalTest extends FunctionalTestCase
             $this->logicalOr(
                 $this->objectHasAttribute('resumeAfter'),
                 $this->objectHasAttribute('startAfter'),
-                $this->objectHasAttribute('startAtOperationTime')
-            )
+                $this->objectHasAttribute('startAtOperationTime'),
+            ),
         );
 
         $aggregateCommands = array_map(
@@ -1244,14 +1242,14 @@ class WatchFunctionalTest extends FunctionalTestCase
                 if (isset($aggregateCommand['pipeline'][0]->{'$changeStream'})) {
                     $aggregateCommand['pipeline'][0]->{'$changeStream'} = array_diff_key(
                         (array) $aggregateCommand['pipeline'][0]->{'$changeStream'},
-                        ['resumeAfter' => false, 'startAfter' => false, 'startAtOperationTime' => false]
+                        ['resumeAfter' => false, 'startAfter' => false, 'startAtOperationTime' => false],
                     );
                 }
 
                 // Remove options we don't want to compare between commands
                 return array_diff_key($aggregateCommand, ['lsid' => false, '$clusterTime' => false]);
             },
-            $aggregateCommands
+            $aggregateCommands,
         );
 
         // Ensure options in original and resuming aggregate command match
@@ -1284,7 +1282,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             },
             function (array $event) use (&$commandCount): void {
                 $commandCount++;
-            }
+            },
         );
 
         $this->assertSame(1, $commandCount);
@@ -1318,11 +1316,9 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->assertNotSame($previousCursorId, $changeStream->getCursorId());
 
         $getCursor = Closure::bind(
-            function () {
-                return $this->iterator->getInnerIterator();
-            },
+            fn () => $this->iterator->getInnerIterator(),
             $changeStream,
-            ChangeStream::class
+            ChangeStream::class,
         );
         $cursor = $getCursor();
         assert($cursor instanceof Cursor);
@@ -1460,7 +1456,7 @@ class WatchFunctionalTest extends FunctionalTestCase
                 }
 
                 $aggregateCommand = $event['started']->getCommand();
-            }
+            },
         );
 
         $this->assertNotNull($aggregateCommand);
@@ -1509,7 +1505,7 @@ class WatchFunctionalTest extends FunctionalTestCase
                 }
 
                 $aggregateCommand = $event['started']->getCommand();
-            }
+            },
         );
 
         $this->assertNotNull($aggregateCommand);
@@ -1525,7 +1521,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             $callable,
             function (array $event) use (&$commands): void {
                 $this->fail(sprintf('"%s" command was executed', $event['started']->getCommandName()));
-            }
+            },
         );
 
         $this->assertEmpty($commands);
@@ -1560,7 +1556,7 @@ class WatchFunctionalTest extends FunctionalTestCase
             $this->getDatabaseName(),
             $this->getCollectionName(),
             $document,
-            ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]
+            ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)],
         );
         $writeResult = $insertOne->execute($this->getPrimaryServer());
         $this->assertEquals(1, $writeResult->getInsertedCount());

--- a/tests/PHPUnit/Functions.php
+++ b/tests/PHPUnit/Functions.php
@@ -2614,7 +2614,7 @@ if (! function_exists('PHPUnit\Framework\atLeast')) {
     function atLeast(int $requiredInvocations): InvokedAtLeastCountMatcher
     {
         return new InvokedAtLeastCountMatcher(
-            $requiredInvocations
+            $requiredInvocations,
         );
     }
 }

--- a/tests/PedantryTest.php
+++ b/tests/PedantryTest.php
@@ -35,7 +35,7 @@ class PedantryTest extends TestCase
             function (ReflectionMethod $method) use ($class) {
                 return $method->getDeclaringClass() == $class // Exclude inherited methods
                     && $method->getFileName() === $class->getFileName(); // Exclude methods inherited from traits
-            }
+            },
         );
 
         $getSortValue = function (ReflectionMethod $method) {
@@ -55,17 +55,11 @@ class PedantryTest extends TestCase
         $sortedMethods = $methods;
         usort(
             $sortedMethods,
-            function (ReflectionMethod $a, ReflectionMethod $b) use ($getSortValue) {
-                return strcasecmp($getSortValue($a), $getSortValue($b));
-            }
+            fn (ReflectionMethod $a, ReflectionMethod $b) => strcasecmp($getSortValue($a), $getSortValue($b))
         );
 
-        $methods = array_map(function (ReflectionMethod $method) {
-            return $method->getName();
-        }, $methods);
-        $sortedMethods = array_map(function (ReflectionMethod $method) {
-            return $method->getName();
-        }, $sortedMethods);
+        $methods = array_map(fn (ReflectionMethod $method) => $method->getName(), $methods);
+        $sortedMethods = array_map(fn (ReflectionMethod $method) => $method->getName(), $sortedMethods);
 
         $this->assertEquals($sortedMethods, $methods);
     }

--- a/tests/PedantryTest.php
+++ b/tests/PedantryTest.php
@@ -55,7 +55,7 @@ class PedantryTest extends TestCase
         $sortedMethods = $methods;
         usort(
             $sortedMethods,
-            fn (ReflectionMethod $a, ReflectionMethod $b) => strcasecmp($getSortValue($a), $getSortValue($b))
+            fn (ReflectionMethod $a, ReflectionMethod $b) => strcasecmp($getSortValue($a), $getSortValue($b)),
         );
 
         $methods = array_map(fn (ReflectionMethod $method) => $method->getName(), $methods);

--- a/tests/SpecTests/AtlasDataLakeSpecTest.php
+++ b/tests/SpecTests/AtlasDataLakeSpecTest.php
@@ -68,8 +68,8 @@ class AtlasDataLakeSpecTest extends FunctionalTestCase
             $this->markTestSkipped($test->skipReason);
         }
 
-        $databaseName = $databaseName ?? $this->getDatabaseName();
-        $collectionName = $collectionName ?? $this->getCollectionName();
+        $databaseName ??= $this->getDatabaseName();
+        $collectionName ??= $this->getCollectionName();
 
         $context = Context::fromCrud($test, $databaseName, $collectionName);
         $this->setContext($context);
@@ -186,7 +186,7 @@ class AtlasDataLakeSpecTest extends FunctionalTestCase
                 $this->assertIsArray($reply->cursorsKilled);
                 $this->assertArrayHasKey(0, $reply->cursorsKilled);
                 $this->assertSame($cursorId, $reply->cursorsKilled[0]);
-            }
+            },
         );
     }
 
@@ -239,7 +239,7 @@ class AtlasDataLakeSpecTest extends FunctionalTestCase
     {
         $cursor = $this->manager->executeCommand(
             $this->getDatabaseName(),
-            new Command(['buildInfo' => 1])
+            new Command(['buildInfo' => 1]),
         );
 
         $document = current($cursor->toArray());

--- a/tests/SpecTests/ClientSideEncryption/Prose21_AutomaticDataEncryptionKeysTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose21_AutomaticDataEncryptionKeysTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\SpecTests\ClientSideEncryption;
 
 use Generator;
 use MongoDB\BSON\Binary;
+use MongoDB\Database;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Exception\CommandException;
@@ -23,8 +24,8 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
 {
     public const SERVER_ERROR_TYPEMISMATCH = 14;
 
-    private $clientEncryption;
-    private $database;
+    private ?ClientEncryption $clientEncryption = null;
+    private ?Database $database = null;
 
     public function setUp(): void
     {
@@ -73,7 +74,7 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
             $this->clientEncryption,
             $kmsProvider,
             $masterKey,
-            ['encryptedFields' => ['fields' => [['path' => 'ssn', 'bsonType' => 'string', 'keyId' => null]]]]
+            ['encryptedFields' => ['fields' => [['path' => 'ssn', 'bsonType' => 'string', 'keyId' => null]]]],
         );
 
         $this->assertCommandSucceeded($result);
@@ -110,7 +111,7 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
             $this->clientEncryption,
             $kmsProvider,
             $masterKey,
-            []
+            [],
         );
     }
 
@@ -126,7 +127,7 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
                 $this->clientEncryption,
                 $kmsProvider,
                 $masterKey,
-                ['encryptedFields' => ['fields' => [['path' => 'ssn', 'bsonType' => 'string', 'keyId' => false]]]]
+                ['encryptedFields' => ['fields' => [['path' => 'ssn', 'bsonType' => 'string', 'keyId' => false]]]],
             );
             $this->fail('CreateEncryptedCollectionException was not thrown');
         } catch (CreateEncryptedCollectionException $e) {
@@ -150,7 +151,7 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
             $this->clientEncryption,
             $kmsProvider,
             $masterKey,
-            ['encryptedFields' => ['fields' => [['path' => 'ssn', 'bsonType' => 'string', 'keyId' => null]]]]
+            ['encryptedFields' => ['fields' => [['path' => 'ssn', 'bsonType' => 'string', 'keyId' => null]]]],
         );
 
         $this->assertCommandSucceeded($result);

--- a/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
@@ -10,6 +10,8 @@ use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
+use MongoDB\Client;
+use MongoDB\Collection;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\EncryptionException;
 use MultipleIterator;
@@ -28,9 +30,9 @@ use function is_int;
  */
 class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
 {
-    private $clientEncryption;
-    private $collection;
-    private $encryptedClient;
+    private ?ClientEncryption $clientEncryption = null;
+    private ?Collection $collection = null;
+    private ?Client $encryptedClient = null;
     private $key1Id;
 
     public function setUp(): void
@@ -446,30 +448,20 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         switch ($type) {
             case 'DecimalNoPrecision':
             case 'DecimalPrecision':
-                return function (int $value) {
-                    return new Decimal128((string) $value);
-                };
+                return fn (int $value) => new Decimal128((string) $value);
 
             case 'DoubleNoPrecision':
             case 'DoublePrecision':
-                return function (int $value) {
-                    return (double) $value;
-                };
+                return fn (int $value) => (double) $value;
 
             case 'Date':
-                return function (int $value) {
-                    return new UTCDateTime($value);
-                };
+                return fn (int $value) => new UTCDateTime($value);
 
             case 'Int':
-                return function (int $value) {
-                    return $value;
-                };
+                return fn (int $value) => $value;
 
             case 'Long':
-                return function (int $value) {
-                    return new Int64($value);
-                };
+                return fn (int $value) => new Int64($value);
 
             default:
                 throw new LogicException('Unsupported type: ' . $type);

--- a/tests/SpecTests/CommandExpectations.php
+++ b/tests/SpecTests/CommandExpectations.php
@@ -20,7 +20,6 @@ use function key;
  */
 class CommandExpectations implements CommandSubscriber
 {
-    /** @var array */
     private array $actualEvents = [];
 
     private array $expectedEvents = [];
@@ -35,7 +34,7 @@ class CommandExpectations implements CommandSubscriber
 
     private bool $ignoreKeyVaultListCollections = false;
 
-    /** @var string[] */
+    /** @var list<string> */
     private array $ignoredCommandNames = [];
 
     private Client $observedClient;

--- a/tests/SpecTests/CommandExpectations.php
+++ b/tests/SpecTests/CommandExpectations.php
@@ -21,31 +21,24 @@ use function key;
 class CommandExpectations implements CommandSubscriber
 {
     /** @var array */
-    private $actualEvents = [];
+    private array $actualEvents = [];
 
-    /** @var array */
-    private $expectedEvents = [];
+    private array $expectedEvents = [];
 
-    /** @var boolean */
-    private $ignoreCommandFailed = false;
+    private bool $ignoreCommandFailed = false;
 
-    /** @var boolean */
-    private $ignoreCommandStarted = false;
+    private bool $ignoreCommandStarted = false;
 
-    /** @var boolean */
-    private $ignoreCommandSucceeded = false;
+    private bool $ignoreCommandSucceeded = false;
 
-    /** @var boolean */
-    private $ignoreExtraEvents = false;
+    private bool $ignoreExtraEvents = false;
 
-    /** @var boolean */
-    private $ignoreKeyVaultListCollections = false;
+    private bool $ignoreKeyVaultListCollections = false;
 
     /** @var string[] */
-    private $ignoredCommandNames = [];
+    private array $ignoredCommandNames = [];
 
-    /** @var Client */
-    private $observedClient;
+    private Client $observedClient;
 
     private function __construct(Client $observedClient, array $events)
     {

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -34,10 +34,8 @@ final class Context
 
     public string $databaseName;
 
-    /** @var array */
     public array $defaultWriteOptions = [];
 
-    /** @var array */
     public array $outcomeReadOptions = [];
 
     public ?string $outcomeCollectionName = null;

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -26,47 +26,35 @@ use function sprintf;
  */
 final class Context
 {
-    /** @var string|null */
-    public $bucketName;
+    public ?string $bucketName = null;
 
-    /** @var Client|null */
-    private $client;
+    private ?Client $client = null;
 
-    /** @var string|null */
-    public $collectionName;
+    public ?string $collectionName = null;
 
-    /** @var string */
-    public $databaseName;
+    public string $databaseName;
 
     /** @var array */
-    public $defaultWriteOptions = [];
+    public array $defaultWriteOptions = [];
 
     /** @var array */
-    public $outcomeReadOptions = [];
+    public array $outcomeReadOptions = [];
 
-    /** @var string|null */
-    public $outcomeCollectionName;
+    public ?string $outcomeCollectionName = null;
 
-    /** @var Session|null */
-    public $session0;
+    public ?Session $session0 = null;
 
-    /** @var object */
-    public $session0Lsid;
+    public object $session0Lsid;
 
-    /** @var Session|null */
-    public $session1;
+    public ?Session $session1 = null;
 
-    /** @var object */
-    public $session1Lsid;
+    public object $session1Lsid;
 
-    /** @var bool */
-    public $useEncryptedClientIfConfigured = false;
+    public bool $useEncryptedClientIfConfigured = false;
 
-    /** @var Client */
-    private $internalClient;
+    private Client $internalClient;
 
-    /** @var Client|null */
-    private $encryptedClient;
+    private ?Client $encryptedClient = null;
 
     private function __construct(string $databaseName, ?string $collectionName)
     {
@@ -306,7 +294,7 @@ final class Context
             $this->databaseName,
             $this->collectionName,
             $collectionOptions,
-            $databaseOptions
+            $databaseOptions,
         );
     }
 
@@ -446,7 +434,7 @@ final class Context
     {
         return $this->getClient()->selectDatabase(
             $databaseName,
-            $this->prepareOptions($databaseOptions)
+            $this->prepareOptions($databaseOptions),
         );
     }
 

--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -39,11 +39,9 @@ class DocumentsMatchConstraint extends Constraint
 {
     use ConstraintTrait;
 
-    /** @var boolean */
-    private $ignoreExtraKeysInRoot = false;
+    private bool $ignoreExtraKeysInRoot = false;
 
-    /** @var boolean */
-    private $ignoreExtraKeysInEmbedded = false;
+    private bool $ignoreExtraKeysInEmbedded = false;
 
     /**
      * TODO: This is not currently used, but was preserved from the design of
@@ -51,19 +49,15 @@ class DocumentsMatchConstraint extends Constraint
      * documents as JSON strings. If the TODO item in matches() is implemented
      * to make document comparisons more efficient, we may consider supporting
      * this option.
-     *
-     * @var boolean
      */
-    private $sortKeys = false;
+    private bool $sortKeys = false;
 
     /** @var BSONArray|BSONDocument */
     private $value;
 
-    /** @var ComparisonFailure|null */
-    private $lastFailure;
+    private ?ComparisonFailure $lastFailure = null;
 
-    /** @var Factory */
-    private $comparatorFactory;
+    private Factory $comparatorFactory;
 
     /**
      * Creates a new constraint.
@@ -104,7 +98,7 @@ class DocumentsMatchConstraint extends Constraint
                 $this->exporter()->export($this->value),
                 $this->exporter()->export($other),
                 false,
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -126,7 +120,7 @@ class DocumentsMatchConstraint extends Constraint
         assertThat(
             $expectedType,
             logicalOr(isType('string'), logicalAnd(isInstanceOf(BSONArray::class), containsOnly('string'))),
-            '$$type requires string or string[]'
+            '$$type requires string or string[]',
         );
 
         IsBsonType::anyOf(...(array) $expectedType)->evaluate($actualValue);
@@ -143,7 +137,7 @@ class DocumentsMatchConstraint extends Constraint
             throw new RuntimeException(sprintf(
                 '%s is not instance of expected class "%s"',
                 $this->exporter()->shortenedExport($actual),
-                get_class($expected)
+                get_class($expected),
             ));
         }
 
@@ -186,8 +180,8 @@ class DocumentsMatchConstraint extends Constraint
                         'Field path "%s": %s is not instance of expected type "%s".',
                         $keyPrefix . $key,
                         $this->exporter()->shortenedExport($actualValue),
-                        $expectedType
-                    )
+                        $expectedType,
+                    ),
                 );
             }
 
@@ -200,7 +194,7 @@ class DocumentsMatchConstraint extends Constraint
                     '',
                     '',
                     false,
-                    sprintf('Field path "%s": %s', $keyPrefix . $key, $failure->getMessage())
+                    sprintf('Field path "%s": %s', $keyPrefix . $key, $failure->getMessage()),
                 );
             }
         }

--- a/tests/SpecTests/DocumentsMatchConstraintTest.php
+++ b/tests/SpecTests/DocumentsMatchConstraintTest.php
@@ -86,7 +86,7 @@ class DocumentsMatchConstraintTest extends TestCase
         $symbol = toPHP(fromJSON('{ "x": {"$symbol": "test"} }'))->x;
         $dbPointer = toPHP(fromJSON('{ "x": {"$dbPointer": {"$ref": "db.coll", "$id" : { "$oid" : "5a2e78accd485d55b405ac12" }  }} }'))->x;
         $int64 = new Int64(1);
-        $long = PHP_INT_SIZE == 4 ? new Int64('4294967296') : 4294967296;
+        $long = PHP_INT_SIZE == 4 ? new Int64('4294967296') : 4_294_967_296;
 
         return [
             'double' => ['double', 1.4],

--- a/tests/SpecTests/ErrorExpectation.php
+++ b/tests/SpecTests/ErrorExpectation.php
@@ -37,10 +37,10 @@ final class ErrorExpectation
 
     private bool $isExpected = false;
 
-    /** @var string[] */
+    /** @var list<string> */
     private array $excludedLabels = [];
 
-    /** @var string[] */
+    /** @var list<string> */
     private array $includedLabels = [];
 
     private string $messageContains;

--- a/tests/SpecTests/ErrorExpectation.php
+++ b/tests/SpecTests/ErrorExpectation.php
@@ -22,12 +22,8 @@ use function sprintf;
  */
 final class ErrorExpectation
 {
-    /**
-     * @see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
-     *
-     * @var array
-     */
-    private static $codeNameMap = [
+    /** @see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err */
+    private static array $codeNameMap = [
         'Interrupted' => 11601,
         'MaxTimeMSExpired' => 50,
         'NoSuchTransaction' => 251,
@@ -35,23 +31,19 @@ final class ErrorExpectation
         'WriteConflict' => 112,
     ];
 
-    /** @var integer */
-    private $code;
+    private int $code;
 
-    /** @var string */
-    private $codeName;
+    private string $codeName;
 
-    /** @var boolean */
-    private $isExpected = false;
+    private bool $isExpected = false;
 
     /** @var string[] */
-    private $excludedLabels = [];
+    private array $excludedLabels = [];
 
     /** @var string[] */
-    private $includedLabels = [];
+    private array $includedLabels = [];
 
-    /** @var string */
-    private $messageContains;
+    private string $messageContains;
 
     private function __construct()
     {

--- a/tests/SpecTests/ErrorExpectation.php
+++ b/tests/SpecTests/ErrorExpectation.php
@@ -22,7 +22,10 @@ use function sprintf;
  */
 final class ErrorExpectation
 {
-    /** @see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err */
+    /**
+     * @see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
+     * @var array<string, int>
+     */
     private static array $codeNameMap = [
         'Interrupted' => 11601,
         'MaxTimeMSExpired' => 50,

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -19,6 +19,8 @@ use function MongoDB\BSON\toPHP;
 use function sprintf;
 use function version_compare;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * Base class for spec test runners.
  *
@@ -35,8 +37,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
     public const SERVERLESS_FORBID = 'forbid';
     public const SERVERLESS_REQUIRE = 'require';
 
-    /** @var Context|null */
-    private $context;
+    private ?Context $context = null;
 
     public function setUp(): void
     {
@@ -165,7 +166,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
         $serverVersion = $this->getServerVersion();
         $topology = $this->getTopology();
 
-        $this->markTestSkipped(sprintf('Server version "%s" and topology "%s" do not meet test requirements: %s', $serverVersion, $topology, json_encode($runOn)));
+        $this->markTestSkipped(sprintf('Server version "%s" and topology "%s" do not meet test requirements: %s', $serverVersion, $topology, json_encode($runOn, JSON_THROW_ON_ERROR)));
     }
 
     /**

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -558,7 +558,7 @@ final class Operation
                 return $session->startTransaction($context->prepareOptions($options));
 
             case 'withTransaction':
-                /** @var self[] $callbackOperations */
+                /** @var list<self> $callbackOperations */
                 $callbackOperations = array_map(fn ($operation) => self::fromConvenientTransactions($operation), $this->arguments['callback']->operations);
 
                 $callback = function () use ($callbackOperations, $test, $context): void {

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -13,7 +13,6 @@ use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\GridFS\Bucket;
 use MongoDB\MapReduceResult;
-use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\FindOneAndReplace;
 use MongoDB\Operation\FindOneAndUpdate;
 use stdClass;
@@ -648,8 +647,13 @@ final class Operation
     private function getIndexNames(Context $context, string $databaseName, string $collectionName): array
     {
         return array_map(
-            fn (IndexInfo $indexInfo) => $indexInfo->getName(),
-            iterator_to_array($context->getInternalClient()->selectCollection($databaseName, $collectionName)->listIndexes()),
+            'strval',
+            iterator_to_array(
+                $context
+                    ->getInternalClient()
+                    ->selectCollection($databaseName, $collectionName)
+                    ->listIndexes(),
+            ),
         );
     }
 

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -558,7 +558,10 @@ final class Operation
 
             case 'withTransaction':
                 /** @var list<self> $callbackOperations */
-                $callbackOperations = array_map(fn ($operation) => self::fromConvenientTransactions($operation), $this->arguments['callback']->operations);
+                $callbackOperations = array_map(
+                    fn ($operation) => self::fromConvenientTransactions($operation),
+                    $this->arguments['callback']->operations,
+                );
 
                 $callback = function () use ($callbackOperations, $test, $context): void {
                     foreach ($callbackOperations as $operation) {

--- a/tests/SpecTests/Operation.php
+++ b/tests/SpecTests/Operation.php
@@ -43,32 +43,23 @@ final class Operation
     public const OBJECT_SESSION1 = 'session1';
     public const OBJECT_TEST_RUNNER = 'testRunner';
 
-    /** @var ErrorExpectation|null */
-    public $errorExpectation;
+    public ?ErrorExpectation $errorExpectation = null;
 
-    /** @var ResultExpectation|null */
-    public $resultExpectation;
+    public ?ResultExpectation $resultExpectation = null;
 
-    /** @var array */
-    private $arguments = [];
+    private array $arguments = [];
 
-    /** @var string|null */
-    private $collectionName;
+    private ?string $collectionName = null;
 
-    /** @var array */
-    private $collectionOptions = [];
+    private array $collectionOptions = [];
 
-    /** @var string|null */
-    private $databaseName;
+    private ?string $databaseName = null;
 
-    /** @var array */
-    private $databaseOptions = [];
+    private array $databaseOptions = [];
 
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var string */
-    private $object = self::OBJECT_COLLECTION;
+    private string $object = self::OBJECT_COLLECTION;
 
     private function __construct(stdClass $operation)
     {
@@ -304,7 +295,7 @@ final class Operation
             case 'watch':
                 return $client->watch(
                     $args['pipeline'] ?? [],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 );
 
             default:
@@ -327,7 +318,7 @@ final class Operation
             case 'aggregate':
                 return $collection->aggregate(
                     $args['pipeline'],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 );
 
             case 'bulkWrite':
@@ -338,19 +329,19 @@ final class Operation
                 return $collection->bulkWrite(
                     // TODO: Check if self can be used with a private static function
                     array_map([$this, 'prepareBulkWriteRequest'], $args['requests']),
-                    $options
+                    $options,
                 );
 
             case 'createIndex':
                 return $collection->createIndex(
                     $args['keys'],
-                    array_diff_key($args, ['keys' => 1])
+                    array_diff_key($args, ['keys' => 1]),
                 );
 
             case 'dropIndex':
                 return $collection->dropIndex(
                     $args['name'],
-                    array_diff_key($args, ['name' => 1])
+                    array_diff_key($args, ['name' => 1]),
                 );
 
             case 'count':
@@ -376,7 +367,7 @@ final class Operation
                 return $collection->distinct(
                     $args['fieldName'],
                     $args['filter'] ?? [],
-                    array_diff_key($args, ['fieldName' => 1, 'filter' => 1])
+                    array_diff_key($args, ['fieldName' => 1, 'filter' => 1]),
                 );
 
             case 'drop':
@@ -421,13 +412,13 @@ final class Operation
 
                 return $collection->insertMany(
                     $args['documents'],
-                    $options
+                    $options,
                 );
 
             case 'insertOne':
                 return $collection->insertOne(
                     $args['document'],
-                    array_diff_key($args, ['document' => 1])
+                    array_diff_key($args, ['document' => 1]),
                 );
 
             case 'listIndexes':
@@ -438,13 +429,13 @@ final class Operation
                     $args['map'],
                     $args['reduce'],
                     $args['out'],
-                    array_diff_key($args, ['map' => 1, 'reduce' => 1, 'out' => 1])
+                    array_diff_key($args, ['map' => 1, 'reduce' => 1, 'out' => 1]),
                 );
 
             case 'watch':
                 return $collection->watch(
                     $args['pipeline'] ?? [],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 );
 
             default:
@@ -467,19 +458,19 @@ final class Operation
             case 'aggregate':
                 return $database->aggregate(
                     $args['pipeline'],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 );
 
             case 'createCollection':
                 return $database->createCollection(
                     $args['collection'],
-                    array_diff_key($args, ['collection' => 1])
+                    array_diff_key($args, ['collection' => 1]),
                 );
 
             case 'dropCollection':
                 return $database->dropCollection(
                     $args['collection'],
-                    array_diff_key($args, ['collection' => 1])
+                    array_diff_key($args, ['collection' => 1]),
                 );
 
             case 'listCollectionNames':
@@ -491,13 +482,13 @@ final class Operation
             case 'runCommand':
                 return $database->command(
                     $args['command'],
-                    array_diff_key($args, ['command' => 1])
+                    array_diff_key($args, ['command' => 1]),
                 )->toArray()[0];
 
             case 'watch':
                 return $database->watch(
                     $args['pipeline'] ?? [],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 );
 
             default:
@@ -568,9 +559,7 @@ final class Operation
 
             case 'withTransaction':
                 /** @var self[] $callbackOperations */
-                $callbackOperations = array_map(function ($operation) {
-                    return self::fromConvenientTransactions($operation);
-                }, $this->arguments['callback']->operations);
+                $callbackOperations = array_map(fn ($operation) => self::fromConvenientTransactions($operation), $this->arguments['callback']->operations);
 
                 $callback = function () use ($callbackOperations, $test, $context): void {
                     foreach ($callbackOperations as $operation) {
@@ -659,10 +648,8 @@ final class Operation
     private function getIndexNames(Context $context, string $databaseName, string $collectionName): array
     {
         return array_map(
-            function (IndexInfo $indexInfo) {
-                return $indexInfo->getName();
-            },
-            iterator_to_array($context->getInternalClient()->selectCollection($databaseName, $collectionName)->listIndexes())
+            fn (IndexInfo $indexInfo) => $indexInfo->getName(),
+            iterator_to_array($context->getInternalClient()->selectCollection($databaseName, $collectionName)->listIndexes()),
         );
     }
 

--- a/tests/SpecTests/PrimaryStepDownSpecTest.php
+++ b/tests/SpecTests/PrimaryStepDownSpecTest.php
@@ -24,11 +24,9 @@ class PrimaryStepDownSpecTest extends FunctionalTestCase
     public const NOT_PRIMARY = 10107;
     public const SHUTDOWN_IN_PROGRESS = 91;
 
-    /** @var Client */
-    private $client;
+    private Client $client;
 
-    /** @var Collection */
-    private $collection;
+    private Collection $collection;
 
     public function setUp(): void
     {
@@ -233,7 +231,7 @@ class PrimaryStepDownSpecTest extends FunctionalTestCase
             },
             function ($event) use (&$events): void {
                 $events[] = $event;
-            }
+            },
         );
         $this->assertTrue($cursor->valid());
         $this->assertCount(1, $events);
@@ -272,7 +270,7 @@ class PrimaryStepDownSpecTest extends FunctionalTestCase
         $cursor = $server->executeCommand(
             $this->getDatabaseName(),
             new Command(['serverStatus' => 1]),
-            new ReadPreference(ReadPreference::PRIMARY)
+            new ReadPreference(ReadPreference::PRIMARY),
         );
 
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);

--- a/tests/SpecTests/ReadWriteConcernSpecTest.php
+++ b/tests/SpecTests/ReadWriteConcernSpecTest.php
@@ -12,8 +12,7 @@ use function glob;
 /** @see https://github.com/mongodb/specifications/tree/master/source/read-write-concern */
 class ReadWriteConcernSpecTest extends FunctionalTestCase
 {
-    /** @var array */
-    private static $incompleteTests = [];
+    private static array $incompleteTests = [];
 
     /**
      * Assert that the expected and actual command documents match.
@@ -57,8 +56,8 @@ class ReadWriteConcernSpecTest extends FunctionalTestCase
             $this->markTestSkipped($test->skipReason);
         }
 
-        $databaseName = $databaseName ?? $this->getDatabaseName();
-        $collectionName = $collectionName ?? $this->getCollectionName();
+        $databaseName ??= $this->getDatabaseName();
+        $collectionName ??= $this->getCollectionName();
 
         $context = Context::fromReadWriteConcern($test, $databaseName, $collectionName);
         $this->setContext($context);

--- a/tests/SpecTests/ResultExpectation.php
+++ b/tests/SpecTests/ResultExpectation.php
@@ -36,8 +36,7 @@ final class ResultExpectation
     public const ASSERT_CALLABLE = 11;
     public const ASSERT_DOCUMENTS_MATCH = 12;
 
-    /** @var integer */
-    private $assertionType = self::ASSERT_NOTHING;
+    private int $assertionType = self::ASSERT_NOTHING;
 
     /** @var mixed */
     private $expectedValue;
@@ -167,7 +166,7 @@ final class ResultExpectation
                  * from the BulkWriteException. */
                 $test->assertThat($actual, $test->logicalOr(
                     $test->isInstanceOf(BulkWriteResult::class),
-                    $test->isInstanceOf(WriteResult::class)
+                    $test->isInstanceOf(WriteResult::class),
                 ));
 
                 if (! $actual->isAcknowledged()) {
@@ -224,7 +223,7 @@ final class ResultExpectation
                  * from the BulkWriteException. */
                 $test->assertThat($actual, $test->logicalOr(
                     $test->isInstanceOf(InsertManyResult::class),
-                    $test->isInstanceOf(WriteResult::class)
+                    $test->isInstanceOf(WriteResult::class),
                 ));
 
                 if (isset($expected->insertedCount)) {
@@ -241,7 +240,7 @@ final class ResultExpectation
             case self::ASSERT_INSERTONE:
                 $test->assertThat($actual, $test->logicalOr(
                     $test->isInstanceOf(InsertOneResult::class),
-                    $test->isInstanceOf(WriteResult::class)
+                    $test->isInstanceOf(WriteResult::class),
                 ));
 
                 if (isset($expected->insertedCount)) {
@@ -251,7 +250,7 @@ final class ResultExpectation
                 if (property_exists($expected, 'insertedId')) {
                     $test->assertSameDocument(
                         ['insertedId' => $expected->insertedId],
-                        ['insertedId' => $actual->getInsertedId()]
+                        ['insertedId' => $actual->getInsertedId()],
                     );
                 }
 
@@ -261,7 +260,7 @@ final class ResultExpectation
                 $test->assertIsObject($expected);
                 $test->assertThat($actual, $test->logicalOr(
                     $test->isType('array'),
-                    $test->isType('object')
+                    $test->isType('object'),
                 ));
                 $test->assertMatchesDocument($expected, $actual);
                 break;
@@ -281,7 +280,7 @@ final class ResultExpectation
                 $test->assertIsObject($expected);
                 $test->assertThat($actual, $test->logicalOr(
                     $test->isType('array'),
-                    $test->isType('object')
+                    $test->isType('object'),
                 ));
                 $test->assertSameDocument($expected, $actual);
                 break;
@@ -312,7 +311,7 @@ final class ResultExpectation
                 if (property_exists($expected, 'upsertedId')) {
                     $test->assertSameDocument(
                         ['upsertedId' => $expected->upsertedId],
-                        ['upsertedId' => $actual->getUpsertedId()]
+                        ['upsertedId' => $actual->getUpsertedId()],
                     );
                 }
 

--- a/tests/SpecTests/RetryableReadsSpecTest.php
+++ b/tests/SpecTests/RetryableReadsSpecTest.php
@@ -18,15 +18,14 @@ use function strpos;
  */
 class RetryableReadsSpecTest extends FunctionalTestCase
 {
-    /** @var array */
-    private static $skippedOperations = [
+    /** @var array<string, string> */
+    private static array $skippedOperations = [
         'listCollectionObjects' => 'Not implemented',
         'listDatabaseObjects' => 'Not implemented',
         'listIndexNames' => 'Not implemented',
     ];
 
-    /** @var array */
-    private static $incompleteTests = [];
+    private static array $incompleteTests = [];
 
     /**
      * Assert that the expected and actual command documents match.

--- a/tests/SpecTests/RetryableWritesSpecTest.php
+++ b/tests/SpecTests/RetryableWritesSpecTest.php
@@ -107,7 +107,7 @@ class RetryableWritesSpecTest extends FunctionalTestCase
         ]);
 
         $subscriber = new class ($this) implements CommandSubscriber {
-            private $testCase;
+            private FunctionalTestCase $testCase;
 
             public function __construct(FunctionalTestCase $testCase)
             {

--- a/tests/SpecTests/RetryableWritesSpecTest.php
+++ b/tests/SpecTests/RetryableWritesSpecTest.php
@@ -107,9 +107,9 @@ class RetryableWritesSpecTest extends FunctionalTestCase
         ]);
 
         $subscriber = new class ($this) implements CommandSubscriber {
-            private FunctionalTestCase $testCase;
+            private RetryableWritesSpecTest $testCase;
 
-            public function __construct(FunctionalTestCase $testCase)
+            public function __construct(RetryableWritesSpecTest $testCase)
             {
                 $this->testCase = $testCase;
             }

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -29,10 +29,8 @@ class TransactionsSpecTest extends FunctionalTestCase
     /**
      * In addition to the useMultipleMongoses tests, these should all pass
      * before the driver can be considered compatible with MongoDB 4.2.
-     *
-     * @var array
      */
-    private static $incompleteTests = [
+    private static array $incompleteTests = [
         'transactions/mongos-recovery-token: commitTransaction retry fails on new mongos' => 'isMaster failpoints cannot be disabled',
         'transactions/pin-mongos: remain pinned after non-transient error on commit' => 'Blocked on SPEC-1320',
         'transactions/pin-mongos: unpin after transient error within a transaction and commit' => 'isMaster failpoints cannot be disabled',
@@ -71,7 +69,7 @@ class TransactionsSpecTest extends FunctionalTestCase
             static::assertObjectHasAttribute('getMore', $actual);
             static::assertThat($actual->getMore, static::logicalOr(
                 static::isInstanceOf(Int64::class),
-                static::isType('integer')
+                static::isType('integer'),
             ));
             unset($expected->getMore);
         }
@@ -155,8 +153,8 @@ class TransactionsSpecTest extends FunctionalTestCase
             $this->markTestSkipped($test->skipReason);
         }
 
-        $databaseName = $databaseName ?? $this->getDatabaseName();
-        $collectionName = $collectionName ?? $this->getCollectionName();
+        $databaseName ??= $this->getDatabaseName();
+        $collectionName ??= $this->getCollectionName();
 
         $context = Context::fromTransactions($test, $databaseName, $collectionName, $useMultipleMongoses);
         $this->setContext($context);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -115,7 +115,7 @@ OUTPUT;
 
         $this->assertEquals(
             toJSON(fromPHP($normalizedExpectedDocument)),
-            toJSON(fromPHP($normalizedActualDocument))
+            toJSON(fromPHP($normalizedActualDocument)),
         );
     }
 
@@ -132,7 +132,7 @@ OUTPUT;
     {
         $this->assertEquals(
             toJSON(fromPHP($this->normalizeBSON($expectedDocument))),
-            toJSON(fromPHP($this->normalizeBSON($actualDocument)))
+            toJSON(fromPHP($this->normalizeBSON($actualDocument))),
         );
     }
 
@@ -146,13 +146,11 @@ OUTPUT;
             throw new InvalidArgumentException('$actualDocuments is not an array or Traversable');
         }
 
-        $normalizeRootDocuments = function ($document) {
-            return toJSON(fromPHP($this->normalizeBSON($document)));
-        };
+        $normalizeRootDocuments = fn ($document) => toJSON(fromPHP($this->normalizeBSON($document)));
 
         $this->assertEquals(
             array_map($normalizeRootDocuments, $expectedDocuments),
-            array_map($normalizeRootDocuments, $actualDocuments)
+            array_map($normalizeRootDocuments, $actualDocuments),
         );
     }
 
@@ -282,7 +280,7 @@ OUTPUT;
                 new ReadPreference(ReadPreference::PRIMARY),
                 new WriteConcern(1),
             ],
-            $includeNull ? ['null' => null] : []
+            $includeNull ? ['null' => null] : [],
         );
     }
 
@@ -302,7 +300,7 @@ OUTPUT;
                 new ReadConcern(),
                 new WriteConcern(1),
             ],
-            $includeNull ? ['null' => null] : []
+            $includeNull ? ['null' => null] : [],
         );
     }
 
@@ -323,7 +321,7 @@ OUTPUT;
                 new ReadPreference(ReadPreference::PRIMARY),
                 new WriteConcern(1),
             ],
-            $includeNull ? ['null' => null] : []
+            $includeNull ? ['null' => null] : [],
         );
     }
 
@@ -351,7 +349,7 @@ OUTPUT;
                 new ReadConcern(),
                 new ReadPreference(ReadPreference::PRIMARY),
             ],
-            $includeNull ? ['null' => null] : []
+            $includeNull ? ['null' => null] : [],
         );
     }
 
@@ -370,9 +368,7 @@ OUTPUT;
      */
     protected function wrapValuesForDataProvider(array $values): array
     {
-        return array_map(function ($value) {
-            return [$value];
-        }, $values);
+        return array_map(fn ($value) => [$value], $values);
     }
 
     /**

--- a/tests/UnifiedSpecTests/CollectionData.php
+++ b/tests/UnifiedSpecTests/CollectionData.php
@@ -20,14 +20,11 @@ use function sprintf;
 
 class CollectionData
 {
-    /** @var string */
-    private $collectionName;
+    private string $collectionName;
 
-    /** @var string */
-    private $databaseName;
+    private string $databaseName;
 
-    /** @var array */
-    private $documents;
+    private array $documents;
 
     public function __construct(stdClass $o)
     {
@@ -46,7 +43,7 @@ class CollectionData
     {
         $database = $client->selectDatabase(
             $this->databaseName,
-            ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]
+            ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)],
         );
 
         $database->dropCollection($this->collectionName);
@@ -68,7 +65,7 @@ class CollectionData
             [
                 'readConcern' => new ReadConcern(ReadConcern::LOCAL),
                 'readPreference' => new ReadPreference(ReadPreference::PRIMARY),
-            ]
+            ],
         );
 
         $cursor = $collection->find([], ['sort' => ['_id' => 1]]);

--- a/tests/UnifiedSpecTests/Constraint/IsBsonType.php
+++ b/tests/UnifiedSpecTests/Constraint/IsBsonType.php
@@ -42,8 +42,7 @@ final class IsBsonType extends Constraint
 {
     use ConstraintTrait;
 
-    /** @var array */
-    private static $types = [
+    private static array $types = [
         'double',
         'string',
         'object',
@@ -68,8 +67,7 @@ final class IsBsonType extends Constraint
         'number',
     ];
 
-    /** @var string */
-    private $type;
+    private string $type;
 
     public function __construct(string $type)
     {
@@ -91,9 +89,7 @@ final class IsBsonType extends Constraint
             return new self(...$types);
         }
 
-        return LogicalOr::fromConstraints(...array_map(function ($type) {
-            return new self($type);
-        }, $types));
+        return LogicalOr::fromConstraints(...array_map(fn ($type) => new self($type), $types));
     }
 
     private function doMatches($other): bool

--- a/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
+++ b/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
@@ -40,7 +40,7 @@ class IsBsonTypeTest extends TestCase
         $symbol = toPHP(fromJSON('{ "x": {"$symbol": "test"} }'))->x;
         $dbPointer = toPHP(fromJSON('{ "x": {"$dbPointer": {"$ref": "db.coll", "$id" : { "$oid" : "5a2e78accd485d55b405ac12" }  }} }'))->x;
         $int64 = new Int64(1);
-        $long = PHP_INT_SIZE == 4 ? new Int64('4294967296') : 4294967296;
+        $long = PHP_INT_SIZE == 4 ? new Int64('4294967296') : 4_294_967_296;
 
         return [
             'double' => ['double', 1.4],

--- a/tests/UnifiedSpecTests/Constraint/Matches.php
+++ b/tests/UnifiedSpecTests/Constraint/Matches.php
@@ -51,23 +51,18 @@ class Matches extends Constraint
 {
     use ConstraintTrait;
 
-    /** @var EntityMap */
-    private $entityMap;
+    private ?EntityMap $entityMap = null;
 
     /** @var mixed */
     private $value;
 
-    /** @var bool */
-    private $allowExtraRootKeys;
+    private bool $allowExtraRootKeys;
 
-    /** @var bool */
-    private $allowOperators;
+    private bool $allowOperators;
 
-    /** @var ComparisonFailure|null */
-    private $lastFailure;
+    private ?ComparisonFailure $lastFailure = null;
 
-    /** @var Factory */
-    private $comparatorFactory;
+    private Factory $comparatorFactory;
 
     public function __construct($value, ?EntityMap $entityMap = null, $allowExtraRootKeys = true, $allowOperators = true)
     {
@@ -102,7 +97,7 @@ class Matches extends Constraint
                 $this->exporter()->export($this->value),
                 $this->exporter()->export($other),
                 false,
-                $e->getMessage()
+                $e->getMessage(),
             );
         }
 
@@ -168,7 +163,7 @@ class Matches extends Constraint
             $this->assertMatches(
                 $expectedValue,
                 $actual[$key],
-                (empty($keyPath) ? $key : $keyPath . '.' . $key)
+                (empty($keyPath) ? $key : $keyPath . '.' . $key),
             );
         }
     }
@@ -222,7 +217,7 @@ class Matches extends Constraint
             $this->assertMatches(
                 $expectedValue,
                 $actual[$key],
-                (empty($keyPath) ? $key : $keyPath . '.' . $key)
+                (empty($keyPath) ? $key : $keyPath . '.' . $key),
             );
         }
 
@@ -260,7 +255,7 @@ class Matches extends Constraint
             assertThat(
                 $operator['$$type'],
                 logicalOr(isType('string'), logicalAnd(isInstanceOf(BSONArray::class), containsOnly('string'))),
-                '$$type requires string or string[]'
+                '$$type requires string or string[]',
             );
 
             $constraint = IsBsonType::anyOf(...(array) $operator['$$type']);
@@ -282,7 +277,7 @@ class Matches extends Constraint
             $this->assertMatches(
                 self::prepare($this->entityMap[$operator['$$matchesEntity']]),
                 $actual,
-                $keyPath
+                $keyPath,
             );
 
             return;
@@ -311,7 +306,7 @@ class Matches extends Constraint
             $this->assertMatches(
                 self::prepare($operator['$$unsetOrMatches']),
                 $actual,
-                $keyPath
+                $keyPath,
             );
 
             return;

--- a/tests/UnifiedSpecTests/Context.php
+++ b/tests/UnifiedSpecTests/Context.php
@@ -42,10 +42,10 @@ final class Context
 
     private EntityMap $entityMap;
 
-    /** @var EventCollector[] */
+    /** @var list<EventCollector> */
     private array $eventCollectors = [];
 
-    /** @var EventObserver[] */
+    /** @var array<string, EventObserver> */
     private array $eventObserversByClient = [];
 
     private Client $internalClient;

--- a/tests/UnifiedSpecTests/Context.php
+++ b/tests/UnifiedSpecTests/Context.php
@@ -38,32 +38,25 @@ use function sprintf;
  */
 final class Context
 {
-    /** @var string */
-    private $activeClient;
+    private ?string $activeClient = null;
 
-    /** @var EntityMap */
-    private $entityMap;
+    private EntityMap $entityMap;
 
     /** @var EventCollector[] */
-    private $eventCollectors = [];
+    private array $eventCollectors = [];
 
     /** @var EventObserver[] */
-    private $eventObserversByClient = [];
+    private array $eventObserversByClient = [];
 
-    /** @var Client */
-    private $internalClient;
+    private Client $internalClient;
 
-    /** @var boolean */
-    private $inLoop = false;
+    private bool $inLoop = false;
 
-    /** @var string */
-    private $uri;
+    private string $uri;
 
-    /** @var string */
-    private $singleMongosUri;
+    private string $singleMongosUri;
 
-    /** @var string */
-    private $multiMongosUri;
+    private string $multiMongosUri;
 
     public function __construct(Client $internalClient, string $uri)
     {
@@ -239,10 +232,10 @@ final class Context
 
                         return [$key => $value];
                     },
-                    $tags
+                    $tags,
                 );
             },
-            (array) $readPreferenceTags
+            (array) $readPreferenceTags,
         );
     }
 
@@ -316,7 +309,7 @@ final class Context
             $driverOptions['serverApi'] = new ServerApi(
                 $serverApi->version,
                 $serverApi->strict ?? null,
-                $serverApi->deprecationErrors ?? null
+                $serverApi->deprecationErrors ?? null,
             );
         }
 

--- a/tests/UnifiedSpecTests/EntityMap.php
+++ b/tests/UnifiedSpecTests/EntityMap.php
@@ -35,7 +35,7 @@ class EntityMap implements ArrayAccess
      * Track lsids so they can be accessed after Session::getLogicalSessionId()
      * has been called.
      *
-     * @var stdClass[]
+     * @var list<stdClass>
      */
     private array $lsidsBySession = [];
 

--- a/tests/UnifiedSpecTests/EntityMap.php
+++ b/tests/UnifiedSpecTests/EntityMap.php
@@ -29,8 +29,7 @@ use function sprintf;
 
 class EntityMap implements ArrayAccess
 {
-    /** @var array */
-    private $map = [];
+    private array $map = [];
 
     /**
      * Track lsids so they can be accessed after Session::getLogicalSessionId()
@@ -38,10 +37,9 @@ class EntityMap implements ArrayAccess
      *
      * @var stdClass[]
      */
-    private $lsidsBySession = [];
+    private array $lsidsBySession = [];
 
-    /** @var Constraint */
-    private static $isSupportedType;
+    private static Constraint $isSupportedType;
 
     public function __destruct()
     {
@@ -102,12 +100,10 @@ class EntityMap implements ArrayAccess
         $parent = $parentId === null ? null : $this->map[$parentId];
 
         $this->map[$id] = new class ($id, $value, $parent) {
-            /** @var string */
-            public $id;
+            public string $id;
             /** @var mixed */
             public $value;
-            /** @var self */
-            public $parent;
+            public ?self $parent;
 
             public function __construct(string $id, $value, ?self $parent = null)
             {
@@ -174,19 +170,17 @@ class EntityMap implements ArrayAccess
 
     private static function isSupportedType(): Constraint
     {
-        if (self::$isSupportedType === null) {
-            self::$isSupportedType = logicalOr(
-                isInstanceOf(Client::class),
-                isInstanceOf(ClientEncryption::class),
-                isInstanceOf(Database::class),
-                isInstanceOf(Collection::class),
-                isInstanceOf(Session::class),
-                isInstanceOf(Bucket::class),
-                isInstanceOf(ChangeStream::class),
-                isInstanceOf(Cursor::class),
-                IsBsonType::any()
-            );
-        }
+        self::$isSupportedType ??= logicalOr(
+            isInstanceOf(Client::class),
+            isInstanceOf(ClientEncryption::class),
+            isInstanceOf(Database::class),
+            isInstanceOf(Collection::class),
+            isInstanceOf(Session::class),
+            isInstanceOf(Bucket::class),
+            isInstanceOf(ChangeStream::class),
+            isInstanceOf(Cursor::class),
+            IsBsonType::any(),
+        );
 
         return self::$isSupportedType;
     }

--- a/tests/UnifiedSpecTests/EntityMap.php
+++ b/tests/UnifiedSpecTests/EntityMap.php
@@ -35,7 +35,7 @@ class EntityMap implements ArrayAccess
      * Track lsids so they can be accessed after Session::getLogicalSessionId()
      * has been called.
      *
-     * @var list<stdClass>
+     * @var array<string, stdClass>
      */
     private array $lsidsBySession = [];
 

--- a/tests/UnifiedSpecTests/EventCollector.php
+++ b/tests/UnifiedSpecTests/EventCollector.php
@@ -29,8 +29,7 @@ use function sprintf;
  */
 final class EventCollector implements CommandSubscriber
 {
-    /** @var array */
-    private static $supportedEvents = [
+    private static array $supportedEvents = [
         'PoolCreatedEvent' => null,
         'PoolReadyEvent' => null,
         'PoolClearedEvent' => null,
@@ -47,17 +46,13 @@ final class EventCollector implements CommandSubscriber
         'CommandFailedEvent' => CommandFailedEvent::class,
     ];
 
-    /** @var string */
-    private $clientId;
+    private string $clientId;
 
-    /** @var Context */
-    private $context;
+    private Context $context;
 
-    /** @var array */
-    private $collectEvents = [];
+    private array $collectEvents = [];
 
-    /** @var BSONArray */
-    private $eventList;
+    private BSONArray $eventList;
 
     public function __construct(BSONArray $eventList, array $collectEvents, string $clientId, Context $context)
     {

--- a/tests/UnifiedSpecTests/EventObserver.php
+++ b/tests/UnifiedSpecTests/EventObserver.php
@@ -44,9 +44,8 @@ final class EventObserver implements CommandSubscriber
      * documents should be redacted).
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.rst#security
-     * @var array
      */
-    private static $sensitiveCommands = [
+    private static array $sensitiveCommands = [
         'authenticate' => 1,
         'saslStart' => 1,
         'saslContinue' => 1,
@@ -63,16 +62,14 @@ final class EventObserver implements CommandSubscriber
      * document includes a speculativeAuthenticate field.
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.rst#security
-     * @var array
      */
-    private static $sensitiveCommandsWithSpeculativeAuthenticate = [
+    private static array $sensitiveCommandsWithSpeculativeAuthenticate = [
         'ismaster' => 1,
         'isMaster' => 1,
         'hello' => 1,
     ];
 
-    /** @var array */
-    private static $supportedEvents = [
+    private static array $supportedEvents = [
         'commandStartedEvent' => CommandStartedEvent::class,
         'commandSucceededEvent' => CommandSucceededEvent::class,
         'commandFailedEvent' => CommandFailedEvent::class,
@@ -81,10 +78,8 @@ final class EventObserver implements CommandSubscriber
     /**
      * These events are defined in the specification but unsupported by PHPLIB
      * (e.g. CMAP events).
-     *
-     * @var array
      */
-    private static $unsupportedEvents = [
+    private static array $unsupportedEvents = [
         'poolCreatedEvent' => 1,
         'poolReadyEvent' => 1,
         'poolClearedEvent' => 1,
@@ -98,28 +93,21 @@ final class EventObserver implements CommandSubscriber
         'connectionCheckedInEvent' => 1,
     ];
 
-    /** @var array */
-    private $actualEvents = [];
+    private array $actualEvents = [];
 
-    /** @var string */
-    private $clientId;
+    private string $clientId;
 
-    /** @var Context */
-    private $context;
+    private Context $context;
 
     /**
      * The configureFailPoint command (used by failPoint and targetedFailPoint
      * operations) is always ignored.
-     *
-     * @var array
      */
-    private $ignoreCommands = ['configureFailPoint' => 1];
+    private array $ignoreCommands = ['configureFailPoint' => 1];
 
-    /** @var array */
-    private $observeEvents = [];
+    private array $observeEvents = [];
 
-    /** @var bool */
-    private $observeSensitiveCommands;
+    private bool $observeSensitiveCommands;
 
     public function __construct(array $observeEvents, array $ignoreCommands, bool $observeSensitiveCommands, string $clientId, Context $context)
     {

--- a/tests/UnifiedSpecTests/ExpectedError.php
+++ b/tests/UnifiedSpecTests/ExpectedError.php
@@ -39,11 +39,8 @@ use function sprintf;
 
 final class ExpectedError
 {
-    /**
-     * @see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
-     * @var array
-     */
-    private static $codeNameMap = [
+    /** @see https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err */
+    private static array $codeNameMap = [
         'Interrupted' => 11601,
         'MaxTimeMSExpired' => 50,
         'NoSuchTransaction' => 251,
@@ -51,32 +48,23 @@ final class ExpectedError
         'WriteConflict' => 112,
     ];
 
-    /** @var bool */
-    private $isError = false;
+    private bool $isError = false;
 
-    /** @var bool|null */
-    private $isClientError;
+    private ?bool $isClientError = null;
 
-    /** @var string|null */
-    private $messageContains;
+    private ?string $messageContains = null;
 
-    /** @var int|null */
-    private $code;
+    private ?int $code = null;
 
-    /** @var string|null */
-    private $codeName;
+    private ?string $codeName = null;
 
-    /** @var Matches|null */
-    private $matchesResultDocument;
+    private ?Matches $matchesResultDocument = null;
 
-    /** @var array */
-    private $includedLabels = [];
+    private array $includedLabels = [];
 
-    /** @var array */
-    private $excludedLabels = [];
+    private array $excludedLabels = [];
 
-    /** @var ExpectedResult|null */
-    private $expectedResult;
+    private ?ExpectedResult $expectedResult = null;
 
     public function __construct(?stdClass $o, EntityMap $entityMap)
     {

--- a/tests/UnifiedSpecTests/ExpectedResult.php
+++ b/tests/UnifiedSpecTests/ExpectedResult.php
@@ -17,19 +17,15 @@ use function property_exists;
 
 final class ExpectedResult
 {
-    /** @var Matches */
-    private $constraint;
+    private ?Matches $constraint = null;
 
-    /** @var EntityMap */
-    private $entityMap;
+    private EntityMap $entityMap;
 
     /**
      * ID of the entity yielding the result. This is mainly used to associate
      * entities with a root client for collation of observed events.
-     *
-     * @var ?string
      */
-    private $yieldingEntityId;
+    private ?string $yieldingEntityId = null;
 
     public function __construct(stdClass $o, EntityMap $entityMap, ?string $yieldingEntityId = null)
     {

--- a/tests/UnifiedSpecTests/FailPointObserver.php
+++ b/tests/UnifiedSpecTests/FailPointObserver.php
@@ -14,7 +14,7 @@ use function MongoDB\Driver\Monitoring\removeSubscriber;
 class FailPointObserver implements CommandSubscriber
 {
     /** @var array */
-    private $failPointsAndServers = [];
+    private array $failPointsAndServers = [];
 
     /** @see https://php.net/manual/en/mongodb-driver-monitoring-commandsubscriber.commandfailed.php */
     public function commandFailed(CommandFailedEvent $event): void

--- a/tests/UnifiedSpecTests/FailPointObserver.php
+++ b/tests/UnifiedSpecTests/FailPointObserver.php
@@ -13,7 +13,6 @@ use function MongoDB\Driver\Monitoring\removeSubscriber;
 
 class FailPointObserver implements CommandSubscriber
 {
-    /** @var array */
     private array $failPointsAndServers = [];
 
     /** @see https://php.net/manual/en/mongodb-driver-monitoring-commandsubscriber.commandfailed.php */

--- a/tests/UnifiedSpecTests/Loop.php
+++ b/tests/UnifiedSpecTests/Loop.php
@@ -22,29 +22,21 @@ use function usleep;
 
 final class Loop
 {
-    /** @var boolean */
-    private static $allowIteration = true;
+    private static bool $allowIteration = true;
 
-    /** @var integer */
-    private static $sleepUsecBetweenIterations = 0;
+    private static int $sleepUsecBetweenIterations = 0;
 
-    /** @var Context */
-    private $context;
+    private Context $context;
 
-    /** @var array */
-    private $operations = [];
+    private array $operations = [];
 
-    /** @var BSONArray */
-    private $errorList;
+    private ?BSONArray $errorList = null;
 
-    /** @var BSONArray */
-    private $failureList;
+    private ?BSONArray $failureList = null;
 
-    /** @var string */
-    private $numSuccessfulOperationsEntityId;
+    private string $numSuccessfulOperationsEntityId;
 
-    /** @var string */
-    private $numIterationsEntityId;
+    private string $numIterationsEntityId;
 
     public function __construct(array $operations, Context $context, array $options = [])
     {

--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -67,35 +67,25 @@ final class Operation
 {
     public const OBJECT_TEST_RUNNER = 'testRunner';
 
-    /** @var bool */
-    private $isTestRunnerOperation;
+    private bool $isTestRunnerOperation;
 
-    /** @var string */
-    private $name;
+    private string $name;
 
-    /** @var ?string */
-    private $object;
+    private ?string $object = null;
 
-    /** @var array */
-    private $arguments = [];
+    private array $arguments = [];
 
-    /** @var Context */
-    private $context;
+    private Context $context;
 
-    /** @var EntityMap */
-    private $entityMap;
+    private EntityMap $entityMap;
 
-    /** @var ExpectedError */
-    private $expectError;
+    private ExpectedError $expectError;
 
-    /** @var ExpectedResult */
-    private $expectResult;
+    private ExpectedResult $expectResult;
 
-    /** @var bool */
-    private $ignoreResultAndError;
+    private bool $ignoreResultAndError;
 
-    /** @var string */
-    private $saveResultAsEntity;
+    private ?string $saveResultAsEntity = null;
 
     public function __construct(stdClass $o, Context $context)
     {
@@ -260,7 +250,7 @@ final class Operation
 
                 return $client->watch(
                     $args['pipeline'],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 );
 
             case 'listDatabaseNames':
@@ -268,10 +258,8 @@ final class Operation
 
             case 'listDatabases':
                 return array_map(
-                    function (DatabaseInfo $info) {
-                        return $info->__debugInfo();
-                    },
-                    iterator_to_array($client->listDatabases($args))
+                    fn (DatabaseInfo $info) => $info->__debugInfo(),
+                    iterator_to_array($client->listDatabases($args)),
                 );
 
             default:
@@ -346,7 +334,7 @@ final class Operation
 
                 return iterator_to_array($collection->aggregate(
                     $args['pipeline'],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 ));
 
             case 'bulkWrite':
@@ -355,12 +343,10 @@ final class Operation
 
                 return $collection->bulkWrite(
                     array_map(
-                        static function ($request) {
-                            return self::prepareBulkWriteRequest($request);
-                        },
-                        $args['requests']
+                        static fn ($request) => self::prepareBulkWriteRequest($request),
+                        $args['requests'],
                     ),
-                    array_diff_key($args, ['requests' => 1])
+                    array_diff_key($args, ['requests' => 1]),
                 );
 
             case 'createChangeStream':
@@ -369,7 +355,7 @@ final class Operation
 
                 return $collection->watch(
                     $args['pipeline'],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 );
 
             case 'createFindCursor':
@@ -378,7 +364,7 @@ final class Operation
 
                 return $collection->find(
                     $args['filter'],
-                    array_diff_key($args, ['filter' => 1])
+                    array_diff_key($args, ['filter' => 1]),
                 );
 
             case 'createIndex':
@@ -387,7 +373,7 @@ final class Operation
 
                 return $collection->createIndex(
                     $args['keys'],
-                    array_diff_key($args, ['keys' => 1])
+                    array_diff_key($args, ['keys' => 1]),
                 );
 
             case 'dropIndex':
@@ -396,7 +382,7 @@ final class Operation
 
                 return $collection->dropIndex(
                     $args['name'],
-                    array_diff_key($args, ['name' => 1])
+                    array_diff_key($args, ['name' => 1]),
                 );
 
             case 'count':
@@ -437,7 +423,7 @@ final class Operation
                 return $collection->distinct(
                     $args['fieldName'],
                     $args['filter'],
-                    array_diff_key($args, ['fieldName' => 1, 'filter' => 1])
+                    array_diff_key($args, ['fieldName' => 1, 'filter' => 1]),
                 );
 
             case 'drop':
@@ -449,7 +435,7 @@ final class Operation
 
                 return iterator_to_array($collection->find(
                     $args['filter'],
-                    array_diff_key($args, ['filter' => 1])
+                    array_diff_key($args, ['filter' => 1]),
                 ));
 
             case 'findOne':
@@ -458,7 +444,7 @@ final class Operation
 
                 return $collection->findOne(
                     $args['filter'],
-                    array_diff_key($args, ['filter' => 1])
+                    array_diff_key($args, ['filter' => 1]),
                 );
 
             case 'findOneAndReplace':
@@ -512,7 +498,7 @@ final class Operation
 
                 return $collection->insertMany(
                     $args['documents'],
-                    array_diff_key($args, ['documents' => 1])
+                    array_diff_key($args, ['documents' => 1]),
                 );
 
             case 'insertOne':
@@ -521,15 +507,13 @@ final class Operation
 
                 return $collection->insertOne(
                     $args['document'],
-                    array_diff_key($args, ['document' => 1])
+                    array_diff_key($args, ['document' => 1]),
                 );
 
             case 'listIndexes':
                 return array_map(
-                    function (IndexInfo $info) {
-                        return $info->__debugInfo();
-                    },
-                    iterator_to_array($collection->listIndexes($args))
+                    fn (IndexInfo $info) => $info->__debugInfo(),
+                    iterator_to_array($collection->listIndexes($args)),
                 );
 
             case 'mapReduce':
@@ -544,7 +528,7 @@ final class Operation
                     $args['map'],
                     $args['reduce'],
                     $args['out'],
-                    array_diff_key($args, ['map' => 1, 'reduce' => 1, 'out' => 1])
+                    array_diff_key($args, ['map' => 1, 'reduce' => 1, 'out' => 1]),
                 );
 
             case 'rename':
@@ -554,7 +538,7 @@ final class Operation
                 return $collection->rename(
                     $args['to'],
                     null, /* $toDatabaseName */
-                    array_diff_key($args, ['to' => 1])
+                    array_diff_key($args, ['to' => 1]),
                 );
 
             default:
@@ -622,7 +606,7 @@ final class Operation
 
                 return iterator_to_array($database->aggregate(
                     $args['pipeline'],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 ));
 
             case 'createChangeStream':
@@ -631,7 +615,7 @@ final class Operation
 
                 return $database->watch(
                     $args['pipeline'],
-                    array_diff_key($args, ['pipeline' => 1])
+                    array_diff_key($args, ['pipeline' => 1]),
                 );
 
             case 'createCollection':
@@ -640,7 +624,7 @@ final class Operation
 
                 return $database->createCollection(
                     $args['collection'],
-                    array_diff_key($args, ['collection' => 1])
+                    array_diff_key($args, ['collection' => 1]),
                 );
 
             case 'dropCollection':
@@ -649,7 +633,7 @@ final class Operation
 
                 return $database->dropCollection(
                     $args['collection'],
-                    array_diff_key($args, ['collection' => 1])
+                    array_diff_key($args, ['collection' => 1]),
                 );
 
             case 'listCollectionNames':
@@ -657,10 +641,8 @@ final class Operation
 
             case 'listCollections':
                 return array_map(
-                    function (CollectionInfo $info) {
-                        return $info->__debugInfo();
-                    },
-                    iterator_to_array($database->listCollections($args))
+                    fn (CollectionInfo $info) => $info->__debugInfo(),
+                    iterator_to_array($database->listCollections($args)),
                 );
 
             case 'modifyCollection':
@@ -757,7 +739,7 @@ final class Operation
 
                 return stream_get_contents($bucket->openDownloadStreamByName(
                     $args['filename'],
-                    array_diff_key($args, ['filename' => 1])
+                    array_diff_key($args, ['filename' => 1]),
                 ));
 
             case 'download':
@@ -778,7 +760,7 @@ final class Operation
                 return $bucket->uploadFromStream(
                     $args['filename'],
                     $args['source'],
-                    array_diff_key($args, ['filename' => 1, 'source' => 1])
+                    array_diff_key($args, ['filename' => 1, 'source' => 1]),
                 );
 
             default:
@@ -907,10 +889,8 @@ final class Operation
     private function getIndexNames(string $databaseName, string $collectionName): array
     {
         return array_map(
-            function (IndexInfo $indexInfo) {
-                return $indexInfo->getName();
-            },
-            iterator_to_array($this->context->getInternalClient()->selectCollection($databaseName, $collectionName)->listIndexes())
+            fn (IndexInfo $indexInfo) => $indexInfo->getName(),
+            iterator_to_array($this->context->getInternalClient()->selectCollection($databaseName, $collectionName)->listIndexes()),
         );
     }
 

--- a/tests/UnifiedSpecTests/RunOnRequirement.php
+++ b/tests/UnifiedSpecTests/RunOnRequirement.php
@@ -10,9 +10,9 @@ use function in_array;
 use function PHPUnit\Framework\assertContains;
 use function PHPUnit\Framework\assertContainsOnly;
 use function PHPUnit\Framework\assertEmpty;
+use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertIsArray;
 use function PHPUnit\Framework\assertIsBool;
-use function PHPUnit\Framework\assertIsObject;
 use function PHPUnit\Framework\assertIsString;
 use function PHPUnit\Framework\assertMatchesRegularExpression;
 use function version_compare;
@@ -37,7 +37,7 @@ class RunOnRequirement
 
     private ?array $topologies = null;
 
-    private ?object $serverParameters = null;
+    private ?stdClass $serverParameters = null;
 
     private ?bool $auth = null;
 
@@ -83,7 +83,7 @@ class RunOnRequirement
         }
 
         if (isset($o->serverParameters)) {
-            assertIsObject($o->serverParameters);
+            assertInstanceOf(stdClass::class, $o->serverParameters);
             $this->serverParameters = $o->serverParameters;
         }
 

--- a/tests/UnifiedSpecTests/RunOnRequirement.php
+++ b/tests/UnifiedSpecTests/RunOnRequirement.php
@@ -31,29 +31,21 @@ class RunOnRequirement
 
     public const VERSION_PATTERN = '/^[0-9]+(\\.[0-9]+){1,2}$/';
 
-    /** @var string */
-    private $minServerVersion;
+    private ?string $minServerVersion = null;
 
-    /** @var string */
-    private $maxServerVersion;
+    private ?string $maxServerVersion = null;
 
-    /** @var array */
-    private $topologies;
+    private ?array $topologies = null;
 
-    /** @var stdClass */
-    private $serverParameters;
+    private ?object $serverParameters = null;
 
-    /** @var bool */
-    private $auth;
+    private ?bool $auth = null;
 
-    /** @var string */
-    private $serverless;
+    private ?string $serverless = null;
 
-    /** @var bool */
-    private $csfle;
+    private ?bool $csfle = null;
 
-    /** @var array */
-    private static $supportedTopologies = [
+    private static array $supportedTopologies = [
         self::TOPOLOGY_SINGLE,
         self::TOPOLOGY_REPLICASET,
         self::TOPOLOGY_SHARDED,
@@ -61,8 +53,7 @@ class RunOnRequirement
         self::TOPOLOGY_LOAD_BALANCED,
     ];
 
-    /** @var array */
-    private static $supportedServerless = [
+    private static array $supportedServerless = [
         self::SERVERLESS_REQUIRE,
         self::SERVERLESS_FORBID,
         self::SERVERLESS_ALLOW,

--- a/tests/UnifiedSpecTests/ServerParameterHelper.php
+++ b/tests/UnifiedSpecTests/ServerParameterHelper.php
@@ -10,17 +10,14 @@ use function array_key_exists;
 
 final class ServerParameterHelper
 {
-    /** @var Client */
-    private $client;
+    private Client $client;
 
     /** @var array<string|mixed> */
-    private $parameters = [];
+    private array $parameters = [];
 
-    /** @var bool */
-    private $fetchAllParametersFailed = false;
+    private bool $fetchAllParametersFailed = false;
 
-    /** @var bool */
-    private $allParametersFetched = false;
+    private bool $allParametersFetched = false;
 
     public function __construct(Client $client)
     {
@@ -66,7 +63,7 @@ final class ServerParameterHelper
                         'document' => 'array',
                         'array' => 'array',
                     ],
-                ]
+                ],
             );
 
             $this->parameters = $cursor->toArray()[0];
@@ -91,7 +88,7 @@ final class ServerParameterHelper
                     'document' => 'array',
                     'array' => 'array',
                 ],
-            ]
+            ],
         );
 
         $this->parameters[$parameter] = $cursor->toArray()[0][$parameter];

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -20,8 +20,7 @@ use function glob;
  */
 class UnifiedSpecTest extends FunctionalTestCase
 {
-    /** @var array */
-    private static $incompleteTests = [
+    private static array $incompleteTests = [
         // Many load balancer tests use CMAP events and/or assertNumberConnectionsCheckedOut
         'load-balancers/cursors are correctly pinned to connections for load-balanced clusters: no connection is pinned if all documents are returned in the initial batch' => 'PHPC does not implement CMAP',
         'load-balancers/cursors are correctly pinned to connections for load-balanced clusters: pinned connections are returned when the cursor is drained' => 'PHPC does not implement CMAP',
@@ -67,8 +66,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         'valid-pass/matches-lte-operator: special lte matching operator' => 'CSOT is not yet implemented (PHPC-1760)',
     ];
 
-    /** @var UnifiedTestRunner */
-    private static $runner;
+    private static UnifiedTestRunner $runner;
 
     public static function setUpBeforeClass(): void
     {

--- a/tests/UnifiedSpecTests/UnifiedTestCase.php
+++ b/tests/UnifiedSpecTests/UnifiedTestCase.php
@@ -25,20 +25,15 @@ use function PHPUnit\Framework\assertIsString;
  */
 final class UnifiedTestCase implements IteratorAggregate
 {
-    /** @var stdClass */
-    private $test;
+    private stdClass $test;
 
-    /** @var string */
-    private $schemaVersion;
+    private string $schemaVersion;
 
-    /** @var array|null */
-    private $runOnRequirements;
+    private ?array $runOnRequirements = null;
 
-    /** @var array|null */
-    private $createEntities;
+    private ?array $createEntities = null;
 
-    /** @var array|null */
-    private $initialData;
+    private ?array $initialData = null;
 
     private function __construct(stdClass $test, string $schemaVersion, ?array $runOnRequirements = null, ?array $createEntities = null, ?array $initialData = null)
     {

--- a/tests/UnifiedSpecTests/UnifiedTestRunner.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunner.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Tests\UnifiedSpecTests;
 
+use MongoDB\Client;
 use MongoDB\Collection;
 use MongoDB\Driver\Exception\ServerException;
 use MongoDB\Driver\Server;
@@ -60,26 +61,20 @@ final class UnifiedTestRunner
      * however, syntax from 1.9, 1.10, and 1.11 has not been implemented. */
     public const MAX_SCHEMA_VERSION = '1.12';
 
-    /** @var MongoDB\Client */
-    private $internalClient;
+    private Client $internalClient;
 
-    /** @var string */
-    private $internalClientUri;
+    private string $internalClientUri;
 
-    /** @var bool */
-    private $allowKillAllSessions = true;
+    private bool $allowKillAllSessions = true;
 
-    /** @var EntityMap */
-    private $entityMap;
+    private ?EntityMap $entityMap = null;
 
     /** @var callable(EntityMap):void */
     private $entityMapObserver;
 
-    /** @var FailPointObserver */
-    private $failPointObserver;
+    private ?FailPointObserver $failPointObserver = null;
 
-    /** @var ServerParameterHelper */
-    private $serverParameterHelper;
+    private ServerParameterHelper $serverParameterHelper;
 
     public function __construct(string $internalClientUri)
     {
@@ -266,7 +261,7 @@ final class UnifiedTestRunner
             'Server (version=%s, topology=%s, auth=%s) does not meet test requirements',
             $cachedIsSatisfiedArgs[0],
             $cachedIsSatisfiedArgs[1],
-            $cachedIsSatisfiedArgs[3] ? 'yes' : 'no'
+            $cachedIsSatisfiedArgs[3] ? 'yes' : 'no',
         ));
     }
 

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -38,7 +38,7 @@ final class Util
     /**
      * Array to fill, which contains the schema of allowed attributes for operations.
      */
-    private static $args = [
+    private static array $args = [
         Operation::OBJECT_TEST_RUNNER => [
             'assertCollectionExists' => ['databaseName', 'collectionName'],
             'assertCollectionNotExists' => ['databaseName', 'collectionName'],

--- a/tools/connect.php
+++ b/tools/connect.php
@@ -92,7 +92,7 @@ function connect(string $host, bool $ssl): void
         'admin.$cmd', /* namespace */
         0, /* numberToSkip */
         1, /* numberToReturn */
-        hex2bin('130000001069734d6173746572000100000000') /* { "isMaster": 1 } */
+        hex2bin('130000001069734d6173746572000100000000'), /* { "isMaster": 1 } */
     );
     $requestLength = 16 /* MsgHeader length */ + strlen($request);
     $header = pack('V4', $requestLength, 0 /* requestID */, 0 /* responseTo */, 2004 /* OP_QUERY */);


### PR DESCRIPTION
PHPLIB-1118

This drops support for PHP 7.2 and 7.3 and updates code for PHP 7.4. Changes have been made automatically using rector and phpcbf. A few manual fixes were applied (a few property types were fixed to exclude `null`).