### PR TITLE
PHPLIB-1305 Support "codec" option in listSearchIndexes()

### DIFF
--- a/src/Operation/ListSearchIndexes.php
+++ b/src/Operation/ListSearchIndexes.php
@@ -63,7 +63,7 @@ class ListSearchIndexes implements Executable
         $this->databaseName = $databaseName;
         $this->collectionName = $collectionName;
         $this->listSearchIndexesOptions = array_intersect_key($options, ['name' => 1]);
-        $this->aggregateOptions = array_intersect_key($options, ['batchSize' => 1, 'collation' => 1, 'comment' => 1, 'maxTimeMS' => 1, 'readConcern' => 1, 'readPreference' => 1, 'session' => 1, 'typeMap' => 1]);
+        $this->aggregateOptions = array_intersect_key($options, ['batchSize' => 1, 'codec' => 1, 'collation' => 1, 'comment' => 1, 'maxTimeMS' => 1, 'readConcern' => 1, 'readPreference' => 1, 'session' => 1, 'typeMap' => 1]);
 
         $this->aggregate = $this->createAggregate();
     }

--- a/tests/Operation/ListSearchIndexesTest.php
+++ b/tests/Operation/ListSearchIndexesTest.php
@@ -28,6 +28,8 @@ class ListSearchIndexesTest extends TestCase
             $options[][] = ['batchSize' => $value];
         }
 
+        $options[][] = ['codec' => 'foo'];
+
         return $options;
     }
 }


### PR DESCRIPTION
Fix PHPLIB-1305

It's definitely not a place where I would expect a codec to be used, but why not.

I don't think we need to test all the options.