### PR TITLE
PHPLIB-1220: Support codec option for GridFS buckets

### DIFF
--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -37,6 +37,7 @@ use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Find;
 
 use function array_intersect_key;
+use function array_key_exists;
 use function assert;
 use function fopen;
 use function get_resource_type;
@@ -319,7 +320,7 @@ class Bucket
      */
     public function find($filter = [], array $options = [])
     {
-        if ($this->codec && ! isset($options['codec'])) {
+        if ($this->codec && ! array_key_exists('codec', $options)) {
             $options['codec'] = $this->codec;
         }
 
@@ -340,7 +341,7 @@ class Bucket
      */
     public function findOne($filter = [], array $options = [])
     {
-        if ($this->codec && ! isset($options['codec'])) {
+        if ($this->codec && ! array_key_exists('codec', $options)) {
             $options['codec'] = $this->codec;
         }
 

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -400,7 +400,7 @@ class Bucket
     {
         $file = $this->getRawFileDocumentForStream($stream);
 
-        if ($this->codec instanceof DocumentCodec) {
+        if ($this->codec) {
             return $this->codec->decode(Document::fromPHP($file));
         }
 

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -171,6 +171,10 @@ class Bucket
             throw InvalidArgumentException::invalidType('"writeConcern" option', $options['writeConcern'], WriteConcern::class);
         }
 
+        if (isset($options['codec']) && isset($options['typeMap'])) {
+            throw InvalidArgumentException::cannotCombineCodecAndTypeMap();
+        }
+
         $this->manager = $manager;
         $this->databaseName = $databaseName;
         $this->bucketName = $options['bucketName'];

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -136,7 +136,7 @@ class WritableStream
             '_id' => $options['_id'],
             'chunkSize' => $this->chunkSize,
             'filename' => $filename,
-            'length' => 0,
+            'length' => null,
             'uploadDate' => null,
         ] + array_intersect_key($options, ['aliases' => 1, 'contentType' => 1, 'metadata' => 1]);
     }

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -137,7 +137,7 @@ class WritableStream
             'chunkSize' => $this->chunkSize,
             'filename' => $filename,
             'length' => 0,
-            'uploadDate' => new UTCDateTime(0),
+            'uploadDate' => null,
         ] + array_intersect_key($options, ['aliases' => 1, 'contentType' => 1, 'metadata' => 1]);
     }
 

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -136,6 +136,8 @@ class WritableStream
             '_id' => $options['_id'],
             'chunkSize' => $this->chunkSize,
             'filename' => $filename,
+            'length' => 0,
+            'uploadDate' => new UTCDateTime(0),
         ] + array_intersect_key($options, ['aliases' => 1, 'contentType' => 1, 'metadata' => 1]);
     }
 

--- a/tests/Fixtures/Codec/TestFileCodec.php
+++ b/tests/Fixtures/Codec/TestFileCodec.php
@@ -31,8 +31,10 @@ final class TestFileCodec implements DocumentCodec
         $fileObject->id = $value->get('_id');
         $fileObject->length = (int) $value->get('length');
         $fileObject->chunkSize = (int) $value->get('chunkSize');
-        $fileObject->uploadDate = DateTimeImmutable::createFromMutable($value->get('uploadDate')->toDateTime());
         $fileObject->filename = $value->get('filename');
+
+        $uploadDate = $value->get('uploadDate');
+        $fileObject->uploadDate = $uploadDate ? DateTimeImmutable::createFromMutable($uploadDate->toDateTime()) : null;
 
         if ($value->has('metadata')) {
             $fileObject->metadata = $value->get('metadata');

--- a/tests/Fixtures/Codec/TestFileCodec.php
+++ b/tests/Fixtures/Codec/TestFileCodec.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace MongoDB\Tests\Fixtures\Codec;
+
+use DateTimeImmutable;
+use MongoDB\BSON\Document;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Codec\DecodeIfSupported;
+use MongoDB\Codec\DocumentCodec;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+use MongoDB\Tests\Fixtures\Document\TestFile;
+
+final class TestFileCodec implements DocumentCodec
+{
+    use DecodeIfSupported;
+    use EncodeIfSupported;
+
+    public function canDecode($value): bool
+    {
+        return $value instanceof Document;
+    }
+
+    public function decode($value): TestFile
+    {
+        if (! $value instanceof Document) {
+            throw UnsupportedValueException::invalidDecodableValue($value);
+        }
+
+        $fileObject = new TestFile();
+        $fileObject->id = $value->get('_id');
+        $fileObject->length = (int) $value->get('length');
+        $fileObject->chunkSize = (int) $value->get('chunkSize');
+        $fileObject->uploadDate = DateTimeImmutable::createFromMutable($value->get('uploadDate')->toDateTime());
+        $fileObject->filename = $value->get('filename');
+
+        if ($value->has('metadata')) {
+            $fileObject->metadata = $value->get('metadata');
+        }
+
+        return $fileObject;
+    }
+
+    public function canEncode($value): bool
+    {
+        return $value instanceof TestFile;
+    }
+
+    public function encode($value): Document
+    {
+        if (! $value instanceof TestFile) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        return Document::fromPHP([
+            '_id' => $value->id,
+            'length' => $value->length,
+            'chunkSize' => $value->chunkSize,
+            'uploadDate' => new UTCDateTime($value->uploadDate),
+            'filename' => $value->filename,
+        ]);
+    }
+}

--- a/tests/Fixtures/Document/TestFile.php
+++ b/tests/Fixtures/Document/TestFile.php
@@ -24,7 +24,7 @@ final class TestFile
     public $id;
     public int $length;
     public int $chunkSize;
-    public DateTimeImmutable $uploadDate;
+    public ?DateTimeImmutable $uploadDate = null;
     public string $filename;
     public $metadata;
 }

