### PR TITLE
PHPLIB-1302: Use Composer\InstalledVersions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-hash": "*",
         "ext-json": "*",
         "ext-mongodb": "^1.18.0",
-        "jean85/pretty-package-versions": "^2.0.1",
+        "composer-runtime-api": "^2.0",
         "psr/log": "^1.1.4|^2|^3",
         "symfony/polyfill-php80": "^1.27",
         "symfony/polyfill-php81": "^1.27"

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,8 +17,8 @@
 
 namespace MongoDB;
 
+use Composer\InstalledVersions;
 use Iterator;
-use Jean85\PrettyVersions;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\InvalidArgumentException as DriverInvalidArgumentException;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
@@ -396,9 +396,9 @@ class Client
     {
         if (self::$version === null) {
             try {
-                self::$version = PrettyVersions::getVersion('mongodb/mongodb')->getPrettyVersion();
+                self::$version = InstalledVersions::getPrettyVersion('mongodb/mongodb') ?? 'unknown';
             } catch (Throwable $t) {
-                return 'unknown';
+                self::$version = 'error';
             }
         }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1302

There is no impact on Composer requirements since jean85/pretty-package-versions 2.0+ previously required composer-runtime-api 2.0+.