### PR TITLE
PHPLIB-1409: Skip $out and mapReduce tests on serverless

### DIFF
--- a/tests/UnifiedSpecTests/read-write-concern/default-write-concern-3.4.json
+++ b/tests/UnifiedSpecTests/read-write-concern/default-write-concern-3.4.json
@@ -1,6 +1,6 @@
 {
   "description": "default-write-concern-3.4",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4"
@@ -55,6 +55,11 @@
   "tests": [
     {
       "description": "Aggregate with $out omits default write concern",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "object": "collection0",
@@ -220,6 +225,11 @@
     },
     {
       "description": "MapReduce omits default write concern",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "mapReduce",


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1409

Complements #1253, although that PR can be left as-is to exclude running these tests on serverless. This PR's Evergreen build will confirm that the modified tests play nice with serverless.

POC for https://github.com/mongodb/specifications/pull/1550

Patch build: https://spruce.mongodb.com/version/65f1b98a7d9e260007b65496/tasks