### PR TITLE
Remove wildcards from cases in run-tests

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -82,11 +82,11 @@ export MONGODB_MULTI_MONGOS_LB_URI="${MONGODB_MULTI_MONGOS_LB_URI}"
 
 # Run the tests, and store the results in a junit result file
 case "$TESTS" in
-   atlas*)
+   atlas)
       php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group atlas
       ;;
 
-   atlas-data-lake*)
+   atlas-data-lake)
       php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group atlas-data-lake
       ;;
 


### PR DESCRIPTION
As mentioned by @jmikola in https://github.com/mongodb/mongo-php-library/pull/1150#discussion_r1317639037, the wildcard character breaks running the data-lake test suite.