### PR TITLE
Remove usage of deprecated BSON functions

### DIFF
--- a/docs/tutorial/custom-types.txt
+++ b/docs/tutorial/custom-types.txt
@@ -151,8 +151,8 @@ back to ``LocalDateTime``.
 .. code-block:: php
 
     <?php
-    $bson = MongoDB\BSON\fromPHP(['date' => new LocalDateTime]);
-    $document = MongoDB\BSON\toPHP($bson);
+    $bson = MongoDB\BSON\Document::fromPHP(['date' => new LocalDateTime]);
+    $document = $bson->toPHP();
 
     var_dump($document);
     var_dump($document->date->toDateTime());

--- a/docs/tutorial/example-data.txt
+++ b/docs/tutorial/example-data.txt
@@ -22,8 +22,8 @@ example imports the ``zips.json`` file into a ``test.zips`` collection using the
    $bulk = new MongoDB\Driver\BulkWrite;
 
    foreach ($lines as $line) {
-       $bson = MongoDB\BSON\fromJSON($line);
-       $document = MongoDB\BSON\toPHP($bson);
+       $bson = MongoDB\BSON\Document::fromJSON($line);
+       $document = $bson->toPHP();
        $bulk->insert($document);
    }
 

--- a/examples/aggregate.php
+++ b/examples/aggregate.php
@@ -3,13 +3,12 @@ declare(strict_types=1);
 
 namespace MongoDB\Examples\Aggregate;
 
+use MongoDB\BSON\Document;
 use MongoDB\Client;
 
 use function assert;
 use function getenv;
 use function is_object;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 use function random_int;
 
@@ -17,7 +16,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {
-    return toRelaxedExtendedJSON(fromPHP($document));
+    return Document::fromPHP($document)->toRelaxedExtendedJSON();
 }
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');

--- a/examples/bulk.php
+++ b/examples/bulk.php
@@ -3,21 +3,20 @@ declare(strict_types=1);
 
 namespace MongoDB\Examples\Bulk;
 
+use MongoDB\BSON\Document;
 use MongoDB\Client;
 use MongoDB\Driver\WriteConcern;
 
 use function assert;
 use function getenv;
 use function is_object;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {
-    return toRelaxedExtendedJSON(fromPHP($document));
+    return Document::fromPHP($document)->toRelaxedExtendedJSON();
 }
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');

--- a/examples/changestream.php
+++ b/examples/changestream.php
@@ -3,13 +3,12 @@ declare(strict_types=1);
 
 namespace MongoDB\Examples\ChangeStream;
 
+use MongoDB\BSON\Document;
 use MongoDB\Client;
 
 use function assert;
 use function getenv;
 use function is_object;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 use function time;
 
@@ -17,7 +16,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {
-    return toRelaxedExtendedJSON(fromPHP($document));
+    return Document::fromPHP($document)->toRelaxedExtendedJSON();
 }
 
 // Change streams require a replica set or sharded cluster

--- a/examples/command_logger.php
+++ b/examples/command_logger.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Examples\CommandLogger;
 
+use MongoDB\BSON\Document;
 use MongoDB\Client;
 use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
@@ -13,15 +14,13 @@ use function assert;
 use function get_class;
 use function getenv;
 use function is_object;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {
-    return toRelaxedExtendedJSON(fromPHP($document));
+    return Document::fromPHP($document)->toRelaxedExtendedJSON();
 }
 
 class CommandLogger implements CommandSubscriber

--- a/examples/sdam_logger.php
+++ b/examples/sdam_logger.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Examples;
 
+use MongoDB\BSON\Document;
 use MongoDB\Client;
 use MongoDB\Driver\Monitoring\SDAMSubscriber;
 use MongoDB\Driver\Monitoring\ServerChangedEvent;
@@ -17,8 +18,6 @@ use MongoDB\Driver\Monitoring\TopologyOpeningEvent;
 
 use function get_class;
 use function getenv;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function printf;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -26,7 +25,7 @@ require __DIR__ . '/../vendor/autoload.php';
 /** @param array|object $document */
 function toJSON($document): string
 {
-    return toRelaxedExtendedJSON(fromPHP($document));
+    return Document::fromPHP($document)->toRelaxedExtendedJSON();
 }
 
 class SDAMLogger implements SDAMSubscriber

