### PR TITLE
Improve coding standard

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -99,39 +99,16 @@
     </rule>
 
 
-    <!-- **************************************************************************** -->
-    <!-- Exclude BC breaking type hints for parameters, properties, and return values -->
-    <!-- **************************************************************************** -->
+    <!-- ****************************************************** -->
+    <!-- Don't require annotations to specify traversable types -->
+    <!-- ****************************************************** -->
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
-        <properties>
-            <!-- Requires PHP 8.0 -->
-            <property name="enableMixedTypeHint" value="false" />
-            <!-- Requires PHP 8.0 -->
-            <property name="enableUnionTypeHint" value="false" />
-        </properties>
-
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
-        <properties>
-            <!-- Requires PHP 8.0 -->
-            <property name="enableMixedTypeHint" value="false" />
-            <!-- Requires PHP 8.0 -->
-            <property name="enableUnionTypeHint" value="false" />
-        </properties>
-
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
-        <properties>
-            <!-- Requires PHP 8.0 -->
-            <property name="enableStaticTypeHint" value="false" />
-            <!-- Requires PHP 8.0 -->
-            <property name="enableMixedTypeHint" value="false" />
-            <!-- Requires PHP 8.0 -->
-            <property name="enableUnionTypeHint" value="false" />
-        </properties>
-
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification" />
     </rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -78,9 +78,13 @@
     </rule>
 
 
-    <!-- ***************************************************** -->
+    <!-- **************************************** -->
+    <!-- Enable rules not enforced by Doctrine CS -->
+    <!-- **************************************** -->
+
+    <!-- Require arrow functions where possible -->
+    <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction"/>
     <!-- Forbid fully qualified names even for colliding names -->
-    <!-- ***************************************************** -->
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
         <properties>
             <property name="allowFallbackGlobalConstants" value="false"/>
@@ -109,7 +113,6 @@
 
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification" />
     </rule>
-
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
         <properties>
             <!-- Requires PHP 8.0 -->
@@ -120,7 +123,6 @@
 
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" />
     </rule>
-
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
         <properties>
             <!-- Requires PHP 8.0 -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -63,7 +63,6 @@
         <!-- Exclude sniffs that cause a huge diff - enable separately -->
         <!-- ********************************************************* -->
         <exclude name="SlevomatCodingStandard.Commenting.DocCommentSpacing.IncorrectAnnotationsGroup" />
