### PR TITLE
PHPLIB-1206 Allow global registration of GridFS buckets with `gridfs://` protocol

### DIFF
--- a/docs/reference/class/MongoDBGridFSBucket.txt
+++ b/docs/reference/class/MongoDBGridFSBucket.txt
@@ -55,5 +55,6 @@ Methods
    /reference/method/MongoDBGridFSBucket-openDownloadStream
    /reference/method/MongoDBGridFSBucket-openDownloadStreamByName
    /reference/method/MongoDBGridFSBucket-openUploadStream
+   /reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias
    /reference/method/MongoDBGridFSBucket-rename
    /reference/method/MongoDBGridFSBucket-uploadFromStream

--- a/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
@@ -1,0 +1,132 @@
+===========================================================
+MongoDB\\GridFS\\Bucket::registerGlobalStreamWrapperAlias()
+===========================================================
+
+.. versionadded:: 1.18
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Definition
+----------
+
+.. phpmethod:: MongoDB\\GridFS\\Bucket::registerGlobalStreamWrapperAlias()
+
+   Registers an alias for the bucket, which enables files within the bucket to
+   be accessed using a basic filename string (e.g.
+   `gridfs://<bucket-alias>/<filename>`).
+
+   .. code-block:: php
+
+      function registerGlobalStreamWrapperAlias(string $alias): void
+
+Parameters
+----------
+
+``$alias`` : array
+  A non-empty string used to identify the GridFS bucket when accessing files
+  using the ``gridfs://`` stream wrapper.
+
+Behavior
+--------
+
+After registering an alias for the bucket, the most recent revision of a file
+can be accessed using a filename string in the form ``gridfs://<bucket-alias>/<filename>``.
+
+Supported stream functions:
+
+- :php:`copy() <copy>`
+- :php:`file_exists() <file_exists>`
+- :php:`file_get_contents() <file_get_contents>`
+- :php:`file_put_contents() <file_put_contents>`
+- :php:`filemtime() <filemtime>`
+- :php:`filesize() <filesize>`
+- :php:`file() <file>`
+- :php:`fopen() <fopen>` (with "r", "rb", "w", and "wb" modes)
+
+In read mode, the stream context can contain the option ``gridfs['revision']``
+to specify the revision number of the file to read. If omitted, the most recent
+revision is read (revision ``-1``).
+
+In write mode, the stream context can contain the option ``gridfs['chunkSizeBytes']``.
+If omitted, the defaults are inherited from the ``Bucket`` instance option.
+
+Example
+-------
+
+Read and write to a GridFS bucket using the ``gridfs://`` stream wrapper
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example demonstrates how to register an alias for a GridFS bucket
+and use the functions ``file_exists()``, ``file_get_contents()``, and
+``file_put_contents()`` to read and write to the bucket.
+
+Each call to these functions makes a request to the server.
+
+.. code-block:: php
+
+   <?php
+
+   $database = (new MongoDB\Client)->selectDatabase('test');
+   $bucket = $database->selectGridFSBucket();
+
+   $bucket->registerGlobalStreamWrapperAlias('mybucket');
+
+   var_dump(file_exists('gridfs://mybucket/hello.txt'));
+
+   file_put_contents('gridfs://mybucket/hello.txt', 'Hello, GridFS!');
+
+   var_dump(file_exists('gridfs://mybucket/hello.txt'));
+
+   echo file_get_contents('gridfs://mybucket/hello.txt');
+
+The output would then resemble:
+
+.. code-block:: none
+
+   bool(false)
+   bool(true)
+   Hello, GridFS!
+
+Read a specific revision of a file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using a stream context, you can specify the revision number of the file to
+read. If omitted, the most recent revision is read.
+
+.. code-block:: php
+
+   <?php
+
+   $database = (new MongoDB\Client)->selectDatabase('test');
+   $bucket = $database->selectGridFSBucket();
+
+   $bucket->registerGlobalStreamWrapperAlias('mybucket');
+
+   // Creating revision 0
+   $handle = fopen('gridfs://mybucket/hello.txt', 'w');
+   fwrite($handle, 'Hello, GridFS! (v0)');
+   fclose($handle);
+
+   // Creating revision 1
+   $handle = fopen('gridfs://mybucket/hello.txt', 'w');
+   fwrite($handle, 'Hello, GridFS! (v1)');
+   fclose($handle);
+
+   // Read revision 0
+   $context = stream_context_create([
+        'gridfs' => ['revision' => 0],
+   ]);
+   $handle = fopen('gridfs://mybucket/hello.txt', 'r', false, $context);
+   echo fread($handle, 1024);
+
+The output would then resemble:
+
+.. code-block:: none
+
+   Hello, GridFS! (v0)

