### PR TITLE
PHPLIB-1372 Fix `RiskyTruthyFalsyComparison`

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -34,5 +34,13 @@
 
         <!-- This is often the result of type checks due to missing native types -->
         <DocblockTypeContradiction errorLevel="info" />
+
+        <!-- If the result of getenv is falsy, using the default URI is fine -->
+        <RiskyTruthyFalsyComparison>
+            <errorLevel type="suppress">
+                <directory name="examples" />
+                <directory name="docs/examples" />
+            </errorLevel>
+        </RiskyTruthyFalsyComparison>
     </issueHandlers>
 </psalm>

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -262,7 +262,7 @@ class ChangeStream implements Iterator
      */
     private function resume(): void
     {
-        if (null === $this->resumeCallable) {
+        if ($this->resumeCallable === null) {
             throw new BadMethodCallException('Cannot resume a closed change stream.');
         }
 

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -262,7 +262,7 @@ class ChangeStream implements Iterator
      */
     private function resume(): void
     {
-        if (! $this->resumeCallable) {
+        if (null === $this->resumeCallable) {
             throw new BadMethodCallException('Cannot resume a closed change stream.');
         }
 

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -187,7 +187,7 @@ class Count implements Executable, Explainable
     {
         $cmd = ['count' => $this->collectionName];
 
-        if (! empty($this->filter)) {
+        if ($this->filter !== []) {
             $cmd['query'] = (object) $this->filter;
         }
 

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -182,7 +182,7 @@ class Distinct implements Executable, Explainable
             'key' => $this->fieldName,
         ];
 
-        if (! empty($this->filter)) {
+        if ($this->filter !== []) {
             $cmd['query'] = (object) $this->filter;
         }
 


### PR DESCRIPTION
Fix PHPLIB-1372

The new [RiskyTruthyFalsyComparison](https://psalm.dev/docs/running_psalm/issues/RiskyTruthyFalsyComparison/) errors are introduced by psalm [5.20.0](https://github.com/vimeo/psalm/releases/tag/5.20.0).

- Disable on example files. Using `getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/'` is safe as any falsy value could be replaced by the default URI.
- Replace `!empty($filter)` by `$filter !== []` as `$filter` is an array or an object, and even `empty(new stdClass)` is true. This might be a necessary bug fix.