--- a/tests/Fixtures/Document/TestFile.php
+++ b/tests/Fixtures/Document/TestFile.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Copyright 2023-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Tests\Fixtures\Document;
+
+use DateTimeImmutable;
+
+final class TestFile
+{
+    public $id;
+    public int $length;
+    public int $chunkSize;
+    public DateTimeImmutable $uploadDate;
+    public string $filename;
+    public $metadata;
+}

--- a/tests/Fixtures/Document/TestFile.php
+++ b/tests/Fixtures/Document/TestFile.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Tests\Fixtures\Document;
 
 use DateTimeImmutable;
+use stdClass;
 
 final class TestFile
 {
@@ -26,5 +27,5 @@ final class TestFile
     public int $chunkSize;
     public ?DateTimeImmutable $uploadDate = null;
     public string $filename;
-    public $metadata;
+    public ?stdClass $metadata = null;
 }

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests\GridFS;
 
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\Document;
 use MongoDB\Collection;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
@@ -15,6 +16,8 @@ use MongoDB\GridFS\Exception\StreamException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\ListIndexes;
+use MongoDB\Tests\Fixtures\Codec\TestFileCodec;
+use MongoDB\Tests\Fixtures\Document\TestFile;
 
 use function array_merge;
 use function call_user_func;
