### PR TITLE
Fix wrong data type in codec tutorial

### DIFF
--- a/docs/examples/codecs/handling-data-types/Person.php
+++ b/docs/examples/codecs/handling-data-types/Person.php
@@ -6,7 +6,7 @@ final class Person
 {
     public function __construct(
         public string $name,
-        public readonly DateTime $createdAt = new DateTime(),
+        public readonly DateTimeImmutable $createdAt = new DateTimeImmutable(),
         public readonly ObjectId $id = new ObjectId(),
     ) {
     }

--- a/docs/tutorial/codecs.txt
+++ b/docs/tutorial/codecs.txt
@@ -74,7 +74,12 @@ BSON date and accompanying timezone string. Those same embedded documents can th
 .. literalinclude:: /examples/codecs/handling-data-types/DateTimeCodec.php
    :language: php
 
-This codec can now be leveraged by other codecs handle date fields.
+.. note::
+   When writing a codec, you should be as lenient as possible when it comes to handling data. In this case, the codec
+   handles any ``DateTimeInterface`` when encoding to BSON, as a ``UTCDateTime`` instance can be created from any such
+   object. When decoding data from BSON, it will always decode to a ``DateTimeImmutable`` instance.
+
+This codec can now be leveraged by other codecs that handle date fields.
 
 First, we add a ``createdAt`` field to the ``Person`` class:
 


### PR DESCRIPTION
As is, the example would cause a type error. Thanks @OskarStark for bringing this to our attention!