### PR TITLE
Use checkout and tag actions from drivers-github-tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,21 +48,11 @@ jobs:
       - name: "Create release output"
         run: echo '🎬 Release process for version ${{ inputs.version }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
 
-      - name: "Create temporary app token"
-        uses: actions/create-github-app-token@v1
-        id: app-token
+      - name: "Generate token and checkout repository"
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: "Store GitHub token in environment"
-        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          token: ${{ env.GH_TOKEN }}
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: "Store version numbers in env variables"
         run: |
@@ -103,9 +93,10 @@ jobs:
         run: echo "RELEASE_URL=$(gh release create ${{ inputs.version }} --target ${{ github.ref_name }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"
 
       - name: "Create release tag"
-        uses: mongodb-labs/drivers-github-tools/git-sign@v2
+        uses: mongodb-labs/drivers-github-tools/tag-version@v2
         with:
-          command: "git tag -m 'Release ${{ inputs.version }}' -s --local-user=${{ env.GPG_KEY_ID }} ${{ inputs.version }}"
+          version: ${{ inputs.version }}
+          tag_message_template: 'Release ${VERSION}'
 
       # TODO: Manually merge using ours strategy. This avoids merge-up pull requests being created
       # Process is:
@@ -113,12 +104,6 @@ jobs:
       # 2. merge release branch using --strategy=ours
       # 3. push next branch
       # 4. switch back to release branch, then push
-
-      - name: "Push changes from release branch"
-        run: git push
-
-      - name: "Push release tag"
-        run: git push origin ${{ inputs.version }}
 
       - name: "Set summary"
         run: |
@@ -146,21 +131,12 @@ jobs:
       contents: write
 
     steps:
-      - name: "Create temporary app token"
-        uses: actions/create-github-app-token@v1
-        id: app-token
+      - name: "Generate token and checkout repository"
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: "Store GitHub token in environment"
-        run: echo "GH_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
-        shell: bash
-
-      - uses: actions/checkout@v4
-        with:
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
           ref: refs/tags/${{ inputs.version }}
-          token: ${{ env.GH_TOKEN }}
 
       # Sets the S3_ASSETS environment variable used later
       - name: "Set up drivers-github-tools"


### PR DESCRIPTION
This PR makes use of the `secure-checkout` and `tag-version` actions from drivers-github-tools to reduce the amount of logic in our release workflow.