### PR TITLE
Increase task timeouts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -11,7 +11,7 @@ pre_error_fails_task: true
 
 # Protect ourselves against rogue test case that runs forever. Tasks are killed after 10 minutes, which shouldn't occur
 # under normal circumstances.
-exec_timeout_secs: 600
+exec_timeout_secs: 1200
 
 # These pre and post rules apply to all tasks not part of a task group, which should only ever be tests against local
 # MongoDB instances. All other tasks that require special preparation should be run from within a task group

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -9,7 +9,7 @@ command_type: system
 # Fail builds when pre tasks fail.
 pre_error_fails_task: true
 
-# Protect ourselves against rogue test case that runs forever. Tasks are killed after 10 minutes, which shouldn't occur
+# Protect ourselves against rogue test case that runs forever. Tasks are killed after 20 minutes, which shouldn't occur
 # under normal circumstances.
 exec_timeout_secs: 1200
 

--- a/.evergreen/config/test-tasks.yml
+++ b/.evergreen/config/test-tasks.yml
@@ -1,5 +1,6 @@
 tasks:
   - name: "test-atlas"
+    exec_timeout_secs: 1800
     commands:
       - func: "start kms servers"
       - func: "run tests"
@@ -8,6 +9,7 @@ tasks:
 
   - name: "test-serverless"
     tags: ["serverless"]
+    exec_timeout_secs: 1800
     commands:
       - func: "create serverless instance"
       - func: "start kms servers"


### PR DESCRIPTION
Follow-Up to PHPLIB-1260.

The default `exec_timeout_secs` of 10 minutes is too short, as sharded tests run significantly longer. 20 minutes seem more appropriate before killing tasks. In addition to that, the Atlas and Serverless tests already run close to 20 minutes, so those tasks get a 30 minute timeout.