### PR TITLE
DOCSP-41495: php v1.20 compat updates

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -17,8 +17,6 @@ MongoDB PHP Library
    FAQ </faq>
    /whats-new
 
-HELLO TEST
-
 The |php-library| provides a high-level abstraction around the lower-level
 :php:`mongodb extension <mongodb>`.
 

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -2,7 +2,22 @@
 MongoDB PHP Library
 ===================
 
-.. default-domain:: mongodb
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+
+.. toctree::
+   :titlesonly:
+
+   Installation </tutorial/install-php-library>
+   /tutorial
+   /upgrade
+   /reference
+   FAQ </faq>
+   /whats-new
+
+HELLO TEST
 
 The |php-library| provides a high-level abstraction around the lower-level
 :php:`mongodb extension <mongodb>`.
@@ -44,6 +59,9 @@ If you have previously worked with the legacy ``mongo`` extension, it will be
 helpful to review the :doc:`/upgrade` for a summary of API changes between the
 old driver and this library.
 
+You can view changes introduced in each version release of the
+{+php-library+} in the :ref:`php-lib-whats-new` section.
+
 New to MongoDB?
 ---------------
 
@@ -59,14 +77,3 @@ encounter in the library documentation:
   :manual:`BSON Types </reference/bson-types>`
 
 - :manual:`MongoDB CRUD Operations </crud>`
-
-.. class:: hidden
-
-   .. toctree::
-      :titlesonly:
-
-      Installation </tutorial/install-php-library>
-      /tutorial
-      /upgrade
-      /reference
-      FAQ </faq>

--- a/docs/whats-new.txt
+++ b/docs/whats-new.txt
@@ -1,0 +1,33 @@
+.. _php-lib-whats-new:
+
+==========
+What's New
+==========
+
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: update, new feature, deprecation, upgrade
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Learn about new features, improvements, and fixes introduced in the
+following versions of the {+php-library+}:
+
+* :ref:`Version 1.20 <php-lib-version-1.20>`
+
+.. _php-lib-version-1.20:
+
+What's New in 1.20
+------------------
+
+.. important:: MongoDB Server v3.6 End-of-Life
+
+   Support for MongoDB Server v3.6 is removed in this release of the
+   library.

--- a/docs/whats-new.txt
+++ b/docs/whats-new.txt
@@ -31,3 +31,5 @@ What's New in 1.20
 
    Support for MongoDB Server v3.6 is removed in this release of the
    library.
+
+- Adds support for MongoDB Server v8.0.


### PR DESCRIPTION
adds whats new page and information about server support removal

https://jira.mongodb.org/browse/DOCSP-41495
staging - https://preview-mongodbrustagir.gatsbyjs.io/php-library/DOCSP-41495-php-server-eol/whats-new/