### PR TITLE
Remove redundant annotations

### DIFF
--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -98,7 +98,6 @@ class ReadableStream
      * Return internal properties for debugging purposes.
      *
      * @see https://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.debuginfo
-     * @return array
      */
     public function __debugInfo(): array
     {

--- a/src/Model/SearchIndexInput.php
+++ b/src/Model/SearchIndexInput.php
@@ -36,7 +36,6 @@ use function MongoDB\is_document;
  */
 class SearchIndexInput implements Serializable
 {
-    /** @var array */
     private array $index;
 
     /**


### PR DESCRIPTION
Fixes some phpcs errors that popped up in https://github.com/mongodb/mongo-php-library/pull/1250. I assume this was related to some upstream change, since the code is quite old.