-        <exclude name="Squiz.Strings.DoubleQuoteUsage" />
 
 
         <!-- ********************* -->

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -232,7 +232,7 @@ class Bucket
      */
     public function downloadToStream($id, $destination)
     {
-        if (! is_resource($destination) || get_resource_type($destination) != "stream") {
+        if (! is_resource($destination) || get_resource_type($destination) != 'stream') {
             throw InvalidArgumentException::invalidType('$destination', $destination, 'resource');
         }
 
@@ -272,7 +272,7 @@ class Bucket
      */
     public function downloadToStreamByName(string $filename, $destination, array $options = [])
     {
-        if (! is_resource($destination) || get_resource_type($destination) != "stream") {
+        if (! is_resource($destination) || get_resource_type($destination) != 'stream') {
             throw InvalidArgumentException::invalidType('$destination', $destination, 'resource');
         }
 
@@ -616,7 +616,7 @@ class Bucket
      */
     public function uploadFromStream(string $filename, $source, array $options = [])
     {
-        if (! is_resource($source) || get_resource_type($source) != "stream") {
+        if (! is_resource($source) || get_resource_type($source) != 'stream') {
             throw InvalidArgumentException::invalidType('$source', $source, 'resource');
         }
 
@@ -685,7 +685,7 @@ class Bucket
      */
     private function getRawFileDocumentForStream($stream): object
     {
-        if (! is_resource($stream) || get_resource_type($stream) != "stream") {
+        if (! is_resource($stream) || get_resource_type($stream) != 'stream') {
             throw InvalidArgumentException::invalidType('$stream', $stream, 'resource');
         }
 

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -1403,7 +1403,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
     private function updateEmployeeInfo3(\MongoDB\Client $client, \MongoDB\Driver\Session $session): void
     {
         $session->startTransaction([
-            'readConcern' => new \MongoDB\Driver\ReadConcern("snapshot"),
+            'readConcern' => new \MongoDB\Driver\ReadConcern('snapshot'),
             'readPrefernece' => new \MongoDB\Driver\ReadPreference(\MongoDB\Driver\ReadPreference::PRIMARY),
             'writeConcern' => new \MongoDB\Driver\WriteConcern(\MongoDB\Driver\WriteConcern::MAJORITY),
         ]);

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -534,7 +534,7 @@ abstract class FunctionalTestCase extends TestCase
     /** @see https://www.mongodb.com/docs/manual/core/queryable-encryption/reference/mongocryptd/ */
     public static function isMongocryptdAvailable(): bool
     {
-        $paths = explode(PATH_SEPARATOR, getenv("PATH"));
+        $paths = explode(PATH_SEPARATOR, getenv('PATH'));
 
         foreach ($paths as $path) {
             if (is_executable($path . DIRECTORY_SEPARATOR . 'mongocryptd')) {

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -140,7 +140,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDownloadingFileWithMissingChunk(): void
     {
-        $id = $this->bucket->uploadFromStream("filename", $this->createStream("foobar"));
+        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'));
 
         $this->chunksCollection->deleteOne(['files_id' => $id, 'n' => 0]);
 
@@ -151,7 +151,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDownloadingFileWithUnexpectedChunkIndex(): void
     {
-        $id = $this->bucket->uploadFromStream("filename", $this->createStream("foobar"));
+        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'));
 
         $this->chunksCollection->updateOne(
             ['files_id' => $id, 'n' => 0],
@@ -165,7 +165,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDownloadingFileWithUnexpectedChunkSize(): void
     {
-        $id = $this->bucket->uploadFromStream("filename", $this->createStream("foobar"));
+        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'));
 
         $this->chunksCollection->updateOne(
             ['files_id' => $id, 'n' => 0],

--- a/tests/PedantryTest.php
+++ b/tests/PedantryTest.php
@@ -32,10 +32,8 @@ class PedantryTest extends TestCase
 
         $methods = array_filter(
             $methods,
-            function (ReflectionMethod $method) use ($class) {
-                return $method->getDeclaringClass() == $class // Exclude inherited methods
-                    && $method->getFileName() === $class->getFileName(); // Exclude methods inherited from traits
-            },
+            fn (ReflectionMethod $method) => $method->getDeclaringClass() == $class // Exclude inherited methods
+                    && $method->getFileName() === $class->getFileName(), // Exclude methods inherited from traits
         );
 
         $getSortValue = function (ReflectionMethod $method) {

--- a/tools/detect-extension.php
+++ b/tools/detect-extension.php
@@ -85,7 +85,7 @@ if ($extensionFileExists) {
 if (defined('PHP_WINDOWS_VERSION_BUILD')) {
     $zts = PHP_ZTS ? 'Thread Safe (TS)' : 'Non Thread Safe (NTS)';
     $arch = PHP_INT_SIZE === 8 ? 'x64' : 'x86';
-    $dll = sprintf("%d.%d %s %s", PHP_MAJOR_VERSION, PHP_MINOR_VERSION, $zts, $arch);
+    $dll = sprintf('%d.%d %s %s', PHP_MAJOR_VERSION, PHP_MINOR_VERSION, $zts, $arch);
 
     printf("You likely need to download a Windows DLL for: %s\n", $dll);
     printf("Windows DLLs should be available from: https://pecl.php.net/package/%s\n", $extension);


### PR DESCRIPTION
This adds a rule requiring arrow functions to our coding standard. In addition to that, I enabled a rule requiring single quotes where possible. Commits are split by rule for a better review experience.

The last commit entails no actual changes, this was left over from before we were specifying a PHP version in the config.