### PR TITLE
PHPLIB-1323 Implement `unlink` for GridFS stream wrapper

### DIFF
--- a/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
@@ -48,8 +48,8 @@ Supported stream functions:
 - :php:`filesize() <filesize>`
 - :php:`file() <file>`
 - :php:`fopen() <fopen>` with "r", "rb", "w", and "wb" modes
-- :php:`rename() <rename>` rename all revisions of a file in the same bucket
-- :php:`unlink() <unlink>` remove all revisions of a file in the same bucket
+- :php:`rename() <rename>`
+- :php:`unlink() <unlink>`
 
 In read mode, the stream context can contain the option ``gridfs['revision']``
 to specify the revision number of the file to read. If omitted, the most recent
@@ -57,6 +57,9 @@ revision is read (revision ``-1``).
 
 In write mode, the stream context can contain the option ``gridfs['chunkSizeBytes']``.
 If omitted, the defaults are inherited from the ``Bucket`` instance option.
+
+The functions `rename` and `unlink` will rename or remove all revisions of a
+filename. If the filename does not exist, these functions will return ``false``.
 
 Example
 -------

--- a/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
@@ -49,7 +49,7 @@ Supported stream functions:
 - :php:`file() <file>`
 - :php:`fopen() <fopen>` with "r", "rb", "w", and "wb" modes
 - :php:`rename() <rename>` rename all revisions of a file in the same bucket
-- :php:`unlink() <unlink>` (remove all revisions of a file)
+- :php:`unlink() <unlink>` remove all revisions of a file in the same bucket
 
 In read mode, the stream context can contain the option ``gridfs['revision']``
 to specify the revision number of the file to read. If omitted, the most recent

--- a/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
@@ -49,6 +49,7 @@ Supported stream functions:
 - :php:`file() <file>`
 - :php:`fopen() <fopen>` with "r", "rb", "w", and "wb" modes
 - :php:`rename() <rename>` rename all revisions of a file in the same bucket
+- :php:`unlink() <unlink>` (remove all revisions of a file)
 
 In read mode, the stream context can contain the option ``gridfs['revision']``
 to specify the revision number of the file to read. If omitted, the most recent
@@ -85,6 +86,8 @@ Each call to these functions makes a request to the server.
    var_dump(file_exists('gridfs://mybucket/hello.txt'));
 
    echo file_get_contents('gridfs://mybucket/hello.txt');
+
+   unlink('gridfs://mybucket/hello.txt');
 
 The output would then resemble:
 

--- a/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
@@ -59,7 +59,7 @@ In write mode, the stream context can contain the option ``gridfs['chunkSizeByte
 If omitted, the defaults are inherited from the ``Bucket`` instance option.
 
 The functions `rename` and `unlink` will rename or remove all revisions of a
-filename. If the filename does not exist, these functions will return ``false``.
+filename. If the filename does not exist, these functions throw a ``FileNotFoundException``.
 
 Example
 -------

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -97,27 +97,22 @@
     </MixedArgument>
   </file>
   <file src="src/GridFS/StreamWrapper.php">
-    <InvalidArgument>
+    <InvalidDocblock>
+      <code>private function getContext(string $path, string $mode): array</code>
+    </InvalidDocblock>
+    <MixedArgumentTypeCoercion>
       <code><![CDATA[$this->getContext($path, $mode)]]></code>
       <code><![CDATA[$this->getContext($path, $mode)]]></code>
-    </InvalidArgument>
-    <InvalidReturnStatement>
-      <code>$context</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code>array{collectionWrapper: CollectionWrapper, file: object}|array{collectionWrapper: CollectionWrapper, filename: string, options: array</code>
-    </InvalidReturnType>
-    <MixedArgument>
-      <code><![CDATA[$context['file']->filename]]></code>
-      <code><![CDATA[$context['file']->filename]]></code>
-    </MixedArgument>
+    </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code>$context</code>
+      <code>$count</code>
+      <code>$count</code>
     </MixedAssignment>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$context['file']]]></code>
-      <code><![CDATA[$context['file']]]></code>
-    </PossiblyUndefinedArrayOffset>
+    <MixedMethodCall>
+      <code>deleteFileAndChunksByFilename</code>
+      <code>updateFilenameForFilename</code>
+    </MixedMethodCall>
   </file>
   <file src="src/Model/BSONArray.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -85,6 +85,11 @@
       <code>$context</code>
     </MixedArgumentTypeCoercion>
   </file>
+  <file src="src/GridFS/CollectionWrapper.php">
+    <MixedAssignment>
+      <code>$ids[]</code>
+    </MixedAssignment>
+  </file>
   <file src="src/GridFS/ReadableStream.php">
     <MixedArgument>
       <code><![CDATA[$currentChunk->n]]></code>