@@ -68,6 +71,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         return $this->createOptionDataProvider([
             'bucketName' => $this->getInvalidStringValues(true),
             'chunkSizeBytes' => $this->getInvalidIntegerValues(true),
+            'codec' => $this->getInvalidDocumentCodecValues(),
             'disableMD5' => $this->getInvalidBooleanValues(true),
             'readConcern' => $this->getInvalidReadConcernValues(),
             'readPreference' => $this->getInvalidReadPreferenceValues(),
@@ -317,6 +321,29 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertInstanceOf(BSONDocument::class, $fileDocument);
     }
 
+    public function testFindUsesCodec(): void
+    {
+        $this->bucket->uploadFromStream('a', $this->createStream('foo'));
+
+        $cursor = $this->bucket->find([], ['codec' => new TestFileCodec()]);
+        $fileDocument = current($cursor->toArray());
+
+        $this->assertInstanceOf(TestFile::class, $fileDocument);
+        $this->assertSame('a', $fileDocument->filename);
+    }
+
+    public function testFindInheritsBucketCodec(): void
+    {
+        $bucket = new Bucket($this->manager, $this->getDatabaseName(), ['codec' => new TestFileCodec()]);
+        $bucket->uploadFromStream('a', $this->createStream('foo'));
+
+        $cursor = $bucket->find();
+        $fileDocument = current($cursor->toArray());
+
+        $this->assertInstanceOf(TestFile::class, $fileDocument);
+        $this->assertSame('a', $fileDocument->filename);
+    }
+
     public function testFindOne(): void
     {
         $this->bucket->uploadFromStream('a', $this->createStream('foo'));
@@ -337,6 +364,46 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $this->assertInstanceOf(BSONDocument::class, $fileDocument);
         $this->assertSameDocument(['filename' => 'b', 'length' => 6], $fileDocument);
+    }
+
+    public function testFindOneUsesCodec(): void
+    {
+        $this->bucket->uploadFromStream('a', $this->createStream('foo'));
+        $this->bucket->uploadFromStream('b', $this->createStream('foobar'));
+        $this->bucket->uploadFromStream('c', $this->createStream('foobarbaz'));
+
+        $fileDocument = $this->bucket->findOne(
+            ['length' => ['$lte' => 6]],
+            [
+                'sort' => ['length' => -1],
+                'codec' => new TestFileCodec(),
+            ],
+        );
+
+        $this->assertInstanceOf(TestFile::class, $fileDocument);
+        $this->assertSame('b', $fileDocument->filename);
+        $this->assertSame(6, $fileDocument->length);
+    }
+
+    public function testFindOneInheritsBucketCodec(): void
+    {
+        $bucket = new Bucket($this->manager, $this->getDatabaseName(), ['codec' => new TestFileCodec()]);
+
+        $bucket->uploadFromStream('a', $this->createStream('foo'));
+        $bucket->uploadFromStream('b', $this->createStream('foobar'));
+        $bucket->uploadFromStream('c', $this->createStream('foobarbaz'));
+
+        $fileDocument = $bucket->findOne(
+            ['length' => ['$lte' => 6]],
+            [
+                'sort' => ['length' => -1],
+                'codec' => new TestFileCodec(),
+            ],
+        );
+
+        $this->assertInstanceOf(TestFile::class, $fileDocument);
+        $this->assertSame('b', $fileDocument->filename);
+        $this->assertSame(6, $fileDocument->length);
     }
 
     public function testGetBucketNameWithCustomValue(): void
@@ -386,6 +453,22 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertInstanceOf(BSONDocument::class, $fileDocument);
         $this->assertInstanceOf(BSONDocument::class, $fileDocument['metadata']);
         $this->assertSame(['foo' => 'bar'], $fileDocument['metadata']->getArrayCopy());
+    }
+
+    public function testGetFileDocumentForStreamUsesCodec(): void
+    {
+        $bucket = new Bucket($this->manager, $this->getDatabaseName(), ['codec' => new TestFileCodec()]);
+
+        $metadata = ['foo' => 'bar'];
+        $stream = $bucket->openUploadStream('filename', ['_id' => 1, 'metadata' => $metadata]);
+
+        $fileDocument = $bucket->getFileDocumentForStream($stream);
+
+        $this->assertInstanceOf(TestFile::class, $fileDocument);
+
+        $this->assertSame('filename', $fileDocument->filename);
+        $this->assertInstanceOf(Document::class, $fileDocument->metadata);
+        $this->assertSame($metadata, $fileDocument->metadata->toPHP(['root' => 'array']));
     }
 
     public function testGetFileDocumentForStreamWithReadableStream(): void

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -16,6 +16,7 @@ use MongoDB\GridFS\Exception\StreamException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\ListIndexes;
+use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Codec\TestFileCodec;
 use MongoDB\Tests\Fixtures\Document\TestFile;
 
@@ -85,6 +86,17 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected "chunkSizeBytes" option to be >= 1, 0 given');
         new Bucket($this->manager, $this->getDatabaseName(), ['chunkSizeBytes' => 0]);
+    }
+
+    public function testConstructorWithCodecAndTypeMapOptions(): void
+    {
+        $options = [
+            'codec' => new TestDocumentCodec(),
+            'typeMap' => ['root' => 'array', 'document' => 'array'],
+        ];
+
+        $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
+        new Bucket($this->manager, $this->getDatabaseName(), $options);
     }
 
     /** @dataProvider provideInputDataAndExpectedChunks */

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -3,7 +3,6 @@
 namespace MongoDB\Tests\GridFS;
 
 use MongoDB\BSON\Binary;
-use MongoDB\BSON\Document;
 use MongoDB\Collection;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
@@ -19,6 +18,7 @@ use MongoDB\Operation\ListIndexes;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Codec\TestFileCodec;
 use MongoDB\Tests\Fixtures\Document\TestFile;
+use stdClass;
 
 use function array_merge;
 use function call_user_func;
@@ -509,8 +509,8 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertInstanceOf(TestFile::class, $fileDocument);
 
         $this->assertSame('filename', $fileDocument->filename);
-        $this->assertInstanceOf(Document::class, $fileDocument->metadata);
-        $this->assertSame($metadata, $fileDocument->metadata->toPHP(['root' => 'array']));
+        $this->assertInstanceOf(stdClass::class, $fileDocument->metadata);
+        $this->assertSame($metadata, (array) $fileDocument->metadata);
     }
 
     public function testGetFileDocumentForStreamWithReadableStream(): void


### PR DESCRIPTION
PHPLIB-1220

Note that the `Bucket` class does not forward the codec option to the underlying collections, as they can't both work with the same codec (it's only applicable to file documents). Setting a codec on the file collection also wouldn't work, as the collection would expect to apply the codec when inserting a file document. To work around these issues, the codec is manually applied in the `findOne`, `find`, and `getFileDocumentForStream` methods.