### PR TITLE
PHPLIB-1482: Skip range V1 tests on ext-mongodb 1.20+

### DIFF
--- a/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
@@ -20,6 +20,8 @@ use function base64_decode;
 use function file_get_contents;
 use function get_debug_type;
 use function is_int;
+use function phpversion;
+use function version_compare;
 
 /**
  * Prose test 22: Range Explicit Encryption
@@ -38,6 +40,10 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        if (version_compare(phpversion('mongodb'), '1.20.0dev', '>=')) {
+            $this->markTestIncomplete('Range protocol V1 is not supported by ext-mongodb 1.20+');
+        }
 
         if ($this->isStandalone()) {
             $this->markTestSkipped('Range explicit encryption tests require replica sets');

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -38,9 +38,12 @@ use function glob;
 use function in_array;
 use function iterator_to_array;
 use function json_decode;
+use function phpversion;
 use function sprintf;
 use function str_repeat;
+use function str_starts_with;
 use function substr;
+use function version_compare;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -161,6 +164,10 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     {
         if (isset(self::$incompleteTests[$this->dataDescription()])) {
             $this->markTestIncomplete(self::$incompleteTests[$this->dataDescription()]);
+        }
+
+        if (str_starts_with($this->dataDescription(), 'fle2v2-Range-') && version_compare(phpversion('mongodb'), '1.20.0dev', '>=')) {
+            $this->markTestIncomplete('Range protocol V1 is not supported by ext-mongodb 1.20+');
         }
 
         if (isset($runOn)) {

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -115,6 +115,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         'timeoutMS: timeoutMS applied to listCollections to get collection schema' => 'Not yet implemented (PHPC-1760)',
         'timeoutMS: remaining timeoutMS applied to find to get keyvault data' => 'Not yet implemented (PHPC-1760)',
         'namedKMS: Automatically encrypt and decrypt with a named KMS provider' => 'Not yet implemented (PHPLIB-1328)',
+        'fle2v2-Compact: Compact works' => 'Failing due to bug in libmongocrypt (LIBMONGOCRYPT-699)',
     ];
 
     public function setUp(): void


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1482

ext-mongodb 1.20 uses libmongoc 1.28, which enables range V2 from libmongocrypt 1.10+ and drops support for range V1.

This should address test failures for `build-php-%phpVersion%-next-minor` tasks in Evergreen.

If this is merged to v1.19 and then merged up to master, there will be a conflict with https://github.com/mongodb/mongo-php-library/pull/1350. Since https://github.com/mongodb/mongo-php-library/pull/1350 is blocked on adding MongoDB 8.0 to CI, it may be prudent to rebase that PR after this is merged and then remove these changes there.