### PR TITLE
PHPLIB-1424: Fix potentially racy w:0 unified tests

### DIFF
--- a/tests/UnifiedSpecTests/command-monitoring/unacknowledgedBulkWrite.json
+++ b/tests/UnifiedSpecTests/command-monitoring/unacknowledgedBulkWrite.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledgedBulkWrite",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.7",
   "createEntities": [
     {
       "client": {
@@ -64,11 +64,29 @@
             ],
             "ordered": false
           }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": "unorderedBulkWriteInsertW0",
+              "x": 44
+            }
+          ]
         }
       ],
       "expectEvents": [
         {
           "client": "client",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1424

Synced with mongodb/specifications@cd08b7248eb4e3ab901a8f7905874da41b908f7c

This PR supersedes https://github.com/mongodb/mongo-php-library/pull/1275