### PR TITLE
Skip queryable encryption tests on standalone servers

### DIFF
--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -360,6 +360,10 @@ OUTPUT;
 
         $this->skipIfServerVersion('<', '7.0.0', 'Queryable encryption tests require MongoDB 7.0 or later');
 
+        if ($this->isStandalone()) {
+            $this->markTestSkipped('Encrypted collections are not supported on standalone');
+        }
+
         /* Ensure that the key vault, collection under test, and any metadata
          * collections are cleaned up before and after the example is run. */
         $this->dropCollection('test', 'coll', ['encryptedFields' => []]);

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -361,7 +361,7 @@ OUTPUT;
         $this->skipIfServerVersion('<', '7.0.0', 'Queryable encryption tests require MongoDB 7.0 or later');
 
         if ($this->isStandalone()) {
-            $this->markTestSkipped('Encrypted collections are not supported on standalone');
+            $this->markTestSkipped('Queryable encryption requires replica sets');
         }
 
         /* Ensure that the key vault, collection under test, and any metadata


### PR DESCRIPTION
Fixes two build failures on 7.0 and latest that started appearing recently.