### PR TITLE
PHPLIB-1330: Update skipped test list to account for moved test

### DIFF
--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -97,13 +97,13 @@ class TransactionsSpecTest extends FunctionalTestCase
         'transactions/mongos-pin-auto: unpin after transient connection error on runCommand insert' => 'libmongoc does not pin for load-balanced topology',
         'transactions/mongos-pin-auto: unpin after transient ShutdownInProgress error on runCommand insert' => 'libmongoc does not pin for load-balanced topology',
         'transactions/mongos-recovery-token: commitTransaction explicit retries include recoveryToken' => 'libmongoc omits recoveryToken for load-balanced topology (CDRIVER-4718)',
-        'transactions/mongos-recovery-token: commitTransaction retry succeeds on new mongos' => 'libmongoc does not pin for load-balanced topology',
         'transactions/mongos-recovery-token: commitTransaction retry fails on new mongos' => 'libmongoc does not pin for load-balanced topology',
         'transactions/mongos-recovery-token: abortTransaction sends recoveryToken' => 'libmongoc does not pin for load-balanced topology',
         'transactions/pin-mongos: multiple commits' => 'libmongoc does not pin for load-balanced topology',
         'transactions/pin-mongos: remain pinned after non-transient error on commit' => 'libmongoc does not pin for load-balanced topology',
         'transactions/pin-mongos: unpin after transient error within a transaction' => 'libmongoc does not pin for load-balanced topology',
         'transactions/pin-mongos: unpin after transient error within a transaction and commit' => 'libmongoc does not pin for load-balanced topology',
+        'transactions/mongos-recovery-token-errorLabels: commitTransaction retry succeeds on new mongos' => 'libmongoc does not pin for load-balanced topology',
     ];
 
     public function setUp(): void


### PR DESCRIPTION
PHPLIB-1330 pulled in a new test file that was extracted for compatibility with different runOnRequirements. The pull request in question however broke load-balanced tests as it didn't rename the incomplete test.

We currently don't run load-balanced tests in pull request - is that something we should add?