### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Following @alcaeus demand: https://github.com/mongodb/laravel-mongodb/pull/2612#pullrequestreview-1619728135. This will open PR when new versions of GitHub actions are available.

https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates