### PR TITLE
PHPLIB-476: Consider transaction readPreference in select_server

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -200,7 +200,7 @@ class Client
             $options['typeMap'] = $this->typeMap;
         }
 
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -260,7 +260,7 @@ class Collection
 
         $operation = new BulkWrite($this->databaseName, $this->collectionName, $operations, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -362,7 +362,7 @@ class Collection
 
         $operation = new CreateIndexes($this->databaseName, $this->collectionName, $indexes, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -418,7 +418,7 @@ class Collection
     public function createSearchIndexes(array $indexes, array $options = []): array
     {
         $operation = new CreateSearchIndexes($this->databaseName, $this->collectionName, $indexes, $options);
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         return $operation->execute($server);
     }
@@ -441,7 +441,7 @@ class Collection
 
         $operation = new DeleteMany($this->databaseName, $this->collectionName, $filter, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -462,7 +462,7 @@ class Collection
 
         $operation = new DeleteOne($this->databaseName, $this->collectionName, $filter, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -503,7 +503,7 @@ class Collection
         $options = $this->inheritWriteOptions($options);
         $options = $this->inheritTypeMap($options);
 
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         if (! isset($options['encryptedFields'])) {
             $options['encryptedFields'] = get_encrypted_fields_from_driver($this->databaseName, $this->collectionName, $this->manager)
@@ -541,7 +541,7 @@ class Collection
 
         $operation = new DropIndexes($this->databaseName, $this->collectionName, $indexName, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -561,7 +561,7 @@ class Collection
 
         $operation = new DropIndexes($this->databaseName, $this->collectionName, '*', $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -577,7 +577,7 @@ class Collection
     public function dropSearchIndex(string $name, array $options = []): void
     {
         $operation = new DropSearchIndex($this->databaseName, $this->collectionName, $name);
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         $operation->execute($server);
     }
@@ -690,7 +690,7 @@ class Collection
 
         $operation = new FindOneAndDelete($this->databaseName, $this->collectionName, $filter, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -720,7 +720,7 @@ class Collection
 
         $operation = new FindOneAndReplace($this->databaseName, $this->collectionName, $filter, $replacement, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -750,7 +750,7 @@ class Collection
 
         $operation = new FindOneAndUpdate($this->databaseName, $this->collectionName, $filter, $update, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -854,7 +854,7 @@ class Collection
 
         $operation = new InsertMany($this->databaseName, $this->collectionName, $documents, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -875,7 +875,7 @@ class Collection
 
         $operation = new InsertOne($this->databaseName, $this->collectionName, $document, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -949,7 +949,7 @@ class Collection
 
         $operation = new MapReduce($this->databaseName, $this->collectionName, $map, $reduce, $out, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -975,7 +975,7 @@ class Collection
 
         $operation = new RenameCollection($this->databaseName, $this->collectionName, $toDatabaseName, $toCollectionName, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -998,7 +998,7 @@ class Collection
 
         $operation = new ReplaceOne($this->databaseName, $this->collectionName, $filter, $replacement, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -1020,7 +1020,7 @@ class Collection
 
         $operation = new UpdateMany($this->databaseName, $this->collectionName, $filter, $update, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -1042,7 +1042,7 @@ class Collection
 
         $operation = new UpdateOne($this->databaseName, $this->collectionName, $filter, $update, $options);
 
-        return $operation->execute(select_server($this->manager, $options));
+        return $operation->execute(select_server_for_write($this->manager, $options));
     }
 
     /**
@@ -1059,7 +1059,7 @@ class Collection
     public function updateSearchIndex(string $name, $definition, array $options = []): void
     {
         $operation = new UpdateSearchIndex($this->databaseName, $this->collectionName, $name, $definition, $options);
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         $operation->execute($server);
     }

--- a/src/Database.php
+++ b/src/Database.php
@@ -282,7 +282,7 @@ class Database
             ? new CreateEncryptedCollection($this->databaseName, $collectionName, $options)
             : new CreateCollection($this->databaseName, $collectionName, $options);
 
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         return $operation->execute($server);
     }
@@ -318,7 +318,7 @@ class Database
         }
 
         $operation = new CreateEncryptedCollection($this->databaseName, $collectionName, $options);
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         try {
             $operation->createDataKeys($clientEncryption, $kmsProvider, $masterKey, $encryptedFields);
@@ -346,7 +346,7 @@ class Database
             $options['typeMap'] = $this->typeMap;
         }
 
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
@@ -374,7 +374,7 @@ class Database
             $options['typeMap'] = $this->typeMap;
         }
 
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
@@ -502,7 +502,7 @@ class Database
             $options['typeMap'] = $this->typeMap;
         }
 
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
@@ -536,7 +536,7 @@ class Database
             $options['typeMap'] = $this->typeMap;
         }
 
-        $server = select_server($this->manager, $options);
+        $server = select_server_for_write($this->manager, $options);
 
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;

--- a/tests/Functions/SelectServerFunctionalTest.php
+++ b/tests/Functions/SelectServerFunctionalTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace MongoDB\Tests\Functions;
+
+use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\Server;
+use MongoDB\Tests\FunctionalTestCase;
+
+use function MongoDB\select_server;
+
+class SelectServerFunctionalTest extends FunctionalTestCase
+{
+    /** @dataProvider providePinnedOptions */
+    public function testSelectServerPrefersPinnedServer(array $options): void
+    {
+        $this->skipIfTransactionsAreNotSupported();
+
+        if (! $this->isShardedCluster()) {
+            $this->markTestSkipped('Pinning requires a sharded cluster');
+        }
+
+        if ($this->isLoadBalanced()) {
+            $this->markTestSkipped('libmongoc does not pin for load-balanced topology');
+        }
+
+        /* By default, the Manager under test is created with a single-mongos
+         * URI. Explicitly create a Client with multiple mongoses. */
+        $client = static::createTestClient(static::getUri(true));
+
+        // Collection must be created before the transaction starts
+        $this->createCollection($this->getDatabaseName(), $this->getCollectionName());
+
+        $session = $client->startSession();
+        $session->startTransaction();
+
+        $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+        $collection->find([], ['session' => $session]);
+
+        $this->assertTrue($session->isInTransaction());
+        $this->assertInstanceOf(Server::class, $session->getServer(), 'Session is pinned');
+        $this->assertEquals($session->getServer(), select_server($client->getManager(), ['session' => $session]));
+    }
+
+    public static function providePinnedOptions(): array
+    {
+        return [
+            [['readPreference' => new ReadPreference(ReadPreference::PRIMARY_PREFERRED)]],
+            [[]],
+        ];
+    }
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-476

This also refactors the conditionals in extract_session_from_options and extract_read_preference_from_options to improve readability.

select_server() previously did not consider the read preference of an active transaction. This isn't very significant, as transactions require a primary read preference, but it is correct to do so.