### PR TITLE
PHPLIB-1187: Run benchmark on Evergreen

### DIFF
--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -483,6 +483,7 @@ functions:
         args:
           - .evergreen/compile-extension.sh
 
+  # Run benchmarks. The filter skips the benchAmpWorkers subjects as they fail due to socket exceptions
   "run benchmark":
     - command: shell.exec
       type: test
@@ -493,4 +494,4 @@ functions:
           export PATH="${PHP_PATH}/bin:$PATH"
           
           php ../composer.phar install --no-suggest
-          vendor/bin/phpbench run --report=env --report=evergreen --report=aggregate --output html
+          vendor/bin/phpbench run --report=env --report=evergreen --report=aggregate --output html --filter='bench(?!AmpWorkers)'

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -492,9 +492,5 @@ functions:
           ${PREPARE_SHELL}
           export PATH="${PHP_PATH}/bin:$PATH"
           
-          php -i | grep memory_limit
-          
-          lscpu
-          
           php ../composer.phar install --no-suggest
-          vendor/bin/phpbench run --report=env --report=aggregate --output html
+          vendor/bin/phpbench run --report=env --report=evergreen --report=aggregate --output html

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -482,3 +482,19 @@ functions:
         binary: bash
         args:
           - .evergreen/compile-extension.sh
+
+  "run benchmark":
+    - command: shell.exec
+      type: test
+      params:
+        working_dir: "src/benchmark"
+        script: |
+          ${PREPARE_SHELL}
+          export PATH="${PHP_PATH}/bin:$PATH"
+          
+          php -i | grep memory_limit
+          
+          lscpu
+          
+          php ../composer.phar install --no-suggest
+          vendor/bin/phpbench run --report=env --report=aggregate --output html

--- a/.evergreen/config/php.ini
+++ b/.evergreen/config/php.ini
@@ -1,1 +1,2 @@
 extension=mongodb.so
+memory_limit=-1

--- a/.evergreen/config/test-tasks.yml
+++ b/.evergreen/config/test-tasks.yml
@@ -20,3 +20,12 @@ tasks:
     commands:
       - func: "bootstrap mongohoused"
       - func: "run atlas data lake test"
+
+  - name: "run-benchmark"
+    exec_timeout_secs: 7200
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "server"
+          MONGODB_VERSION: "v6.0-perf"
+      - func: "run benchmark"

--- a/.evergreen/config/test-tasks.yml
+++ b/.evergreen/config/test-tasks.yml
@@ -22,7 +22,7 @@ tasks:
       - func: "run atlas data lake test"
 
   - name: "run-benchmark"
-    exec_timeout_secs: 7200
+    exec_timeout_secs: 3600
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:

--- a/.evergreen/config/test-tasks.yml
+++ b/.evergreen/config/test-tasks.yml
@@ -29,3 +29,6 @@ tasks:
           TOPOLOGY: "server"
           MONGODB_VERSION: "v6.0-perf"
       - func: "run benchmark"
+      - command: perf.send
+        params:
+          file: src/benchmark/.phpbench/results.json

--- a/.evergreen/config/test-variants.yml
+++ b/.evergreen/config/test-variants.yml
@@ -114,3 +114,18 @@ buildvariants:
     tasks:
       - "test_atlas_task_group"
       - ".csfle"
+
+  # Run benchmarks
+  - name: benchmark-rhel90
+    tags: ["benchmark", "rhel", "x64"]
+    display_name: "Benchmark: RHEL 9.0, MongoDB 6.0"
+    run_on: rhel90-dbx-perf-large
+    expansions:
+      FETCH_BUILD_VARIANT: "build-rhel90"
+      FETCH_BUILD_TASK: "build-php-8.2"
+      PHP_VERSION: "8.2"
+    depends_on:
+      - variant: "build-rhel90"
+        name: "build-php-8.2"
+    tasks:
+      - "run-benchmark"

--- a/benchmark/phpbench.json.dist
+++ b/benchmark/phpbench.json.dist
@@ -6,6 +6,5 @@
     "runner.file_pattern": "*Bench.php",
     "runner.path": "src",
     "runner.php_config": { "memory_limit": "1G" },
-    "runner.iterations": 3,
-    "runner.revs": 10
+    "runner.iterations": 3
 }