@@ -99,6 +104,11 @@
     <MixedAssignment>
       <code>$context</code>
     </MixedAssignment>
+  </file>
+  <file src="src/GridFS/WritableStream.php">
+    <MixedArgument>
+      <code><![CDATA[$this->file['filename']]]></code>
+    </MixedArgument>
   </file>
   <file src="src/Model/BSONArray.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -98,17 +98,26 @@
   </file>
   <file src="src/GridFS/StreamWrapper.php">
     <InvalidArgument>
-      <code>$context</code>
-      <code>$context</code>
+      <code><![CDATA[$this->getContext($path, $mode)]]></code>
+      <code><![CDATA[$this->getContext($path, $mode)]]></code>
     </InvalidArgument>
+    <InvalidReturnStatement>
+      <code>$context</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code>array{collectionWrapper: CollectionWrapper, file: object}|array{collectionWrapper: CollectionWrapper, filename: string, options: array</code>
+    </InvalidReturnType>
+    <MixedArgument>
+      <code><![CDATA[$context['file']->filename]]></code>
+      <code><![CDATA[$context['file']->filename]]></code>
+    </MixedArgument>
     <MixedAssignment>
       <code>$context</code>
     </MixedAssignment>
-  </file>
-  <file src="src/GridFS/WritableStream.php">
-    <MixedArgument>
-      <code><![CDATA[$this->file['filename']]]></code>
-    </MixedArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$context['file']]]></code>
+      <code><![CDATA[$context['file']]]></code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="src/Model/BSONArray.php">
     <MixedAssignment>

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -284,7 +284,7 @@ class CollectionWrapper
         return $this->filesCollection->updateMany(
             ['filename' => $filename],
             ['$set' => ['filename' => $newFilename]],
-        )->getModifiedCount();
+        )->getMatchedCount();
     }
 
     /**

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -81,16 +81,8 @@ class CollectionWrapper
     }
 
     /**
-     * Deletes a GridFS file and related chunks by ID.
-     *
-     * @param mixed $id
+     * Delete all GridFS files and chunks for a given filename.
      */
-    public function deleteFileAndChunksById($id): void
-    {
-        $this->filesCollection->deleteOne(['_id' => $id]);
-        $this->chunksCollection->deleteMany(['files_id' => $id]);
-    }
-
     public function deleteFileAndChunksByFilename(string $filename): int
     {
         /** @var iterable<array{_id: mixed}> $files */
@@ -110,6 +102,17 @@ class CollectionWrapper
         $this->chunksCollection->deleteMany(['files_id' => ['$in' => $ids]]);
 
         return $count ?? 0;
+    }
+
+    /**
+     * Deletes a GridFS file and related chunks by ID.
+     *
+     * @param mixed $id
+     */
+    public function deleteFileAndChunksById($id): void
+    {
+        $this->filesCollection->deleteOne(['_id' => $id]);
+        $this->chunksCollection->deleteMany(['files_id' => $id]);
     }
 
     /**

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -83,7 +83,7 @@ class CollectionWrapper
     /**
      * Delete all GridFS files and chunks for a given filename.
      */
