### PR TITLE
Add `RiskyTruthyFalsyComparison` psalm errors to the baseline for maintenance branch

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.18.0@b113f3ed0259fd6e212d87c3df80eec95a6abf19">
+<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4">
   <file src="docs/examples/encryption/csfle-explicit_encryption.php">
     <MixedArgument>
       <code><![CDATA[$clientEncryption->decrypt($document->encryptedField)]]></code>
@@ -50,6 +50,9 @@
     <DeprecatedConstant>
       <code>self::CURSOR_NOT_FOUND</code>
     </DeprecatedConstant>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[! $this->resumeCallable]]></code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Client.php">
     <MixedArgument>
@@ -321,6 +324,9 @@
     <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[empty($this->filter)]]></code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Operation/CreateCollection.php">
     <MixedArgument>
@@ -395,6 +401,9 @@
     <MixedMethodCall>
       <code>isInTransaction</code>
     </MixedMethodCall>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[empty($this->filter)]]></code>
+    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Operation/DropCollection.php">
     <MixedArgument>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -34,5 +34,13 @@
 
         <!-- This is often the result of type checks due to missing native types -->
         <DocblockTypeContradiction errorLevel="info" />
+
+        <!-- If the result of getenv is falsy, using the default URI is fine -->
+        <RiskyTruthyFalsyComparison>
+            <errorLevel type="suppress">
+                <directory name="examples" />
+                <directory name="docs/examples" />
+            </errorLevel>
+        </RiskyTruthyFalsyComparison>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
Same as #1218 for branch v1.17.
I don't backport the code fixes to not introduce behavior change in a bugfix release. Adding the errors to the psalm-baseline instead.

Follows @jmikola comment: https://github.com/mongodb/mongo-php-library/pull/1201#issuecomment-1910698984