### PR TITLE
PHPLIB-1461: Use single mongos in unacknowledgedBulkWrite command monitoring test

### DIFF
--- a/tests/UnifiedSpecTests/command-monitoring/unacknowledgedBulkWrite.json
+++ b/tests/UnifiedSpecTests/command-monitoring/unacknowledgedBulkWrite.json
@@ -5,6 +5,7 @@
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeEvents": [
           "commandStartedEvent",
           "commandSucceededEvent",


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1461

POC for https://github.com/mongodb/specifications/pull/1595