### PR TITLE
Stop testing on RHEL 7.6

### DIFF
--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -53,12 +53,6 @@ buildvariants:
     run_on: rhel80-small
     tasks:
       - name: "build-all-php"
-  - name: build-rhel76
-    display_name: "Build: RHEL 7.6"
-    tags: ["build", "rhel", "x64"]
-    run_on: rhel76-small
-    tasks:
-      - name: "build-all-php"
 
   # Ubuntu LTS
   - name: build-ubuntu2204


### PR DESCRIPTION
RHEL 7.6 currently fails due to it not being able to connect to pecl.php.net. Since the OS is EOL'd and doesn't play a big role for the PHP driver, there's no harm in removing it from the build pipeline. We're still testing RHEL 9.0 and 8.0 for x64 platforms, as well as 8.3 for Z, 8.2 for ARM64, and 8.1 for PPC.