--- a/examples/gridfs-stream-wrapper.php
+++ b/examples/gridfs-stream-wrapper.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * For applications that need to interact with GridFS using only a filename string,
+ * a bucket can be registered with an alias. Files can then be accessed using the
+ * following pattern: gridfs://<bucket-alias>/<filename>
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Examples;
+
+use MongoDB\Client;
+
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function getenv;
+use function stream_context_create;
+
+use const PHP_EOL;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
+$bucket = $client->test->selectGridFSBucket();
+$bucket->drop();
+
+// Register the alias "mybucket" for default bucket of the "test" database
+$bucket->registerGlobalStreamWrapperAlias('mybucket');
+
+echo 'File exists: ';
+echo file_exists('gridfs://mybucket/hello.txt') ? 'yes' : 'no';
+echo PHP_EOL;
+
+echo 'Writing file';
+file_put_contents('gridfs://mybucket/hello.txt', 'Hello, GridFS!');
+echo PHP_EOL;
+
+echo 'File exists: ';
+echo file_exists('gridfs://mybucket/hello.txt') ? 'yes' : 'no';
+echo PHP_EOL;
+
+echo 'Reading file: ';
+echo file_get_contents('gridfs://mybucket/hello.txt');
+echo PHP_EOL;
+
+echo 'Writing new version of the file';
+file_put_contents('gridfs://mybucket/hello.txt', 'Hello, GridFS! (v2)');
+echo PHP_EOL;
+
+echo 'Reading new version of the file: ';
+echo file_get_contents('gridfs://mybucket/hello.txt');
+echo PHP_EOL;
+
+echo 'Reading previous version of the file: ';
+$context = stream_context_create(['gridfs' => ['revision' => -2]]);
+echo file_get_contents('gridfs://mybucket/hello.txt', false, $context);
+echo PHP_EOL;

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -81,6 +81,9 @@
       <code><![CDATA[$options['revision']]]></code>
       <code><![CDATA[$options['revision']]]></code>
     </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code>$context</code>
+    </MixedArgumentTypeCoercion>
   </file>
   <file src="src/GridFS/ReadableStream.php">
     <MixedArgument>
@@ -89,20 +92,13 @@
     </MixedArgument>
   </file>
   <file src="src/GridFS/StreamWrapper.php">
-    <MixedArgument>
-      <code><![CDATA[$context[$this->protocol]['collectionWrapper']]]></code>
-      <code><![CDATA[$context[$this->protocol]['collectionWrapper']]]></code>
-      <code><![CDATA[$context[$this->protocol]['file']]]></code>
-      <code><![CDATA[$context[$this->protocol]['filename']]]></code>
-      <code><![CDATA[$context[$this->protocol]['options']]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$context[$this->protocol]['collectionWrapper']]]></code>
-      <code><![CDATA[$context[$this->protocol]['collectionWrapper']]]></code>
-      <code><![CDATA[$context[$this->protocol]['file']]]></code>
-      <code><![CDATA[$context[$this->protocol]['filename']]]></code>
-      <code><![CDATA[$context[$this->protocol]['options']]]></code>
-    </MixedArrayAccess>
+    <InvalidArgument>
+      <code>$context</code>
+      <code>$context</code>
+    </InvalidArgument>
+    <MixedAssignment>
+      <code>$context</code>
+    </MixedAssignment>
   </file>
   <file src="src/Model/BSONArray.php">
     <MixedAssignment>

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -31,6 +31,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\GridFS\Exception\CorruptFileException;
 use MongoDB\GridFS\Exception\FileNotFoundException;
+use MongoDB\GridFS\Exception\LogicException;
 use MongoDB\GridFS\Exception\StreamException;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
@@ -39,6 +40,7 @@ use MongoDB\Operation\Find;
 use function array_intersect_key;
 use function array_key_exists;
 use function assert;
+use function explode;
 use function fopen;
 use function get_resource_type;
 use function in_array;
@@ -54,6 +56,7 @@ use function MongoDB\BSON\fromPHP;
 use function MongoDB\BSON\toJSON;
 use function property_exists;
 use function sprintf;
+use function str_contains;
 use function stream_context_create;
 use function stream_copy_to_stream;
 use function stream_get_meta_data;
