### PR TITLE
Use stable version of release tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
       # This step creates the signed release tag
       - name: "Create release tag"
-        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@main
+        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v1
         with:
           command: "git tag -m 'Release ${{ inputs.version }}' -s --local-user=${{ vars.GPG_KEY_ID }} ${{ inputs.version }}"
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}


### PR DESCRIPTION
With significant changes being introduced to the release tooling in the shared repository, we should rely on a tagged version of those release tools.