### PR TITLE
PHPLIB-1182: Support codec option in operation classes

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -199,6 +199,7 @@
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[2]</code>
+      <code>$args[2]</code>
     </MixedArgument>
     <MixedArrayAccess>
       <code>$args[0]</code>
@@ -206,6 +207,8 @@
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
+      <code>$args[0]</code>
+      <code>$args[0]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -220,6 +223,9 @@
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
+      <code>$args[1]</code>
+      <code>$args[1]</code>
+      <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
@@ -263,6 +269,8 @@
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
+      <code>encodeIfSupported</code>
+      <code>encodeIfSupported</code>
       <code>isInTransaction</code>
     </MixedMethodCall>
     <MixedOperand>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -473,7 +473,7 @@
       <code><![CDATA[$options['fields']]]></code>
     </MixedAssignment>
     <RedundantConditionGivenDocblockType>
-      <code>is_object($replacementDocument)</code>
+      <code>is_object($replacement)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Operation/FindOneAndUpdate.php">
@@ -483,6 +483,7 @@
   </file>
   <file src="src/Operation/InsertMany.php">
     <MixedAssignment>
+      <code>$document</code>
       <code>$insertedIds[$i]</code>
       <code>$options[$option]</code>
       <code><![CDATA[$options['session']]]></code>
@@ -501,9 +502,12 @@
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>encodeIfSupported</code>
       <code>isInTransaction</code>
     </MixedMethodCall>
+    <RedundantConditionGivenDocblockType>
+      <code>assert(is_array($document) || is_object($document))</code>
+      <code>is_array($document)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Operation/ListIndexes.php">
     <MixedAssignment>
@@ -553,7 +557,7 @@
   </file>
   <file src="src/Operation/ReplaceOne.php">
     <RedundantConditionGivenDocblockType>
-      <code>is_object($replacementDocument)</code>
+      <code>is_object($replacement)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Operation/Update.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -442,6 +442,7 @@
       <code>array|object|null</code>
     </MixedInferredReturnType>
     <MixedMethodCall>
+      <code>decodeIfSupported</code>
       <code>isInTransaction</code>
     </MixedMethodCall>
     <MixedReturnStatement>
@@ -470,6 +471,9 @@
     <MixedAssignment>
       <code><![CDATA[$options['fields']]]></code>
     </MixedAssignment>
+    <RedundantConditionGivenDocblockType>
+      <code>is_object($replacementDocument)</code>
+    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Operation/FindOneAndUpdate.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -401,6 +401,7 @@
   </file>
   <file src="src/Operation/Find.php">
     <MixedArgument>
+      <code><![CDATA[$this->options['codec']]]></code>
       <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
     <MixedArrayAccess>
@@ -437,6 +438,18 @@
     <MixedReturnStatement>
       <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
       <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Operation/FindOne.php">
