### PR TITLE
Fix CI issues

### DIFF
--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -158,12 +158,17 @@ functions:
     - command: shell.exec
       params:
         script: |
-          VARIANT=${VARIANT} DRIVERS_TOOLS="${DRIVERS_TOOLS}" ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          cd ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake
+
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" \
+          ./pull-mongohouse-image.sh
     - command: shell.exec
       params:
-        background: true
         script: |
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+          cd ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake
+
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" \
+          ./run-mongohouse-image.sh
 
   "create serverless instance":
     - command: shell.exec

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -141,7 +141,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          SKIP_CRYPT_SHARED=${SKIP_CRYPT_SHARED} SKIP_LEGACY_SHELL=true MONGODB_VERSION=${MONGODB_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+          SKIP_CRYPT_SHARED=${SKIP_CRYPT_SHARED} SKIP_LEGACY_SHELL=true MONGODB_VERSION=${MONGODB_VERSION} ORCHESTRATION_FILE=${ORCHESTRATION_FILE} TOPOLOGY=${TOPOLOGY} AUTH=${AUTH} SSL=${SSL} STORAGE_ENGINE=${STORAGE_ENGINE} LOAD_BALANCER=${LOAD_BALANCER} REQUIRE_API_VERSION=${REQUIRE_API_VERSION} ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:
@@ -152,18 +152,18 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          sh ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
+          ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
 
   "bootstrap mongohoused":
     - command: shell.exec
       params:
         script: |
-          VARIANT=${VARIANT} DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
+          VARIANT=${VARIANT} DRIVERS_TOOLS="${DRIVERS_TOOLS}" ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/build-mongohouse-local.sh
     - command: shell.exec
       params:
         background: true
         script: |
-          DRIVERS_TOOLS="${DRIVERS_TOOLS}" sh ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
+          DRIVERS_TOOLS="${DRIVERS_TOOLS}" ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake/run-mongohouse-local.sh
 
   "create serverless instance":
     - command: shell.exec
@@ -272,7 +272,7 @@ functions:
           PHP_VERSION=${PHP_VERSION} \
           SSL=${SSL} \
           TESTS=${TESTS} \
-          sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run atlas data lake test":
     - command: shell.exec
@@ -285,7 +285,7 @@ functions:
           
           MONGODB_URI="mongodb://mhuser:pencil@127.0.0.1:27017" \
           TESTS="atlas-data-lake" \
-          sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "run serverless tests":
     - command: shell.exec
@@ -318,7 +318,7 @@ functions:
           CRYPT_SHARED_LIB_PATH=${CRYPT_SHARED_LIB_PATH} \
           MONGODB_URI="${SERVERLESS_URI}" \
           TESTS="serverless" \
-          sh ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
+          ${PROJECT_DIRECTORY}/.evergreen/run-tests.sh
 
   "cleanup":
     - command: shell.exec

--- a/.evergreen/config/test-variants.yml
+++ b/.evergreen/config/test-variants.yml
@@ -21,7 +21,6 @@ buildvariants:
       - ".sharded .local !.csfle !.3.6 !.4.0 !.4.2 !.4.4 !.5.0"
       - ".loadbalanced .local !.csfle !.3.6 !.4.0 !.4.2 !.4.4 !.5.0"
       - ".serverless"
-      - "test-atlas-data-lake"
   - name: test-debian92-php82-local
     tags: ["test", "debian", "x64"]
     display_name: "Test: Debian 9.2, PHP 8.2"
@@ -156,3 +155,18 @@ buildvariants:
         name: "build-php-8.2"
     tasks:
       - "run-benchmark"
+
+  # Run Atlas Data Lake Tests on Ubuntu
+  - name: test-ubuntu2204-php82-local
+    tags: ["test", "ubuntu", "x64"]
+    display_name: "Test: Ubuntu 22.04 x64, PHP 8.2"
+    run_on: ubuntu2204-small
+    expansions:
+      FETCH_BUILD_VARIANT: "build-ubuntu2204"
+      FETCH_BUILD_TASK: "build-php-8.2"
+      PHP_VERSION: "8.2"
+    depends_on:
+      - variant: "build-ubuntu2204"
+        name: "build-php-8.2"
+    tasks:
+      - "test-atlas-data-lake"

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -1762,7 +1762,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         ];
 
         if (! $shouldSucceed) {
-            $this->expectException(AuthenticationException::class);
+            $this->expectException(RuntimeException::class);
         }
 
         $dataKeyId = $clientEncryption->createDataKey('aws', $dataKeyOpts);

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -83,6 +83,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         'valid-pass/createEntities-operation: createEntities operation' => 'CSOT is not yet implemented (PHPC-1760)',
         'valid-pass/entity-cursor-iterateOnce: iterateOnce' => 'CSOT is not yet implemented (PHPC-1760)',
         'valid-pass/matches-lte-operator: special lte matching operator' => 'CSOT is not yet implemented (PHPC-1760)',