-    public function deleteFileAndChunksByFilename(string $filename): int
+    public function deleteFileAndChunksByFilename(string $filename): ?int
     {
         /** @var iterable<array{_id: mixed}> $files */
         $files = $this->findFiles(['filename' => $filename], [
@@ -100,7 +100,7 @@ class CollectionWrapper
         $count = $this->filesCollection->deleteMany(['_id' => ['$in' => $ids]])->getDeletedCount();
         $this->chunksCollection->deleteMany(['files_id' => ['$in' => $ids]]);
 
-        return $count ?? 0;
+        return $count;
     }
 
     /**
@@ -279,12 +279,12 @@ class CollectionWrapper
     /**
      * Updates the filename field in the file document for all the files with a given filename.
      */
-    public function updateFilenameForFilename(string $filename, string $newFilename): UpdateResult
+    public function updateFilenameForFilename(string $filename, string $newFilename): ?int
     {
         return $this->filesCollection->updateMany(
             ['filename' => $filename],
             ['$set' => ['filename' => $newFilename]],
-        );
+        )->getModifiedCount();
     }
 
     /**

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -91,6 +91,27 @@ class CollectionWrapper
         $this->chunksCollection->deleteMany(['files_id' => $id]);
     }
 
+    public function deleteFileAndChunksByFilename(string $filename): int
+    {
+        /** @var iterable<array{_id: mixed}> $files */
+        $files = $this->findFiles(['filename' => $filename], [
+            'codec' => null,
+            'typeMap' => ['root' => 'array'],
+            'projection' => ['_id' => 1],
+        ]);
+
+        /** @var list<mixed> $ids */
+        $ids = [];
+        foreach ($files as $file) {
+            $ids[] = $file['_id'];
+        }
+
+        $count = $this->filesCollection->deleteMany(['_id' => ['$in' => $ids]])->getDeletedCount();
+        $this->chunksCollection->deleteMany(['files_id' => ['$in' => $ids]]);
+
+        return $count ?? 0;
+    }
+
     /**
      * Drops the GridFS files and chunks collections.
      */

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -87,7 +87,6 @@ class CollectionWrapper
     {
         /** @var iterable<array{_id: mixed}> $files */
         $files = $this->findFiles(['filename' => $filename], [
-            'codec' => null,
             'typeMap' => ['root' => 'array'],
             'projection' => ['_id' => 1],
         ]);

--- a/src/GridFS/Exception/FileNotFoundException.php
+++ b/src/GridFS/Exception/FileNotFoundException.php
@@ -26,6 +26,17 @@ use function sprintf;
 class FileNotFoundException extends RuntimeException
 {
     /**
+     * Thrown when a file cannot be found by its filename.
+     *
+     * @param string $filename Filename
+     * @return self
+     */
+    public static function byFilename(string $filename)
+    {
+        return new self(sprintf('File with name "%s" not found', $filename));
+    }
+
+    /**
      * Thrown when a file cannot be found by its filename and revision.
      *
      * @param string  $filename  Filename

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -22,14 +22,12 @@ use MongoDB\BSON\Binary;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\Exception\CorruptFileException;
-use MongoDB\GridFS\Exception\LogicException;
 
 use function assert;
 use function ceil;
 use function floor;
 use function is_integer;
 use function is_object;
-use function is_string;
 use function property_exists;
 use function sprintf;
 use function strlen;
@@ -176,20 +174,6 @@ class ReadableStream
         }
 
         return $data;
-    }
-
-    /**
-     * Rename all revisions of the file.
-     */
-    public function rename(string $newFilename): bool
-    {
-        if (! isset($this->file->filename) || ! is_string($this->file->filename)) {
-            throw new LogicException('Cannot rename file without a filename');
-        }
-
-        $this->collectionWrapper->updateFilenameForFilename($this->file->filename, $newFilename);
-
-        return true;
     }
 
     /**

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -324,6 +324,19 @@ class StreamWrapper
         return $this->stream->writeBytes($data);
     }
 
+    public function unlink(string $path): bool
+    {
+        try {
+            $this->stream_open($path, 'w', 0, $openedPath);
+        } catch (FileNotFoundException $e) {
+            return false;
+        }
+
+        assert($this->stream instanceof WritableStream);
+
+        return $this->stream->delete() > 0;
+    }
+
     /** @return false|array */
     public function url_stat(string $path, int $flags)
     {

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -96,7 +96,8 @@ class StreamWrapper
     /**
      * Rename all revisions of a filename.
      *
-     * @return bool True on success or false on failure.
+     * @return true
+     * @throws FileNotFoundException
      */
     public function rename(string $fromPath, string $toPath): bool
     {
@@ -110,9 +111,12 @@ class StreamWrapper
         $newFilename = explode('/', $toPath, 4)[3] ?? '';
         $count = $context['collectionWrapper']->updateFilenameForFilename($context['filename'], $newFilename);
 
-        // If $count === 0, the file does not exist.
+        if ($count === 0) {
+            throw FileNotFoundException::byFilename($fromPath);
+        }
+
         // If $count is null, the update is unacknowledged, the operation is considered successful.
-        return $count !== 0;
+        return true;
     }
 
     /**
@@ -293,12 +297,23 @@ class StreamWrapper
         return $this->stream->writeBytes($data);
     }
 
+    /**
+     * Remove all revisions of a filename.
+     *
+     * @return true
+     * @throws FileNotFoundException
+     */
     public function unlink(string $path): bool
     {
         $context = $this->getContext($path, 'w');
         $count = $context['collectionWrapper']->deleteFileAndChunksByFilename($context['filename']);
 
-        return $count !== 0;
+        if ($count === 0) {
+            throw FileNotFoundException::byFilename($path);
+        }
+
+        // If $count is null, the update is unacknowledged, the operation is considered successful.
+        return true;
     }
 
     /** @return false|array */

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -317,7 +317,7 @@ class StreamWrapper
         return $this->stream_stat();
     }
 
-    /** @return array{collectionWrapper: CollectionWrapper, file: object}|array{collectionWrapper: CollectionWrapper, filename: string, options: array */
+    /** @return array{collectionWrapper: CollectionWrapper, file: object}|array{collectionWrapper: CollectionWrapper, filename: string, options: array} */
     private function getContext(string $path, string $mode): array
     {
         $context = [];

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -330,7 +330,10 @@ class StreamWrapper
         return $this->stream_stat();
     }
 
-    /** @psalm-return ($mode == 'r' ? array{collectionWrapper: CollectionWrapper, file: object} : array{collectionWrapper: CollectionWrapper, filename: string, options: array}) */
+    /**
+     * @return array{collectionWrapper: CollectionWrapper, file: object}|array{collectionWrapper: CollectionWrapper, filename: string, options: array}
+     * @psalm-return ($mode == 'r' or $mode == 'rb' ? array{collectionWrapper: CollectionWrapper, file: object} : array{collectionWrapper: CollectionWrapper, filename: string, options: array})
+     */
     private function getContext(string $path, string $mode): array
     {
         $context = [];

--- a/src/GridFS/WritableStream.php
+++ b/src/GridFS/WritableStream.php
@@ -174,21 +174,6 @@ class WritableStream
     }
 
     /**
-     * Delete all files and chunks associated with this stream filename.
-     *
-     * @return int The number of deleted files
-     */
-    public function delete(): int
-    {
-        try {
-            return $this->collectionWrapper->deleteFileAndChunksByFilename($this->file['filename']);
-        } finally {
-            // Prevent further operations on this stream
-            $this->abort();
-        }
-    }
-
-    /**
      * Return the stream's file document.
      */
     public function getFile(): object

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -386,6 +386,24 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         rename($path, $path . '.renamed');
     }
 
+    public function testRenameSameFilename(): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+        $path = 'gridfs://bucket/filename';
+
+        $this->assertSame(6, file_put_contents($path, 'foobar'));
+
+        $result = rename($path, $path);
+        $this->assertTrue($result);
+        $this->assertTrue(file_exists($path));
+        $this->assertSame('foobar', file_get_contents($path));
+
+        $path = 'gridfs://bucket/missing';
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessage('File with name "gridfs://bucket/missing" not found');
+        rename($path, $path);
+    }
+
     public function testRenamePathMismatch(): void
     {
         $this->expectException(LogicException::class);

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -381,8 +381,9 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $this->assertFalse(file_exists($path));
         $this->assertSame('foobar', file_get_contents($path . '.renamed'));
 
-        $result = rename($path, $path . '.renamed');
-        $this->assertFalse($result, 'File does not exist anymore');
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessage('File with name "gridfs://bucket/filename" not found');
+        rename($path, $path . '.renamed');
     }
 
     public function testRenamePathMismatch(): void
