### PR TITLE
PHPLIB-1205: Sync runCommand spec tests for removal of "sharded-replicaset"

### DIFF
--- a/tests/UnifiedSpecTests/run-command/runCommand.json
+++ b/tests/UnifiedSpecTests/run-command/runCommand.json
@@ -124,6 +124,68 @@
       ]
     },
     {
+      "description": "always gossips the $clusterTime on the sent command",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ping"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$clusterTime": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "attaches the provided session lsid to given command",
       "operations": [
         {
@@ -167,7 +229,6 @@
         {
           "topologies": [
             "replicaset",
-            "sharded-replicaset",
             "load-balanced",
             "sharded"
           ]
@@ -346,7 +407,7 @@
               "insert": "collection",
               "documents": [
                 {
-                  "_id": 1
+                  "foo": "bar"
                 }
               ],
               "ordered": true
@@ -431,7 +492,7 @@
         {
           "minServerVersion": "4.2",
           "topologies": [
-            "sharded-replicaset",
+            "sharded",
             "load-balanced"
           ]
         }
@@ -452,7 +513,7 @@
                     "insert": "collection",
                     "documents": [
                       {
-                        "_id": 2
+                        "foo": "transaction"
                       }
                     ],
                     "ordered": true
@@ -480,7 +541,7 @@
                   "insert": "collection",
                   "documents": [
                     {
-                      "_id": 2
+                      "foo": "transaction"
                     }
                   ],
                   "ordered": true,


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1205

POC for https://github.com/mongodb/specifications/pull/1443

Includes some changes from pending runCursorCommand spec work (PHPLIB-1077).

Patch build with various topologies: https://spruce.mongodb.com/version/64b575990305b9d6044c42ce/tasks