+        // libmongoc always adds readConcern to aggregate command
+        'index-management/search index operations ignore read and write concern: listSearchIndexes ignores read and write concern' => 'libmongoc appends readConcern to aggregate command',
     ];
 
     private static UnifiedTestRunner $runner;

--- a/tests/UnifiedSpecTests/index-management/createSearchIndex.json
+++ b/tests/UnifiedSpecTests/index-management/createSearchIndex.json
@@ -55,7 +55,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -102,7 +102,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/tests/UnifiedSpecTests/index-management/createSearchIndexes.json
+++ b/tests/UnifiedSpecTests/index-management/createSearchIndexes.json
@@ -49,7 +49,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -89,7 +89,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -138,7 +138,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/tests/UnifiedSpecTests/index-management/dropSearchIndex.json
+++ b/tests/UnifiedSpecTests/index-management/dropSearchIndex.json
@@ -49,7 +49,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/tests/UnifiedSpecTests/index-management/listSearchIndexes.json
+++ b/tests/UnifiedSpecTests/index-management/listSearchIndexes.json
@@ -46,7 +46,7 @@
           "object": "collection0",
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -81,7 +81,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -122,7 +122,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/tests/UnifiedSpecTests/index-management/searchIndexIgnoresReadWriteConcern.json
+++ b/tests/UnifiedSpecTests/index-management/searchIndexIgnoresReadWriteConcern.json
@@ -1,0 +1,252 @@
+{
+  "description": "search index operations ignore read and write concern",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "uriOptions": {
+          "readConcernLevel": "local",
+          "w": 1
+        },
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "7.0.0",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "createSearchIndex ignores read and write concern",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              }
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      }
+                    }
+                  ],
+                  "$db": "database0",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "createSearchIndexes ignores read and write concern",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": []
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [],
+                  "$db": "database0",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "dropSearchIndex ignores read and write concern",
+      "operations": [
+        {
+          "name": "dropSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "name": "test index"
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "dropSearchIndex": "collection0",
+                  "name": "test index",
+                  "$db": "database0",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listSearchIndexes ignores read and write concern",
+      "operations": [
+        {
+          "name": "listSearchIndexes",
+          "object": "collection0",
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "pipeline": [
+                    {
+                      "$listSearchIndexes": {}
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateSearchIndex ignores the read and write concern",
+      "operations": [
+        {
+          "name": "updateSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "name": "test index",
+            "definition": {}
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "updateSearchIndex": "collection0",
+                  "name": "test index",
+                  "definition": {},
+                  "$db": "database0",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/UnifiedSpecTests/index-management/updateSearchIndex.json
+++ b/tests/UnifiedSpecTests/index-management/updateSearchIndex.json
@@ -50,7 +50,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],


### PR DESCRIPTION
This PR takes care of a number of test failures:
* no-aws-cred tests were failing due to exception class changing. Instead of the expected `AuthenticationException`, it now throws an `EncryptionException`. I don't think the exception class matters for the tests (as the spec only suggests checking for failures, not a specific failure), but I can take a closer look at the reason for the change if necessary.
* PHPLIB-1327: Index management tests fail on latest due to recent changes. This PR syncs the tests with mongodb/specifications@e54cb7c3da226cb14285a14fa7219cdc5c8ed997.
* PHPLIB-1304: changes for ADL tests were only merged to the main branch, I backported these changes to v1.17 to avoid the system failure. Tests still fail however as we can't connect to the local ADL instance. This is a failure I've seen with other drivers as well and I'm still investigating this for a later fix.

This leaves the serverless tests to fail, which I'm investigating as part of PHPLIB-1303.

The patch build for this PR includes the no-aws-creds tasks that currently fail.