### PR TITLE
PHPLIB-1137: Mark is_document() as internal

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -192,6 +192,7 @@ function get_encrypted_fields_from_server(string $databaseName, string $collecti
  * This method returns true for any array or object, but specifically excludes
  * BSON PackedArray instances
  *
+ * @internal
  * @param mixed $document
  */
 function is_document($document): bool


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1137

This was missed in 88731a55c3dfd97b38ce0360f53b5b2674209754