### PR TITLE
Fix signatures of bsonSerialize() methods

### DIFF
--- a/examples/persistable.php
+++ b/examples/persistable.php
@@ -7,6 +7,7 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Persistable;
 use MongoDB\Client;
 use MongoDB\Model\BSONArray;
+use stdClass;
 use UnexpectedValueException;
 
 use function getenv;
@@ -34,7 +35,7 @@ class PersistableEntry implements Persistable
         return $this->id;
     }
 
-    public function bsonSerialize(): object
+    public function bsonSerialize(): stdClass
     {
         return (object) [
             '_id' => $this->id,
@@ -73,7 +74,7 @@ class PersistableEmail implements Persistable
         $this->address = $address;
     }
 
-    public function bsonSerialize(): object
+    public function bsonSerialize(): stdClass
     {
         return (object) [
             'type' => $this->type,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,23 @@
       <code><![CDATA[$clientEncryption->decrypt($document->encryptedField)]]></code>
     </MixedArgument>
   </file>
+  <file src="examples/persistable.php">
+    <LessSpecificReturnStatement>
+      <code><![CDATA[(object) [
+            '_id' => $this->id,
+            'name' => $this->name,
+            'emails' => $this->emails,
+        ]]]></code>
+      <code><![CDATA[(object) [
+            'type' => $this->type,
+            'address' => $this->address,
+        ]]]></code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>stdClass</code>
+      <code>stdClass</code>
+    </MoreSpecificReturnType>
+  </file>
   <file src="src/ChangeStream.php">
     <DeprecatedConstant>
       <code>self::CURSOR_NOT_FOUND</code>
@@ -159,6 +176,9 @@
     </MixedArrayOffset>
   </file>
   <file src="src/Model/IndexInput.php">
+    <LessSpecificReturnStatement>
+      <code><![CDATA[(object) $this->index]]></code>
+    </LessSpecificReturnStatement>
     <MixedArgument>
       <code>$fieldName</code>
       <code><![CDATA[$index['key']]]></code>
@@ -173,6 +193,17 @@
     <MixedReturnStatement>
       <code><![CDATA[$this->index['name']]]></code>
     </MixedReturnStatement>
+    <MoreSpecificReturnType>
+      <code>stdClass</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="src/Model/SearchIndexInput.php">
+    <LessSpecificReturnStatement>
+      <code><![CDATA[(object) $this->index]]></code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code>stdClass</code>
+    </MoreSpecificReturnType>
   </file>
   <file src="src/Operation/Aggregate.php">
     <MixedArgument>

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -19,6 +19,7 @@ namespace MongoDB\Model;
 
 use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
+use stdClass;
 
 use function is_float;
 use function is_int;
@@ -86,7 +87,7 @@ class IndexInput implements Serializable
      * @see \MongoDB\Collection::createIndexes()
      * @see https://php.net/mongodb-bson-serializable.bsonserialize
      */
-    public function bsonSerialize(): object
+    public function bsonSerialize(): stdClass
     {
         return (object) $this->index;
     }

--- a/src/Model/SearchIndexInput.php
+++ b/src/Model/SearchIndexInput.php
@@ -19,6 +19,7 @@ namespace MongoDB\Model;
 
 use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
+use stdClass;
 
 use function is_string;
 use function MongoDB\is_document;
@@ -66,7 +67,7 @@ class SearchIndexInput implements Serializable
      * @see \MongoDB\Collection::createSearchIndexes()
      * @see https://php.net/mongodb-bson-serializable.bsonserialize
      */
-    public function bsonSerialize(): object
+    public function bsonSerialize(): stdClass
     {
         return (object) $this->index;
     }


### PR DESCRIPTION
https://github.com/mongodb/mongo-php-driver/pull/1449 changed the tentative return type of `MongoDB\BSON\Serializable` to no longer allow any `object` (which was incorrect as we never supported returning any object other than `stdClass` instances), instead restricting it to `stdClass` instances. This PR deals with the resulting deprecation notices emitted on PHP 8.1 and newer.