### PR TITLE
PHPLIB-1315: Fix psalm errors

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.16.0@2897ba636551a8cb61601cc26f6ccfbba6c36591">
   <file src="docs/examples/encryption/csfle-explicit_encryption.php">
     <MixedArgument>
       <code><![CDATA[$clientEncryption->decrypt($document->encryptedField)]]></code>
@@ -148,14 +148,6 @@
       <code><![CDATA[$this->current()]]></code>
     </PossiblyNullArgument>
   </file>
-  <file src="src/Model/CollectionInfo.php">
-    <MixedArgument>
-      <code>$key</code>
-    </MixedArgument>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->info[$key]]]></code>
-    </MixedArrayOffset>
-  </file>
   <file src="src/Model/CollectionInfoCommandIterator.php">
     <MixedArrayAssignment>
       <code><![CDATA[$info['idIndex']['ns']]]></code>
@@ -163,14 +155,6 @@
     <MixedOperand>
       <code><![CDATA[$info['name']]]></code>
     </MixedOperand>
-  </file>
-  <file src="src/Model/DatabaseInfo.php">
-    <MixedArgument>
-      <code>$key</code>
-    </MixedArgument>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->info[$key]]]></code>
-    </MixedArrayOffset>
   </file>
   <file src="src/Model/DatabaseInfoLegacyIterator.php">
     <MixedArgument>
@@ -180,14 +164,6 @@
       <code>int</code>
       <code><![CDATA[key($this->databases)]]></code>
     </MixedReturnTypeCoercion>
-  </file>
-  <file src="src/Model/IndexInfo.php">
-    <MixedArgument>
-      <code>$key</code>
-    </MixedArgument>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->info[$key]]]></code>
-    </MixedArrayOffset>
   </file>
   <file src="src/Model/IndexInput.php">
     <LessSpecificReturnStatement>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -639,6 +639,13 @@
       <code><![CDATA[$this->changeStreamOptions['startAfter']]]></code>
     </MixedReturnStatement>
   </file>
+  <file src="src/PsrLogAdapter.php">
+    <MethodSignatureMismatch>
+      <code>$domain</code>
+      <code>$level</code>
+      <code>$message</code>
+    </MethodSignatureMismatch>
+  </file>
   <file src="src/UpdateResult.php">
     <MixedAssignment>
       <code>$id</code>

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -147,39 +147,41 @@ class CollectionInfo implements ArrayAccess
      * Check whether a field exists in the collection information.
      *
      * @see https://php.net/arrayaccess.offsetexists
-     * @param mixed $key
+     * @param mixed $offset
      * @return boolean
+     * @psalm-param array-key $offset
      */
     #[ReturnTypeWillChange]
-    public function offsetExists($key)
+    public function offsetExists($offset)
     {
-        return array_key_exists($key, $this->info);
+        return array_key_exists($offset, $this->info);
     }
 
     /**
      * Return the field's value from the collection information.
      *
      * @see https://php.net/arrayaccess.offsetget
-     * @param mixed $key
+     * @param mixed $offset
      * @return mixed
+     * @psalm-param array-key $offset
      */
     #[ReturnTypeWillChange]
-    public function offsetGet($key)
+    public function offsetGet($offset)
     {
-        return $this->info[$key];
+        return $this->info[$offset];
     }
 
     /**
      * Not supported.
      *
      * @see https://php.net/arrayaccess.offsetset
-     * @param mixed $key
+     * @param mixed $offset
      * @param mixed $value
      * @throws BadMethodCallException
      * @return void
      */
     #[ReturnTypeWillChange]
-    public function offsetSet($key, $value)
+    public function offsetSet($offset, $value)
     {
         throw BadMethodCallException::classIsImmutable(self::class);
     }
@@ -188,12 +190,12 @@ class CollectionInfo implements ArrayAccess
      * Not supported.
      *
      * @see https://php.net/arrayaccess.offsetunset
-     * @param mixed $key
+     * @param mixed $offset
      * @throws BadMethodCallException
      * @return void
      */
     #[ReturnTypeWillChange]
-    public function offsetUnset($key)
+    public function offsetUnset($offset)
     {
         throw BadMethodCallException::classIsImmutable(self::class);
     }

--- a/src/Model/DatabaseInfo.php
+++ b/src/Model/DatabaseInfo.php
@@ -89,39 +89,41 @@ class DatabaseInfo implements ArrayAccess
      * Check whether a field exists in the database information.
      *
      * @see https://php.net/arrayaccess.offsetexists
-     * @param mixed $key
+     * @param mixed $offset
      * @return boolean
+     * @psalm-param array-key $offset
      */
     #[ReturnTypeWillChange]
