### PR TITLE
PHPLIB-1321: Use correct method in createSearchIndexes() example

### DIFF
--- a/docs/reference/method/MongoDBCollection-createSearchIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-createSearchIndexes.txt
@@ -91,12 +91,14 @@ to index all document fields containing
 
    $collection = (new MongoDB\Client)->selectCollection('test', 'articles');
 
-   $indexNames = $collection->createSearchIndexes([
+   $indexNames = $collection->createSearchIndexes(
        [
-           'name' => 'test-search-index',
-           'definition' => ['mappings' => ['dynamic' => true]],
-       ],
-   ]);
+           [
+               'name' => 'test-search-index',
+               'definition' => ['mappings' => ['dynamic' => true]],
+           ],
+       ]
+   );
 
    var_dump($indexNames);
 

--- a/docs/reference/method/MongoDBCollection-createSearchIndexes.txt
+++ b/docs/reference/method/MongoDBCollection-createSearchIndexes.txt
@@ -77,8 +77,8 @@ Behavior
 Examples
 --------
 
-Create Indexes with Static and Dynamic Mappings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Create an Index with Dynamic Mappings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example creates an Atlas Search index using
 `dynamic mappings <https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#dynamic-mappings>`__
@@ -91,18 +91,23 @@ to index all document fields containing
 
    $collection = (new MongoDB\Client)->selectCollection('test', 'articles');
 
-   $indexName = $collection->createSearchIndex(
-      ['mappings' => ['dynamic' => true]],
-      ['name' => 'test-search-index']
-   );
+   $indexNames = $collection->createSearchIndexes([
+       [
+           'name' => 'test-search-index',
+           'definition' => ['mappings' => ['dynamic' => true]],
+       ],
+   ]);
 
-   var_dump($indexName);
+   var_dump($indexNames);
 
 The output would then resemble:
 
 .. code-block:: none
 
-   string(17) "test-search-index"
+   array(1) {
+     [0]=>
+     string(17) "test-search-index"
+   }
 
 See Also
 --------


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1321

I opted not to pull in a more complex example from https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings that creates multiple indexes at once, since we already link to that page. Demonstrating the argument and return type difference seems sufficient.