### PR TITLE
Add test on `UnifiedTestRunner::setEntityMapObserver()`

### DIFF
--- a/tests/UnifiedSpecTests/UnifiedTestRunner.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunner.php
@@ -125,6 +125,8 @@ final class UnifiedTestRunner
      *
      * This function is primarily used by the Atlas testing workload executor.
      *
+     * @see https://github.com/mongodb-labs/drivers-atlas-testing/
+     *
      * @param callable(EntityMap):void $entityMapObserver
      */
     public function setEntityMapObserver(callable $entityMapObserver): void

--- a/tests/UnifiedSpecTests/UnifiedTestRunnerTest.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunnerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MongoDB\Tests\UnifiedSpecTests;
+
+use MongoDB\Tests\FunctionalTestCase;
+
+class UnifiedTestRunnerTest extends FunctionalTestCase
+{
+    public function testEntityMapObserver(): void
+    {
+        $test = UnifiedTestCase::fromFile(__DIR__ . '/crud/find.json');
+        $calls = 0;
+
+        $runner = new UnifiedTestRunner(static::getUri());
+        $runner->setEntityMapObserver(function (EntityMap $entityMap) use (&$calls): void {
+            $this->assertArrayHasKey('client0', $entityMap);
+            $this->assertArrayHasKey('database0', $entityMap);
+            $this->assertArrayHasKey('collection0', $entityMap);
+            $calls++;
+        });
+
+        $runner->run($test->current());
+        $this->assertSame(1, $calls);
+    }
+}

--- a/tests/UnifiedSpecTests/UnifiedTestRunnerTest.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunnerTest.php
@@ -8,7 +8,7 @@ class UnifiedTestRunnerTest extends FunctionalTestCase
 {
     public function testEntityMapObserver(): void
     {
-        $test = UnifiedTestCase::fromFile(__DIR__ . '/crud/find.json');
+        $test = UnifiedTestCase::fromFile(__DIR__ . '/runner/entity-map-observer.json');
         $calls = 0;
 
         $runner = new UnifiedTestRunner(static::getUri());

--- a/tests/UnifiedSpecTests/runner/entity-map-observer.json
+++ b/tests/UnifiedSpecTests/runner/entity-map-observer.json
@@ -1,0 +1,68 @@
+{
+  "description": "find",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "runner-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "runner-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "basic find",
+      "operations": [
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {}
+          },
+          "object": "collection0",
+          "expectResult": []
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {}
+                },
+                "commandName": "find",
+                "databaseName": "runner-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
`UnifiedTestRunner::setEntityMapObserver()` is used in `[drivers-atlas-testing](https://github.com/mongodb-labs/drivers-atlas-testing/).