@@ -588,6 +591,29 @@ class Bucket
     }
 
     /**
+     * Register an alias to enable basic filename access for this bucket.
+     *
+     * For applications that need to interact with GridFS using only a filename
+     * string, a bucket can be registered with an alias. Files can then be
+     * accessed using the following pattern:
+     *
+     *     gridfs://<bucket-alias>/<filename>
+     *
+     * Read operations will always target the most recent revision of a file.
+     *
+     * @param non-empty-string string $alias The alias to use for the bucket
+     */
+    public function registerGlobalStreamWrapperAlias(string $alias): void
+    {
+        if ($alias === '' || str_contains($alias, '/')) {
+            throw new InvalidArgumentException(sprintf('The bucket alias must be a non-empty string without any slash, "%s" given', $alias));
+        }
+
+        // Use a closure to expose the private method into another class
+        StreamWrapper::setContextResolver($alias, fn (string $path, string $mode, array $context) => $this->resolveStreamContext($path, $mode, $context));
+    }
+
+    /**
      * Renames the GridFS file with the specified ID.
      *
      * @param mixed  $id          File ID
@@ -755,5 +781,51 @@ class Bucket
         }
 
         StreamWrapper::register(self::STREAM_WRAPPER_PROTOCOL);
+    }
+
+    /**
+     * Create a stream context from the path and mode provided to fopen().
+     *
+     * @see StreamWrapper::setContextResolver()
+     *
+     * @param string                                                         $path    The full url provided to fopen(). It contains the filename.
+     *                                                                                gridfs://database_name/collection_name.files/file_name
+     * @param array{revision?: int, chunkSizeBytes?: int, disableMD5?: bool} $context The options provided to fopen()
+     *
+     * @return array{collectionWrapper: CollectionWrapper, file: object}|array{collectionWrapper: CollectionWrapper, filename: string, options: array}
+     *
+     * @throws FileNotFoundException
+     * @throws LogicException
+     */
+    private function resolveStreamContext(string $path, string $mode, array $context): array
+    {
+        // Fallback to an empty filename if the path does not contain one: "gridfs://alias"
+        $filename = explode('/', $path, 4)[3] ?? '';
+
+        if ($mode === 'r' || $mode === 'rb') {
+            $file = $this->collectionWrapper->findFileByFilenameAndRevision($filename, $context['revision'] ?? -1);
+
+            if (! is_object($file)) {
+                throw FileNotFoundException::byFilenameAndRevision($filename, $context['revision'] ?? -1, $path);
+            }
+
+            return [
+                'collectionWrapper' => $this->collectionWrapper,
+                'file' => $file,
+            ];
+        }
+
+        if ($mode === 'w' || $mode === 'wb') {
+            return [
+                'collectionWrapper' => $this->collectionWrapper,
+                'filename' => $filename,
+                'options' => $context + [
+                    'chunkSizeBytes' => $this->chunkSizeBytes,
+                    'disableMD5' => $this->disableMD5,
+                ],
+            ];
+        }
+
+        throw LogicException::openModeNotSupported($mode);
     }
 }

--- a/src/GridFS/Exception/LogicException.php
+++ b/src/GridFS/Exception/LogicException.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\GridFS\Exception;
+
+use LogicException as BaseLogicException;
+use MongoDB\Exception\Exception;
+use MongoDB\GridFS\CollectionWrapper;
+
+use function get_debug_type;
+use function sprintf;
+
+class LogicException extends BaseLogicException implements Exception
+{
+    /**
+     * Throw when a bucket alias is used with global gridfs stream wrapper, but the alias is not registered.
+     *
+     * @internal
+     */
+    public static function bucketAliasNotRegistered(string $alias): self
+    {
+        return new self(sprintf('GridFS stream wrapper has no bucket alias: "%s"', $alias));
+    }
+
+    /**
+     * Throw when an invalid "gridfs" context option is provided.
+     *
+     * @param mixed $context
+     * @internal
+     */
+    public static function invalidContext($context): self
+    {
+        return new self(sprintf('Expected "gridfs" stream context to have type "array" but found "%s"', get_debug_type($context)));
+    }
+
+    /**
+     * Thrown when a context is provided with an incorrect collection wrapper.
+     *
+     * @param mixed $object
+     * @internal
+     */
+    public static function invalidContextCollectionWrapper($object): self
+    {
+        return new self(sprintf('Expected "collectionWrapper" in "gridfs" stream context to have type "%s" but found "%s"', CollectionWrapper::class, get_debug_type($object)));
+    }
+
+    /**
+     * Thrown when using an unsupported stream mode with fopen('gridfs://...', $mode).
+     *
+     * @internal
+     */
+    public static function openModeNotSupported(string $mode): self
+    {
+        return new self(sprintf('Mode "%s" is not supported by "gridfs://" files. Use one of "r", "rb", "w", or "wb".', $mode));
+    }
+}

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -17,11 +17,15 @@
 
 namespace MongoDB\GridFS;
 