+    <MixedAssignment>
+      <code>$document</code>
+    </MixedAssignment>
+    <MixedInferredReturnType>
+      <code>array|object|null</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code>$document === false ? null : $document</code>
+      <code>$document === false ? null : $document</code>
     </MixedReturnStatement>
   </file>
   <file src="src/Operation/FindOneAndDelete.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -193,6 +193,8 @@
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
+      <code>$args[0]</code>
+      <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -236,8 +238,6 @@
       <code><![CDATA[$args[2]['upsert']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
-      <code>$args[0]</code>
-      <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -250,6 +250,8 @@
       <code>$args[2]</code>
       <code><![CDATA[$args[2]['multi']]]></code>
       <code><![CDATA[$args[2]['multi']]]></code>
+      <code>$operations[$i][$type][0]</code>
+      <code>$operations[$i][$type][1]</code>
       <code>$operations[$i][$type][1]</code>
       <code>$operations[$i][$type][2]</code>
       <code>$operations[$i][$type][2]</code>
@@ -257,8 +259,6 @@
     <MixedAssignment>
       <code>$args</code>
       <code>$args</code>
-      <code>$args[0]</code>
-      <code>$args[1]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$insertedIds[$i]</code>
@@ -270,8 +270,6 @@
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>encodeIfSupported</code>
-      <code>encodeIfSupported</code>
       <code>isInTransaction</code>
     </MixedMethodCall>
     <MixedOperand>
@@ -472,10 +470,9 @@
     <MixedAssignment>
       <code><![CDATA[$options['fields']]]></code>
     </MixedAssignment>
-    <RedundantConditionGivenDocblockType>
-      <code>assert(is_array($replacement) || is_object($replacement))</code>
-      <code>is_array($replacement)</code>
-    </RedundantConditionGivenDocblockType>
+    <PossiblyInvalidArgument>
+      <code>$replacement</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/FindOneAndUpdate.php">
     <MixedAssignment>
@@ -484,16 +481,17 @@
   </file>
   <file src="src/Operation/InsertMany.php">
     <MixedAssignment>
-      <code>$document</code>
       <code>$insertedIds[$i]</code>
       <code>$options[$option]</code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>encodeIfSupported</code>
       <code>isInTransaction</code>
     </MixedMethodCall>
+    <PossiblyInvalidArgument>
+      <code>$document</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/InsertOne.php">
     <MixedAssignment>
@@ -505,10 +503,9 @@
     <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
-    <RedundantConditionGivenDocblockType>
-      <code>assert(is_array($document) || is_object($document))</code>
-      <code>is_array($document)</code>
-    </RedundantConditionGivenDocblockType>
+    <PossiblyInvalidArgument>
+      <code>$document</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/ListIndexes.php">
     <MixedAssignment>
@@ -557,10 +554,9 @@
     </MixedMethodCall>
   </file>
   <file src="src/Operation/ReplaceOne.php">
-    <RedundantConditionGivenDocblockType>
-      <code>assert(is_array($replacement) || is_object($replacement))</code>
-      <code>is_array($replacement)</code>
-    </RedundantConditionGivenDocblockType>
+    <PossiblyInvalidArgument>
+      <code>$replacement</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/Update.php">
     <MixedArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -441,10 +441,11 @@
       <code>array|object|null</code>
     </MixedInferredReturnType>
     <MixedMethodCall>
-      <code>decodeIfSupported</code>
+      <code>decode</code>
       <code>isInTransaction</code>
     </MixedMethodCall>
     <MixedReturnStatement>
+      <code><![CDATA[$this->options['codec']->decode($result->get('value'))]]></code>
       <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
       <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
     </MixedReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -436,6 +436,7 @@
       <code><![CDATA[$cmd['upsert']]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
+      <code>$value</code>
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>array|object|null</code>
@@ -445,7 +446,8 @@
       <code>isInTransaction</code>
     </MixedMethodCall>
     <MixedReturnStatement>
-      <code><![CDATA[$this->options['codec']->decode($result->get('value'))]]></code>
+      <code><![CDATA[$value === null ? $value : $this->options['codec']->decode($value)]]></code>
+      <code><![CDATA[$value === null ? $value : $this->options['codec']->decode($value)]]></code>
       <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
       <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
     </MixedReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -200,7 +200,6 @@
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[2]</code>
-      <code>$args[2]</code>
     </MixedArgument>
     <MixedArrayAccess>
       <code>$args[0]</code>
@@ -209,7 +208,6 @@
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[0]</code>
-      <code>$args[0]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -225,8 +223,6 @@
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
@@ -240,6 +236,8 @@
       <code><![CDATA[$args[2]['upsert']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
+      <code>$args[0]</code>
+      <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
       <code>$args[1]</code>
@@ -259,6 +257,8 @@
     <MixedAssignment>
       <code>$args</code>
       <code>$args</code>
+      <code>$args[0]</code>
+      <code>$args[1]</code>
       <code>$args[2]</code>
       <code>$args[2]</code>
       <code>$insertedIds[$i]</code>
@@ -473,7 +473,8 @@
       <code><![CDATA[$options['fields']]]></code>
     </MixedAssignment>
     <RedundantConditionGivenDocblockType>
-      <code>is_object($replacement)</code>
+      <code>assert(is_array($replacement) || is_object($replacement))</code>
+      <code>is_array($replacement)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Operation/FindOneAndUpdate.php">
@@ -557,7 +558,8 @@
   </file>
   <file src="src/Operation/ReplaceOne.php">
     <RedundantConditionGivenDocblockType>
-      <code>is_object($replacement)</code>
+      <code>assert(is_array($replacement) || is_object($replacement))</code>
+      <code>is_array($replacement)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Operation/Update.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -537,6 +537,11 @@
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
+  <file src="src/Operation/ReplaceOne.php">
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($replacementDocument)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
   <file src="src/Operation/Update.php">
     <MixedArgument>
       <code><![CDATA[$this->options['writeConcern']]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -475,6 +475,7 @@
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
+      <code>encodeIfSupported</code>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>
@@ -486,6 +487,7 @@
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
+      <code>encodeIfSupported</code>
       <code>isInTransaction</code>
     </MixedMethodCall>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -101,6 +101,7 @@
       <code><![CDATA[$reply->cursor->nextBatch]]></code>
     </MixedArgument>
     <MixedAssignment>
+      <code>$resumeToken</code>
       <code><![CDATA[$this->postBatchResumeToken]]></code>
     </MixedAssignment>
     <MixedPropertyFetch>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -170,6 +170,7 @@
   </file>
   <file src="src/Operation/Aggregate.php">
     <MixedArgument>
+      <code><![CDATA[$this->options['codec']]]></code>
       <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
     <MixedAssignment>
@@ -538,7 +539,7 @@
     </MixedMethodCall>
   </file>
   <file src="src/Operation/ReplaceOne.php">
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_object($replacementDocument)</code>
     </RedundantConditionGivenDocblockType>
   </file>

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -18,7 +18,6 @@
 namespace MongoDB;
 
 use Iterator;
-use MongoDB\BSON\Document;
 use MongoDB\Codec\DocumentCodec;
 use MongoDB\Driver\CursorId;
 use MongoDB\Driver\Exception\ConnectionException;
@@ -29,7 +28,6 @@ use MongoDB\Exception\ResumeTokenException;
 use MongoDB\Model\ChangeStreamIterator;
 use ReturnTypeWillChange;
 
-use function assert;
 use function call_user_func;
 use function in_array;
 
@@ -115,8 +113,6 @@ class ChangeStream implements Iterator
         if (! $this->codec) {
             return $value;
         }
-
-        assert($value === null || $value instanceof Document);
 
         return $this->codec->decodeIfSupported($value);
     }

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -18,6 +18,7 @@
 namespace MongoDB;
 
 use Iterator;
+use MongoDB\BSON\Document;
 use MongoDB\Codec\DocumentCodec;
 use MongoDB\Driver\CursorId;
 use MongoDB\Driver\Exception\ConnectionException;
@@ -28,6 +29,7 @@ use MongoDB\Exception\ResumeTokenException;
 use MongoDB\Model\ChangeStreamIterator;
 use ReturnTypeWillChange;
 
+use function assert;
 use function call_user_func;
 use function in_array;
 
@@ -114,7 +116,9 @@ class ChangeStream implements Iterator
             return $value;
         }
 
-        return $this->codec->decodeIfSupported($value);
+        assert($value instanceof Document);
+
+        return $this->codec->decode($value);
     }
 
     /** @return CursorId */

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -258,9 +258,8 @@ class Collection
      */
     public function bulkWrite(array $operations, array $options = [])
     {
-        $options = $this->inheritWriteOptions(
-            $this->inheritCodec($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritCodec($options);
 
         $operation = new BulkWrite($this->databaseName, $this->collectionName, $operations, $options);
 
@@ -426,9 +425,8 @@ class Collection
      */
     public function distinct(string $fieldName, $filter = [], array $options = [])
     {
-        $options = $this->inheritReadOptions(
-            $this->inheritTypeMap($options),
-        );
+        $options = $this->inheritReadOptions($options);
+        $options = $this->inheritTypeMap($options);
 
         $operation = new Distinct($this->databaseName, $this->collectionName, $fieldName, $filter, $options);
 
@@ -449,9 +447,8 @@ class Collection
     {
         $server = select_server($this->manager, $options);
 
-        $options = $this->inheritWriteOptions(
-            $this->inheritTypeMap($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritTypeMap($options);
 
         if (! isset($options['encryptedFields'])) {
             $options['encryptedFields'] = get_encrypted_fields_from_driver($this->databaseName, $this->collectionName, $this->manager)
@@ -484,9 +481,8 @@ class Collection
             throw new InvalidArgumentException('dropIndexes() must be used to drop multiple indexes');
         }
 
-        $options = $this->inheritWriteOptions(
-            $this->inheritTypeMap($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritTypeMap($options);
 
         $operation = new DropIndexes($this->databaseName, $this->collectionName, $indexName, $options);
 
@@ -505,9 +501,8 @@ class Collection
      */
     public function dropIndexes(array $options = [])
     {
-        $options = $this->inheritWriteOptions(
-            $this->inheritTypeMap($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritTypeMap($options);
 
         $operation = new DropIndexes($this->databaseName, $this->collectionName, '*', $options);
 
@@ -573,9 +568,8 @@ class Collection
      */
     public function find($filter = [], array $options = [])
     {
-        $options = $this->inheritReadOptions(
-            $this->inheritCodecOrTypeMap($options),
-        );
+        $options = $this->inheritReadOptions($options);
+        $options = $this->inheritCodecOrTypeMap($options);
 
         $operation = new Find($this->databaseName, $this->collectionName, $filter, $options);
 
@@ -596,9 +590,8 @@ class Collection
      */
     public function findOne($filter = [], array $options = [])
     {
-        $options = $this->inheritReadOptions(
-            $this->inheritCodecOrTypeMap($options),
-        );
+        $options = $this->inheritReadOptions($options);
+        $options = $this->inheritCodecOrTypeMap($options);
 
         $operation = new FindOne($this->databaseName, $this->collectionName, $filter, $options);
 
@@ -622,9 +615,8 @@ class Collection
      */
     public function findOneAndDelete($filter, array $options = [])
     {
-        $options = $this->inheritWriteOptions(
-            $this->inheritCodecOrTypeMap($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritCodecOrTypeMap($options);
 
         $operation = new FindOneAndDelete($this->databaseName, $this->collectionName, $filter, $options);
 
@@ -653,9 +645,8 @@ class Collection
      */
     public function findOneAndReplace($filter, $replacement, array $options = [])
     {
-        $options = $this->inheritWriteOptions(
-            $this->inheritCodecOrTypeMap($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritCodecOrTypeMap($options);
 
         $operation = new FindOneAndReplace($this->databaseName, $this->collectionName, $filter, $replacement, $options);
 
@@ -684,9 +675,8 @@ class Collection
      */
     public function findOneAndUpdate($filter, $update, array $options = [])
     {
-        $options = $this->inheritWriteOptions(
-            $this->inheritCodecOrTypeMap($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritCodecOrTypeMap($options);
 
         $operation = new FindOneAndUpdate($this->databaseName, $this->collectionName, $filter, $update, $options);
 
@@ -789,9 +779,8 @@ class Collection
      */
     public function insertMany(array $documents, array $options = [])
     {
-        $options = $this->inheritWriteOptions(
-            $this->inheritCodec($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritCodec($options);
 
         $operation = new InsertMany($this->databaseName, $this->collectionName, $documents, $options);
 
@@ -811,9 +800,8 @@ class Collection
      */
     public function insertOne($document, array $options = [])
     {
-        $options = $this->inheritWriteOptions(
-            $this->inheritCodec($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritCodec($options);
 
         $operation = new InsertOne($this->databaseName, $this->collectionName, $document, $options);
 
@@ -872,9 +860,8 @@ class Collection
             $options['readConcern'] = $this->readConcern;
         }
 
-        $options = $this->inheritWriteOptions(
-            $this->inheritTypeMap($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritTypeMap($options);
 
         $operation = new MapReduce($this->databaseName, $this->collectionName, $map, $reduce, $out, $options);
 
@@ -899,9 +886,8 @@ class Collection
             $toDatabaseName = $this->databaseName;
         }
 
-        $options = $this->inheritWriteOptions(
-            $this->inheritTypeMap($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritTypeMap($options);
 
         $operation = new RenameCollection($this->databaseName, $this->collectionName, $toDatabaseName, $toCollectionName, $options);
 
@@ -923,9 +909,8 @@ class Collection
      */
     public function replaceOne($filter, $replacement, array $options = [])
     {
-        $options = $this->inheritWriteOptions(
-            $this->inheritCodec($options),
-        );
+        $options = $this->inheritWriteOptions($options);
+        $options = $this->inheritCodec($options);
 
         $operation = new ReplaceOne($this->databaseName, $this->collectionName, $filter, $replacement, $options);
 
@@ -987,9 +972,8 @@ class Collection
      */
     public function watch(array $pipeline = [], array $options = [])
     {
-        $options = $this->inheritReadOptions(
-            $this->inheritCodecOrTypeMap($options),
-        );
+        $options = $this->inheritReadOptions($options);
+        $options = $this->inheritCodecOrTypeMap($options);
 
         $operation = new Watch($this->manager, $this->databaseName, $this->collectionName, $pipeline, $options);
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -19,7 +19,6 @@ namespace MongoDB;
 
 use Iterator;
 use MongoDB\BSON\JavascriptInterface;
-use MongoDB\Driver\Cursor;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Manager;
@@ -190,7 +189,7 @@ class Collection
      * @see Aggregate::__construct() for supported options
      * @param array $pipeline Aggregation pipeline
      * @param array $options  Command options
-     * @return Cursor
+     * @return CursorInterface&Iterator
      * @throws UnexpectedValueException if the command response was malformed
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -234,7 +234,7 @@ class Collection
             $options['readConcern'] = $this->readConcern;
         }
 
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -264,7 +264,7 @@ class Collection
      */
     public function bulkWrite(array $operations, array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -648,7 +648,7 @@ class Collection
      */
     public function find($filter = [], array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -685,7 +685,7 @@ class Collection
      */
     public function findOne($filter = [], array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -725,7 +725,7 @@ class Collection
      */
     public function findOneAndDelete($filter, array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -766,7 +766,7 @@ class Collection
      */
     public function findOneAndReplace($filter, $replacement, array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -807,7 +807,7 @@ class Collection
      */
     public function findOneAndUpdate($filter, $update, array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -922,7 +922,7 @@ class Collection
      */
     public function insertMany(array $documents, array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -949,7 +949,7 @@ class Collection
      */
     public function insertOne($document, array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -1079,7 +1079,7 @@ class Collection
      */
     public function replaceOne($filter, $replacement, array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 
@@ -1154,7 +1154,7 @@ class Collection
      */
     public function watch(array $pipeline = [], array $options = [])
     {
-        if (! array_key_exists('codec', $options)) {
+        if (! array_key_exists('codec', $options) && ! isset($options['typeMap'])) {
             $options['codec'] = $this->codec;
         }
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -263,9 +263,8 @@ class Collection
         );
 
         $operation = new BulkWrite($this->databaseName, $this->collectionName, $operations, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -286,11 +285,9 @@ class Collection
     {
         $options = $this->inheritReadOptions($options);
 
-        $server = select_server($this->manager, $options);
-
         $operation = new Count($this->databaseName, $this->collectionName, $filter, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -309,11 +306,9 @@ class Collection
     {
         $options = $this->inheritReadOptions($options);
 
-        $server = select_server($this->manager, $options);
-
         $operation = new CountDocuments($this->databaseName, $this->collectionName, $filter, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -367,13 +362,11 @@ class Collection
      */
     public function createIndexes(array $indexes, array $options = [])
     {
-        $server = select_server($this->manager, $options);
-
         $options = $this->inheritWriteOptions($options);
 
         $operation = new CreateIndexes($this->databaseName, $this->collectionName, $indexes, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -393,9 +386,8 @@ class Collection
         $options = $this->inheritWriteOptions($options);
 
         $operation = new DeleteMany($this->databaseName, $this->collectionName, $filter, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -415,9 +407,8 @@ class Collection
         $options = $this->inheritWriteOptions($options);
 
         $operation = new DeleteOne($this->databaseName, $this->collectionName, $filter, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -439,11 +430,9 @@ class Collection
             $this->inheritTypeMap($options),
         );
 
-        $server = select_server($this->manager, $options);
-
         $operation = new Distinct($this->databaseName, $this->collectionName, $fieldName, $filter, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -495,15 +484,13 @@ class Collection
             throw new InvalidArgumentException('dropIndexes() must be used to drop multiple indexes');
         }
 
-        $server = select_server($this->manager, $options);
-
         $options = $this->inheritWriteOptions(
             $this->inheritTypeMap($options),
         );
 
         $operation = new DropIndexes($this->databaseName, $this->collectionName, $indexName, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -518,15 +505,13 @@ class Collection
      */
     public function dropIndexes(array $options = [])
     {
-        $server = select_server($this->manager, $options);
-
         $options = $this->inheritWriteOptions(
             $this->inheritTypeMap($options),
         );
 
         $operation = new DropIndexes($this->databaseName, $this->collectionName, '*', $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -544,11 +529,9 @@ class Collection
     {
         $options = $this->inheritReadOptions($options);
 
-        $server = select_server($this->manager, $options);
-
         $operation = new EstimatedDocumentCount($this->databaseName, $this->collectionName, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -571,11 +554,9 @@ class Collection
 
         $options = $this->inheritTypeMap($options);
 
-        $server = select_server($this->manager, $options);
-
         $operation = new Explain($this->databaseName, $explainable, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -596,11 +577,9 @@ class Collection
             $this->inheritCodecOrTypeMap($options),
         );
 
-        $server = select_server($this->manager, $options);
-
         $operation = new Find($this->databaseName, $this->collectionName, $filter, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -621,11 +600,9 @@ class Collection
             $this->inheritCodecOrTypeMap($options),
         );
 
-        $server = select_server($this->manager, $options);
-
         $operation = new FindOne($this->databaseName, $this->collectionName, $filter, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -645,15 +622,13 @@ class Collection
      */
     public function findOneAndDelete($filter, array $options = [])
     {
-        $server = select_server($this->manager, $options);
-
         $options = $this->inheritWriteOptions(
             $this->inheritCodecOrTypeMap($options),
         );
 
         $operation = new FindOneAndDelete($this->databaseName, $this->collectionName, $filter, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -678,15 +653,13 @@ class Collection
      */
     public function findOneAndReplace($filter, $replacement, array $options = [])
     {
-        $server = select_server($this->manager, $options);
-
         $options = $this->inheritWriteOptions(
             $this->inheritCodecOrTypeMap($options),
         );
 
         $operation = new FindOneAndReplace($this->databaseName, $this->collectionName, $filter, $replacement, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -711,15 +684,13 @@ class Collection
      */
     public function findOneAndUpdate($filter, $update, array $options = [])
     {
-        $server = select_server($this->manager, $options);
-
         $options = $this->inheritWriteOptions(
             $this->inheritCodecOrTypeMap($options),
         );
 
         $operation = new FindOneAndUpdate($this->databaseName, $this->collectionName, $filter, $update, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -823,9 +794,8 @@ class Collection
         );
 
         $operation = new InsertMany($this->databaseName, $this->collectionName, $documents, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -846,9 +816,8 @@ class Collection
         );
 
         $operation = new InsertOne($this->databaseName, $this->collectionName, $document, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -862,9 +831,8 @@ class Collection
     public function listIndexes(array $options = [])
     {
         $operation = new ListIndexes($this->databaseName, $this->collectionName, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -895,8 +863,6 @@ class Collection
             $options['readPreference'] = new ReadPreference(ReadPreference::PRIMARY);
         }
 
-        $server = select_server($this->manager, $options);
-
         /* A "majority" read concern is not compatible with inline output, so
          * avoid providing the Collection's read concern if it would conflict.
          *
@@ -912,7 +878,7 @@ class Collection
 
         $operation = new MapReduce($this->databaseName, $this->collectionName, $map, $reduce, $out, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -933,15 +899,13 @@ class Collection
             $toDatabaseName = $this->databaseName;
         }
 
-        $server = select_server($this->manager, $options);
-
         $options = $this->inheritWriteOptions(
             $this->inheritTypeMap($options),
         );
 
         $operation = new RenameCollection($this->databaseName, $this->collectionName, $toDatabaseName, $toCollectionName, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -964,9 +928,8 @@ class Collection
         );
 
         $operation = new ReplaceOne($this->databaseName, $this->collectionName, $filter, $replacement, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -987,9 +950,8 @@ class Collection
         $options = $this->inheritWriteOptions($options);
 
         $operation = new UpdateMany($this->databaseName, $this->collectionName, $filter, $update, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -1010,9 +972,8 @@ class Collection
         $options = $this->inheritWriteOptions($options);
 
         $operation = new UpdateOne($this->databaseName, $this->collectionName, $filter, $update, $options);
-        $server = select_server($this->manager, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**
@@ -1030,11 +991,9 @@ class Collection
             $this->inheritCodecOrTypeMap($options),
         );
 
-        $server = select_server($this->manager, $options);
-
         $operation = new Watch($this->manager, $this->databaseName, $this->collectionName, $pipeline, $options);
 
-        return $operation->execute($server);
+        return $operation->execute(select_server($this->manager, $options));
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -445,10 +445,10 @@ class Collection
      */
     public function drop(array $options = [])
     {
-        $server = select_server($this->manager, $options);
-
         $options = $this->inheritWriteOptions($options);
         $options = $this->inheritTypeMap($options);
+
+        $server = select_server($this->manager, $options);
 
         if (! isset($options['encryptedFields'])) {
             $options['encryptedFields'] = get_encrypted_fields_from_driver($this->databaseName, $this->collectionName, $this->manager)

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -781,8 +781,8 @@ class Collection
      *
      * @see InsertMany::__construct() for supported options
      * @see https://mongodb.com/docs/manual/reference/command/insert/
-     * @param array[]|object[] $documents The documents to insert
-     * @param array            $options   Command options
+     * @param list<object|array> $documents The documents to insert
+     * @param array              $options   Command options
      * @return InsertManyResult
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -17,8 +17,10 @@
 
 namespace MongoDB;
 
+use Iterator;
 use MongoDB\BSON\JavascriptInterface;
 use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadConcern;
@@ -618,7 +620,7 @@ class Collection
      * @see https://mongodb.com/docs/manual/crud/#read-operations
      * @param array|object $filter  Query by which to filter documents
      * @param array        $options Additional options
-     * @return Cursor
+     * @return CursorInterface&Iterator
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -29,6 +29,11 @@ use function sprintf;
 
 class InvalidArgumentException extends DriverInvalidArgumentException implements Exception
 {
+    public static function cannotCombineCodecAndTypeMap(): self
+    {
+        return new self('Cannot provide both "codec" and "typeMap" options');
+    }
+
     /**
      * Thrown when an argument or option is expected to be a document.
      *

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -17,8 +17,9 @@
 
 namespace MongoDB\GridFS;
 
+use Iterator;
 use MongoDB\Collection;
-use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadConcern;
@@ -301,7 +302,7 @@ class Bucket
      * @see Find::__construct() for supported options
      * @param array|object $filter  Query by which to filter documents
      * @param array        $options Additional options
-     * @return Cursor
+     * @return CursorInterface&Iterator
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -18,8 +18,9 @@
 namespace MongoDB\GridFS;
 
 use ArrayIterator;
+use Iterator;
 use MongoDB\Collection;
-use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Exception\InvalidArgumentException;
@@ -104,8 +105,9 @@ class CollectionWrapper
      *
      * @param mixed   $id        File ID
      * @param integer $fromChunk Starting chunk (inclusive)
+     * @return CursorInterface&Iterator
      */
-    public function findChunksByFileId($id, int $fromChunk = 0): Cursor
+    public function findChunksByFileId($id, int $fromChunk = 0)
     {
         return $this->chunksCollection->find(
             [
@@ -182,7 +184,7 @@ class CollectionWrapper
      * @see Find::__construct() for supported options
      * @param array|object $filter  Query by which to filter documents
      * @param array        $options Additional options
-     * @return Cursor
+     * @return CursorInterface&Iterator
      */
     public function findFiles($filter, array $options = [])
     {

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -17,8 +17,9 @@
 
 namespace MongoDB\GridFS;
 
+use Iterator;
 use MongoDB\BSON\Binary;
-use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\Exception\CorruptFileException;
 
@@ -47,7 +48,8 @@ class ReadableStream
 
     private int $chunkOffset = 0;
 
-    private ?Cursor $chunksIterator = null;
+    /** @var (CursorInterface&Iterator)|null */
+    private $chunksIterator = null;
 
     private CollectionWrapper $collectionWrapper;
 

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -49,7 +49,7 @@ class ReadableStream
     private int $chunkOffset = 0;
 
     /** @var (CursorInterface&Iterator)|null */
-    private $chunksIterator = null;
+    private ?Iterator $chunksIterator = null;
 
     private CollectionWrapper $collectionWrapper;
 

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -255,9 +255,7 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
         }
 
         if ($document instanceof Document) {
-            $resumeToken = $document->has('_id')
-                ? $document->get('_id')
-                : null;
+            $resumeToken = $document->get('_id');
 
             if ($resumeToken instanceof Document) {
                 $resumeToken = $resumeToken->toPHP();

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -149,11 +149,14 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      * iterator. This could be side-stepped due to the class not being final,
      * but it's very much an invalid use-case. This method can be dropped in 2.0
      * once the class is final.
+     *
+     * @return CursorInterface<int, TValue>&Iterator<int, TValue>
      */
-    final public function getInnerIterator(): CursorInterface
+    final public function getInnerIterator(): Iterator
     {
         $cursor = parent::getInnerIterator();
         assert($cursor instanceof CursorInterface);
+        assert($cursor instanceof Iterator);
 
         return $cursor;
     }

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -75,6 +75,14 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      */
     public function __construct(CursorInterface $cursor, int $firstBatchSize, $initialResumeToken, ?object $postBatchResumeToken)
     {
+        if (! $cursor instanceof Iterator) {
+            throw InvalidArgumentException::invalidType(
+                '$cursor',
+                $cursor,
+                CursorInterface::class . '&' . Iterator::class,
+            );
+        }
+
         if (isset($initialResumeToken) && ! is_document($initialResumeToken)) {
             throw InvalidArgumentException::expectedDocumentType('$initialResumeToken', $initialResumeToken);
         }

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -49,7 +49,7 @@ use function MongoDB\is_document;
  *
  * @internal
  * @template TValue of array|object
- * @template-extends IteratorIterator<int, TValue, Iterator<int, TValue>>
+ * @template-extends IteratorIterator<int, TValue, CursorInterface<int, TValue>&Iterator<int, TValue>>
  */
 class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 {

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -19,6 +19,7 @@ namespace MongoDB\Model;
 
 use Iterator;
 use IteratorIterator;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
@@ -245,9 +246,19 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
             return $this->extractResumeToken($document->bsonSerialize());
         }
 
-        $resumeToken = is_array($document)
-            ? ($document['_id'] ?? null)
-            : ($document->_id ?? null);
+        if ($document instanceof Document) {
+            $resumeToken = $document->has('_id')
+                ? $document->get('_id')
+                : null;
+
+            if ($resumeToken instanceof Document) {
+                $resumeToken = $resumeToken->toPHP();
+            }
+        } else {
+            $resumeToken = is_array($document)
+                ? ($document['_id'] ?? null)
+                : ($document->_id ?? null);
+        }
 
         if (! isset($resumeToken)) {
             $this->isValid = false;

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -17,9 +17,10 @@
 
 namespace MongoDB\Model;
 
+use Iterator;
 use IteratorIterator;
 use MongoDB\BSON\Serializable;
-use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
@@ -47,7 +48,7 @@ use function MongoDB\is_document;
  *
  * @internal
  * @template TValue of array|object
- * @template-extends IteratorIterator<int, TValue, Cursor<TValue>>
+ * @template-extends IteratorIterator<int, TValue, Iterator<int, TValue>>
  */
 class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
 {
@@ -69,9 +70,9 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
     /**
      * @internal
      * @param array|object|null $initialResumeToken
-     * @psalm-param Cursor<TValue> $cursor
+     * @psalm-param CursorInterface<int, TValue>&Iterator<int, TValue> $cursor
      */
-    public function __construct(Cursor $cursor, int $firstBatchSize, $initialResumeToken, ?object $postBatchResumeToken)
+    public function __construct(CursorInterface $cursor, int $firstBatchSize, $initialResumeToken, ?object $postBatchResumeToken)
     {
         if (isset($initialResumeToken) && ! is_document($initialResumeToken)) {
             throw InvalidArgumentException::expectedDocumentType('$initialResumeToken', $initialResumeToken);
@@ -140,10 +141,10 @@ class ChangeStreamIterator extends IteratorIterator implements CommandSubscriber
      * but it's very much an invalid use-case. This method can be dropped in 2.0
      * once the class is final.
      */
-    final public function getInnerIterator(): Cursor
+    final public function getInnerIterator(): CursorInterface
     {
         $cursor = parent::getInnerIterator();
-        assert($cursor instanceof Cursor);
+        assert($cursor instanceof CursorInterface);
 
         return $cursor;
     }

--- a/src/Model/CodecCursor.php
+++ b/src/Model/CodecCursor.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Model;
+
+use Iterator;
+use MongoDB\BSON\Document;
+use MongoDB\Codec\DocumentCodec;
+use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorId;
+use MongoDB\Driver\CursorInterface;
+use MongoDB\Driver\Server;
+
+use function assert;
+use function iterator_to_array;
+
+/**
+ * @template TValue of object
+ * @template-implements CursorInterface<int, TValue>
+ * @template-implements Iterator<int, TValue>
+ */
+class CodecCursor implements CursorInterface, Iterator
+{
+    private const TYPEMAP = ['root' => 'bson'];
+
+    private Cursor $cursor;
+
+    /** @var DocumentCodec<TValue> */
+    private DocumentCodec $codec;
+
+    /** @var TValue|null */
+    private ?object $current = null;
+
+    /** @return TValue */
+    public function current(): ?object
+    {
+        if (! $this->current && $this->valid()) {
+            $value = $this->cursor->current();
+            assert($value instanceof Document);
+            $this->current = $this->codec->decode($value);
+        }
+
+        return $this->current;
+    }
+
+    /**
+     * @template NativeClass of Object
+     * @param DocumentCodec<NativeClass> $codec
+     * @return self<NativeClass>
+     */
+    public static function fromCursor(Cursor $cursor, DocumentCodec $codec): self
+    {
+        $cursor->setTypeMap(self::TYPEMAP);
+
+        return new self($cursor, $codec);
+    }
+
+    public function getId(): CursorId
+    {
+        return $this->cursor->getId();
+    }
+
+    public function getServer(): Server
+    {
+        return $this->cursor->getServer();
+    }
+
+    public function isDead(): bool
+    {
+        return $this->cursor->isDead();
+    }
+
+    public function key(): int
+    {
+        return $this->cursor->key();
+    }
+
+    public function next(): void
+    {
+        $this->current = null;
+        $this->cursor->next();
+    }
+
+    public function rewind(): void
+    {
+        $this->current = null;
+        $this->cursor->rewind();
+    }
+
+    public function setTypeMap(array $typemap): void
+    {
+        // Not supported
+    }
+
+    /** @return array<int, TValue> */
+    public function toArray(): array
+    {
+        return iterator_to_array($this);
+    }
+
+    public function valid(): bool
+    {
+        return $this->cursor->valid();
+    }
+
+    /** @param DocumentCodec<TValue> $codec */
+    private function __construct(Cursor $cursor, DocumentCodec $codec)
+    {
+        $this->cursor = $cursor;
+        $this->codec = $codec;
+    }
+}

--- a/src/Model/CodecCursor.php
+++ b/src/Model/CodecCursor.php
@@ -27,6 +27,10 @@ use MongoDB\Driver\Server;
 
 use function assert;
 use function iterator_to_array;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_WARNING;
 
 /**
  * @template TValue of object
@@ -104,6 +108,7 @@ class CodecCursor implements CursorInterface, Iterator
     public function setTypeMap(array $typemap): void
     {
         // Not supported
+        trigger_error(sprintf('Discarding type map for %s', __METHOD__), E_USER_WARNING);
     }
 
     /** @return array<int, TValue> */

--- a/src/Operation/Aggregate.php
+++ b/src/Operation/Aggregate.php
@@ -204,6 +204,10 @@ class Aggregate implements Executable, Explainable
             unset($options['writeConcern']);
         }
 
+        if (isset($options['codec']) && isset($options['typeMap'])) {
+            throw InvalidArgumentException::cannotCombineCodecAndTypeMap();
+        }
+
         $this->isWrite = is_last_pipeline_operator_write($pipeline) && ! ($options['explain'] ?? false);
 
         if ($this->isWrite) {

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -346,6 +346,7 @@ class BulkWrite implements Executable
                         : $args[0];
                     // Psalm's assert-if-true annotation does not work with unions, so
                     // assert the type manually instead of using is_document
+                    // See https://github.com/vimeo/psalm/issues/6831
                     assert(is_array($insertedDocument) || is_object($insertedDocument));
 
                     $insertedIds[$i] = $bulk->insert($insertedDocument);
@@ -357,6 +358,7 @@ class BulkWrite implements Executable
                         : $args[1];
                     // Psalm's assert-if-true annotation does not work with unions, so
                     // assert the type manually instead of using is_document
+                    // See https://github.com/vimeo/psalm/issues/6831
                     assert(is_array($replacementDocument) || is_object($replacementDocument));
 
                     $bulk->update($args[0], $replacementDocument, $args[2]);

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -341,28 +341,30 @@ class BulkWrite implements Executable
                     break;
 
                 case self::INSERT_ONE:
-                    $insertedDocument = isset($this->options['codec'])
-                        ? $this->options['codec']->encodeIfSupported($args[0])
-                        : $args[0];
-                    // Psalm's assert-if-true annotation does not work with unions, so
-                    // assert the type manually instead of using is_document
-                    // See https://github.com/vimeo/psalm/issues/6831
-                    assert(is_array($insertedDocument) || is_object($insertedDocument));
+                    if (isset($this->options['codec'])) {
+                        $args[0] = $this->options['codec']->encodeIfSupported($args[0]);
 
-                    $insertedIds[$i] = $bulk->insert($insertedDocument);
+                        // Psalm's assert-if-true annotation does not work with unions, so
+                        // assert the type manually instead of using is_document
+                        // See https://github.com/vimeo/psalm/issues/6831
+                        assert(is_array($args[0]) || is_object($args[0]));
+                    }
+
+                    $insertedIds[$i] = $bulk->insert($args[0]);
                     break;
 
                 case self::REPLACE_ONE:
-                    $replacementDocument = isset($this->options['codec'])
-                        ? $this->options['codec']->encodeIfSupported($args[1])
-                        : $args[1];
-                    // Psalm's assert-if-true annotation does not work with unions, so
-                    // assert the type manually instead of using is_document
-                    // See https://github.com/vimeo/psalm/issues/6831
-                    assert(is_array($replacementDocument) || is_object($replacementDocument));
+                    if (isset($this->options['codec'])) {
+                        $args[1] = $this->options['codec']->encodeIfSupported($args[1]);
 
-                    $bulk->update($args[0], $replacementDocument, $args[2]);
-                    break;
+                        // Psalm's assert-if-true annotation does not work with unions, so
+                        // assert the type manually instead of using is_document
+                        // See https://github.com/vimeo/psalm/issues/6831
+                        assert(is_array($args[1]) || is_object($args[1]));
+                    }
+
+                    // break intentionally missing, as replace is handled
+                    // through update as well
 
                 case self::UPDATE_MANY:
                 case self::UPDATE_ONE:

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -294,6 +294,8 @@ class BulkWrite implements Executable
 
             switch ($type) {
                 case self::INSERT_ONE:
+                    // $args[0] was already validated above. Since DocumentCodec::encode will always return a Document
+                    // instance, there is no need to re-validate the returned value here.
                     if ($codec) {
                         $operations[$i][$type][0] = $codec->encode($args[0]);
                     }

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -300,6 +300,10 @@ class Find implements Executable, Explainable
             trigger_error('The "maxScan" option is deprecated and will be removed in a future release', E_USER_DEPRECATED);
         }
 
+        if (isset($options['codec']) && isset($options['typeMap'])) {
+            throw InvalidArgumentException::cannotCombineCodecAndTypeMap();
+        }
+
         $this->databaseName = $databaseName;
         $this->collectionName = $collectionName;
         $this->filter = $filter;

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -262,10 +262,7 @@ class FindAndModify implements Executable, Explainable
             $result = current($cursor->toArray());
             assert($result instanceof Document);
 
-            $decoded = $this->options['codec']->decodeIfSupported($result->get('value'));
-            assert($decoded === null || is_object($decoded));
-
-            return $decoded;
+            return $this->options['codec']->decode($result->get('value'));
         }
 
         if (isset($this->options['typeMap'])) {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -262,7 +262,9 @@ class FindAndModify implements Executable, Explainable
             $result = current($cursor->toArray());
             assert($result instanceof Document);
 
-            return $this->options['codec']->decode($result->get('value'));
+            $value = $result->get('value');
+
+            return $value === null ? $value : $this->options['codec']->decode($value);
         }
 
         if (isset($this->options['typeMap'])) {

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -215,6 +215,10 @@ class FindAndModify implements Executable, Explainable
             unset($options['writeConcern']);
         }
 
+        if (isset($options['codec']) && isset($options['typeMap'])) {
+            throw InvalidArgumentException::cannotCombineCodecAndTypeMap();
+        }
+
         $this->databaseName = $databaseName;
         $this->collectionName = $collectionName;
         $this->options = $options;

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -258,7 +258,7 @@ class FindAndModify implements Executable, Explainable
             $result = current($cursor->toArray());
             assert($result instanceof Document);
 
-            $decoded = $this->options['codec']->decodeIfSupported($result->get('value') ?? null);
+            $decoded = $this->options['codec']->decodeIfSupported($result->get('value'));
             assert($decoded === null || is_object($decoded));
 
             return $decoded;

--- a/src/Operation/FindOne.php
+++ b/src/Operation/FindOne.php
@@ -40,6 +40,9 @@ class FindOne implements Executable, Explainable
      *
      * Supported options:
      *
+     *  * codec (MongoDB\Codec\DocumentCodec): Codec used to decode documents
+     *    from BSON to PHP objects.
+     *
      *  * collation (document): Collation specification.
      *
      *  * comment (mixed): BSON value to attach as a comment to this command.

--- a/src/Operation/FindOneAndDelete.php
+++ b/src/Operation/FindOneAndDelete.php
@@ -39,6 +39,9 @@ class FindOneAndDelete implements Executable, Explainable
      *
      * Supported options:
      *
+     *  * codec (MongoDB\Codec\DocumentCodec): Codec used to decode documents
+     *    from BSON to PHP objects.
+     *
      *  * collation (document): Collation specification.
      *
      *  * comment (mixed): BSON value to attach as a comment to this command.

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -160,12 +160,12 @@ class FindOneAndReplace implements Executable, Explainable
 
         if (isset($options['codec'])) {
             $replacement = $options['codec']->encodeIfSupported($replacement);
-        }
 
-        // Psalm's assert-if-true annotation does not work with unions, so
-        // assert the type manually instead of using is_document
-        // See https://github.com/vimeo/psalm/issues/6831
-        assert(is_array($replacement) || is_object($replacement));
+            // Psalm's assert-if-true annotation does not work with unions, so
+            // assert the type manually instead of using is_document
+            // See https://github.com/vimeo/psalm/issues/6831
+            assert(is_array($replacement) || is_object($replacement));
+        }
 
         $this->findAndModify = new FindAndModify(
             $databaseName,

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -158,17 +158,18 @@ class FindOneAndReplace implements Executable, Explainable
 
         unset($options['projection'], $options['returnDocument']);
 
-        $replacementDocument = isset($options['codec'])
-            ? $options['codec']->encodeIfSupported($replacement)
-            : $replacement;
+        if (isset($options['codec'])) {
+            $replacement = $options['codec']->encodeIfSupported($replacement);
+        }
+
         // Psalm's assert-if-true annotation does not work with unions, so
         // assert the type manually instead of using is_document
-        assert(is_array($replacementDocument) || is_object($replacementDocument));
+        assert(is_array($replacement) || is_object($replacement));
 
         $this->findAndModify = new FindAndModify(
             $databaseName,
             $collectionName,
-            ['query' => $filter, 'update' => $replacementDocument] + $options,
+            ['query' => $filter, 'update' => $replacement] + $options,
         );
     }
 

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -164,6 +164,7 @@ class FindOneAndReplace implements Executable, Explainable
 
         // Psalm's assert-if-true annotation does not work with unions, so
         // assert the type manually instead of using is_document
+        // See https://github.com/vimeo/psalm/issues/6831
         assert(is_array($replacement) || is_object($replacement));
 
         $this->findAndModify = new FindAndModify(

--- a/src/Operation/FindOneAndUpdate.php
+++ b/src/Operation/FindOneAndUpdate.php
@@ -54,6 +54,9 @@ class FindOneAndUpdate implements Executable, Explainable
      *  * bypassDocumentValidation (boolean): If true, allows the write to
      *    circumvent document level validation.
      *
+     *  * codec (MongoDB\Codec\DocumentCodec): Codec used to decode documents
+     *    from BSON to PHP objects.
+     *
      *  * collation (document): Collation specification.
      *
      *  * comment (mixed): BSON value to attach as a comment to this command.

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -153,14 +153,15 @@ class InsertMany implements Executable
         $insertedIds = [];
 
         foreach ($this->documents as $i => $document) {
-            $insertedDocument = isset($this->options['codec'])
-                ? $this->options['codec']->encodeIfSupported($document)
-                : $document;
+            if (isset($this->options['codec'])) {
+                $document = $this->options['codec']->encodeIfSupported($document);
+            }
+
             // Psalm's assert-if-true annotation does not work with unions, so
             // assert the type manually instead of using is_document
-            assert(is_array($insertedDocument) || is_object($insertedDocument));
+            assert(is_array($document) || is_object($document));
 
-            $insertedIds[$i] = $bulk->insert($insertedDocument);
+            $insertedIds[$i] = $bulk->insert($document);
         }
 
         $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $this->createExecuteOptions());

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -155,12 +155,12 @@ class InsertMany implements Executable
         foreach ($this->documents as $i => $document) {
             if (isset($this->options['codec'])) {
                 $document = $this->options['codec']->encodeIfSupported($document);
-            }
 
-            // Psalm's assert-if-true annotation does not work with unions, so
-            // assert the type manually instead of using is_document
-            // See https://github.com/vimeo/psalm/issues/6831
-            assert(is_array($document) || is_object($document));
+                // Psalm's assert-if-true annotation does not work with unions, so
+                // assert the type manually instead of using is_document
+                // See https://github.com/vimeo/psalm/issues/6831
+                assert(is_array($document) || is_object($document));
+            }
 
             $insertedIds[$i] = $bulk->insert($document);
         }

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -159,6 +159,7 @@ class InsertMany implements Executable
 
             // Psalm's assert-if-true annotation does not work with unions, so
             // assert the type manually instead of using is_document
+            // See https://github.com/vimeo/psalm/issues/6831
             assert(is_array($document) || is_object($document));
 
             $insertedIds[$i] = $bulk->insert($document);

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -110,6 +110,7 @@ class InsertOne implements Executable
 
             // Psalm's assert-if-true annotation does not work with unions, so
             // assert the type manually instead of using is_document
+            // See https://github.com/vimeo/psalm/issues/6831
             assert(is_array($document) || is_object($document));
         }
 

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -113,6 +113,7 @@ class ReplaceOne implements Executable
 
         // Psalm's assert-if-true annotation does not work with unions, so
         // assert the type manually instead of using is_document
+        // See https://github.com/vimeo/psalm/issues/6831
         assert(is_array($replacement) || is_object($replacement));
 
         $this->update = new Update(

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -107,18 +107,19 @@ class ReplaceOne implements Executable
             throw InvalidArgumentException::invalidType('"codec" option', $options['codec'], DocumentCodec::class);
         }
 
-        $replacementDocument = isset($options['codec'])
-            ? $options['codec']->encodeIfSupported($replacement)
-            : $replacement;
+        if (isset($options['codec'])) {
+            $replacement = $options['codec']->encodeIfSupported($replacement);
+        }
+
         // Psalm's assert-if-true annotation does not work with unions, so
         // assert the type manually instead of using is_document
-        assert(is_array($replacementDocument) || is_object($replacementDocument));
+        assert(is_array($replacement) || is_object($replacement));
 
         $this->update = new Update(
             $databaseName,
             $collectionName,
             $filter,
-            $replacementDocument,
+            $replacement,
             ['multi' => false] + $options,
         );
     }

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -113,12 +113,12 @@ class ReplaceOne implements Executable
             }
 
             $replacement = $options['codec']->encodeIfSupported($replacement);
-        }
 
-        // Psalm's assert-if-true annotation does not work with unions, so
-        // assert the type manually instead of using is_document
-        // See https://github.com/vimeo/psalm/issues/6831
-        assert(is_array($replacement) || is_object($replacement));
+            // Psalm's assert-if-true annotation does not work with unions, so
+            // assert the type manually instead of using is_document
+            // See https://github.com/vimeo/psalm/issues/6831
+            assert(is_array($replacement) || is_object($replacement));
+        }
 
         $this->update = new Update(
             $databaseName,

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -87,10 +87,8 @@ class ReplaceOne implements Executable
             throw InvalidArgumentException::invalidType('"codec" option', $options['codec'], DocumentCodec::class);
         }
 
-        if (isset($options['codec'])) {
-            if (isset($options['typeMap'])) {
-                throw InvalidArgumentException::cannotCombineCodecAndTypeMap();
-            }
+        if (isset($options['codec'], $options['typeMap'])) {
+            throw InvalidArgumentException::cannotCombineCodecAndTypeMap();
         }
 
         $this->update = new Update(

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -108,6 +108,10 @@ class ReplaceOne implements Executable
         }
 
         if (isset($options['codec'])) {
+            if (isset($options['typeMap'])) {
+                throw InvalidArgumentException::cannotCombineCodecAndTypeMap();
+            }
+
             $replacement = $options['codec']->encodeIfSupported($replacement);
         }
 

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -20,6 +20,7 @@ namespace MongoDB\Operation;
 use Iterator;
 use MongoDB\BSON\TimestampInterface;
 use MongoDB\ChangeStream;
+use MongoDB\Codec\DocumentCodec;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\Manager;
@@ -92,12 +93,17 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
 
     private ?object $postBatchResumeToken = null;
 
+    private ?DocumentCodec $codec;
+
     /**
      * Constructs an aggregate command for creating a change stream.
      *
      * Supported options:
      *
      *  * batchSize (integer): The number of documents to return per batch.
+     *
+     *  * codec (MongoDB\Codec\DocumentCodec): Codec used to decode documents
+     *    from BSON to PHP objects.
      *
      *  * collation (document): Specifies a collation.
      *
@@ -200,6 +206,10 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
             'readPreference' => new ReadPreference(ReadPreference::PRIMARY),
         ];
 
+        if (isset($options['codec']) && ! $options['codec'] instanceof DocumentCodec) {
+            throw InvalidArgumentException::invalidType('"codec" option', $options['codec'], DocumentCodec::class);
+        }
+
         if (array_key_exists('fullDocument', $options) && ! is_string($options['fullDocument'])) {
             throw InvalidArgumentException::invalidType('"fullDocument" option', $options['fullDocument'], 'string');
         }
@@ -255,6 +265,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
         $this->databaseName = $databaseName;
         $this->collectionName = $collectionName;
         $this->pipeline = $pipeline;
+        $this->codec = $options['codec'] ?? null;
 
         $this->aggregate = $this->createAggregate();
     }
@@ -315,6 +326,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
         return new ChangeStream(
             $this->createChangeStreamIterator($server),
             fn ($resumeToken, $hasAdvanced): ChangeStreamIterator => $this->resume($resumeToken, $hasAdvanced),
+            $this->codec,
         );
     }
 

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -17,9 +17,10 @@
 
 namespace MongoDB\Operation;
 
+use Iterator;
 use MongoDB\BSON\TimestampInterface;
 use MongoDB\ChangeStream;
-use MongoDB\Driver\Cursor;
+use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
@@ -348,8 +349,10 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      *
      * The command will be executed using APM so that we can capture data from
      * its response (e.g. firstBatch size, postBatchResumeToken).
+     *
+     * @return CursorInterface&Iterator
      */
-    private function executeAggregate(Server $server): Cursor
+    private function executeAggregate(Server $server)
     {
         addSubscriber($this);
 

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -210,6 +210,10 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
             throw InvalidArgumentException::invalidType('"codec" option', $options['codec'], DocumentCodec::class);
         }
 
+        if (isset($options['codec']) && isset($options['typeMap'])) {
+            throw InvalidArgumentException::cannotCombineCodecAndTypeMap();
+        }
+
         if (array_key_exists('fullDocument', $options) && ! is_string($options['fullDocument'])) {
             throw InvalidArgumentException::invalidType('"fullDocument" option', $options['fullDocument'], 'string');
         }

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace MongoDB\Tests\Collection;
+
+use Generator;
+use MongoDB\BulkWriteResult;
+use MongoDB\Collection;
+use MongoDB\Driver\BulkWrite;
+use MongoDB\Model\BSONDocument;
+use MongoDB\Operation\FindOneAndReplace;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use MongoDB\Tests\Fixtures\Document\TestObject;
+
+class CodecCollectionFunctionalTest extends FunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->collection = new Collection(
+            $this->manager,
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            ['codec' => new TestDocumentCodec()],
+        );
+    }
+
+    public static function provideAggregateOptions(): Generator
+    {
+        yield 'Default codec' => [
+            'expected' => [
+                TestObject::createForFixture(2, true),
+                TestObject::createForFixture(3, true),
+            ],
+            'options' => [],
+        ];
+
+        yield 'No codec' => [
+            'expected' => [
+                self::createFixtureResult(2),
+                self::createFixtureResult(3),
+            ],
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideAggregateOptions */
+    public function testAggregate($expected, $options): void
+    {
+        $this->createFixtures(3);
+
+        $cursor = $this->collection->aggregate([['$match' => ['_id' => ['$gt' => 1]]]], $options);
+
+        $this->assertEquals($expected, $cursor->toArray());
+    }
+
+    public static function provideBulkWriteOptions(): Generator
+    {
+        $replacedObject = TestObject::createForFixture(3, true);
+        $replacedObject->x->foo = 'baz';
+
+        yield 'Default codec' => [
+            'expected' => [
+                TestObject::createForFixture(1, true),
+                TestObject::createForFixture(2, true),
+                $replacedObject,
+                TestObject::createForFixture(4, true),
+            ],
+            'options' => [],
+        ];
+
+        $replacedObject = new BSONDocument(['_id' => 3, 'id' => 3, 'x' => new BSONDocument(['foo' => 'baz']), 'decoded' => false]);
+        $replacedObject->x->foo = 'baz';
+
+        yield 'No codec' => [
+            'expected' => [
+                self::createFixtureResult(1),
+                self::createFixtureResult(2),
+                $replacedObject,
+                self::createObjectFixtureResult(4, true),
+            ],
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideBulkWriteOptions */
+    public function testBulkWrite($expected, $options): void
+    {
+        $this->createFixtures(3);
+
+        $replaceObject = TestObject::createForFixture(3);
+        $replaceObject->x->foo = 'baz';
+
+        $operations = [
+            ['insertOne' => [TestObject::createForFixture(4)]],
+            ['replaceOne' => [['_id' => 3], $replaceObject]],
+        ];
+
+        $result = $this->collection->bulkWrite($operations, $options);
+
+        $this->assertInstanceOf(BulkWriteResult::class, $result);
+        $this->assertSame(1, $result->getInsertedCount());
+        $this->assertSame(1, $result->getMatchedCount());
+        $this->assertSame(1, $result->getModifiedCount());
+
+        // Extract inserted ID when not using codec as it's an automatically generated ObjectId
+        if ($expected[3] instanceof BSONDocument && $expected[3]->_id === null) {
+            $expected[3]->_id = $result->getInsertedIds()[0];
+        }
+
+        $this->assertEquals(
+            $expected,
+            $this->collection->find([], $options)->toArray(),
+        );
+    }
+
+    public function provideFindOneAndModifyOptions(): Generator
+    {
+        yield 'Default codec' => [
+            'expected' => TestObject::createForFixture(1, true),
+            'options' => [],
+        ];
+
+        yield 'No codec' => [
+            'expected' => self::createFixtureResult(1),
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideFindOneAndModifyOptions */
+    public function testFindOneAndDelete($expected, $options): void
+    {
+        $this->createFixtures(1);
+
+        $result = $this->collection->findOneAndDelete(['_id' => 1], $options);
+
+        self::assertEquals($expected, $result);
+    }
+
+    /** @dataProvider provideFindOneAndModifyOptions */
+    public function testFindOneAndUpdate($expected, $options): void
+    {
+        $this->createFixtures(1);
+
+        $result = $this->collection->findOneAndUpdate(['_id' => 1], ['$set' => ['x.foo' => 'baz']], $options);
+
+        self::assertEquals($expected, $result);
+    }
+
+    public static function provideFindOneAndReplaceOptions(): Generator
+    {
+        $replacedObject = TestObject::createForFixture(1, true);
+        $replacedObject->x->foo = 'baz';
+
+        yield 'Default codec' => [
+            'expected' => $replacedObject,
+            'options' => [],
+        ];
+
+        $replacedObject = self::createObjectFixtureResult(1);
+        $replacedObject->x->foo = 'baz';
+
+        yield 'No codec' => [
+            'expected' => $replacedObject,
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideFindOneAndReplaceOptions */
+    public function testFindOneAndReplace($expected, $options): void
+    {
+        $this->createFixtures(1);
+
+        $replaceObject = TestObject::createForFixture(1);
+        $replaceObject->x->foo = 'baz';
+
+        $result = $this->collection->findOneAndReplace(
+            ['_id' => 1],
+            $replaceObject,
+            $options + ['returnDocument' => FindOneAndReplace::RETURN_DOCUMENT_AFTER],
+        );
+
+        self::assertEquals($expected, $result);
+    }
+
+    public static function provideFindOptions(): Generator
+    {
+        yield 'Default codec' => [
+            'expected' => [
+                TestObject::createForFixture(1, true),
+                TestObject::createForFixture(2, true),
+                TestObject::createForFixture(3, true),
+            ],
+            'options' => [],
+        ];
+
+        yield 'No codec' => [
+            'expected' => [
+                self::createFixtureResult(1),
+                self::createFixtureResult(2),
+                self::createFixtureResult(3),
+            ],
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideFindOptions */
+    public function testFind($expected, $options): void
+    {
+        $this->createFixtures(3);
+
+        $cursor = $this->collection->find([], $options);
+
+        $this->assertEquals($expected, $cursor->toArray());
+    }
+
+    public static function provideFindOneOptions(): Generator
+    {
+        yield 'Default codec' => [
+            'expected' => TestObject::createForFixture(1, true),
+            'options' => [],
+        ];
+
+        yield 'No codec' => [
+            'expected' => self::createFixtureResult(1),
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideFindOneOptions */
+    public function testFindOne($expected, $options): void
+    {
+        $this->createFixtures(1);
+
+        $document = $this->collection->findOne([], $options);
+
+        $this->assertEquals($expected, $document);
+    }
+
+    public static function provideInsertManyOptions(): Generator
+    {
+        yield 'Default codec' => [
+            'expected' => [
+                TestObject::createForFixture(1, true),
+                TestObject::createForFixture(2, true),
+                TestObject::createForFixture(3, true),
+            ],
+            'options' => [],
+        ];
+
+        yield 'No codec' => [
+            'expected' => [
+                self::createObjectFixtureResult(1, true),
+                self::createObjectFixtureResult(2, true),
+                self::createObjectFixtureResult(3, true),
+            ],
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideInsertManyOptions */
+    public function testInsertMany($expected, $options): void
+    {
+        $documents = [
+            TestObject::createForFixture(1),
+            TestObject::createForFixture(2),
+            TestObject::createForFixture(3),
+        ];
+
+        $result = $this->collection->insertMany($documents, $options);
+        $this->assertSame(3, $result->getInsertedCount());
+
+        foreach ($expected as $index => $expectedDocument) {
+            if ($expectedDocument instanceof BSONDocument && $expectedDocument->_id === null) {
+                $expectedDocument->_id = $result->getInsertedIds()[$index];
+            }
+        }
+
+        $this->assertEquals($expected, $this->collection->find([], $options)->toArray());
+    }
+
+    public static function provideInsertOneOptions(): Generator
+    {
+        yield 'Default codec' => [
+            'expected' => TestObject::createForFixture(1, true),
+            'options' => [],
+        ];
+
+        yield 'No codec' => [
+            'expected' => self::createObjectFixtureResult(1, true),
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideInsertOneOptions */
+    public function testInsertOne($expected, $options): void
+    {
+        $result = $this->collection->insertOne(TestObject::createForFixture(1), $options);
+        $this->assertSame(1, $result->getInsertedCount());
+
+        if ($expected instanceof BSONDocument && $expected->_id === null) {
+            $expected->_id = $result->getInsertedId();
+        }
+
+        $this->assertEquals($expected, $this->collection->findOne([], $options));
+    }
+
+    public static function provideReplaceOneOptions(): Generator
+    {
+        $replacedObject = TestObject::createForFixture(1, true);
+        $replacedObject->x->foo = 'baz';
+
+        yield 'Default codec' => [
+            'expected' => $replacedObject,
+            'options' => [],
+        ];
+
+        $replacedObject = self::createObjectFixtureResult(1);
+        $replacedObject->x->foo = 'baz';
+
+        yield 'No codec' => [
+            'expected' => $replacedObject,
+            'options' => ['codec' => null],
+        ];
+    }
+
+    /** @dataProvider provideReplaceOneOptions */
+    public function testReplaceOne($expected, $options): void
+    {
+        $this->createFixtures(1);
+
+        $replaceObject = TestObject::createForFixture(1);
+        $replaceObject->x->foo = 'baz';
+
+        $result = $this->collection->replaceOne(['_id' => 1], $replaceObject, $options);
+        $this->assertSame(1, $result->getMatchedCount());
+        $this->assertSame(1, $result->getModifiedCount());
+
+        $this->assertEquals($expected, $this->collection->findOne([], $options));
+    }
+
+    /**
+     * Create data fixtures.
+     */
+    private function createFixtures(int $n, array $executeBulkWriteOptions = []): void
+    {
+        $bulkWrite = new BulkWrite(['ordered' => true]);
+
+        for ($i = 1; $i <= $n; $i++) {
+            $bulkWrite->insert([
+                '_id' => $i,
+                'x' => (object) ['foo' => 'bar'],
+            ]);
+        }
+
+        $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite, $executeBulkWriteOptions);
+
+        $this->assertEquals($n, $result->getInsertedCount());
+    }
+
+    private static function createFixtureResult(int $id): BSONDocument
+    {
+        return new BSONDocument(['_id' => $id, 'x' => new BSONDocument(['foo' => 'bar'])]);
+    }
+
+    private static function createObjectFixtureResult(int $id, bool $isInserted = false): BSONDocument
+    {
+        return new BSONDocument(['_id' => $isInserted ? null : $id, 'id' => $id, 'x' => new BSONDocument(['foo' => 'bar']), 'decoded' => false]);
+    }
+}

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests\Collection;
 
 use Generator;
+use MongoDB\BSON\Document;
 use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite;
@@ -41,6 +42,14 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
                 self::createFixtureResult(3),
             ],
             'options' => ['codec' => null],
+        ];
+
+        yield 'BSON type map' => [
+            'expected' => [
+                Document::fromPHP(self::createFixtureResult(2)),
+                Document::fromPHP(self::createFixtureResult(3)),
+            ],
+            'options' => ['typeMap' => ['root' => 'bson']],
         ];
     }
 
@@ -81,6 +90,16 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
             ],
             'options' => ['codec' => null],
         ];
+
+        yield 'BSON type map' => [
+            'expected' => [
+                Document::fromPHP(self::createFixtureResult(1)),
+                Document::fromPHP(self::createFixtureResult(2)),
+                Document::fromPHP($replacedObject),
+                Document::fromPHP(self::createObjectFixtureResult(4, true)),
+            ],
+            'options' => ['typeMap' => ['root' => 'bson']],
+        ];
     }
 
     /** @dataProvider provideBulkWriteOptions */
@@ -108,6 +127,12 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
             $expected[3]->_id = $result->getInsertedIds()[0];
         }
 
+        if ($expected[3] instanceof Document && $expected[3]->get('_id') === null) {
+            $inserted = $expected[3]->toPHP();
+            $inserted->_id = $result->getInsertedIds()[0];
+            $expected[3] = Document::fromPHP($inserted);
+        }
+
         $this->assertEquals(
             $expected,
             $this->collection->find([], $options)->toArray(),
@@ -124,6 +149,11 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         yield 'No codec' => [
             'expected' => self::createFixtureResult(1),
             'options' => ['codec' => null],
+        ];
+
+        yield 'BSON type map' => [
+            'expected' => Document::fromPHP(self::createFixtureResult(1)),
+            'options' => ['typeMap' => ['root' => 'bson']],
         ];
     }
 
@@ -164,6 +194,11 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
             'expected' => $replacedObject,
             'options' => ['codec' => null],
         ];
+
+        yield 'BSON type map' => [
+            'expected' => Document::FromPHP($replacedObject),
+            'options' => ['typeMap' => ['root' => 'bson']],
+        ];
     }
 
     /** @dataProvider provideFindOneAndReplaceOptions */
@@ -202,6 +237,15 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
             ],
             'options' => ['codec' => null],
         ];
+
+        yield 'BSON type map' => [
+            'expected' => [
+                Document::fromPHP(self::createFixtureResult(1)),
+                Document::fromPHP(self::createFixtureResult(2)),
+                Document::fromPHP(self::createFixtureResult(3)),
+            ],
+            'options' => ['typeMap' => ['root' => 'bson']],
+        ];
     }
 
     /** @dataProvider provideFindOptions */
@@ -224,6 +268,11 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         yield 'No codec' => [
             'expected' => self::createFixtureResult(1),
             'options' => ['codec' => null],
+        ];
+
+        yield 'BSON type map' => [
+            'expected' => Document::fromPHP(self::createFixtureResult(1)),
+            'options' => ['typeMap' => ['root' => 'bson']],
         ];
     }
 
@@ -256,6 +305,15 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
             ],
             'options' => ['codec' => null],
         ];
+
+        yield 'BSON type map' => [
+            'expected' => [
+                Document::fromPHP(self::createObjectFixtureResult(1, true)),
+                Document::fromPHP(self::createObjectFixtureResult(2, true)),
+                Document::fromPHP(self::createObjectFixtureResult(3, true)),
+            ],
+            'options' => ['typeMap' => ['root' => 'bson']],
+        ];
     }
 
     /** @dataProvider provideInsertManyOptions */
@@ -270,9 +328,15 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $result = $this->collection->insertMany($documents, $options);
         $this->assertSame(3, $result->getInsertedCount());
 
-        foreach ($expected as $index => $expectedDocument) {
+        foreach ($expected as $index => &$expectedDocument) {
             if ($expectedDocument instanceof BSONDocument && $expectedDocument->_id === null) {
                 $expectedDocument->_id = $result->getInsertedIds()[$index];
+            }
+
+            if ($expectedDocument instanceof Document && $expectedDocument->get('_id') === null) {
+                $inserted = $expectedDocument->toPHP();
+                $inserted->_id = $result->getInsertedIds()[$index];
+                $expectedDocument = Document::fromPHP($inserted);
             }
         }
 
@@ -290,6 +354,11 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
             'expected' => self::createObjectFixtureResult(1, true),
             'options' => ['codec' => null],
         ];
+
+        yield 'BSON type map' => [
+            'expected' => Document::fromPHP(self::createObjectFixtureResult(1, true)),
+            'options' => ['typeMap' => ['root' => 'bson']],
+        ];
     }
 
     /** @dataProvider provideInsertOneOptions */
@@ -300,6 +369,12 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
 
         if ($expected instanceof BSONDocument && $expected->_id === null) {
             $expected->_id = $result->getInsertedId();
+        }
+
+        if ($expected instanceof Document && $expected->get('_id') === null) {
+            $inserted = $expected->toPHP();
+            $inserted->_id = $result->getInsertedId();
+            $expected = Document::fromPHP($inserted);
         }
 
         $this->assertEquals($expected, $this->collection->findOne([], $options));
@@ -321,6 +396,11 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         yield 'No codec' => [
             'expected' => $replacedObject,
             'options' => ['codec' => null],
+        ];
+
+        yield 'BSON type map' => [
+            'expected' => Document::fromPHP($replacedObject),
+            'options' => ['typeMap' => ['root' => 'bson']],
         ];
     }
 

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -505,10 +505,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $bulkWrite = new BulkWrite(['ordered' => true]);
 
         for ($i = 1; $i <= $n; $i++) {
-            $bulkWrite->insert([
-                '_id' => $i,
-                'x' => (object) ['foo' => 'bar'],
-            ]);
+            $bulkWrite->insert(TestObject::createDocument($i));
         }
 
         $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite, $executeBulkWriteOptions);

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -7,6 +7,7 @@ use MongoDB\BSON\Document;
 use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite;
+use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindOneAndReplace;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
@@ -61,6 +62,17 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $cursor = $this->collection->aggregate([['$match' => ['_id' => ['$gt' => 1]]]], $options);
 
         $this->assertEquals($expected, $cursor->toArray());
+    }
+
+    public function testAggregateWithCodecAndTypemap(): void
+    {
+        $options = [
+            'codec' => new TestDocumentCodec(),
+            'typeMap' => ['root' => 'array', 'document' => 'array'],
+        ];
+
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+        $this->collection->aggregate([['$match' => ['_id' => ['$gt' => 1]]]], $options);
     }
 
     public static function provideBulkWriteOptions(): Generator
@@ -167,6 +179,17 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         self::assertEquals($expected, $result);
     }
 
+    public function testFindOneAndDeleteWithCodecAndTypemap(): void
+    {
+        $options = [
+            'codec' => new TestDocumentCodec(),
+            'typeMap' => ['root' => 'array', 'document' => 'array'],
+        ];
+
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+        $this->collection->findOneAndDelete(['_id' => 1], $options);
+    }
+
     /** @dataProvider provideFindOneAndModifyOptions */
     public function testFindOneAndUpdate($expected, $options): void
     {
@@ -175,6 +198,17 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $result = $this->collection->findOneAndUpdate(['_id' => 1], ['$set' => ['x.foo' => 'baz']], $options);
 
         self::assertEquals($expected, $result);
+    }
+
+    public function testFindOneAndUpdateWithCodecAndTypemap(): void
+    {
+        $options = [
+            'codec' => new TestDocumentCodec(),
+            'typeMap' => ['root' => 'array', 'document' => 'array'],
+        ];
+
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+        $this->collection->findOneAndUpdate(['_id' => 1], ['$set' => ['x.foo' => 'baz']], $options);
     }
 
     public static function provideFindOneAndReplaceOptions(): Generator
@@ -218,6 +252,17 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         self::assertEquals($expected, $result);
     }
 
+    public function testFindOneAndReplaceWithCodecAndTypemap(): void
+    {
+        $options = [
+            'codec' => new TestDocumentCodec(),
+            'typeMap' => ['root' => 'array', 'document' => 'array'],
+        ];
+
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+        $this->collection->findOneAndReplace(['_id' => 1], ['foo' => 'bar'], $options);
+    }
+
     public static function provideFindOptions(): Generator
     {
         yield 'Default codec' => [
@@ -258,6 +303,17 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $this->assertEquals($expected, $cursor->toArray());
     }
 
+    public function testFindWithCodecAndTypemap(): void
+    {
+        $options = [
+            'codec' => new TestDocumentCodec(),
+            'typeMap' => ['root' => 'array', 'document' => 'array'],
+        ];
+
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+        $this->collection->find([], $options);
+    }
+
     public static function provideFindOneOptions(): Generator
     {
         yield 'Default codec' => [
@@ -284,6 +340,17 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $document = $this->collection->findOne([], $options);
 
         $this->assertEquals($expected, $document);
+    }
+
+    public function testFindOneWithCodecAndTypemap(): void
+    {
+        $options = [
+            'codec' => new TestDocumentCodec(),
+            'typeMap' => ['root' => 'array', 'document' => 'array'],
+        ];
+
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+        $this->collection->findOne([], $options);
     }
 
     public static function provideInsertManyOptions(): Generator
@@ -417,6 +484,17 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame(1, $result->getModifiedCount());
 
         $this->assertEquals($expected, $this->collection->findOne([], $options));
+    }
+
+    public function testReplaceOneWithCodecAndTypemap(): void
+    {
+        $options = [
+            'codec' => new TestDocumentCodec(),
+            'typeMap' => ['root' => 'array', 'document' => 'array'],
+        ];
+
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+        $this->collection->replaceOne(['_id' => 1], ['foo' => 'bar'], $options);
     }
 
     /**

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -395,6 +395,8 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $result = $this->collection->insertMany($documents, $options);
         $this->assertSame(3, $result->getInsertedCount());
 
+        // Add missing identifiers. This is relevant for the "No codec" data set, as the encoded document will not have
+        // an "_id" field and the driver will automatically generate one.
         foreach ($expected as $index => &$expectedDocument) {
             if ($expectedDocument instanceof BSONDocument && $expectedDocument->_id === null) {
                 $expectedDocument->_id = $result->getInsertedIds()[$index];
@@ -434,6 +436,8 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $result = $this->collection->insertOne(TestObject::createForFixture(1), $options);
         $this->assertSame(1, $result->getInsertedCount());
 
+        // Add missing identifiers. This is relevant for the "No codec" data set, as the encoded document will not have
+        // an "_id" field and the driver will automatically generate one.
         if ($expected instanceof BSONDocument && $expected->_id === null) {
             $expected->_id = $result->getInsertedId();
         }

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -523,6 +523,11 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
 
     private static function createObjectFixtureResult(int $id, bool $isInserted = false): BSONDocument
     {
-        return new BSONDocument(['_id' => $isInserted ? null : $id, 'id' => $id, 'x' => new BSONDocument(['foo' => 'bar']), 'decoded' => false]);
+        return new BSONDocument([
+            '_id' => $isInserted ? null : $id,
+            'id' => $id,
+            'x' => new BSONDocument(['foo' => 'bar']),
+            'decoded' => false,
+        ]);
     }
 }

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -436,8 +436,8 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $result = $this->collection->insertOne(TestObject::createForFixture(1), $options);
         $this->assertSame(1, $result->getInsertedCount());
 
-        // Add missing identifiers. This is relevant for the "No codec" data set, as the encoded document will not have
-        // an "_id" field and the driver will automatically generate one.
+        // Add missing identifiers. This is relevant for the "No codec" data set, as the encoded document will have an
+        // automatically generated identifier, which needs to be used in the expected document.
         if ($expected instanceof BSONDocument && $expected->_id === null) {
             $expected->_id = $result->getInsertedId();
         }

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -260,7 +260,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
 
         $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
-        $this->collection->findOneAndReplace(['_id' => 1], ['foo' => 'bar'], $options);
+        $this->collection->findOneAndReplace(['_id' => 1], TestObject::createForFixture(1), $options);
     }
 
     public static function provideFindOptions(): Generator

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -31,8 +31,8 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
     {
         yield 'Default codec' => [
             'expected' => [
-                TestObject::createForFixture(2, true),
-                TestObject::createForFixture(3, true),
+                TestObject::createDecodedForFixture(2),
+                TestObject::createDecodedForFixture(3),
             ],
             'options' => [],
         ];
@@ -77,15 +77,15 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
 
     public static function provideBulkWriteOptions(): Generator
     {
-        $replacedObject = TestObject::createForFixture(3, true);
+        $replacedObject = TestObject::createDecodedForFixture(3);
         $replacedObject->x->foo = 'baz';
 
         yield 'Default codec' => [
             'expected' => [
-                TestObject::createForFixture(1, true),
-                TestObject::createForFixture(2, true),
+                TestObject::createDecodedForFixture(1),
+                TestObject::createDecodedForFixture(2),
                 $replacedObject,
-                TestObject::createForFixture(4, true),
+                TestObject::createDecodedForFixture(4),
             ],
             'options' => [],
         ];
@@ -154,7 +154,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
     public function provideFindOneAndModifyOptions(): Generator
     {
         yield 'Default codec' => [
-            'expected' => TestObject::createForFixture(1, true),
+            'expected' => TestObject::createDecodedForFixture(1),
             'options' => [],
         ];
 
@@ -213,7 +213,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
 
     public static function provideFindOneAndReplaceOptions(): Generator
     {
-        $replacedObject = TestObject::createForFixture(1, true);
+        $replacedObject = TestObject::createDecodedForFixture(1);
         $replacedObject->x->foo = 'baz';
 
         yield 'Default codec' => [
@@ -267,9 +267,9 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
     {
         yield 'Default codec' => [
             'expected' => [
-                TestObject::createForFixture(1, true),
-                TestObject::createForFixture(2, true),
-                TestObject::createForFixture(3, true),
+                TestObject::createDecodedForFixture(1),
+                TestObject::createDecodedForFixture(2),
+                TestObject::createDecodedForFixture(3),
             ],
             'options' => [],
         ];
@@ -317,7 +317,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
     public static function provideFindOneOptions(): Generator
     {
         yield 'Default codec' => [
-            'expected' => TestObject::createForFixture(1, true),
+            'expected' => TestObject::createDecodedForFixture(1),
             'options' => [],
         ];
 
@@ -357,9 +357,9 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
     {
         yield 'Default codec' => [
             'expected' => [
-                TestObject::createForFixture(1, true),
-                TestObject::createForFixture(2, true),
-                TestObject::createForFixture(3, true),
+                TestObject::createDecodedForFixture(1),
+                TestObject::createDecodedForFixture(2),
+                TestObject::createDecodedForFixture(3),
             ],
             'options' => [],
         ];
@@ -413,7 +413,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
     public static function provideInsertOneOptions(): Generator
     {
         yield 'Default codec' => [
-            'expected' => TestObject::createForFixture(1, true),
+            'expected' => TestObject::createDecodedForFixture(1),
             'options' => [],
         ];
 
@@ -449,7 +449,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
 
     public static function provideReplaceOneOptions(): Generator
     {
-        $replacedObject = TestObject::createForFixture(1, true);
+        $replacedObject = TestObject::createDecodedForFixture(1);
         $replacedObject->x->foo = 'baz';
 
         yield 'Default codec' => [

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -66,6 +66,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
     public function provideInvalidConstructorOptions(): array
     {
         return $this->createOptionDataProvider([
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'readConcern' => $this->getInvalidReadConcernValues(),
             'readPreference' => $this->getInvalidReadPreferenceValues(),
             'typeMap' => $this->getInvalidArrayValues(),

--- a/tests/Fixtures/Codec/TestDocumentCodec.php
+++ b/tests/Fixtures/Codec/TestDocumentCodec.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Tests\Fixtures\Codec;
+
+use MongoDB\BSON\Document;
+use MongoDB\Codec\DecodeIfSupported;
+use MongoDB\Codec\DocumentCodec;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+use MongoDB\Tests\Fixtures\Document\TestNestedObject;
+use MongoDB\Tests\Fixtures\Document\TestObject;
+
+final class TestDocumentCodec implements DocumentCodec
+{
+    use DecodeIfSupported;
+    use EncodeIfSupported;
+
+    public function canDecode($value): bool
+    {
+        return $value instanceof Document;
+    }
+
+    public function decode($value): TestObject
+    {
+        if (! $value instanceof Document) {
+            throw UnsupportedValueException::invalidDecodableValue($value);
+        }
+
+        $object = new TestObject();
+        $object->id = $value->get('_id');
+        $object->decoded = true;
+
+        $object->x = new TestNestedObject();
+        $object->x->foo = $value->get('x')->get('foo');
+
+        return $object;
+    }
+
+    public function canEncode($value): bool
+    {
+        return $value instanceof TestObject;
+    }
+
+    public function encode($value): Document
+    {
+        if (! $value instanceof TestObject) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        return Document::fromPHP([
+            '_id' => $value->id,
+            'x' => Document::fromPHP(['foo' => $value->x->foo]),
+            'encoded' => true,
+        ]);
+    }
+}

--- a/tests/Fixtures/Document/TestNestedObject.php
+++ b/tests/Fixtures/Document/TestNestedObject.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Tests\Fixtures\Document;
+
+class TestNestedObject
+{
+    public string $foo;
+}

--- a/tests/Fixtures/Document/TestObject.php
+++ b/tests/Fixtures/Document/TestObject.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Tests\Fixtures\Document;
+
+final class TestObject
+{
+    public int $id;
+
+    public TestNestedObject $x;
+
+    public bool $decoded;
+
+    public static function createForFixture(int $i, bool $decoded = false): self
+    {
+        $instance = new self();
+        $instance->id = $i;
+        $instance->decoded = $decoded;
+
+        $instance->x = new TestNestedObject();
+        $instance->x->foo = 'bar';
+
+        return $instance;
+    }
+}

--- a/tests/Fixtures/Document/TestObject.php
+++ b/tests/Fixtures/Document/TestObject.php
@@ -23,16 +23,23 @@ final class TestObject
 
     public TestNestedObject $x;
 
-    public bool $decoded;
+    public bool $decoded = false;
 
-    public static function createForFixture(int $i, bool $decoded = false): self
+    public static function createForFixture(int $id): self
     {
         $instance = new self();
-        $instance->id = $i;
-        $instance->decoded = $decoded;
+        $instance->id = $id;
 
         $instance->x = new TestNestedObject();
         $instance->x->foo = 'bar';
+
+        return $instance;
+    }
+
+    public static function createDecodedForFixture(int $id): self
+    {
+        $instance = self::createForFixture($id);
+        $instance->decoded = true;
 
         return $instance;
     }

--- a/tests/Fixtures/Document/TestObject.php
+++ b/tests/Fixtures/Document/TestObject.php
@@ -17,6 +17,8 @@
 
 namespace MongoDB\Tests\Fixtures\Document;
 
+use MongoDB\BSON\Document;
+
 final class TestObject
 {
     public int $id;
@@ -24,6 +26,14 @@ final class TestObject
     public TestNestedObject $x;
 
     public bool $decoded = false;
+
+    public static function createDocument(int $id): Document
+    {
+        return Document::fromPHP([
+            '_id' => $id,
+            'x' => ['foo' => 'bar'],
+        ]);
+    }
 
     public static function createForFixture(int $id): self
     {

--- a/tests/Model/CodecCursorFunctionalTest.php
+++ b/tests/Model/CodecCursorFunctionalTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MongoDB\Tests\Model;
+
+use MongoDB\Codec\DocumentCodec;
+use MongoDB\Model\CodecCursor;
+use MongoDB\Tests\FunctionalTestCase;
+
+class CodecCursorFunctionalTest extends FunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dropCollection($this->getDatabaseName(), $this->getCollectionName());
+    }
+
+    public function testSetTypeMap(): void
+    {
+        $collection = self::createTestClient()->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+        $cursor = $collection->find();
+
+        $codecCursor = CodecCursor::fromCursor($cursor, $this->createMock(DocumentCodec::class));
+
+        $this->expectWarning();
+        $this->expectWarningMessage('Discarding type map for MongoDB\Model\CodecCursor::setTypeMap');
+
+        $codecCursor->setTypeMap(['root' => 'array']);
+    }
+}

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -354,8 +354,8 @@ class AggregateFunctionalTest extends FunctionalTestCase
 
         $this->assertEquals(
             [
-                TestObject::createForFixture(2, true),
-                TestObject::createForFixture(3, true),
+                TestObject::createDecodedForFixture(2),
+                TestObject::createDecodedForFixture(3),
             ],
             $cursor->toArray(),
         );

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -369,10 +369,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
         $bulkWrite = new BulkWrite(['ordered' => true]);
 
         for ($i = 1; $i <= $n; $i++) {
-            $bulkWrite->insert([
-                '_id' => $i,
-                'x' => (object) ['foo' => 'bar'],
-            ]);
+            $bulkWrite->insert(TestObject::createDocument($i));
         }
 
         $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite, $executeBulkWriteOptions);

--- a/tests/Operation/AggregateTest.php
+++ b/tests/Operation/AggregateTest.php
@@ -30,6 +30,7 @@ class AggregateTest extends TestCase
             'allowDiskUse' => $this->getInvalidBooleanValues(),
             'batchSize' => $this->getInvalidIntegerValues(),
             'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'collation' => $this->getInvalidDocumentValues(),
             'hint' => $this->getInvalidHintValues(),
             'let' => $this->getInvalidDocumentValues(),

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -479,14 +479,14 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $this->assertSame(1, $result->getMatchedCount());
         $this->assertSame(1, $result->getModifiedCount());
 
-        $replacedObject = TestObject::createForFixture(3, true);
+        $replacedObject = TestObject::createDecodedForFixture(3);
         $replacedObject->x->foo = 'baz';
 
         // Only read the last two documents as the other two don't fit our codec
         $this->assertEquals(
             [
                 $replacedObject,
-                TestObject::createForFixture(4, true),
+                TestObject::createDecodedForFixture(4),
             ],
             $this->collection->find(['_id' => ['$gte' => 3]], ['codec' => $codec])->toArray(),
         );

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -425,6 +425,7 @@ class BulkWriteTest extends TestCase
     {
         return $this->createOptionDataProvider([
             'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'ordered' => $this->getInvalidBooleanValues(true),
             'session' => $this->getInvalidSessionValues(),
             'writeConcern' => $this->getInvalidWriteConcernValues(),

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -3,7 +3,9 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\BulkWrite;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 
 class BulkWriteTest extends TestCase
 {
@@ -61,6 +63,18 @@ class BulkWriteTest extends TestCase
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
             [BulkWrite::INSERT_ONE => [$document]],
         ]);
+    }
+
+    public function testInsertOneWithCodecRejectsInvalidDocuments(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+
+        new BulkWrite(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            [[BulkWrite::INSERT_ONE => [['x' => 1]]]],
+            ['codec' => new TestDocumentCodec()],
+        );
     }
 
     public function testDeleteManyFilterArgumentMissing(): void
@@ -221,6 +235,18 @@ class BulkWriteTest extends TestCase
     public function provideInvalidBooleanValues()
     {
         return $this->wrapValuesForDataProvider($this->getInvalidBooleanValues());
+    }
+
+    public function testReplaceOneWithCodecRejectsInvalidDocuments(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+
+        new BulkWrite(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            [[BulkWrite::REPLACE_ONE => [['x' => 1], ['y' => 1]]]],
+            ['codec' => new TestDocumentCodec()],
+        );
     }
 
     public function testUpdateManyFilterArgumentMissing(): void

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -10,6 +10,8 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindAndModify;
 use MongoDB\Tests\CommandObserver;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use MongoDB\Tests\Fixtures\Document\TestObject;
 use stdClass;
 
 class FindAndModifyFunctionalTest extends FunctionalTestCase
@@ -277,6 +279,51 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
                 ['_id' => 1, 'x' => ['foo' => 'bar']],
             ],
         ];
+    }
+
+    public function testFindOneAndDeleteWithCodec(): void
+    {
+        $this->createFixtures(1);
+
+        $operation = new FindAndModify(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            ['remove' => true, 'codec' => new TestDocumentCodec()],
+        );
+
+        $result = $operation->execute($this->getPrimaryServer());
+
+        self::assertEquals(TestObject::createForFixture(1, true), $result);
+    }
+
+    public function testFindOneAndUpdateWithCodec(): void
+    {
+        $this->createFixtures(1);
+
+        $operation = new FindAndModify(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            ['update' => ['$set' => ['x.foo' => 'baz']], 'codec' => new TestDocumentCodec()],
+        );
+
+        $result = $operation->execute($this->getPrimaryServer());
+
+        self::assertEquals(TestObject::createForFixture(1, true), $result);
+    }
+
+    public function testFindOneAndReplaceWithCodec(): void
+    {
+        $this->createFixtures(1);
+
+        $operation = new FindAndModify(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            ['update' => ['_id' => 1], 'codec' => new TestDocumentCodec()],
+        );
+
+        $result = $operation->execute($this->getPrimaryServer());
+
+        self::assertEquals(TestObject::createForFixture(1, true), $result);
     }
 
     /**

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -334,10 +334,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         $bulkWrite = new BulkWrite(['ordered' => true]);
 
         for ($i = 1; $i <= $n; $i++) {
-            $bulkWrite->insert([
-                '_id' => $i,
-                'x' => (object) ['foo' => 'bar'],
-            ]);
+            $bulkWrite->insert(TestObject::createDocument($i));
         }
 
         $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite);

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -296,6 +296,20 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         self::assertEquals(TestObject::createDecodedForFixture(1), $result);
     }
 
+    public function testFindOneAndDeleteNothingWithCodec(): void
+    {
+        // When the query does not match any documents, the operation returns null
+        $operation = new FindAndModify(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            ['remove' => true, 'codec' => new TestDocumentCodec()],
+        );
+
+        $result = $operation->execute($this->getPrimaryServer());
+
+        self::assertNull($result);
+    }
+
     public function testFindOneAndUpdateWithCodec(): void
     {
         $this->createFixtures(1);
@@ -311,6 +325,20 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         self::assertEquals(TestObject::createDecodedForFixture(1), $result);
     }
 
+    public function testFindOneAndUpdateNothingWithCodec(): void
+    {
+        // When the query does not match any documents, the operation returns null
+        $operation = new FindAndModify(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            ['update' => ['$set' => ['x.foo' => 'baz']], 'codec' => new TestDocumentCodec()],
+        );
+
+        $result = $operation->execute($this->getPrimaryServer());
+
+        self::assertNull($result);
+    }
+
     public function testFindOneAndReplaceWithCodec(): void
     {
         $this->createFixtures(1);
@@ -324,6 +352,20 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         $result = $operation->execute($this->getPrimaryServer());
 
         self::assertEquals(TestObject::createDecodedForFixture(1), $result);
+    }
+
+    public function testFindOneAndReplaceNothingWithCodec(): void
+    {
+        // When the query does not match any documents, the operation returns null
+        $operation = new FindAndModify(
+            $this->getDatabaseName(),
+            $this->getCollectionName(),
+            ['update' => ['_id' => 1], 'codec' => new TestDocumentCodec()],
+        );
+
+        $result = $operation->execute($this->getPrimaryServer());
+
+        self::assertNull($result);
     }
 
     /**

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -293,7 +293,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
         $result = $operation->execute($this->getPrimaryServer());
 
-        self::assertEquals(TestObject::createForFixture(1, true), $result);
+        self::assertEquals(TestObject::createDecodedForFixture(1), $result);
     }
 
     public function testFindOneAndUpdateWithCodec(): void
@@ -308,7 +308,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
         $result = $operation->execute($this->getPrimaryServer());
 
-        self::assertEquals(TestObject::createForFixture(1, true), $result);
+        self::assertEquals(TestObject::createDecodedForFixture(1), $result);
     }
 
     public function testFindOneAndReplaceWithCodec(): void
@@ -323,7 +323,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
 
         $result = $operation->execute($this->getPrimaryServer());
 
-        self::assertEquals(TestObject::createForFixture(1, true), $result);
+        self::assertEquals(TestObject::createDecodedForFixture(1), $result);
     }
 
     /**

--- a/tests/Operation/FindAndModifyTest.php
+++ b/tests/Operation/FindAndModifyTest.php
@@ -20,6 +20,7 @@ class FindAndModifyTest extends TestCase
         return $this->createOptionDataProvider([
             'arrayFilters' => $this->getInvalidArrayValues(),
             'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'collation' => $this->getInvalidDocumentValues(),
             'fields' => $this->getInvalidDocumentValues(),
             'maxTimeMS' => $this->getInvalidIntegerValues(),

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -9,6 +9,8 @@ use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use MongoDB\Tests\Fixtures\Document\TestObject;
 use stdClass;
 
 use function microtime;
@@ -194,6 +196,25 @@ class FindFunctionalTest extends FunctionalTestCase
                 ],
             ],
         ];
+    }
+
+    public function testCodecOption(): void
+    {
+        $this->createFixtures(3);
+
+        $codec = new TestDocumentCodec();
+
+        $operation = new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['codec' => $codec]);
+        $cursor = $operation->execute($this->getPrimaryServer());
+
+        $this->assertEquals(
+            [
+                TestObject::createForFixture(1, true),
+                TestObject::createForFixture(2, true),
+                TestObject::createForFixture(3, true),
+            ],
+            $cursor->toArray(),
+        );
     }
 
     public function testMaxAwaitTimeMS(): void

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -323,10 +323,7 @@ class FindFunctionalTest extends FunctionalTestCase
         $bulkWrite = new BulkWrite(['ordered' => true]);
 
         for ($i = 1; $i <= $n; $i++) {
-            $bulkWrite->insert([
-                '_id' => $i,
-                'x' => (object) ['foo' => 'bar'],
-            ]);
+            $bulkWrite->insert(TestObject::createDocument($i));
         }
 
         $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite, $executeBulkWriteOptions);

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -209,9 +209,9 @@ class FindFunctionalTest extends FunctionalTestCase
 
         $this->assertEquals(
             [
-                TestObject::createForFixture(1, true),
-                TestObject::createForFixture(2, true),
-                TestObject::createForFixture(3, true),
+                TestObject::createDecodedForFixture(1),
+                TestObject::createDecodedForFixture(2),
+                TestObject::createDecodedForFixture(3),
             ],
             $cursor->toArray(),
         );

--- a/tests/Operation/FindOneAndReplaceFunctionalTest.php
+++ b/tests/Operation/FindOneAndReplaceFunctionalTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace MongoDB\Tests\Operation;
+
+use MongoDB\Driver\BulkWrite;
+use MongoDB\Operation\FindOneAndReplace;
+use MongoDB\Tests\CommandObserver;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use MongoDB\Tests\Fixtures\Document\TestObject;
+
+class FindOneAndReplaceFunctionalTest extends FunctionalTestCase
+{
+    public function testFindAndReplaceOneWithCodec(): void
+    {
+        $this->createFixtures(1);
+
+        (new CommandObserver())->observe(
+            function (): void {
+                $replaceObject = TestObject::createForFixture(1);
+                $replaceObject->x->foo = 'baz';
+
+                $operation = new FindOneAndReplace(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    ['_id' => 1],
+                    $replaceObject,
+                    ['codec' => new TestDocumentCodec()],
+                );
+
+                $this->assertEquals(
+                    TestObject::createForFixture(1, true),
+                    $operation->execute($this->getPrimaryServer()),
+                );
+            },
+            function (array $event): void {
+                $this->assertEquals(
+                    (object) [
+                        '_id' => 1,
+                        'x' => (object) ['foo' => 'baz'],
+                        'encoded' => true,
+                    ],
+                    $event['started']->getCommand()->update ?? null,
+                );
+            },
+        );
+    }
+
+    /**
+     * Create data fixtures.
+     */
+    private function createFixtures(int $n): void
+    {
+        $bulkWrite = new BulkWrite(['ordered' => true]);
+
+        for ($i = 1; $i <= $n; $i++) {
+            $bulkWrite->insert([
+                '_id' => $i,
+                'x' => (object) ['foo' => 'bar'],
+            ]);
+        }
+
+        $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite);
+
+        $this->assertEquals($n, $result->getInsertedCount());
+    }
+}

--- a/tests/Operation/FindOneAndReplaceFunctionalTest.php
+++ b/tests/Operation/FindOneAndReplaceFunctionalTest.php
@@ -53,10 +53,7 @@ class FindOneAndReplaceFunctionalTest extends FunctionalTestCase
         $bulkWrite = new BulkWrite(['ordered' => true]);
 
         for ($i = 1; $i <= $n; $i++) {
-            $bulkWrite->insert([
-                '_id' => $i,
-                'x' => (object) ['foo' => 'bar'],
-            ]);
+            $bulkWrite->insert(TestObject::createDocument($i));
         }
 
         $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite);

--- a/tests/Operation/FindOneAndReplaceFunctionalTest.php
+++ b/tests/Operation/FindOneAndReplaceFunctionalTest.php
@@ -28,7 +28,7 @@ class FindOneAndReplaceFunctionalTest extends FunctionalTestCase
                 );
 
                 $this->assertEquals(
-                    TestObject::createForFixture(1, true),
+                    TestObject::createDecodedForFixture(1),
                     $operation->execute($this->getPrimaryServer()),
                 );
             },

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -60,6 +60,7 @@ class FindOneAndReplaceTest extends TestCase
     public function provideInvalidConstructorOptions()
     {
         return $this->createOptionDataProvider([
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'projection' => $this->getInvalidDocumentValues(),
             'returnDocument' => $this->getInvalidIntegerValues(true),
         ]);

--- a/tests/Operation/FindOneFunctionalTest.php
+++ b/tests/Operation/FindOneFunctionalTest.php
@@ -4,6 +4,8 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Operation\FindOne;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use MongoDB\Tests\Fixtures\Document\TestObject;
 
 class FindOneFunctionalTest extends FunctionalTestCase
 {
@@ -34,6 +36,18 @@ class FindOneFunctionalTest extends FunctionalTestCase
                 ['_id' => 1, 'x' => (object) ['foo' => 'bar']],
             ],
         ];
+    }
+
+    public function testCodecOption(): void
+    {
+        $this->createFixtures(1);
+
+        $codec = new TestDocumentCodec();
+
+        $operation = new FindOne($this->getDatabaseName(), $this->getCollectionName(), [], ['codec' => $codec]);
+        $document = $operation->execute($this->getPrimaryServer());
+
+        $this->assertEquals(TestObject::createForFixture(1, true), $document);
     }
 
     /**

--- a/tests/Operation/FindOneFunctionalTest.php
+++ b/tests/Operation/FindOneFunctionalTest.php
@@ -47,7 +47,7 @@ class FindOneFunctionalTest extends FunctionalTestCase
         $operation = new FindOne($this->getDatabaseName(), $this->getCollectionName(), [], ['codec' => $codec]);
         $document = $operation->execute($this->getPrimaryServer());
 
-        $this->assertEquals(TestObject::createForFixture(1, true), $document);
+        $this->assertEquals(TestObject::createDecodedForFixture(1), $document);
     }
 
     /**

--- a/tests/Operation/FindOneFunctionalTest.php
+++ b/tests/Operation/FindOneFunctionalTest.php
@@ -58,10 +58,7 @@ class FindOneFunctionalTest extends FunctionalTestCase
         $bulkWrite = new BulkWrite(['ordered' => true]);
 
         for ($i = 1; $i <= $n; $i++) {
-            $bulkWrite->insert([
-                '_id' => $i,
-                'x' => (object) ['foo' => 'bar'],
-            ]);
+            $bulkWrite->insert(TestObject::createDocument($i));
         }
 
         $result = $this->manager->executeBulkWrite($this->getNamespace(), $bulkWrite);

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -28,6 +28,7 @@ class FindTest extends TestCase
         return $this->createOptionDataProvider([
             'allowPartialResults' => $this->getInvalidBooleanValues(),
             'batchSize' => $this->getInvalidIntegerValues(),
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'collation' => $this->getInvalidDocumentValues(),
             'cursorType' => $this->getInvalidIntegerValues(),
             'hint' => $this->getInvalidHintValues(),

--- a/tests/Operation/InsertManyTest.php
+++ b/tests/Operation/InsertManyTest.php
@@ -40,6 +40,7 @@ class InsertManyTest extends TestCase
     {
         return $this->createOptionDataProvider([
             'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'ordered' => $this->getInvalidBooleanValues(true),
             'session' => $this->getInvalidSessionValues(),
             'writeConcern' => $this->getInvalidWriteConcernValues(),

--- a/tests/Operation/InsertManyTest.php
+++ b/tests/Operation/InsertManyTest.php
@@ -53,6 +53,6 @@ class InsertManyTest extends TestCase
     {
         $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
 
-        new InsertMany($this->getDatabaseName(), $this->getCollectionName(), [[]], ['codec' => new TestDocumentCodec()]);
+        new InsertMany($this->getDatabaseName(), $this->getCollectionName(), [['x' => 1]], ['codec' => new TestDocumentCodec()]);
     }
 }

--- a/tests/Operation/InsertManyTest.php
+++ b/tests/Operation/InsertManyTest.php
@@ -3,7 +3,9 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\InsertMany;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 
 class InsertManyTest extends TestCase
 {
@@ -45,5 +47,12 @@ class InsertManyTest extends TestCase
             'session' => $this->getInvalidSessionValues(),
             'writeConcern' => $this->getInvalidWriteConcernValues(),
         ]);
+    }
+
+    public function testCodecRejectsInvalidDocuments(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+
+        new InsertMany($this->getDatabaseName(), $this->getCollectionName(), [[]], ['codec' => new TestDocumentCodec()]);
     }
 }

--- a/tests/Operation/InsertOneTest.php
+++ b/tests/Operation/InsertOneTest.php
@@ -25,6 +25,7 @@ class InsertOneTest extends TestCase
     {
         return $this->createOptionDataProvider([
             'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'session' => $this->getInvalidSessionValues(),
             'writeConcern' => $this->getInvalidWriteConcernValues(),
         ]);

--- a/tests/Operation/InsertOneTest.php
+++ b/tests/Operation/InsertOneTest.php
@@ -37,6 +37,6 @@ class InsertOneTest extends TestCase
     {
         $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
 
-        new InsertOne($this->getDatabaseName(), $this->getCollectionName(), [], ['codec' => new TestDocumentCodec()]);
+        new InsertOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], ['codec' => new TestDocumentCodec()]);
     }
 }

--- a/tests/Operation/InsertOneTest.php
+++ b/tests/Operation/InsertOneTest.php
@@ -3,7 +3,9 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\InsertOne;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 
 class InsertOneTest extends TestCase
 {
@@ -29,5 +31,12 @@ class InsertOneTest extends TestCase
             'session' => $this->getInvalidSessionValues(),
             'writeConcern' => $this->getInvalidWriteConcernValues(),
         ]);
+    }
+
+    public function testCodecRejectsInvalidDocuments(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+
+        new InsertOne($this->getDatabaseName(), $this->getCollectionName(), [], ['codec' => new TestDocumentCodec()]);
     }
 }

--- a/tests/Operation/ReplaceOneFunctionalTest.php
+++ b/tests/Operation/ReplaceOneFunctionalTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MongoDB\Tests\Operation;
+
+use MongoDB\Operation\ReplaceOne;
+use MongoDB\Tests\CommandObserver;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use MongoDB\Tests\Fixtures\Document\TestObject;
+
+class ReplaceOneFunctionalTest extends FunctionalTestCase
+{
+    public function testReplaceOneWithCodec(): void
+    {
+        (new CommandObserver())->observe(
+            function (): void {
+                $operation = new ReplaceOne(
+                    $this->getDatabaseName(),
+                    $this->getCollectionName(),
+                    ['x' => 1],
+                    TestObject::createForFixture(1),
+                    ['codec' => new TestDocumentCodec()],
+                );
+
+                $operation->execute($this->getPrimaryServer());
+            },
+            function (array $event): void {
+                $this->assertEquals(
+                    (object) [
+                        '_id' => 1,
+                        'x' => (object) ['foo' => 'bar'],
+                        'encoded' => true,
+                    ],
+                    $event['started']->getCommand()->updates[0]->u ?? null,
+                );
+            },
+        );
+    }
+}

--- a/tests/Operation/ReplaceOneTest.php
+++ b/tests/Operation/ReplaceOneTest.php
@@ -48,4 +48,18 @@ class ReplaceOneTest extends TestCase
         $this->expectExceptionMessageMatches('#(\$replacement is an update pipeline)|(Expected \$replacement to have type "document" \(array or object\))#');
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
+
+    /** @dataProvider provideInvalidConstructorOptions */
+    public function testConstructorOptionsTypeCheck($options): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], ['y' => 1], $options);
+    }
+
+    public function provideInvalidConstructorOptions()
+    {
+        return $this->createOptionDataProvider([
+            'codec' => $this->getInvalidDocumentCodecValues(),
+        ]);
+    }
 }

--- a/tests/Operation/ReplaceOneTest.php
+++ b/tests/Operation/ReplaceOneTest.php
@@ -3,7 +3,9 @@
 namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\ReplaceOne;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 
 class ReplaceOneTest extends TestCase
 {
@@ -61,5 +63,12 @@ class ReplaceOneTest extends TestCase
         return $this->createOptionDataProvider([
             'codec' => $this->getInvalidDocumentCodecValues(),
         ]);
+    }
+
+    public function testCodecRejectsInvalidDocuments(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+
+        new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], ['y' => 1], ['codec' => new TestDocumentCodec()]);
     }
 }

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -42,6 +42,7 @@ class WatchTest extends FunctionalTestCase
     {
         return $this->createOptionDataProvider([
             'batchSize' => $this->getInvalidIntegerValues(),
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'collation' => $this->getInvalidDocumentValues(),
             'fullDocument' => $this->getInvalidStringValues(true),
             'fullDocumentBeforeChange' => $this->getInvalidStringValues(),

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Watch;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use stdClass;
 
 /**
@@ -55,6 +56,14 @@ class WatchTest extends FunctionalTestCase
             'startAtOperationTime' => $this->getInvalidTimestampValues(),
             'typeMap' => $this->getInvalidArrayValues(),
         ]);
+    }
+
+    public function testConstructorRejectsCodecAndTypemap(): void
+    {
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+
+        $options = ['codec' => new TestDocumentCodec(), 'typeMap' => ['root' => 'array']];
+        new Watch($this->manager, $this->getDatabaseName(), $this->getCollectionName(), [], $options);
     }
 
     private function getInvalidTimestampValues()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests;
 
 use InvalidArgumentException;
 use MongoDB\BSON\PackedArray;
+use MongoDB\Codec\Codec;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
@@ -246,6 +247,11 @@ OUTPUT;
     protected function getInvalidDocumentValues(bool $includeNull = false): array
     {
         return array_merge([123, 3.14, 'foo', true, PackedArray::fromPHP([])], $includeNull ? [null] : []);
+    }
+
+    protected function getInvalidDocumentCodecValues(): array
+    {
+        return [123, 3.14, 'foo', true, [], new stdClass(), $this->createMock(Codec::class)];
     }
 
     /**


### PR DESCRIPTION
PHPLIB-1182

This PR adds support for a `codec` option to the `MongoDB\Collection` class as well as the following operations:
* aggregate
* bulkWrite (for `insertOne` and `replaceOne` operations)
* find
* findOne
* findOneAndDelete (returned documents only)
* findOneAndUpdate (returned documents only)
* findOneAndReplace (replacement document and returned documents)
* insertMany
* insertOne
* replaceOne
* watch

When specifying a codec, the `typeMap` option is ignored entirely, and a `bson` type is applied for the `root` element. The collection class supports a class-level `codec` option, which will be applied when not explicitly specifying a `codec` option to any of the above operations. Specifying a `null` value for the `codec` option allows users to disable using the collection-level codec and instead rely on type maps to deserialise data.