### PR TITLE
PHPLIB-1259 Enable Opcache and add timeout on benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,6 +57,7 @@ jobs:
           coverage: "none"
           extensions: "mongodb-${{ ENV.DRIVER_VERSION }}"
           php-version: "${{ env.PHP_VERSION }}"
+          ini-values: "extension=opcache.so, opcache.enable_cli=1, opcache.file_cache=${{ runner.temp }}/php-opcache"
 
       - name: "Show driver information"
         run: "php --ri mongodb"

--- a/benchmark/phpbench.json.dist
+++ b/benchmark/phpbench.json.dist
@@ -5,6 +5,7 @@
     "runner.bootstrap": "vendor/autoload.php",
     "runner.file_pattern": "*Bench.php",
     "runner.path": "src",
+    "runner.timeout": 60,
     "runner.php_config": { "memory_limit": "1G" },
     "runner.iterations": 3
 }


### PR DESCRIPTION
Fix PHPLIB-1259

> I guess opcache is just one of the bigger things that can affect performance. ([quote](https://github.com/phpbench/phpbench/issues/637))

Also adding a timeout.

