### PR TITLE
PHPLIB-1277: Rename "Reference" to "API Documentation"

### DIFF
--- a/docs/reference.txt
+++ b/docs/reference.txt
@@ -1,6 +1,6 @@
-=========
-Reference
-=========
+=================
+API Documentation
+=================
 
 .. default-domain:: mongodb
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1277

Not going to bother back-porting this, as it wasn't requested in the JIRA ticket and honestly isn't worth the trouble of coordinating deploys for old branches.