### PR TITLE
PHPLIB-1247 Don't drop the database in `ExamplesTest`

### DIFF
--- a/examples/atlas-search.php
+++ b/examples/atlas-search.php
@@ -81,7 +81,7 @@ $collection->createSearchIndex(
     ['name' => 'default'],
 );
 
-// Wait for the index to be ready.
+// Wait for the index to be queryable.
 wait(function () use ($collection) {
     echo '.';
     foreach ($collection->listSearchIndexes() as $index) {

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -24,8 +24,6 @@ final class ExamplesTest extends FunctionalTestCase
         if ($this->isApiVersionRequired()) {
             $this->markTestSkipped('Examples are not tested when the server requires specifying an API version.');
         }
-
-        self::createTestClient()->dropDatabase('test');
     }
 
     /** @dataProvider provideExamples */


### PR DESCRIPTION
Fix [PHPLIB-1247](https://jira.mongodb.org/browse/PHPLIB-1247)

This operation is not allowed on Atlas and each example takes care of cleaning the server state before creating objects.