--- a/examples/with_transaction.php
+++ b/examples/with_transaction.php
@@ -3,14 +3,13 @@ declare(strict_types=1);
 
 namespace MongoDB\Examples\WithTransaction;
 
+use MongoDB\BSON\Document;
 use MongoDB\Client;
 use MongoDB\Driver\Session;
 
 use function assert;
 use function getenv;
 use function is_object;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toRelaxedExtendedJSON;
 use function MongoDB\with_transaction;
 use function printf;
 
@@ -18,7 +17,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 function toJSON(object $document): string
 {
-    return toRelaxedExtendedJSON(fromPHP($document));
+    return Document::fromPHP($document)->toRelaxedExtendedJSON();
 }
 
 // Transactions require a replica set (MongoDB >= 4.0) or sharded cluster (MongoDB >= 4.2)

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -135,19 +135,6 @@
       <code>stdClass</code>
     </MoreSpecificReturnType>
   </file>
-  <file src="src/Model/BSONIterator.php">
-    <MixedArgument>
-      <code>$documentLength</code>
-      <code>$documentLength</code>
-      <code><![CDATA[$this->options['typeMap']]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$this->position]]></code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code>$documentLength</code>
-    </MixedOperand>
-  </file>
   <file src="src/Model/ChangeStreamIterator.php">
     <MixedArgument>
       <code><![CDATA[$reply->cursor->nextBatch]]></code>

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -52,8 +52,6 @@ use function is_resource;
 use function is_string;
 use function method_exists;
 use function MongoDB\apply_type_map_to_document;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toJSON;
 use function property_exists;
 use function sprintf;
 use function str_contains;
@@ -705,7 +703,7 @@ class Bucket
     private function createPathForFile(object $file): string
     {
         if (is_array($file->_id) || (is_object($file->_id) && ! method_exists($file->_id, '__toString'))) {
-            $id = toJSON(fromPHP(['_id' => $file->_id]));
+            $id = Document::fromPHP(['_id' => $file->_id])->toRelaxedExtendedJSON();
         } else {
             $id = (string) $file->_id;
         }

--- a/src/GridFS/Exception/FileNotFoundException.php
+++ b/src/GridFS/Exception/FileNotFoundException.php
@@ -17,10 +17,9 @@
 
 namespace MongoDB\GridFS\Exception;
 
+use MongoDB\BSON\Document;
 use MongoDB\Exception\RuntimeException;
 
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toJSON;
 use function sprintf;
 
 class FileNotFoundException extends RuntimeException
@@ -58,7 +57,7 @@ class FileNotFoundException extends RuntimeException
      */
     public static function byId($id, string $namespace)
     {
-        $json = toJSON(fromPHP(['_id' => $id]));
+        $json = Document::fromPHP(['_id' => $id])->toRelaxedExtendedJSON();
 
         return new self(sprintf('File "%s" not found in "%s"', $json, $namespace));
     }

--- a/src/GridFS/Exception/StreamException.php
+++ b/src/GridFS/Exception/StreamException.php
@@ -2,10 +2,9 @@
 
 namespace MongoDB\GridFS\Exception;
 
+use MongoDB\BSON\Document;
 use MongoDB\Exception\RuntimeException;
 
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toJSON;
 use function sprintf;
 use function stream_get_meta_data;
 
@@ -30,7 +29,7 @@ class StreamException extends RuntimeException
      */
     public static function downloadFromIdFailed($id, $source, $destination): self
     {
-        $idString = toJSON(fromPHP(['_id' => $id]));
+        $idString = Document::fromPHP(['_id' => $id])->toRelaxedExtendedJSON();
         $sourceMetadata = stream_get_meta_data($source);
         $destinationMetadata = stream_get_meta_data($destination);
 

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -18,12 +18,12 @@
 namespace MongoDB\Model;
 
 use Iterator;
+use MongoDB\BSON\Document;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
 use ReturnTypeWillChange;
 
 use function is_array;
-use function MongoDB\BSON\toPHP;
 use function sprintf;
 use function strlen;
 use function substr;
@@ -147,7 +147,7 @@ class BSONIterator implements Iterator
             throw new UnexpectedValueException(sprintf('Expected %d bytes; %d remaining', $documentLength, $this->bufferLength - $this->position));
         }
 
-        $this->current = toPHP(substr($this->buffer, $this->position, $documentLength), $this->options['typeMap']);
+        $this->current = Document::fromBSON(substr($this->buffer, $this->position, $documentLength))->toPHP($this->options['typeMap']);
         $this->position += $documentLength;
     }
 }

