### PR TITLE
PHPLIB-1236 Implement Multi-Doc Benchmarks

### DIFF
--- a/benchmark/DriverBench/GridFSBench.php
+++ b/benchmark/DriverBench/GridFSBench.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace MongoDB\Benchmark\DriverBench;
+
+use MongoDB\Benchmark\Fixtures\Data;
+use MongoDB\Benchmark\Utils;
+use MongoDB\GridFS\Bucket;
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+
+/**
+ * For accurate results, run benchmarks on a standalone server.
+ *
+ * @see https://github.com/mongodb/specifications/blob/ddfc8b583d49aaf8c4c19fa01255afb66b36b92e/source/benchmarking/benchmarking.rst#multi-doc-benchmarks
+ */
+#[AfterMethods('afterAll')]
+final class GridFSBench
+{
+    /** @var resource */
+    private $stream;
+    private Bucket $bucket;
+    private mixed $id;
+
+    /** @see https://github.com/mongodb/specifications/blob/ddfc8b583d49aaf8c4c19fa01255afb66b36b92e/source/benchmarking/benchmarking.rst#gridfs-upload */
+    #[BeforeMethods('beforeUpload')]
+    public function benchUpload(): void
+    {
+        $this->bucket->uploadFromStream('test', $this->stream);
+    }
+
+    public function beforeUpload(): void
+    {
+        $database = Utils::getDatabase();
+        $database->drop();
+
+        $this->bucket = $database->selectGridFSBucket();
+        // Init the GridFS bucket
+        $this->bucket->uploadFromStream('init', Data::getStream(1));
+        // Prepare the 50MB stream to upload
+        $this->stream = Data::getStream(50 * 1024 * 1024);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/ddfc8b583d49aaf8c4c19fa01255afb66b36b92e/source/benchmarking/benchmarking.rst#gridfs-download */
+    #[BeforeMethods('beforeDownload')]
+    public function benchDownload(): void
+    {
+        $this->bucket->downloadToStream($this->id, $this->stream);
+    }
+
+    public function beforeDownload(): void
+    {
+        $database = Utils::getDatabase();
+        $database->drop();
+
+        $this->bucket = $database->selectGridFSBucket();
+        // Upload a 50MB file
+        $this->id = $this->bucket->uploadFromStream('init', Data::getStream(50 * 1024 * 1024));
+        // Prepare the stream to receive the download
+        $this->stream = Data::getStream(0);
+    }
+
+    public function afterAll(): void
+    {
+        unset($this->bucket, $this->stream, $this->id);
+        Utils::getDatabase()->drop();
+    }
+}

--- a/benchmark/DriverBench/MultiDocBench.php
+++ b/benchmark/DriverBench/MultiDocBench.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace MongoDB\Benchmark\DriverBench;
+
+use Generator;
+use MongoDB\Benchmark\Fixtures\Data;
+use MongoDB\Benchmark\Utils;
+use MongoDB\BSON\Document;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\ParamProviders;
+
+use function array_fill;
+use function file_get_contents;
+
+/**
+ * For accurate results, run benchmarks on a standalone server.
+ *
+ * @see https://github.com/mongodb/specifications/blob/ddfc8b583d49aaf8c4c19fa01255afb66b36b92e/source/benchmarking/benchmarking.rst#multi-doc-benchmarks
+ */
+#[BeforeMethods('prepareDatabase')]
+class MultiDocBench
+{
+    public function prepareDatabase(): void
+    {
+        Utils::getCollection()->drop();
+    }
+
+    /**
+     * @see https://github.com/mongodb/specifications/blob/master/source/benchmarking/benchmarking.rst#find-many-and-empty-the-cursor
+     * @param array{options: array} $params
+     */
+    #[BeforeMethods('setupFindMany')]
+    #[ParamProviders('provideFindManyParams')]
+    public function benchFindMany(array $params): void
+    {
+        $collection = Utils::getCollection();
+
+        // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedForeach
+        // phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed
+        foreach ($collection->find([], $params['options']) as $document);
+    }
+
+    public function setupFindMany(): void
+    {
+        $tweet = Data::readJsonFile(Data::TWEET_FILE_PATH);
+        $documents = array_fill(0, 9_999, $tweet);
+        Utils::getCollection()->insertMany($documents);
+    }
+
+    public static function provideFindManyParams(): Generator
+    {
+        yield 'Driver default typemap' => [
+            'options' => [],
+        ];
+
+        yield 'Raw BSON' => [
+            'options' => ['typeMap' => ['root' => 'bson']],
+        ];
+    }
+
+    /**
+     * @see https://github.com/mongodb/specifications/blob/ddfc8b583d49aaf8c4c19fa01255afb66b36b92e/source/benchmarking/benchmarking.rst#small-doc-bulk-insert
+     * @see https://github.com/mongodb/specifications/blob/ddfc8b583d49aaf8c4c19fa01255afb66b36b92e/source/benchmarking/benchmarking.rst#large-doc-bulk-insert
+     * @param array{documents: array} $params
+     */
+    #[BeforeMethods('setupBulkInsert')]
+    #[ParamProviders('provideBulkInsertParams')]
+    public function benchBulkInsert(array $params): void
+    {
+        $collection = Utils::getCollection();
+
+        // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedForeach
+        // phpcs:ignore Generic.ControlStructures.InlineControlStructure.NotAllowed
+        $collection->insertMany($params['documents']);
+    }
+
+    public function setupBulkInsert(): void
+    {
+        $collectionName = Utils::getCollection()->getCollectionName();
+        Utils::getClient()
+            ->selectDatabase(Utils::getDatabase())
+            ->createCollection($collectionName);
+    }
+
+    public static function provideBulkInsertParams(): Generator
+    {
+        yield 'Small doc' => [
+            'documents' => array_fill(0, 9_999, Data::readJsonFile(Data::SMALL_FILE_PATH)),
+        ];
+
+        yield 'Small BSON doc' => [
+            'documents' => array_fill(0, 9_999, Document::fromJSON(file_get_contents(Data::SMALL_FILE_PATH))),
+        ];
+
+        yield 'Large doc' => [
+            'documents' => array_fill(0, 9, Data::readJsonFile(Data::LARGE_FILE_PATH)),
+        ];
+
+        yield 'Large BSON doc' => [
+            'documents' => array_fill(0, 9, Document::fromJSON(file_get_contents(Data::LARGE_FILE_PATH))),
+        ];
+    }
+}

--- a/benchmark/Extension/EnvironmentProvider.php
+++ b/benchmark/Extension/EnvironmentProvider.php
@@ -60,7 +60,7 @@ class EnvironmentProvider implements ProviderInterface
     private function getBuildInfo(Manager $manager): array
     {
         $buildInfo = $manager->executeCommand(
-            Utils::getDatabase(),
+            Utils::getDatabaseName(),
             new Command(['buildInfo' => 1]),
             new ReadPreference(ReadPreference::PRIMARY),
         )->toArray()[0];

--- a/benchmark/Fixtures/Data.php
+++ b/benchmark/Fixtures/Data.php
@@ -3,7 +3,11 @@
 namespace MongoDB\Benchmark\Fixtures;
 
 use function file_get_contents;
+use function fopen;
+use function fwrite;
 use function json_decode;
+use function rewind;
+use function str_repeat;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -16,5 +20,19 @@ final class Data
     public static function readJsonFile(string $path): array
     {
         return json_decode(file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Generates an in-memory stream of the given size.
+     *
+     * @return resource
+     */
+    public static function getStream(int $size)
+    {
+        $stream = fopen('php://memory', 'w+');
+        fwrite($stream, str_repeat("\0", $size));
+        rewind($stream);
+
+        return $stream;
     }
 }

--- a/benchmark/Utils.php
+++ b/benchmark/Utils.php
@@ -4,22 +4,29 @@ namespace MongoDB\Benchmark;
 
 use MongoDB\Client;
 use MongoDB\Collection;
+use MongoDB\Database;
 
 use function getenv;
 
 final class Utils
 {
     private static ?Client $client;
+    private static ?Database $database;
     private static ?Collection $collection;
 
     public static function getClient(): Client
     {
-        return self::$client ??= self::createClient();
+        return self::$client ??= new Client(self::getUri());
+    }
+
+    public static function getDatabase(): Database
+    {
+        return self::$database ??= self::getClient()->selectDatabase(self::getDatabaseName());
     }
 
     public static function getCollection(): Collection
     {
-        return self::$collection ??= self::createCollection();
+        return self::$collection ??= self::getDatabase()->selectCollection(self::getCollectionName());
     }
 
     public static function getUri(): string
@@ -27,18 +34,13 @@ final class Utils
         return getenv('MONGODB_URI') ?: 'mongodb://localhost:27017/';
     }
 
-    public static function getDatabase(): string
+    public static function getDatabaseName(): string
     {
         return getenv('MONGODB_DATABASE') ?: 'phplib_test';
     }
 
-    private static function createClient(): Client
+    public static function getCollectionName(): string
     {
-        return new Client(self::getUri());
-    }
-
-    private static function createCollection(): Collection
-    {
-        return self::getClient()->selectCollection(self::getDatabase(), 'perftest');
+        return 'perftest';
     }
 }

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -5,6 +5,7 @@
     "runner.bootstrap": "vendor/autoload.php",
     "runner.file_pattern": "*Bench.php",
     "runner.path": "benchmark",
+    "runner.php_config": { "memory_limit": "1G" },
     "runner.iterations": 3,
     "runner.revs": 10
 }


### PR DESCRIPTION
Fix [PHPLIB-1236](https://jira.mongodb.org/browse/PHPLIB-1236)

https://github.com/mongodb/specifications/blob/master/source/benchmarking/benchmarking.rst#multi-doc-benchmarks

- [x] Find many and empty the cursor
- [x] Small doc bulk insert
- [x] Large doc bulk insert
- [x] GridFS upload
- [x] GridFS download

```
\MongoDB\Benchmark\DriverBench\MultiDocBench

    benchFindMany # Driver default typemap..I2 - Mo133.957ms (±0.20%)
    benchFindMany # Raw BSON................I2 - Mo17.109ms (±0.86%)
    benchBulkInsert # Small doc.............I2 - Mo53.328ms (±0.25%)
    benchBulkInsert # Small BSON doc........I2 - Mo53.180ms (±0.36%)
    benchBulkInsert # Large doc.............I2 - Mo242.104ms (±2.10%)
    benchBulkInsert # Large BSON doc........I2 - Mo239.291ms (±0.63%)

\MongoDB\Benchmark\DriverBench\GridFSBench

    benchUpload.............................I2 - Mo31.448ms (±0.47%)
    benchDownload...........................I2 - Mo67.099ms (±11.71%)

Subjects: 4, Assertions: 0, Failures: 0, Errors: 0
```