### PR TITLE
PHPLIB-1412: Skip range encryption tests on MongoDB 8.0+

### DIFF
--- a/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
@@ -44,6 +44,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         }
 
         $this->skipIfServerVersion('<', '7.0.0', 'Range explicit encryption tests require MongoDB 7.0 or later');
+        $this->skipIfServerVersion('>=', '8.0.0', 'Range explicit encryption tests require MongoDB 8.0 or earlier');
 
         $client = static::createTestClient();
 

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -111,6 +111,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         'fle2v2-Range-Decimal-Update: FLE2 Range Decimal. Update.' => 'Bundled libmongocrypt does not support Decimal128 (PHPC-2207)',
         'timeoutMS: timeoutMS applied to listCollections to get collection schema' => 'Not yet implemented (PHPC-1760)',
         'timeoutMS: remaining timeoutMS applied to find to get keyvault data' => 'Not yet implemented (PHPC-1760)',
+        'namedKMS: Automatically encrypt and decrypt with a named KMS provider' => 'Not yet implemented (PHPLIB-1328)',
     ];
 
     public function setUp(): void

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-MissingKey.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-MissingKey.json
@@ -54,7 +54,7 @@
   "key_vault_data": [],
   "tests": [
     {
-      "description": "FLE2 encrypt fails with mising key",
+      "description": "FLE2 encrypt fails with missing key",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {
@@ -85,7 +85,7 @@
       ]
     },
     {
-      "description": "FLE2 decrypt fails with mising key",
+      "description": "FLE2 decrypt fails with missing key",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Date-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Aggregate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Correctness.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Delete.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-InsertFind.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Decimal-Update.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DecimalPrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Double-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-DoublePrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Int-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Aggregate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Correctness.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Delete.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-InsertFind.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Update.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-Long-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-WrongType.json
+++ b/tests/SpecTests/client-side-encryption/tests/fle2v2-Range-WrongType.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/tests/SpecTests/client-side-encryption/tests/namedKMS.json
+++ b/tests/SpecTests/client-side-encryption/tests/namedKMS.json
@@ -1,0 +1,197 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "json_schema": {
+    "properties": {
+      "encrypted_string": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "local+name2+AAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      }
+    },
+    "bsonType": "object"
+  },
+  "key_vault_data": [
+    {
+      "_id": {
+        "$binary": {
+          "base64": "local+name2+AAAAAAAAAA==",
+          "subType": "04"
+        }
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "status": {
+        "$numberInt": "0"
+      },
+      "masterKey": {
+        "provider": "local:name2"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Automatically encrypt and decrypt with a named KMS provider",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local:name2": {
+              "key": {
+                "$binary": {
+                  "base64": "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          }
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": [
+            {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          ]
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "local+name2+AAAAAAAAAA==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault",
+              "readConcern": {
+                "level": "majority"
+              }
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 1,
+                  "encrypted_string": {
+                    "$binary": {
+                      "base64": "AZaHGpfp2pntvgAAAAAAAAAC07sFvTQ0I4O2U49hpr4HezaK44Ivluzv5ntQBTYHDlAJMLyRMyB6Dl+UGHBgqhHe/Xw+pcT9XdiUoOJYAx9g+w==",
+                      "subType": "06"
+                    }
+                  }
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "default",
+              "filter": {
+                "_id": 1
+              }
+            },
+            "command_name": "find"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "encrypted_string": {
+                "$binary": {
+                  "base64": "AZaHGpfp2pntvgAAAAAAAAAC07sFvTQ0I4O2U49hpr4HezaK44Ivluzv5ntQBTYHDlAJMLyRMyB6Dl+UGHBgqhHe/Xw+pcT9XdiUoOJYAx9g+w==",
+                  "subType": "06"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
PHPLIB-1412

This syncs spec tests with mongodb/specifications@d036675f5e91ad9f45bcee5292a2d9a829224495