### PR TITLE
PHPLIB-1400: Add missing use statement

### DIFF
--- a/tests/UnifiedSpecTests/CollectionData.php
+++ b/tests/UnifiedSpecTests/CollectionData.php
@@ -6,6 +6,7 @@ use ArrayIterator;
 use MongoDB\Client;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
+use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Tests\UnifiedSpecTests\Constraint\Matches;
 use MultipleIterator;


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1400

Fixes an issue from https://github.com/mongodb/mongo-php-library/pull/1232

Patch build: https://spruce.mongodb.com/version/65d8d2b72a60edef51646df4/tasks