### PR TITLE
PHPLIB-1208: Split example namespaces

### DIFF
--- a/examples/aggregate.php
+++ b/examples/aggregate.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace MongoDB\Examples;
+namespace MongoDB\Examples\Aggregate;
 
 use MongoDB\Client;
 

--- a/examples/bulk.php
+++ b/examples/bulk.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace MongoDB\Examples;
+namespace MongoDB\Examples\Bulk;
 
 use MongoDB\Client;
 use MongoDB\Driver\WriteConcern;

--- a/examples/changestream.php
+++ b/examples/changestream.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace MongoDB\Examples;
+namespace MongoDB\Examples\ChangeStream;
 
 use MongoDB\Client;
 

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace MongoDB\Examples;
+namespace MongoDB\Examples\CommandLogger;
 
 use MongoDB\Client;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;

--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace MongoDB\Examples;
+namespace MongoDB\Examples\Persistable;
 
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Persistable;

--- a/examples/typemap.php
+++ b/examples/typemap.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace MongoDB\Examples;
+namespace MongoDB\Examples\Typemap;
 
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Unserializable;

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace MongoDB\Examples;
+namespace MongoDB\Examples\WithTransaction;
 
 use MongoDB\Client;
 use MongoDB\Driver\Session;

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -90,9 +90,9 @@ OUTPUT;
         ];
 
         $expectedOutput = <<<'OUTPUT'
-MongoDB\Examples\PersistableEntry Object
+MongoDB\Examples\Persistable\PersistableEntry Object
 (
-    [id:MongoDB\Examples\PersistableEntry:private] => MongoDB\BSON\ObjectId Object
+    [id:MongoDB\Examples\Persistable\PersistableEntry:private] => MongoDB\BSON\ObjectId Object
         (
             [oid] => %s
         )
@@ -100,13 +100,13 @@ MongoDB\Examples\PersistableEntry Object
     [name] => alcaeus
     [emails] => Array
         (
-            [0] => MongoDB\Examples\PersistableEmail Object
+            [0] => MongoDB\Examples\Persistable\PersistableEmail Object
                 (
                     [type] => work
                     [address] => alcaeus@example.com
                 )
 
-            [1] => MongoDB\Examples\PersistableEmail Object
+            [1] => MongoDB\Examples\Persistable\PersistableEmail Object
                 (
                     [type] => private
                     [address] => secret@example.com
@@ -123,26 +123,26 @@ OUTPUT;
         ];
 
         $expectedOutput = <<<'OUTPUT'
-MongoDB\Examples\TypeMapEntry Object
+MongoDB\Examples\Typemap\TypeMapEntry Object
 (
-    [id:MongoDB\Examples\TypeMapEntry:private] => MongoDB\BSON\ObjectId Object
+    [id:MongoDB\Examples\Typemap\TypeMapEntry:private] => MongoDB\BSON\ObjectId Object
         (
             [oid] => %s
         )
 
-    [name:MongoDB\Examples\TypeMapEntry:private] => alcaeus
-    [emails:MongoDB\Examples\TypeMapEntry:private] => Array
+    [name:MongoDB\Examples\Typemap\TypeMapEntry:private] => alcaeus
+    [emails:MongoDB\Examples\Typemap\TypeMapEntry:private] => Array
         (
-            [0] => MongoDB\Examples\TypeMapEmail Object
+            [0] => MongoDB\Examples\Typemap\TypeMapEmail Object
                 (
-                    [type:MongoDB\Examples\TypeMapEmail:private] => work
-                    [address:MongoDB\Examples\TypeMapEmail:private] => alcaeus@example.com
+                    [type:MongoDB\Examples\Typemap\TypeMapEmail:private] => work
+                    [address:MongoDB\Examples\Typemap\TypeMapEmail:private] => alcaeus@example.com
                 )
 
-            [1] => MongoDB\Examples\TypeMapEmail Object
+            [1] => MongoDB\Examples\Typemap\TypeMapEmail Object
                 (
-                    [type:MongoDB\Examples\TypeMapEmail:private] => private
-                    [address:MongoDB\Examples\TypeMapEmail:private] => secret@example.com
+                    [type:MongoDB\Examples\Typemap\TypeMapEmail:private] => private
+                    [address:MongoDB\Examples\Typemap\TypeMapEmail:private] => secret@example.com
                 )
 
         )


### PR DESCRIPTION
PHPLIB-1208

The appstract/laravel-opcache package looks compiles all php files using `opcache_compile_file`. This creates some duplicate function declarations in our example files. Since we want to ship the examples for users' benefit, these files need to be excluded by another measure. ~Luckily, the package [excludes files containing a shebang](https://github.com/appstract/laravel-opcache/blob/d2ce88cddda6af54c14d1f9ceaaf94b54f38f9d3/src/OpcacheClass.php#L61), so adding that and making the examples executable not only fixes the opcache issues, but also makes them a little easier to run.~

The above solution does not work on all PHP versions, as our tests require the files and the addition of the shebang makes the `declare` and `namespace` declarations no longer the first statements in the file. To work around the conflicts observed when compiling for opcache, the examples now use separate namespaces.