+use Closure;
 use MongoDB\BSON\UTCDateTime;
+use MongoDB\GridFS\Exception\FileNotFoundException;
+use MongoDB\GridFS\Exception\LogicException;
 
 use function assert;
 use function explode;
 use function in_array;
+use function is_array;
 use function is_integer;
 use function is_resource;
 use function stream_context_get_options;
@@ -40,16 +44,18 @@ use const STREAM_IS_URL;
  * @internal
  * @see Bucket::openUploadStream()
  * @see Bucket::openDownloadStream()
+ * @psalm-type ContextOptions = array{collectionWrapper: CollectionWrapper, file: object}|array{collectionWrapper: CollectionWrapper, filename: string, options: array}
  */
 class StreamWrapper
 {
     /** @var resource|null Stream context (set by PHP) */
     public $context;
 
-    private ?string $protocol = null;
-
     /** @var ReadableStream|WritableStream|null */
     private $stream;
+
+    /** @var array<string, Closure(string, string, array): ContextOptions> */
+    private static array $contextResolvers = [];
 
     public function __destruct()
     {
@@ -82,6 +88,20 @@ class StreamWrapper
         }
 
         stream_wrapper_register($protocol, static::class, STREAM_IS_URL);
+    }
+
+    /**
+     * @see Bucket::resolveStreamContext()
+     *
+     * @param Closure(string, string, array):ContextOptions|null $resolver
+     */
+    public static function setContextResolver(string $name, ?Closure $resolver): void
+    {
+        if ($resolver === null) {
+            unset(self::$contextResolvers[$name]);
+        } else {
+            self::$contextResolvers[$name] = $resolver;
+        }
     }
 
     /**
@@ -123,17 +143,44 @@ class StreamWrapper
      */
     public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
     {
-        $this->initProtocol($path);
+        $context = [];
 
-        if ($mode === 'r') {
-            return $this->initReadableStream();
+        /**
+         * The Bucket methods { @see Bucket::openUploadStream() } and { @see Bucket::openDownloadStreamByFile() }
+         * always set an internal context. But the context can also be set by the user.
+         */
+        if (is_resource($this->context)) {
+            $context = stream_context_get_options($this->context)['gridfs'] ?? [];
+
+            if (! is_array($context)) {
+                throw LogicException::invalidContext($context);
+            }
         }
 
-        if ($mode === 'w') {
-            return $this->initWritableStream();
+        // When the stream is opened using fopen(), the context is not required, it can contain only options.
+        if (! isset($context['collectionWrapper'])) {
+            $bucketAlias = explode('/', $path, 4)[2] ?? '';
+
+            if (! isset(self::$contextResolvers[$bucketAlias])) {
+                throw LogicException::bucketAliasNotRegistered($bucketAlias);
+            }
+
+            $context = self::$contextResolvers[$bucketAlias]($path, $mode, $context);
         }
 
-        return false;
+        if (! $context['collectionWrapper'] instanceof CollectionWrapper) {
+            throw LogicException::invalidContextCollectionWrapper($context['collectionWrapper']);
+        }
+
+        if ($mode === 'r' || $mode === 'rb') {
+            return $this->initReadableStream($context);
+        }
+
+        if ($mode === 'w' || $mode === 'wb') {
+            return $this->initWritableStream($context);
+        }
+
+        throw LogicException::openModeNotSupported($mode);
     }
 
     /**
@@ -250,6 +297,20 @@ class StreamWrapper
         return $this->stream->writeBytes($data);
     }
 
+    /** @return false|array */
+    public function url_stat(string $path, int $flags)
+    {
+        assert($this->stream === null);
+
+        try {
+            $this->stream_open($path, 'r', 0, $openedPath);
+        } catch (FileNotFoundException $e) {
+            return false;
+        }
+
+        return $this->stream_stat();
+    }
+
     /**
      * Returns a stat template with default values.
      */
@@ -275,30 +336,15 @@ class StreamWrapper
     }
 
     /**
-     * Initialize the protocol from the given path.
-     *
-     * @see StreamWrapper::stream_open()
-     */
-    private function initProtocol(string $path): void
-    {
-        $parts = explode('://', $path, 2);
-        $this->protocol = $parts[0] ?: 'gridfs';
-    }
-
-    /**
      * Initialize the internal stream for reading.
      *
-     * @see StreamWrapper::stream_open()
+     * @param array{collectionWrapper: CollectionWrapper, file: object} $contextOptions
      */
-    private function initReadableStream(): bool
+    private function initReadableStream(array $contextOptions): bool
     {
-        assert(is_resource($this->context));
-        $context = stream_context_get_options($this->context);
-
-        assert($this->protocol !== null);
         $this->stream = new ReadableStream(
-            $context[$this->protocol]['collectionWrapper'],
-            $context[$this->protocol]['file'],
+            $contextOptions['collectionWrapper'],
+            $contextOptions['file'],
         );
 
         return true;
@@ -307,18 +353,14 @@ class StreamWrapper
     /**
      * Initialize the internal stream for writing.
      *
-     * @see StreamWrapper::stream_open()
+     * @param array{collectionWrapper: CollectionWrapper, filename: string, options: array} $contextOptions
      */
-    private function initWritableStream(): bool
+    private function initWritableStream(array $contextOptions): bool
     {
-        assert(is_resource($this->context));
-        $context = stream_context_get_options($this->context);
-
-        assert($this->protocol !== null);
         $this->stream = new WritableStream(
-            $context[$this->protocol]['collectionWrapper'],
-            $context[$this->protocol]['filename'],
-            $context[$this->protocol]['options'],
+            $contextOptions['collectionWrapper'],
+            $contextOptions['filename'],
+            $contextOptions['options'],
         );
 
         return true;

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -100,6 +100,21 @@ OUTPUT;
         ];
 
         $expectedOutput = <<<'OUTPUT'
+File exists: no
+Writing file
+File exists: yes
+Reading file: Hello, GridFS!
+Writing new version of the file
+Reading new version of the file: Hello, GridFS! (v2)
+Reading previous version of the file: Hello, GridFS!
+OUTPUT;
+
+        yield 'gridfs-stream-wrapper' => [
+            'file' => __DIR__ . '/../examples/gridfs-stream-wrapper.php',
+            'expectedOutput' => $expectedOutput,
+        ];
+
+        $expectedOutput = <<<'OUTPUT'
 MongoDB\Examples\Persistable\PersistableEntry Object
 (
     [id:MongoDB\Examples\Persistable\PersistableEntry:private] => MongoDB\BSON\ObjectId Object

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -4,13 +4,31 @@ namespace MongoDB\Tests\GridFS;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\UTCDateTime;
+use MongoDB\GridFS\Exception\FileNotFoundException;
+use MongoDB\GridFS\Exception\LogicException;
+use MongoDB\GridFS\StreamWrapper;
 
+use function copy;
 use function fclose;
 use function feof;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function filemtime;
+use function filesize;
+use function filetype;
+use function fopen;
 use function fread;
 use function fseek;
 use function fstat;
 use function fwrite;
+use function is_dir;
+use function is_file;
+use function is_link;
+use function stream_context_create;
+use function stream_get_contents;
+use function time;
+use function usleep;
 
 use const SEEK_CUR;
 use const SEEK_END;
@@ -34,6 +52,13 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
             ['_id' => 2, 'files_id' => 'length-10', 'n' => 1, 'data' => new Binary('efgh')],
             ['_id' => 3, 'files_id' => 'length-10', 'n' => 2, 'data' => new Binary('ij')],
         ]);
+    }
+
+    public function tearDown(): void
+    {
+        StreamWrapper::setContextResolver('bucket', null);
+
+        parent::tearDown();
     }
 
     public function testReadableStreamClose(): void
