### PR TITLE
Fix refs used for code scanning results

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
       - name: "Generate SARIF report from code scanning alerts"
         uses: mongodb-labs/drivers-github-tools/code-scanning-export@v2
         with:
-          ref: ${{ inputs.version }}
+          ref: refs/tags/${{ inputs.version }}
           output-file: ${{ env.S3_ASSETS }}/code-scanning-alerts.json
 
       - name: "Generate compliance report"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
+      - name: "Get SHA hash of checked out ref"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo CHECKED_OUT_SHA=$(git rev-parse HEAD) >> $GITHUB_ENV
+
       - name: "Setup"
         uses: "./.github/actions/setup"
         with:
@@ -44,7 +49,15 @@ jobs:
         run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --report=psalm.sarif"
 
       - name: "Upload SARIF report"
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: "github/codeql-action/upload-sarif@v3"
         with:
           sarif_file: psalm.sarif
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      - name: "Upload SARIF report"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: "github/codeql-action/upload-sarif@v3"
+        with:
+          sarif_file: psalm.sarif
+          ref: ${{ inputs.ref }}
+          sha: ${{ env.CHECKED_OUT_SHA }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,3 +47,4 @@ jobs:
         uses: "github/codeql-action/upload-sarif@v3"
         with:
           sarif_file: psalm.sarif
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}


### PR DESCRIPTION
There are two changes here:
- When invoking the static analysis job from the release job, the `github.ref` variable is set to the branch that the release workflow was triggered in. This is changed to the tag reference we just created.
- The code scanning export action was invoked with the same `github.ref`, which was also changed to using the ref of the newly created tag.