### PR TITLE
Don't skip static checks for docs changes

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,15 +6,11 @@ on:
       - "v*.*"
       - "master"
       - "feature/*"
-    paths-ignore:
-      - "docs/**"
   push:
     branches:
       - "v*.*"
       - "master"
       - "feature/*"
-    paths-ignore:
-      - "docs/**"
 
 env:
   PHP_VERSION: "8.2"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,15 +6,11 @@ on:
       - "v*.*"
       - "master"
       - "feature/*"
-    paths-ignore:
-      - "docs/**"
   push:
     branches:
       - "v*.*"
       - "master"
       - "feature/*"
-    paths-ignore:
-      - "docs/**"
 
 env:
   PHP_VERSION: "8.2"


### PR DESCRIPTION
Since coding-standards and psalm are required through branch protection rules, skipping them for docs-only PRs results in an unmergeable pull request. This PR undoes those changes. Note that phpunit checks in GitHub Actions are still skipped, as those are not required in the rules.