@@ -203,5 +228,139 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $stream = $this->bucket->openUploadStream('filename');
 
         $this->assertSame(6, fwrite($stream, 'foobar'));
+    }
+
+    /** @dataProvider provideUrl */
+    public function testStreamWithContextResolver(string $url, string $expectedFilename): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+
+        $stream = fopen($url, 'wb');
+
+        $this->assertSame(6, fwrite($stream, 'foobar'));
+        $this->assertTrue(fclose($stream));
+
+        $file = $this->filesCollection->findOne(['filename' => $expectedFilename]);
+        $this->assertNotNull($file);
+
+        $stream = fopen($url, 'rb');
+
+        $this->assertSame('foobar', fread($stream, 10));
+        $this->assertTrue(fclose($stream));
+    }
+
+    public static function provideUrl()
+    {
+        yield 'simple file' => ['gridfs://bucket/filename', 'filename'];
+        yield 'subdirectory file' => ['gridfs://bucket/path/to/filename.txt', 'path/to/filename.txt'];
+        yield 'question mark can be used in file name' => ['gridfs://bucket/file%20name?foo=bar', 'file%20name?foo=bar'];
+    }
+
+    public function testFilePutAndGetContents(): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+
+        $filename = 'gridfs://bucket/path/to/filename';
+
+        $this->assertSame(6, file_put_contents($filename, 'foobar'));
+
+        $file = $this->filesCollection->findOne(['filename' => 'path/to/filename']);
+        $this->assertNotNull($file);
+
+        $this->assertSame('foobar', file_get_contents($filename));
+    }
+
+    public function testEmptyFilename(): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+
+        $filename = 'gridfs://bucket';
+
+        $this->assertSame(6, file_put_contents($filename, 'foobar'));
+
+        $file = $this->filesCollection->findOne(['filename' => '']);
+        $this->assertNotNull($file);
+
+        $this->assertSame('foobar', file_get_contents($filename));
+    }
+
+    public function testOpenSpecificRevision(): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+
+        $filename = 'gridfs://bucket/path/to/filename';
+
+        // Insert 3 revisions, wait 1ms between each to ensure they have different uploadDate
+        file_put_contents($filename, 'version 0');
+        usleep(1000);
+        file_put_contents($filename, 'version 1');
+        usleep(1000);
+        file_put_contents($filename, 'version 2');
+
+        $context = stream_context_create([
+            'gridfs' => ['revision' => -2],
+        ]);
+        $stream = fopen($filename, 'r', false, $context);
+        $this->assertSame('version 1', stream_get_contents($stream));
+        fclose($stream);
+
+        // Revision not existing
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessage('File with name "path/to/filename" and revision "10" not found in "gridfs://bucket/path/to/filename"');
+        $context = stream_context_create([
+            'gridfs' => ['revision' => 10],
+        ]);
+        fopen($filename, 'r', false, $context);
+    }
+
+    public function testFileNoFoundWithContextResolver(): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessage('File with name "filename" and revision "-1" not found in "gridfs://bucket/filename"');
+
+        fopen('gridfs://bucket/filename', 'r');
+    }
+
+    public function testFileNoFoundWithoutDefaultResolver(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('GridFS stream wrapper has no bucket alias: "bucket"');
+
+        fopen('gridfs://bucket/filename', 'w');
+    }
+
+    public function testFileStats(): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+        $path = 'gridfs://bucket/filename';
+
+        $this->assertFalse(file_exists($path));
+        $this->assertFalse(is_file($path));
+
+        $time = time();
+        $this->assertSame(6, file_put_contents($path, 'foobar'));
+
+        $this->assertTrue(file_exists($path));
+        $this->assertSame('file', filetype($path));
+        $this->assertTrue(is_file($path));
+        $this->assertFalse(is_dir($path));
+        $this->assertFalse(is_link($path));
+        $this->assertSame(6, filesize($path));
+        $this->assertGreaterThanOrEqual($time, filemtime($path));
+        $this->assertLessThanOrEqual(time(), filemtime($path));
+    }
+
+    public function testCopy(): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+        $path = 'gridfs://bucket/filename';
+
+        $this->assertSame(6, file_put_contents($path, 'foobar'));
+
+        copy($path, $path . '.copy');
+        $this->assertSame('foobar', file_get_contents($path . '.copy'));
+        $this->assertSame('foobar', file_get_contents($path));
     }
 }


### PR DESCRIPTION
Fix [PHPLIB-1206](https://jira.mongodb.org/browse/PHPLIB-1206)
Fix https://github.com/mongodb/mongo-php-library/issues/1137

Allows to register an alias for the stream wrapper. File urls looks like:
```
gridfs://<bucket-alias>/<filename>
```

Where `<bucket-alias>` is an alias for the bucket

```php
$client = new Client();
$bucket = $client->selectDatabase('test_db')->selectGridFSBucket();
$bucket->registerGlobalStreamWrapperAlias('mybucket');

file_put_contents("gridfs://mybucket/filename.txt", 'Hello GridFS!');

if (file_exists("gridfs://mybucket/filename.txt")) {
    echo file_get_contents("gridfs://mybucket/filename.txt") . PHP_EOL;
}
```

Todo:

- [x] Add reference doc for the method `Bucket::registerGlobalStreamWrapperAlias`