-    public function offsetExists($key)
+    public function offsetExists($offset)
     {
-        return array_key_exists($key, $this->info);
+        return array_key_exists($offset, $this->info);
     }
 
     /**
      * Return the field's value from the database information.
      *
      * @see https://php.net/arrayaccess.offsetget
-     * @param mixed $key
+     * @param mixed $offset
      * @return mixed
+     * @psalm-param array-key $offset
      */
     #[ReturnTypeWillChange]
-    public function offsetGet($key)
+    public function offsetGet($offset)
     {
-        return $this->info[$key];
+        return $this->info[$offset];
     }
 
     /**
      * Not supported.
      *
      * @see https://php.net/arrayaccess.offsetset
-     * @param mixed $key
+     * @param mixed $offset
      * @param mixed $value
      * @throws BadMethodCallException
      * @return void
      */
     #[ReturnTypeWillChange]
-    public function offsetSet($key, $value)
+    public function offsetSet($offset, $value)
     {
         throw BadMethodCallException::classIsImmutable(self::class);
     }
@@ -130,12 +132,12 @@ class DatabaseInfo implements ArrayAccess
      * Not supported.
      *
      * @see https://php.net/arrayaccess.offsetunset
-     * @param mixed $key
+     * @param mixed $offset
      * @throws BadMethodCallException
      * @return void
      */
     #[ReturnTypeWillChange]
-    public function offsetUnset($key)
+    public function offsetUnset($offset)
     {
         throw BadMethodCallException::classIsImmutable(self::class);
     }

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -183,13 +183,14 @@ class IndexInfo implements ArrayAccess
      * Check whether a field exists in the index information.
      *
      * @see https://php.net/arrayaccess.offsetexists
-     * @param mixed $key
+     * @param mixed $offset
      * @return boolean
+     * @psalm-param array-key $offset
      */
     #[ReturnTypeWillChange]
-    public function offsetExists($key)
+    public function offsetExists($offset)
     {
-        return array_key_exists($key, $this->info);
+        return array_key_exists($offset, $this->info);
     }
 
     /**
@@ -201,26 +202,27 @@ class IndexInfo implements ArrayAccess
      *
      * @see https://php.net/arrayaccess.offsetget
      * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst#getting-full-index-information
-     * @param mixed $key
+     * @param mixed $offset
      * @return mixed
+     * @psalm-param array-key $offset
      */
     #[ReturnTypeWillChange]
-    public function offsetGet($key)
+    public function offsetGet($offset)
     {
-        return $this->info[$key];
+        return $this->info[$offset];
     }
 
     /**
      * Not supported.
      *
      * @see https://php.net/arrayaccess.offsetset
-     * @param mixed $key
+     * @param mixed $offset
      * @param mixed $value
      * @throws BadMethodCallException
      * @return void
      */
     #[ReturnTypeWillChange]
-    public function offsetSet($key, $value)
+    public function offsetSet($offset, $value)
     {
         throw BadMethodCallException::classIsImmutable(self::class);
     }
@@ -229,12 +231,12 @@ class IndexInfo implements ArrayAccess
      * Not supported.
      *
      * @see https://php.net/arrayaccess.offsetunset
-     * @param mixed $key
+     * @param mixed $offset
      * @throws BadMethodCallException
      * @return void
      */
     #[ReturnTypeWillChange]
-    public function offsetUnset($key)
+    public function offsetUnset($offset)
     {
         throw BadMethodCallException::classIsImmutable(self::class);
     }

--- a/src/PsrLogAdapter.php
+++ b/src/PsrLogAdapter.php
@@ -90,21 +90,21 @@ final class PsrLogAdapter implements LogSubscriber
      *
      * @see LogSubscriber::log()
      */
-    public function log(int $mongocLevel, string $domain, string $message): void
+    public function log(int $level, string $domain, string $message): void
     {
-        if (! isset(self::MONGOC_TO_PSR[$mongocLevel])) {
+        if (! isset(self::MONGOC_TO_PSR[$level])) {
             throw new UnexpectedValueException(sprintf(
                 'Expected level to be >= %d and <= %d, %d given for domain "%s" and message: %s',
                 LogSubscriber::LEVEL_ERROR,
                 LogSubscriber::LEVEL_DEBUG,
-                $mongocLevel,
+                $level,
                 $domain,
                 $message,
             ));
         }
 
         $instance = self::getInstance();
-        $psrLevel = self::MONGOC_TO_PSR[$mongocLevel];
+        $psrLevel = self::MONGOC_TO_PSR[$level];
         $context = ['domain' => $domain];
 
         foreach ($instance->loggers as $logger) {


### PR DESCRIPTION
PHPLIB-1315

Some of the errors have been fixed. Additional errors in `PsrLogAdapter` have been added to the baseline pending the merge of new signatures in the psalm call map (see https://github.com/vimeo/psalm/pull/10402).