### PR TITLE
Revert "Bump mongodb-labs/drivers-github-tools from 1 to 2"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
       # This step creates the signed release tag
       - name: "Create release tag"
-        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v2
+        uses: mongodb-labs/drivers-github-tools/garasign/git-sign@v1
         with:
           command: "git tag -m 'Release ${{ inputs.version }}' -s --local-user=${{ vars.GPG_KEY_ID }} ${{ inputs.version }}"
           garasign_username: ${{ secrets.GRS_CONFIG_USER1_USERNAME }}


### PR DESCRIPTION
Reverts mongodb/mongo-php-library#1332. v2 uses a different setup process to fetch credentials which wouldn't work with our setup. I'll be migrating to v2 separately and have created PHPLIB-1462 to track this.