### PR TITLE
PHPLIB-1324 Implement `rename` for GridFS stream wrapper 

### DIFF
--- a/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
+++ b/docs/reference/method/MongoDBGridFSBucket-registerGlobalStreamWrapperAlias.txt
@@ -47,7 +47,8 @@ Supported stream functions:
 - :php:`filemtime() <filemtime>`
 - :php:`filesize() <filesize>`
 - :php:`file() <file>`
-- :php:`fopen() <fopen>` (with "r", "rb", "w", and "wb" modes)
+- :php:`fopen() <fopen>` with "r", "rb", "w", and "wb" modes
+- :php:`rename() <rename>` rename all revisions of a file in the same bucket
 
 In read mode, the stream context can contain the option ``gridfs['revision']``
 to specify the revision number of the file to read. If omitted, the most recent

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -162,11 +162,4 @@
     <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
         <exclude-pattern>/docs/examples/codecs/</exclude-pattern>
     </rule>
-
-    <!-- **************************************** -->
-    <!-- Exclude certain rules for stream wrapper -->
-    <!-- **************************************** -->
-    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
-        <exclude-pattern>/src/GridFS/StreamWrapper.php</exclude-pattern>
-    </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -162,4 +162,11 @@
     <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
         <exclude-pattern>/docs/examples/codecs/</exclude-pattern>
     </rule>
+
+    <!-- **************************************** -->
+    <!-- Exclude certain rules for stream wrapper -->
+    <!-- **************************************** -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
+        <exclude-pattern>/src/GridFS/StreamWrapper.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -254,6 +254,17 @@ class CollectionWrapper
     }
 
     /**
+     * Updates the filename field in the file document for all the files with a given filename.
+     */
+    public function updateFilenameForFilename(string $filename, string $newFilename): UpdateResult
+    {
+        return $this->filesCollection->updateMany(
+            ['filename' => $filename],
+            ['$set' => ['filename' => $newFilename]],
+        );
+    }
+
+    /**
      * Updates the filename field in the file document for a given ID.
      *
      * @param mixed $id

--- a/src/GridFS/Exception/LogicException.php
+++ b/src/GridFS/Exception/LogicException.php
@@ -67,4 +67,14 @@ class LogicException extends BaseLogicException implements Exception
     {
         return new self(sprintf('Mode "%s" is not supported by "gridfs://" files. Use one of "r", "rb", "w", or "wb".', $mode));
     }
+
+    /**
+     * Thrown when the origin and destination paths are not in the same bucket.
+     *
+     * @internal
+     */
+    public static function renamePathMismatch(string $from, string $to): self
+    {
+        return new self(sprintf('Cannot rename "%s" to "%s" because they are not in the same GridFS bucket.', $from, $to));
+    }
 }

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -98,20 +98,20 @@ class StreamWrapper
      *
      * @return bool True on success or false on failure.
      */
-    public function rename(string $path_from, string $path_to): bool
+    public function rename(string $fromPath, string $toPath): bool
     {
-        $prefix = implode('/', array_slice(explode('/', $path_from, 4), 0, 3)) . '/';
-        if (! str_starts_with($path_to, $prefix)) {
-            throw LogicException::renamePathMismatch($path_from, $path_to);
+        $prefix = implode('/', array_slice(explode('/', $fromPath, 4), 0, 3)) . '/';
+        if (! str_starts_with($toPath, $prefix)) {
+            throw LogicException::renamePathMismatch($fromPath, $toPath);
         }
 
         try {
-            $this->stream_open($path_from, 'r', 0, $openedPath);
+            $this->stream_open($fromPath, 'r', 0, $openedPath);
         } catch (FileNotFoundException $e) {
             return false;
         }
 
-        $newName = explode('/', $path_to, 4)[3] ?? '';
+        $newName = explode('/', $toPath, 4)[3] ?? '';
         assert($this->stream instanceof ReadableStream);
 
         return $this->stream->rename($newName) > 0;

--- a/src/GridFS/StreamWrapper.php
+++ b/src/GridFS/StreamWrapper.php
@@ -114,7 +114,7 @@ class StreamWrapper
         $newName = explode('/', $toPath, 4)[3] ?? '';
         assert($this->stream instanceof ReadableStream);
 
-        return $this->stream->rename($newName) > 0;
+        return $this->stream->rename($newName);
     }
 
     /**


### PR DESCRIPTION
Fix PHPLIB-1324

Rename all the revisions as [defined in the spec](https://github.com/mongodb/specifications/blob/0b47194538aa817978fae0f77f684f6d5e62ebab/source/gridfs/gridfs-spec.rst#renaming-stored-files)

> To rename multiple revisions of the same filename, users must retrieve the full list of files collection documents for a given filename and execute “rename” on each corresponding “_id”.


### Example

```php
file_put_contents('gridfs://bucket/filename', 'Hello, GridFS!');
rename('gridfs://bucket/filename', 'gridfs://bucket/newname');
echo file_get_contents('gridfs://bucket/newname');
```