@@ -406,7 +407,8 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $this->assertTrue($result);
         $this->assertFalse(file_exists($path));
 
-        $result = unlink($path);
-        $this->assertFalse($result, 'File does not exist anymore');
+        $this->expectException(FileNotFoundException::class);
+        $this->expectExceptionMessage('File with name "gridfs://bucket/path/to/filename" not found');
+        unlink($path);
     }
 }

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -29,6 +29,7 @@ use function rename;
 use function stream_context_create;
 use function stream_get_contents;
 use function time;
+use function unlink;
 use function usleep;
 
 use const SEEK_CUR;
@@ -386,5 +387,19 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $this->expectExceptionMessage('Cannot rename "gridfs://bucket/filename" to "gridfs://other/newname" because they are not in the same GridFS bucket.');
 
         rename('gridfs://bucket/filename', 'gridfs://other/newname');
+    }
+
+    public function testUnlinkAllRevisions(): void
+    {
+        $this->bucket->registerGlobalStreamWrapperAlias('bucket');
+        $path = 'gridfs://bucket/path/to/filename';
+
+        file_put_contents($path, 'version 0');
+        file_put_contents($path, 'version 1');
+
+        $result = unlink($path);
+
+        $this->assertTrue($result);
+        $this->assertFalse(file_exists($path));
     }
 }

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -375,10 +375,14 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $this->assertSame(6, file_put_contents($path, 'foobar'));
         $this->assertSame(6, file_put_contents($path, 'foobar'));
 
-        $this->assertTrue(rename($path, $path . '.renamed'));
+        $result = rename($path, $path . '.renamed');
+        $this->assertTrue($result);
         $this->assertTrue(file_exists($path . '.renamed'));
         $this->assertFalse(file_exists($path));
         $this->assertSame('foobar', file_get_contents($path . '.renamed'));
+
+        $result = rename($path, $path . '.renamed');
+        $this->assertFalse($result, 'File does not exist anymore');
     }
 
     public function testRenamePathMismatch(): void
@@ -401,5 +405,8 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
 
         $this->assertTrue($result);
         $this->assertFalse(file_exists($path));
+
+        $result = unlink($path);
+        $this->assertFalse($result, 'File does not exist anymore');
     }
 }


### PR DESCRIPTION
Fix PHPLIB-1323

This is not optimized as it creates a `WritableStream` instance that is not really used.
The context resolver mechanism introduces in #1138 doesn't give direct access to the `CollectionWrapper` which is required for this feature.