### PR TITLE
Harden explain tests

### DIFF
--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -185,10 +185,11 @@ class AggregateFunctionalTest extends FunctionalTestCase
         $this->assertCount(1, $results);
 
         $checkResult = $results[0];
+
         // Sharded clusters and load balanced servers list plans per shard
-        if (array_key_exists('shards', $results[0])) {
-            $firstShard = array_key_first((array) $results[0]['shards']);
-            $checkResult = (array) $results[0]['shards']->$firstShard;
+        if (array_key_exists('shards', $checkResult)) {
+            $firstShard = array_key_first((array) $checkResult['shards']);
+            $checkResult = (array) $checkResult['shards']->$firstShard;
         }
 
         /* MongoDB 4.2 may optimize aggregate pipelines into queries, which can

--- a/tests/Operation/ExplainFunctionalTest.php
+++ b/tests/Operation/ExplainFunctionalTest.php
@@ -341,7 +341,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $explainOperation = new Explain($this->getDatabaseName(), $operation, ['verbosity' => Explain::VERBOSITY_QUERY, 'typeMap' => ['root' => 'array', 'document' => 'array']]);
         $result = $explainOperation->execute($this->getPrimaryServer());
 
-        $this->assertExplainResult($result, false, false, true);
+        $this->assertExplainResult($result, false, false);
     }
 
     /** @dataProvider provideVerbosityInformation */
@@ -369,7 +369,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    private function assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected, $stagesExpected = false): void
+    private function assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $checkResult = $result;
 
@@ -378,11 +378,10 @@ class ExplainFunctionalTest extends FunctionalTestCase
             $checkResult = $result['shards'][$firstShard];
         }
 
-        if ($stagesExpected) {
-            $this->assertArrayHasKey('stages', $checkResult);
-        } else {
-            $this->assertArrayHasKey('queryPlanner', $checkResult);
-        }
+        $this->assertThat($checkResult, $this->logicalOr(
+            $this->arrayHasKey('stages'),
+            $this->arrayHasKey('queryPlanner'),
+        ));
 
         if ($executionStatsExpected) {
             $this->assertArrayHasKey('executionStats', $checkResult);


### PR DESCRIPTION
Once again, the latest server versions broke explain tests. This commit is yet another attempt at hardening the checks, short of removing the test altogether.