--- a/src/Model/BSONIterator.php
+++ b/src/Model/BSONIterator.php
@@ -23,7 +23,9 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
 use ReturnTypeWillChange;
 
+use function assert;
 use function is_array;
+use function is_int;
 use function sprintf;
 use function strlen;
 use function substr;
@@ -49,6 +51,7 @@ class BSONIterator implements Iterator
 
     private int $position = 0;
 
+    /** @var array{typeMap: array, ...} */
     private array $options;
 
     /**
@@ -142,6 +145,7 @@ class BSONIterator implements Iterator
         }
 
         [, $documentLength] = unpack('V', substr($this->buffer, $this->position, self::BSON_SIZE));
+        assert(is_int($documentLength));
 
         if ($this->bufferLength - $this->position < $documentLength) {
             throw new UnexpectedValueException(sprintf('Expected %d bytes; %d remaining', $documentLength, $this->bufferLength - $this->position));

--- a/src/functions.php
+++ b/src/functions.php
@@ -43,8 +43,6 @@ use function get_object_vars;
 use function is_array;
 use function is_object;
 use function is_string;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toPHP;
 use function str_ends_with;
 use function substr;
 
@@ -115,7 +113,7 @@ function apply_type_map_to_document($document, array $typeMap)
         throw InvalidArgumentException::expectedDocumentType('$document', $document);
     }
 
-    return toPHP(fromPHP($document), $typeMap);
+    return Document::fromPHP($document)->toPHP($typeMap);
 }
 
 /**

--- a/tests/Model/BSONIteratorTest.php
+++ b/tests/Model/BSONIteratorTest.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Tests\Model;
 
+use MongoDB\BSON\Document;
 use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\Model\BSONIterator;
 use MongoDB\Tests\TestCase;
@@ -9,7 +10,6 @@ use MongoDB\Tests\TestCase;
 use function array_map;
 use function implode;
 use function iterator_to_array;
-use function MongoDB\BSON\fromPHP;
 use function substr;
 
 class BSONIteratorTest extends TestCase
@@ -30,7 +30,7 @@ class BSONIteratorTest extends TestCase
             [
                 null,
                 implode(array_map(
-                    'MongoDB\BSON\fromPHP',
+                    fn ($input) => (string) Document::fromPHP($input),
                     [
                         ['_id' => 1, 'x' => ['foo' => 'bar']],
                         ['_id' => 3, 'x' => ['foo' => 'bar']],
@@ -44,7 +44,7 @@ class BSONIteratorTest extends TestCase
             [
                 ['root' => 'array', 'document' => 'array'],
                 implode(array_map(
-                    'MongoDB\BSON\fromPHP',
+                    fn ($input) => (string) Document::fromPHP($input),
                     [
                         ['_id' => 1, 'x' => ['foo' => 'bar']],
                         ['_id' => 3, 'x' => ['foo' => 'bar']],
@@ -58,7 +58,7 @@ class BSONIteratorTest extends TestCase
             [
                 ['root' => 'object', 'document' => 'array'],
                 implode(array_map(
-                    'MongoDB\BSON\fromPHP',
+                    fn ($input) => (string) Document::fromPHP($input),
                     [
                         ['_id' => 1, 'x' => ['foo' => 'bar']],
                         ['_id' => 3, 'x' => ['foo' => 'bar']],
@@ -72,7 +72,7 @@ class BSONIteratorTest extends TestCase
             [
                 ['root' => 'array', 'document' => 'stdClass'],
                 implode(array_map(
-                    'MongoDB\BSON\fromPHP',
+                    fn ($input) => (string) Document::fromPHP($input),
                     [
                         ['_id' => 1, 'x' => ['foo' => 'bar']],
                         ['_id' => 3, 'x' => ['foo' => 'bar']],
@@ -88,7 +88,7 @@ class BSONIteratorTest extends TestCase
 
     public function testCannotReadLengthFromFirstDocument(): void
     {
-        $binaryString = substr(fromPHP([]), 0, 3);
+        $binaryString = substr((string) Document::fromPHP([]), 0, 3);
 
         $bsonIt = new BSONIterator($binaryString);
 
@@ -99,7 +99,7 @@ class BSONIteratorTest extends TestCase
 
     public function testCannotReadLengthFromSubsequentDocument(): void
     {
-        $binaryString = fromPHP([]) . substr(fromPHP([]), 0, 3);
+        $binaryString = (string) Document::fromPHP([]) . substr((string) Document::fromPHP([]), 0, 3);
 
         $bsonIt = new BSONIterator($binaryString);
         $bsonIt->rewind();
@@ -111,7 +111,7 @@ class BSONIteratorTest extends TestCase
 
     public function testCannotReadFirstDocument(): void
     {
-        $binaryString = substr(fromPHP([]), 0, 4);
+        $binaryString = substr((string) Document::fromPHP([]), 0, 4);
 
         $bsonIt = new BSONIterator($binaryString);
 
@@ -122,7 +122,7 @@ class BSONIteratorTest extends TestCase
 
     public function testCannotReadSecondDocument(): void
     {
-        $binaryString = fromPHP([]) . substr(fromPHP([]), 0, 4);
+        $binaryString = (string) Document::fromPHP([]) . substr((string) Document::fromPHP([]), 0, 4);
 
         $bsonIt = new BSONIterator($binaryString);
         $bsonIt->rewind();

--- a/tests/SpecTests/DocumentsMatchConstraintTest.php
+++ b/tests/SpecTests/DocumentsMatchConstraintTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\SpecTests;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\Javascript;
 use MongoDB\BSON\MaxKey;
@@ -16,9 +17,6 @@ use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Tests\TestCase;
 use PHPUnit\Framework\ExpectationFailedException;
-
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 
 use const PHP_INT_SIZE;
 
@@ -82,9 +80,9 @@ class DocumentsMatchConstraintTest extends TestCase
 
     public function provideBSONTypes()
     {
-        $undefined = toPHP(fromJSON('{ "x": {"$undefined": true} }'))->x;
-        $symbol = toPHP(fromJSON('{ "x": {"$symbol": "test"} }'))->x;
-        $dbPointer = toPHP(fromJSON('{ "x": {"$dbPointer": {"$ref": "db.coll", "$id" : { "$oid" : "5a2e78accd485d55b405ac12" }  }} }'))->x;
+        $undefined = Document::fromJSON('{ "x": {"$undefined": true} }')->toPHP()->x;
+        $symbol = Document::fromJSON('{ "x": {"$symbol": "test"} }')->toPHP()->x;
+        $dbPointer = Document::fromJSON('{ "x": {"$dbPointer": {"$ref": "db.coll", "$id" : { "$oid" : "5a2e78accd485d55b405ac12" }  }} }')->toPHP()->x;
         $int64 = new Int64(1);
         $long = PHP_INT_SIZE == 4 ? new Int64('4294967296') : 4_294_967_296;
 

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\SpecTests;
 
 use ArrayIterator;
 use LogicException;
+use MongoDB\BSON\Document;
 use MongoDB\Collection;
 use MongoDB\Driver\Server;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
@@ -14,8 +15,6 @@ use UnexpectedValueException;
 
 use function in_array;
 use function json_encode;
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 use function sprintf;
 use function version_compare;
 
@@ -179,7 +178,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      */
     protected function decodeJson(string $json)
     {
-        return toPHP(fromJSON($json));
+        return Document::fromJSON($json)->toPHP();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests;
 
 use InvalidArgumentException;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Codec\Codec;
 use MongoDB\Driver\ReadConcern;
@@ -27,8 +28,6 @@ use function is_int;
 use function is_object;
 use function is_string;
 use function iterator_to_array;
-use function MongoDB\BSON\fromPHP;
-use function MongoDB\BSON\toJSON;
 use function preg_match;
 use function preg_replace;
 use function restore_error_handler;
@@ -115,8 +114,8 @@ OUTPUT;
         }
 
         $this->assertEquals(
-            toJSON(fromPHP($normalizedExpectedDocument)),
-            toJSON(fromPHP($normalizedActualDocument)),
+            Document::fromPHP($normalizedExpectedDocument)->toRelaxedExtendedJSON(),
+            Document::fromPHP($normalizedActualDocument)->toRelaxedExtendedJSON(),
         );
     }
 
