### PR TITLE
Test all builds in pull requests and tags

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -36,7 +36,7 @@ github_pr_aliases: &github_pr_aliases
     task_tags: ["pr"]
   # Run all tasks in PR variants for PHP 8.3 (excluding MongoDB latest)
   - variant_tags: ["pr php8.3"]
-    task_tags: ["!latest"]
+    task_tags: ["pr !latest"]
   # Run PR tasks for all PR variants (only MongoDB 7.0)
   - variant_tags: ["pr"]
     task_tags: ["pr 7.0"]

--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -5,19 +5,19 @@ buildvariants:
   # Debian
   - name: build-debian11
     display_name: "Build: Debian 11"
-    tags: ["build", "debian", "x64"]
+    tags: ["build", "debian", "x64", "pr", "tag"]
     run_on: debian11-small
     tasks:
       - name: "build-all-php"
   - name: build-debian10
     display_name: "Build: Debian 10"
-    tags: ["build", "debian", "x64"]
+    tags: ["build", "debian", "x64", "pr", "tag"]
     run_on: debian10-small
     tasks:
       - name: "build-all-php"
   - name: build-debian92
     display_name: "Build: Debian 9.2"
-    tags: ["build", "debian", "x64"]
+    tags: ["build", "debian", "x64", "pr", "tag"]
     run_on: debian92-small
     tasks:
       - name: "build-all-php"
@@ -25,31 +25,31 @@ buildvariants:
   # RHEL
   - name: build-rhel90
     display_name: "Build: RHEL 9.0"
-    tags: ["build", "rhel", "x64"]
+    tags: ["build", "rhel", "x64", "pr", "tag"]
     run_on: rhel90-small
     tasks:
       - name: "build-php-openssl3"
   - name: build-rhel83-zseries
     display_name: "Build: RHEL 8.3 Zseries"
-    tags: ["build", "rhel", "zseries"]
+    tags: ["build", "rhel", "zseries", "tag"]
     run_on: rhel83-zseries-small
     tasks:
       - name: "build-all-php"
   - name: build-rhel82-arm64
     display_name: "Build: RHEL 8.2 ARM64"
-    tags: ["build", "rhel", "arm64"]
+    tags: ["build", "rhel", "arm64", "tag"]
     run_on: rhel82-arm64
     tasks:
       - name: "build-all-php"
   - name: build-rhel81-power8
     display_name: "Build: RHEL 8.1 Power8"
-    tags: ["build", "rhel", "power8"]
+    tags: ["build", "rhel", "power8", "tag"]
     run_on: rhel81-power8-large
     tasks:
       - name: "build-all-php"
   - name: build-rhel80
     display_name: "Build: RHEL 8.0"
-    tags: ["build", "rhel", "x64"]
+    tags: ["build", "rhel", "x64", "pr", "tag"]
     run_on: rhel80-small
     tasks:
       - name: "build-all-php"
@@ -57,25 +57,25 @@ buildvariants:
   # Ubuntu LTS
   - name: build-ubuntu2204
     display_name: "Build: Ubuntu 22.04 x64"
-    tags: ["build", "ubuntu", "x64"]
+    tags: ["build", "ubuntu", "x64", "pr", "tag"]
     run_on: ubuntu2204-small
     tasks:
       - name: "build-php-openssl3"
   - name: build-ubuntu2204-arm64
     display_name: "Build: Ubuntu 22.04 ARM64"
-    tags: ["build", "ubuntu", "arm64"]
+    tags: ["build", "ubuntu", "arm64", "tag"]
     run_on: ubuntu2204-arm64-small
     tasks:
       - name: "build-php-openssl3"
   - name: build-ubuntu2004
     display_name: "Build: Ubuntu 20.04 x64"
-    tags: ["build", "ubuntu", "x64"]
+    tags: ["build", "ubuntu", "x64", "pr", "tag"]
     run_on: ubuntu2004-small
     tasks:
       - name: "build-all-php"
   - name: build-ubuntu2004-arm64
     display_name: "Build: Ubuntu 20.04 ARM64"
-    tags: ["build", "ubuntu", "arm64"]
+    tags: ["build", "ubuntu", "arm64", "tag"]
     run_on: ubuntu2004-arm64-small
     tasks:
       - name: "build-all-php"


### PR DESCRIPTION
This PR makes some adjustments to what we test in pull requests and tags:
- All "build" variants are run for tags
-  "build" variants on x64 platforms are run for pull requests
- Only run tasks tagged "pr" on pull requests for PHP 8