--- a/benchmark/src/BSON/DocumentBench.php
+++ b/benchmark/src/BSON/DocumentBench.php
@@ -5,6 +5,7 @@ namespace MongoDB\Benchmark\BSON;
 use MongoDB\Benchmark\Fixtures\Data;
 use MongoDB\BSON\Document;
 use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Revs;
 use PhpBench\Attributes\Warmup;
 use stdClass;
 
@@ -12,6 +13,7 @@ use function file_get_contents;
 use function iterator_to_array;
 
 #[BeforeMethods('prepareData')]
+#[Revs(10)]
 #[Warmup(1)]
 final class DocumentBench
 {

--- a/benchmark/src/BSON/PackedArrayBench.php
+++ b/benchmark/src/BSON/PackedArrayBench.php
@@ -5,12 +5,14 @@ namespace MongoDB\Benchmark\BSON;
 use MongoDB\Benchmark\Fixtures\Data;
 use MongoDB\BSON\PackedArray;
 use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Revs;
 use PhpBench\Attributes\Warmup;
 
 use function array_values;
 use function iterator_to_array;
 
 #[BeforeMethods('prepareData')]
+#[Revs(10)]
 #[Warmup(1)]
 final class PackedArrayBench
 {

--- a/benchmark/src/DriverBench/ParallelMultiFileExportBench.php
+++ b/benchmark/src/DriverBench/ParallelMultiFileExportBench.php
@@ -72,15 +72,15 @@ final class ParallelMultiFileExportBench
      * Using a single thread to export multiple files.
      * By executing a single Find command for multiple files, we can reduce the number of roundtrips to the server.
      *
-     * @param array{chunk:int} $params
+     * @param array{chunkSize:int} $params
      */
     #[ParamProviders(['provideChunkParams'])]
     public function benchSequential(array $params): void
     {
-        foreach (array_chunk(self::getFileNames(), $params['chunk']) as $i => $files) {
+        foreach (array_chunk(self::getFileNames(), $params['chunkSize']) as $i => $files) {
             self::exportFile($files, [], [
-                'limit' => 5_000 * $params['chunk'],
-                'skip' => 5_000 * $params['chunk'] * $i,
+                'limit' => 5_000 * $params['chunkSize'],
+                'skip' => 5_000 * $params['chunkSize'] * $i,
             ]);
         }
     }
@@ -101,12 +101,12 @@ final class ParallelMultiFileExportBench
         Utils::reset();
 
         // Create a child process for each chunk of files
-        foreach (array_chunk(self::getFileNames(), $params['chunk']) as $i => $files) {
+        foreach (array_chunk(self::getFileNames(), $params['chunkSize']) as $i => $files) {
             $pid = pcntl_fork();
             if ($pid === 0) {
                 self::exportFile($files, [], [
-                    'limit' => 5_000 * $params['chunk'],
-                    'skip' => 5_000 * $params['chunk'] * $i,
+                    'limit' => 5_000 * $params['chunkSize'],
+                    'skip' => 5_000 * $params['chunkSize'] * $i,
                 ]);
 
                 // Exit the child process
@@ -131,21 +131,21 @@ final class ParallelMultiFileExportBench
     /**
      * Using amphp/parallel with worker pool
      *
-     * @param array{chunk:int} $params
+     * @param array{chunkSize:int} $params
      */
     #[ParamProviders(['provideChunkParams'])]
     public function benchAmpWorkers(array $params): void
     {
-        $workerPool = new ContextWorkerPool(ceil(100 / $params['chunk']), new ContextWorkerFactory());
+        $workerPool = new ContextWorkerPool(ceil(100 / $params['chunkSize']), new ContextWorkerFactory());
 
         $futures = [];
-        foreach (array_chunk(self::getFileNames(), $params['chunk']) as $i => $files) {
+        foreach (array_chunk(self::getFileNames(), $params['chunkSize']) as $i => $files) {
             $futures[] = $workerPool->submit(
                 new ExportFileTask(
                     files: $files,
                     options: [
-                        'limit' => 5_000 * $params['chunk'],
-                        'skip' => 5_000 * $params['chunk'] * $i,
+                        'limit' => 5_000 * $params['chunkSize'],
+                        'skip' => 5_000 * $params['chunkSize'] * $i,
                     ],
                 ),
             )->getFuture();
@@ -158,13 +158,9 @@ final class ParallelMultiFileExportBench
 
     public static function provideChunkParams(): Generator
     {
-        yield 'by 1' => ['chunk' => 1];
-        yield 'by 2' => ['chunk' => 2];
-        yield 'by 4' => ['chunk' => 4];
-        yield 'by 8' => ['chunk' => 8];
-        yield 'by 13' => ['chunk' => 13];
-        yield 'by 20' => ['chunk' => 20];
-        yield 'by 100' => ['chunk' => 100];
+        yield '100 chunks' => ['chunkSize' => 1];
+        yield '25 chunks' => ['chunkSize' => 4];
+        yield '10 chunks' => ['chunkSize' => 10];
     }
 
     /**

--- a/benchmark/src/DriverBench/ParallelMultiFileExportBench.php
+++ b/benchmark/src/DriverBench/ParallelMultiFileExportBench.php
@@ -15,7 +15,6 @@ use PhpBench\Attributes\AfterMethods;
 use PhpBench\Attributes\BeforeClassMethods;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\ParamProviders;
-use PhpBench\Attributes\Revs;
 use RuntimeException;
 
 use function array_chunk;
@@ -44,7 +43,6 @@ use function unlink;
 #[AfterClassMethods('afterClass')]
 #[AfterMethods('afterIteration')]
 #[Iterations(1)]
-#[Revs(1)]
 final class ParallelMultiFileExportBench
 {
     public static function beforeClass(): void

--- a/benchmark/src/DriverBench/ParallelMultiFileImportBench.php
+++ b/benchmark/src/DriverBench/ParallelMultiFileImportBench.php
@@ -16,7 +16,6 @@ use PhpBench\Attributes\BeforeClassMethods;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\ParamProviders;
-use PhpBench\Attributes\Revs;
 use RuntimeException;
 
 use function array_chunk;
@@ -47,7 +46,6 @@ use function unlink;
 #[AfterClassMethods('afterClass')]
 #[BeforeMethods('beforeIteration')]
 #[Iterations(1)]
-#[Revs(1)]
 final class ParallelMultiFileImportBench
 {
     public static function beforeClass(): void

--- a/benchmark/src/DriverBench/SingleDocBench.php
+++ b/benchmark/src/DriverBench/SingleDocBench.php
@@ -9,7 +9,6 @@ use MongoDB\BSON\Document;
 use MongoDB\Driver\Command;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\ParamProviders;
-use PhpBench\Attributes\Revs;
 
 use function array_map;
 use function file_get_contents;
@@ -45,7 +44,6 @@ final class SingleDocBench
      */
     #[BeforeMethods('beforeFindOneById')]
     #[ParamProviders('provideFindOneByIdParams')]
-    #[Revs(1)]
     public function benchFindOneById(array $params): void
     {
         $collection = Utils::getCollection();
@@ -79,7 +77,6 @@ final class SingleDocBench
      * @param array{document: object|array, repeat: int, options?: array} $params
      */
     #[ParamProviders('provideInsertOneParams')]
-    #[Revs(1)]
     public function benchInsertOne(array $params): void
     {
         $collection = Utils::getCollection();

--- a/benchmark/src/Extension/EvergreenReport.php
+++ b/benchmark/src/Extension/EvergreenReport.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace MongoDB\Benchmark\Extension;
+
+use PhpBench\Compat\SymfonyOptionsResolverCompat;
+use PhpBench\Model\Suite;
+use PhpBench\Model\SuiteCollection;
+use PhpBench\Path\Path;
+use PhpBench\Registry\Config;
+use PhpBench\Report\GeneratorInterface;
+use PhpBench\Report\Model\Reports;
+use RuntimeException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+use function assert;
+use function date;
+use function dirname;
+use function file_exists;
+use function file_put_contents;
+use function json_encode;
+use function mkdir;
+use function sprintf;
+
+use const DATE_ATOM;
+use const JSON_PRETTY_PRINT;
+
+class EvergreenReport implements GeneratorInterface
+{
+    private const PARAM_PATH = 'path';
+
+    public function __construct(private string $cwd)
+    {
+    }
+
+    public function configure(OptionsResolver $options): void
+    {
+        $options->setDefaults([self::PARAM_PATH => '.phpbench/results.json']);
+        $options->setAllowedTypes(self::PARAM_PATH, ['string']);
+
+        SymfonyOptionsResolverCompat::setInfos($options, [self::PARAM_PATH => 'Path to output file']);
+    }
+
+    public function generate(SuiteCollection $collection, Config $config): Reports
+    {
+        $tests = [];
+
+        foreach ($collection as $suite) {
+            assert($suite instanceof Suite);
+            foreach ($suite as $benchmark) {
+                foreach ($benchmark as $subject) {
+                    foreach ($subject->getVariants() as $variant) {
+                        $stats = $variant->getStats()->getStats();
+                        $name = sprintf('%s::%s', $benchmark->getName(), $subject->getName());
+                        if ($variant->getParameterSet()->getName()) {
+                            $name .= '#' . $variant->getParameterSet()->getName();
+                        }
+
+                        $tests[] = [
+                            'info' => ['test_name' => $name],
+                            'created_at' => date(DATE_ATOM),
+                            'completed_at' => date(DATE_ATOM),
+                            'metrics' => [
+                                [
+                                    'name' => 'Avg. Time',
+                                    'type' => 'MEAN',
+                                    'value' => $stats['mean'],
+                                ],
+                                [
+                                    'name' => 'Min. Time',
+                                    'type' => 'MIN',
+                                    'value' => $stats['min'],
+                                ],
+                                [
+                                    'name' => 'Max. Time',
+                                    'type' => 'MAX',
+                                    'value' => $stats['max'],
+                                ],
+                                [
+                                    'name' => 'Std. Deviation',
+                                    'type' => 'STANDARD_DEVIATION',
+                                    'value' => $stats['stdev'],
+                                ],
+                            ],
+                        ];
+                    }
+                }
+            }
+        }
+
+        $outputPath = Path::makeAbsolute($config[self::PARAM_PATH], $this->cwd);
+        $outputDir = dirname($outputPath);
+
+        if (! file_exists($outputDir)) {
+            if (! @mkdir($outputDir, 0777, true)) {
+                throw new RuntimeException(sprintf(
+                    'Could not create directory "%s"',
+                    $outputDir,
+                ));
+            }
+        }
+
+        if (false === file_put_contents($outputPath, json_encode($tests, JSON_PRETTY_PRINT) . "\n")) {
+            throw new RuntimeException(sprintf(
+                'Could not write report to file "%s"',
+                $outputPath,
+            ));
+        }
+
+        // Return an empty report to not confuse the report renderer
+        return Reports::empty();
+    }
+}

--- a/benchmark/src/Extension/MongoDBExtension.php
+++ b/benchmark/src/Extension/MongoDBExtension.php
@@ -4,6 +4,8 @@ namespace MongoDB\Benchmark\Extension;
 
 use PhpBench\DependencyInjection\Container;
 use PhpBench\DependencyInjection\ExtensionInterface;
+use PhpBench\Extension\CoreExtension;
+use PhpBench\Extension\ReportExtension;
 use PhpBench\Extension\RunnerExtension;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -15,6 +17,14 @@ class MongoDBExtension implements ExtensionInterface
             EnvironmentProvider::class,
             fn (Container $container) => new EnvironmentProvider(),
             [RunnerExtension::TAG_ENV_PROVIDER => ['name' => 'mongodb']],
+        );
+
+        $container->register(
+            EvergreenReport::class,
+            fn (Container $container) => new EvergreenReport(
+                $container->getParameter(CoreExtension::PARAM_WORKING_DIR),
+            ),
+            [ReportExtension::TAG_REPORT_GENERATOR => ['name' => 'evergreen']],
         );
     }
 


### PR DESCRIPTION
PHPLIB-1187

This pull request adds a task to run benchmarks on Evergreen. It also uses `perf.send` to store benchmark metrics in CI so we can analyse the performance.

I've also removed a couple of benchmarks in order to bring the benchmark time down. Most recent tests show a 33 minute runtime on Evergreen. I also had to skip the AMP subjects as I ran into issues with socket creation. Since AMP does not perform significantly different from forking, I think it's safe to exclude them from the metrics we collect on Evergreen.