### PR TITLE
PHPLIB-1237 Implement Parallel Multi File Export Bench

### DIFF
--- a/benchmark/composer.json
+++ b/benchmark/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=8.1",
         "ext-pcntl": "*",
-        "amphp/parallel-functions": "^1.1",
+        "amphp/parallel": "^2.2",
         "mongodb/mongodb": "@dev",
         "phpbench/phpbench": "^1.2"
     },
@@ -26,5 +26,8 @@
     },
     "scripts": {
         "benchmark": "phpbench run --report=aggregate"
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/benchmark/src/DriverBench/Amp/ExportFileTask.php
+++ b/benchmark/src/DriverBench/Amp/ExportFileTask.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MongoDB\Benchmark\DriverBench\Amp;
+
+use Amp\Cancellation;
+use Amp\Parallel\Worker\Task;
+use Amp\Sync\Channel;
+use MongoDB\Benchmark\DriverBench\ParallelMultiFileExportBench;
+
+final class ExportFileTask implements Task
+{
+    public function __construct(
+        private string|array $files,
+        private array $filter = [],
+        private array $options = [],
+    ) {
+    }
+
+    public function run(Channel $channel, Cancellation $cancellation): mixed
+    {
+        ParallelMultiFileExportBench::exportFile($this->files, $this->filter, $this->options);
+
+        return $this->files;
+    }
+}

--- a/benchmark/src/DriverBench/Amp/ImportFileTask.php
+++ b/benchmark/src/DriverBench/Amp/ImportFileTask.php
@@ -10,14 +10,14 @@ use MongoDB\Benchmark\DriverBench\ParallelMultiFileImportBench;
 final class ImportFileTask implements Task
 {
     public function __construct(
-        private string $file,
+        private array $files,
     ) {
     }
 
     public function run(Channel $channel, Cancellation $cancellation): mixed
     {
-        ParallelMultiFileImportBench::importFile($this->file);
+        ParallelMultiFileImportBench::importFile($this->files);
 
-        return null;
+        return $this->files;
     }
 }

--- a/benchmark/src/DriverBench/Amp/ImportFileTask.php
+++ b/benchmark/src/DriverBench/Amp/ImportFileTask.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MongoDB\Benchmark\DriverBench\Amp;
+
+use Amp\Cancellation;
+use Amp\Parallel\Worker\Task;
+use Amp\Sync\Channel;
+use MongoDB\Benchmark\DriverBench\ParallelMultiFileImportBench;
+
+final class ImportFileTask implements Task
+{
+    public function __construct(
+        private string $file,
+    ) {
+    }
+
+    public function run(Channel $channel, Cancellation $cancellation): mixed
+    {
+        ParallelMultiFileImportBench::importFile($this->file);
+
+        return null;
+    }
+}

--- a/benchmark/src/DriverBench/BSONMicroBench.php
+++ b/benchmark/src/DriverBench/BSONMicroBench.php
@@ -16,6 +16,7 @@ use function file_get_contents;
  */
 final class BSONMicroBench
 {
+    /** @param array{document:Document} $params */
     #[ParamProviders('provideParams')]
     public function benchEncoding(array $params): void
     {
@@ -25,12 +26,13 @@ final class BSONMicroBench
         }
     }
 
+    /** @param array{bson:string} $params */
     #[ParamProviders('provideParams')]
     public function benchDecoding(array $params): void
     {
-        $document = $params['document'];
+        $bson = $params['bson'];
         for ($i = 0; $i < 10_000; $i++) {
-            Document::fromBSON($document);
+            Document::fromBSON($bson);
         }
     }
 

--- a/benchmark/src/DriverBench/ParallelMultiFileImportBench.php
+++ b/benchmark/src/DriverBench/ParallelMultiFileImportBench.php
@@ -97,13 +97,15 @@ final class ParallelMultiFileImportBench
             $docs = [];
             // Read file contents into BSON documents
             $fh = fopen($file, 'r');
-            while (($line = fgets($fh)) !== false) {
-                if ($line !== '') {
-                    $docs[] = Document::fromJSON($line);
+            try {
+                while (($line = fgets($fh)) !== false) {
+                    if ($line !== '') {
+                        $docs[] = Document::fromJSON($line);
+                    }
                 }
+            } finally {
+                fclose($fh);
             }
-
-            fclose($fh);
 
             // Insert documents in bulk
             $collection->insertMany($docs);
@@ -197,11 +199,13 @@ final class ParallelMultiFileImportBench
         $bulkWrite = new BulkWrite();
         foreach ((array) $files as $file) {
             $fh = fopen($file, 'r');
-            while (($line = stream_get_line($fh, 10_000, "\n")) !== false) {
-                $bulkWrite->insert(Document::fromJSON($line));
+            try {
+                while (($line = stream_get_line($fh, 10_000, "\n")) !== false) {
+                    $bulkWrite->insert(Document::fromJSON($line));
+                }
+            } finally {
+                fclose($fh);
             }
-
-            fclose($fh);
         }
 
         Utils::getClient()->getManager()->executeBulkWrite($namespace, $bulkWrite);


### PR DESCRIPTION
Fix [PHPLIB-1237](https://jira.mongodb.org/browse/PHPLIB-1237)
Follows https://github.com/mongodb/mongo-php-library/pull/1166

Parallel Benchmarks specs: [LDJSON multi-file export](https://github.com/mongodb/specifications/blob/e09b41df206f9efaa36ba4c332c47d04ddb7d6d1/source/benchmarking/benchmarking.rst#ldjson-multi-file-export)

Upgrade to AMPHP with Fibers.

Implementations:

- 🥇 Using multiple forked threads
- 🥈 Using `amphp/parallel` with worker pool
- 🥉 Using a single process 

The scenario have 3 critical steps that I tried to optimize:

## Find documents
I grouped files by chunks to perform a single query for several files and reduce server round trips.

I had to use `limit`/`skip` to paginate on results. I tried an aggregation pipeline to get the first ID of each chunk, but it takes ~600ms, which is too significant with no benefit on the query.

<details>
<summary>Aggregation pipeline to get the first ID of each chunk</summary>

```php
function getFirstIdOfEachChunk(int $chunkSize = 5_000): array
{
    $ids = [];
    $cursor = Utils::getCollection()->aggregate([
        ['$sort' => ['_id' => 1]],
        // We work with the _id field only
        ['$project' => ['_id' => 1]],
        // Add a rank field to each document
        ['$setWindowFields' => ['sortBy' => ['_id' => 1], 'output' => ['rank' => ['$rank' => (object) []]]]],
        // Get 1 id every 5000
        ['$match' => ['rank' => ['$mod' => [$chunkSize, 1]]]],
    ], [
        'typeMap' => ['root' => 'bson'],
    ]);

    $ids = [];
    foreach ($cursor as $document) {
        $ids[] = $document->get('_id');
    }

    return $ids;
}
```
</details>

## Encoding documents to JSON

Initially I used the methods of `MongoDB\BSON\Document`: `toCanonicalExtendedJSON` and `toRelaxedExtendedJSON` but this methods are slow compared to `json_encode`. And they don't return the expected document format.

Even if the `bson` typeMap is faster for the query, I had to use `array` typeMap to convert to JSON. `json_encode($document->toPHP())` is slower than encoding an array.

## Writing the file
I tested several approaches for writing the file. One `fwrite` per document was 1.1x slower than a `file_put_contents` of the whole file. I didn't see any benefit of doing async write using [`stream_set_blocking`](https://www.php.net/manual/en/function.stream-set-blocking.php). Tried AMP's [`WritableStream`](https://amphp.org/byte-stream#writablestream) but it was much slower. And in any case, it's not what takes the longest overall. 

