### PR TITLE
PHP 7.3 polyfill is not necessary because PHP 7.4 is required

### DIFF
--- a/benchmark/composer.json
+++ b/benchmark/composer.json
@@ -1,26 +1,30 @@
 {
-  "name": "mongodb/mongodb-benchmark",
-  "type": "project",
-  "repositories": [
-    {
-      "type": "path",
-      "url": "../",
-      "symlink": true
+    "name": "mongodb/mongodb-benchmark",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../",
+            "symlink": true
+        }
+    ],
+    "replace": {
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*"
+    },
+    "require": {
+        "php": ">=8.1",
+        "ext-pcntl": "*",
+        "amphp/parallel-functions": "^1.1",
+        "mongodb/mongodb": "@dev",
+        "phpbench/phpbench": "^1.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "MongoDB\\Benchmark\\": "src/"
+        }
+    },
+    "scripts": {
+        "benchmark": "phpbench run --report=aggregate"
     }
-  ],
-  "require": {
-    "php": ">=8.1",
-    "ext-pcntl": "*",
-    "amphp/parallel-functions": "^1.1",
-    "mongodb/mongodb": "@dev",
-    "phpbench/phpbench": "^1.2"
-  },
-  "autoload": {
-    "psr-4": {
-      "MongoDB\\Benchmark\\": "src/"
-    }
-  },
-  "scripts": {
-    "benchmark": "phpbench run --report=aggregate"
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "ext-json": "*",
         "ext-mongodb": "^1.16.0",
         "jean85/pretty-package-versions": "^2.0.1",
-        "symfony/polyfill-php73": "^1.27",
         "symfony/polyfill-php80": "^1.27",
         "symfony/polyfill-php81": "^1.27"
     },


### PR DESCRIPTION
I think it has been forgotten in https://github.com/mongodb/mongo-php-library/pull/1128

- PHP 7.4 don't need PHP.3 polyfill
- the function `get_debug_type` from PHP 8.0 polyfill is used
- the function `array_is_list` from PHP 8.1 polyfill is used

The benchmark sub-project requires PHP 8.1, I disable the installation of this polyfills.