### PR TITLE
DOCSP-36898: Fix seealso syntax in CSFLE tutorial

### DIFF
--- a/docs/tutorial/client-side-encryption.txt
+++ b/docs/tutorial/client-side-encryption.txt
@@ -57,7 +57,7 @@ more than one encryption key or create them dynamically.
 
 .. seealso::
 
-   :manual:`Encryption Key Management </csfle/fundamentals/manage-keys/>` in the MongoDB manual
+   :manual:`Encryption Key Management </core/csfle/fundamentals/manage-keys/>` in the MongoDB manual
 
 
 Automatic Encryption and Decryption

--- a/docs/tutorial/client-side-encryption.txt
+++ b/docs/tutorial/client-side-encryption.txt
@@ -55,7 +55,9 @@ more than one encryption key or create them dynamically.
    // To store the key ID for later use, you can use serialize or var_export
    $keyId = $clientEncryption->createDataKey('local', ['keyAltNames' => ['my-encryption-key']]);
 
-.. seealso:: :manual:`Encryption Key Management </csfle/fundamentals/manage-keys/>` in the MongoDB manual
+.. seealso::
+
+   :manual:`Encryption Key Management </csfle/fundamentals/manage-keys/>` in the MongoDB manual
 
 
 Automatic Encryption and Decryption


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-36898

This was missed in https://github.com/mongodb/mongo-php-library/pull/1230