@@ -132,8 +131,8 @@ OUTPUT;
     public function assertSameDocument($expectedDocument, $actualDocument): void
     {
         $this->assertEquals(
-            toJSON(fromPHP($this->normalizeBSON($expectedDocument))),
-            toJSON(fromPHP($this->normalizeBSON($actualDocument))),
+            Document::fromPHP($this->normalizeBSON($expectedDocument))->toRelaxedExtendedJSON(),
+            Document::fromPHP($this->normalizeBSON($actualDocument))->toRelaxedExtendedJSON(),
         );
     }
 
@@ -147,7 +146,7 @@ OUTPUT;
             throw new InvalidArgumentException('$actualDocuments is not an array or Traversable');
         }
 
-        $normalizeRootDocuments = fn ($document) => toJSON(fromPHP($this->normalizeBSON($document)));
+        $normalizeRootDocuments = fn ($document) => Document::fromPHP($this->normalizeBSON($document))->toRelaxedExtendedJSON();
 
         $this->assertEquals(
             array_map($normalizeRootDocuments, $expectedDocuments),

--- a/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
+++ b/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\UnifiedSpecTests\Constraint;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\Javascript;
 use MongoDB\BSON\MaxKey;
@@ -21,8 +22,6 @@ use PHPUnit\Framework\ExpectationFailedException;
 use stdClass;
 
 use function fopen;
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 
 use const PHP_INT_SIZE;
 
@@ -36,9 +35,9 @@ class IsBsonTypeTest extends TestCase
 
     public function provideTypes()
     {
-        $undefined = toPHP(fromJSON('{ "x": {"$undefined": true} }'))->x;
-        $symbol = toPHP(fromJSON('{ "x": {"$symbol": "test"} }'))->x;
-        $dbPointer = toPHP(fromJSON('{ "x": {"$dbPointer": {"$ref": "db.coll", "$id" : { "$oid" : "5a2e78accd485d55b405ac12" }  }} }'))->x;
+        $undefined = Document::fromJSON('{ "x": {"$undefined": true} }')->toPHP()->x;
+        $symbol = Document::fromJSON('{ "x": {"$symbol": "test"} }')->toPHP()->x;
+        $dbPointer = Document::fromJSON('{ "x": {"$dbPointer": {"$ref": "db.coll", "$id" : { "$oid" : "5a2e78accd485d55b405ac12" }  }} }')->toPHP()->x;
         $int64 = new Int64(1);
         $long = PHP_INT_SIZE == 4 ? new Int64('4294967296') : 4_294_967_296;
 

--- a/tests/UnifiedSpecTests/UnifiedTestCase.php
+++ b/tests/UnifiedSpecTests/UnifiedTestCase.php
@@ -4,12 +4,11 @@ namespace MongoDB\Tests\UnifiedSpecTests;
 
 use Generator;
 use IteratorAggregate;
+use MongoDB\BSON\Document;
 use stdClass;
 use Traversable;
 
 use function file_get_contents;
-use function MongoDB\BSON\fromJSON;
-use function MongoDB\BSON\toPHP;
 use function PHPUnit\Framework\assertIsArray;
 use function PHPUnit\Framework\assertIsObject;
 use function PHPUnit\Framework\assertIsString;
@@ -69,7 +68,7 @@ final class UnifiedTestCase implements IteratorAggregate
     {
         /* Decode the file through the driver's extended JSON parser to ensure
          * proper handling of special types. */
-        $json = toPHP(fromJSON(file_get_contents($filename)));
+        $json = Document::fromJSON(file_get_contents($filename))->toPHP();
 
         yield from static::fromJSON($json);
     }


### PR DESCRIPTION
This fixes a number of failures due to unexpected deprecation messages after these methods were deprecated in PHPC 1.20