### PR TITLE
Use phpunit group instead of Atlas Data Lake test suite

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -83,7 +83,7 @@ export MONGODB_MULTI_MONGOS_LB_URI="${MONGODB_MULTI_MONGOS_LB_URI}"
 # Run the tests, and store the results in a junit result file
 case "$TESTS" in
    atlas-data-lake*)
-      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --testsuite "Atlas Data Lake Test Suite"
+      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group atlas-data-lake
       ;;
 
    csfle)

--- a/phpunit.evergreen.xml
+++ b/phpunit.evergreen.xml
@@ -23,10 +23,6 @@
         <testsuite name="Default Test Suite">
             <directory>./tests/</directory>
         </testsuite>
-
-        <testsuite name="Atlas Data Lake Test Suite">
-            <file>tests/SpecTests/AtlasDataLakeSpecTest.php</file>
-        </testsuite>
     </testsuites>
 
     <logging>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,9 +22,5 @@
         <testsuite name="Default Test Suite">
             <directory>./tests/</directory>
         </testsuite>
-
-        <testsuite name="Atlas Data Lake Test Suite">
-            <file>tests/SpecTests/AtlasDataLakeSpecTest.php</file>
-        </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/SpecTests/AtlasDataLakeSpecTest.php
+++ b/tests/SpecTests/AtlasDataLakeSpecTest.php
@@ -18,6 +18,7 @@ use function parse_url;
  * Atlas Data Lake spec tests.
  *
  * @see https://github.com/mongodb/specifications/tree/master/source/atlas-data-lake-testing/tests
+ * @group atlas-data-lake
  */
 class AtlasDataLakeSpecTest extends FunctionalTestCase
 {


### PR DESCRIPTION
Why using a named test suite while we use groups for other environment-specific tests?

This test suite was introduced by #771 before groups started to be used in the project.