### PR TITLE
Create sarif report when running psalm

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -58,7 +58,13 @@ jobs:
           composer-options: "--no-suggest"
 
       - name: "Run Psalm"
-        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"
+        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --report=psalm.sarif"
 
       - name: "Run Rector"
         run: "vendor/bin/rector --ansi --dry-run"
+
+      - name: "Upload Psalm report"
+        uses: actions/upload-artifact@v4
+        with:
+          name: psalm.sarif
+          path: psalm.sarif


### PR DESCRIPTION
This PR changes the static analysis job to create and store a report for psalm in the SARIF format, which is then added as a build artifact. We can later attach this artifact to a release as part of our SSDLC documentation.