### PR TITLE
Fix build

### DIFF
--- a/.evergreen/config/generated/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/generated/test-variant/legacy-php-full.yml
@@ -16,10 +16,10 @@ buildvariants:
         name: "build-php-8.0"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
+      - ".standalone .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
       - "test-atlas-data-lake"
 
   # Test versions < 5.0
@@ -72,10 +72,10 @@ buildvariants:
         name: "build-php-7.4"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
+      - ".standalone .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
       - "test-atlas-data-lake"
 
   # Test versions < 5.0

--- a/.evergreen/config/generated/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/generated/test-variant/legacy-php-full.yml
@@ -20,8 +20,6 @@ buildvariants:
       - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
       - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
       - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - "test_serverless_task_group"
-      - "test_serverless_proxy_task_group"
       - "test-atlas-data-lake"
 
   # Test versions < 5.0
@@ -78,8 +76,6 @@ buildvariants:
       - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
       - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
       - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - "test_serverless_task_group"
-      - "test_serverless_proxy_task_group"
       - "test-atlas-data-lake"
 
   # Test versions < 5.0

--- a/.evergreen/config/templates/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/templates/test-variant/legacy-php-full.yml
@@ -18,8 +18,6 @@
       - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
       - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
       - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - "test_serverless_task_group"
-      - "test_serverless_proxy_task_group"
       - "test-atlas-data-lake"
 
   # Test versions < 5.0

--- a/.evergreen/config/templates/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/templates/test-variant/legacy-php-full.yml
@@ -14,10 +14,10 @@
         name: "build-php-%phpVersion%"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
-      - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0"
+      - ".standalone .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.8.0 !.rapid !.latest"
       - "test-atlas-data-lake"
 
   # Test versions < 5.0


### PR DESCRIPTION
This PR removes serverless tests on Debian 11 as our serverless test clusters run MongoDB 8.0. It also removes MongoDB rapid and latest from testing on Debian 11 which was left in when I refactored the build configuration.

This removes all test failures on master, except for the serverless proxy tests where a single retryable reads test fails. I'll investigate that separately as we may end up removing those tests entirely.