### PR TITLE
PHPLIB-1489: Handle CursorId deprecations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.18.0@b113f3ed0259fd6e212d87c3df80eec95a6abf19">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="examples/atlas_search.php">
     <MixedArgument>
       <code><![CDATA[$document['name']]]></code>
@@ -9,10 +9,10 @@
       <code><![CDATA[$document['name']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code>$document</code>
-      <code>$index</code>
-      <code>$index</code>
-      <code>$index</code>
+      <code><![CDATA[$document]]></code>
+      <code><![CDATA[$index]]></code>
+      <code><![CDATA[$index]]></code>
+      <code><![CDATA[$index]]></code>
     </MixedAssignment>
     <MixedPropertyFetch>
       <code><![CDATA[$index->name]]></code>
@@ -21,7 +21,7 @@
       <code><![CDATA[$index->queryable]]></code>
     </MixedPropertyFetch>
     <PossiblyFalseArgument>
-      <code>$uri</code>
+      <code><![CDATA[$uri]]></code>
     </PossiblyFalseArgument>
   </file>
   <file src="examples/persistable.php">
@@ -37,14 +37,17 @@
         ]]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
-      <code>stdClass</code>
-      <code>stdClass</code>
+      <code><![CDATA[stdClass]]></code>
+      <code><![CDATA[stdClass]]></code>
     </MoreSpecificReturnType>
   </file>
   <file src="src/ChangeStream.php">
     <DeprecatedConstant>
-      <code>self::CURSOR_NOT_FOUND</code>
+      <code><![CDATA[self::CURSOR_NOT_FOUND]]></code>
     </DeprecatedConstant>
+    <TooManyArguments>
+      <code><![CDATA[getId]]></code>
+    </TooManyArguments>
   </file>
   <file src="src/Client.php">
     <MixedArgument>
@@ -56,18 +59,18 @@
   </file>
   <file src="src/Collection.php">
     <MixedArgumentTypeCoercion>
-      <code>$options</code>
+      <code><![CDATA[$options]]></code>
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/Command/ListCollections.php">
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
     </MixedAssignment>
   </file>
   <file src="src/Command/ListDatabases.php">
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
     </MixedAssignment>
   </file>
@@ -77,12 +80,12 @@
       <code><![CDATA[$options['revision']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code>$context</code>
+      <code><![CDATA[$context]]></code>
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/GridFS/CollectionWrapper.php">
     <MixedAssignment>
-      <code>$ids[]</code>
+      <code><![CDATA[$ids[]]]></code>
     </MixedAssignment>
   </file>
   <file src="src/GridFS/ReadableStream.php">
@@ -93,26 +96,26 @@
   </file>
   <file src="src/GridFS/StreamWrapper.php">
     <InvalidDocblock>
-      <code>private function getContext(string $path, string $mode): array</code>
+      <code><![CDATA[private function getContext(string $path, string $mode): array]]></code>
     </InvalidDocblock>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$this->getContext($path, $mode)]]></code>
       <code><![CDATA[$this->getContext($path, $mode)]]></code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
-      <code>$context</code>
-      <code>$count</code>
-      <code>$count</code>
+      <code><![CDATA[$context]]></code>
+      <code><![CDATA[$count]]></code>
+      <code><![CDATA[$count]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>deleteFileAndChunksByFilename</code>
-      <code>updateFilenameForFilename</code>
+      <code><![CDATA[deleteFileAndChunksByFilename]]></code>
+      <code><![CDATA[updateFilenameForFilename]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Model/BSONArray.php">
     <MixedAssignment>
-      <code>$this[$key]</code>
-      <code>$value</code>
+      <code><![CDATA[$this[$key]]]></code>
+      <code><![CDATA[$value]]></code>
     </MixedAssignment>
   </file>
   <file src="src/Model/BSONDocument.php">
@@ -123,11 +126,11 @@
       <code><![CDATA[(object) $this->getArrayCopy()]]></code>
     </LessSpecificReturnStatement>
     <MixedAssignment>
-      <code>$this[$key]</code>
-      <code>$value</code>
+      <code><![CDATA[$this[$key]]]></code>
+      <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MoreSpecificReturnType>
-      <code>stdClass</code>
+      <code><![CDATA[stdClass]]></code>
     </MoreSpecificReturnType>
   </file>
   <file src="src/Model/ChangeStreamIterator.php">
@@ -135,7 +138,7 @@
       <code><![CDATA[$reply->cursor->nextBatch]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$resumeToken</code>
+      <code><![CDATA[$resumeToken]]></code>
       <code><![CDATA[$this->postBatchResumeToken]]></code>
     </MixedAssignment>
     <MixedPropertyFetch>
@@ -145,6 +148,14 @@
     <PossiblyNullArgument>
       <code><![CDATA[$this->current()]]></code>
     </PossiblyNullArgument>
+  </file>
+  <file src="src/Model/CodecCursor.php">
+    <ImplementedReturnTypeMismatch>
+      <code><![CDATA[CursorId|Int64]]></code>
+    </ImplementedReturnTypeMismatch>
+    <TooManyArguments>
+      <code><![CDATA[getId]]></code>
+    </TooManyArguments>
   </file>
   <file src="src/Model/CollectionInfoCommandIterator.php">
     <MixedArrayAssignment>
@@ -159,7 +170,7 @@
       <code><![CDATA[current($this->databases)]]></code>
     </MixedArgument>
     <MixedReturnTypeCoercion>
-      <code>int</code>
+      <code><![CDATA[int]]></code>
       <code><![CDATA[key($this->databases)]]></code>
     </MixedReturnTypeCoercion>
   </file>
@@ -168,21 +179,21 @@
       <code><![CDATA[(object) $this->index]]></code>
     </LessSpecificReturnStatement>
     <MixedArgument>
-      <code>$fieldName</code>
+      <code><![CDATA[$fieldName]]></code>
       <code><![CDATA[$index['key']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$fieldName</code>
-      <code>$type</code>
+      <code><![CDATA[$fieldName]]></code>
+      <code><![CDATA[$type]]></code>
     </MixedAssignment>
     <MixedOperand>
-      <code>$type</code>
+      <code><![CDATA[$type]]></code>
     </MixedOperand>
     <MixedReturnStatement>
       <code><![CDATA[$this->index['name']]]></code>
     </MixedReturnStatement>
     <MoreSpecificReturnType>
-      <code>stdClass</code>
+      <code><![CDATA[stdClass]]></code>
     </MoreSpecificReturnType>
   </file>
   <file src="src/Model/SearchIndexInput.php">
@@ -190,7 +201,7 @@
       <code><![CDATA[(object) $this->index]]></code>
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
-      <code>stdClass</code>
+      <code><![CDATA[stdClass]]></code>
     </MoreSpecificReturnType>
   </file>
   <file src="src/Operation/Aggregate.php">
@@ -200,110 +211,110 @@
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$cmdOptions['maxAwaitTimeMS']]]></code>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$cmd['hint']]]></code>
       <code><![CDATA[$cmd['readConcern']]]></code>
-      <code>$options[$option]</code>
+      <code><![CDATA[$options[$option]]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/BulkWrite.php">
     <MixedArgument>
-      <code>$args</code>
-      <code>$args</code>
-      <code>$args</code>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[2]</code>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[2]]]></code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[0]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
       <code><![CDATA[$args[2]['upsert']]]></code>
       <code><![CDATA[$args[2]['upsert']]]></code>
       <code><![CDATA[$args[2]['upsert']]]></code>
       <code><![CDATA[$args[2]['upsert']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
-      <code>$args[1]</code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]['limit']]]></code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
       <code><![CDATA[$args[2]['multi']]]></code>
       <code><![CDATA[$args[2]['multi']]]></code>
-      <code>$operations[$i][$type][0]</code>
-      <code>$operations[$i][$type][1]</code>
-      <code>$operations[$i][$type][1]</code>
-      <code>$operations[$i][$type][2]</code>
-      <code>$operations[$i][$type][2]</code>
+      <code><![CDATA[$operations[$i][$type][0]]]></code>
+      <code><![CDATA[$operations[$i][$type][1]]]></code>
+      <code><![CDATA[$operations[$i][$type][1]]]></code>
+      <code><![CDATA[$operations[$i][$type][2]]]></code>
+      <code><![CDATA[$operations[$i][$type][2]]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code>$args</code>
-      <code>$args</code>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
-      <code>$insertedIds[$i]</code>
-      <code>$operations[$i][$type][1]</code>
-      <code>$operations[$i][$type][2]</code>
-      <code>$operations[$i][$type][2]</code>
-      <code>$options[$option]</code>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$insertedIds[$i]]]></code>
+      <code><![CDATA[$operations[$i][$type][1]]]></code>
+      <code><![CDATA[$operations[$i][$type][2]]]></code>
+      <code><![CDATA[$operations[$i][$type][2]]]></code>
+      <code><![CDATA[$options[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$args[2]</code>
-      <code>$args[2]</code>
+      <code><![CDATA[$args[2]]]></code>
+      <code><![CDATA[$args[2]]]></code>
     </MixedOperand>
   </file>
   <file src="src/Operation/Count.php">
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$cmd['hint']]]></code>
       <code><![CDATA[$cmd['readConcern']]]></code>
       <code><![CDATA[$options['readConcern']]]></code>
@@ -311,7 +322,7 @@
       <code><![CDATA[$options['session']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/CreateCollection.php">
@@ -319,7 +330,7 @@
       <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
@@ -332,18 +343,18 @@
   </file>
   <file src="src/Operation/CreateIndexes.php">
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$cmd['commitQuorum']]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/CreateSearchIndexes.php">
     <MixedArgumentTypeCoercion>
-      <code>$index</code>
+      <code><![CDATA[$index]]></code>
     </MixedArgumentTypeCoercion>
     <MixedAssignment>
       <code><![CDATA[$cmd['comment']]]></code>
@@ -370,7 +381,7 @@
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/Distinct.php">
@@ -378,14 +389,14 @@
       <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$cmd['readConcern']]]></code>
       <code><![CDATA[$options['readConcern']]]></code>
       <code><![CDATA[$options['readPreference']]]></code>
       <code><![CDATA[$options['session']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/DropCollection.php">
@@ -398,7 +409,7 @@
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/DropDatabase.php">
@@ -421,12 +432,12 @@
       <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/DropSearchIndex.php">
@@ -439,7 +450,7 @@
       <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['readPreference']]]></code>
       <code><![CDATA[$options['session']]]></code>
     </MixedAssignment>
@@ -453,13 +464,13 @@
       <code><![CDATA[$options['modifiers'][$modifier[1]]]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code>$options[$modifier[0]]</code>
-      <code>$options[$option]</code>
+      <code><![CDATA[$options[$modifier[0]]]]></code>
+      <code><![CDATA[$options[$option]]]></code>
       <code><![CDATA[$options['readPreference']]]></code>
       <code><![CDATA[$options['session']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/FindAndModify.php">
@@ -468,19 +479,19 @@
       <code><![CDATA[$this->options['writeConcern']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$cmd['new']]]></code>
       <code><![CDATA[$cmd['upsert']]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>array|object|null</code>
+      <code><![CDATA[array|object|null]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
-      <code>decode</code>
-      <code>isInTransaction</code>
+      <code><![CDATA[decode]]></code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
     <MixedReturnStatement>
       <code><![CDATA[$value === null ? $value : $this->options['codec']->decode($value)]]></code>
@@ -491,14 +502,14 @@
   </file>
   <file src="src/Operation/FindOne.php">
     <MixedAssignment>
-      <code>$document</code>
+      <code><![CDATA[$document]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>array|object|null</code>
+      <code><![CDATA[array|object|null]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$document === false ? null : $document</code>
-      <code>$document === false ? null : $document</code>
+      <code><![CDATA[$document === false ? null : $document]]></code>
+      <code><![CDATA[$document === false ? null : $document]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Operation/FindOneAndDelete.php">
@@ -514,7 +525,7 @@
       <code><![CDATA[$options['fields']]]></code>
     </MixedAssignment>
     <PossiblyInvalidArgument>
-      <code>$replacement</code>
+      <code><![CDATA[$replacement]]></code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/FindOneAndUpdate.php">
@@ -524,35 +535,35 @@
   </file>
   <file src="src/Operation/InsertMany.php">
     <MixedAssignment>
-      <code>$insertedIds[$i]</code>
-      <code>$options[$option]</code>
+      <code><![CDATA[$insertedIds[$i]]]></code>
+      <code><![CDATA[$options[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
     <PossiblyInvalidArgument>
-      <code>$document</code>
+      <code><![CDATA[$document]]></code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/InsertOne.php">
     <MixedAssignment>
-      <code>$insertedId</code>
-      <code>$options[$option]</code>
+      <code><![CDATA[$insertedId]]></code>
+      <code><![CDATA[$options[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
     <PossiblyInvalidArgument>
-      <code>$document</code>
+      <code><![CDATA[$document]]></code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/ListIndexes.php">
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
     </MixedAssignment>
   </file>
@@ -563,14 +574,14 @@
       <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['readConcern']]]></code>
       <code><![CDATA[$options['readPreference']]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/ModifyCollection.php">
@@ -588,17 +599,17 @@
       <code><![CDATA[$this->options['typeMap']]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$cmd[$option]</code>
+      <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/ReplaceOne.php">
     <PossiblyInvalidArgument>
-      <code>$replacement</code>
+      <code><![CDATA[$replacement]]></code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/Update.php">
@@ -607,13 +618,13 @@
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$cmd['bypassDocumentValidation']]]></code>
-      <code>$options[$option]</code>
+      <code><![CDATA[$options[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
-      <code>$updateOptions[$option]</code>
+      <code><![CDATA[$updateOptions[$option]]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>isInTransaction</code>
+      <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/Operation/UpdateSearchIndex.php">
@@ -629,7 +640,7 @@
       <code><![CDATA[$this->postBatchResumeToken]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>array|object|null</code>
+      <code><![CDATA[array|object|null]]></code>
     </MixedInferredReturnType>
     <MixedPropertyFetch>
       <code><![CDATA[$reply->cursor->firstBatch]]></code>
@@ -642,13 +653,13 @@
   </file>
   <file src="src/UpdateResult.php">
     <MixedAssignment>
-      <code>$id</code>
+      <code><![CDATA[$id]]></code>
     </MixedAssignment>
   </file>
   <file src="src/functions.php">
     <MixedArgument>
-      <code>$stage</code>
-      <code>$wireVersionForWriteStageOnSecondary</code>
+      <code><![CDATA[$stage]]></code>
+      <code><![CDATA[$wireVersionForWriteStageOnSecondary]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$manager->getServers()]]></code>
@@ -661,16 +672,16 @@
       <code><![CDATA[$typeMap['fieldPaths'][substr($fieldPath, 0, -2)]]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code>$element[$key]</code>
-      <code>$stage</code>
-      <code>$type</code>
+      <code><![CDATA[$element[$key]]]></code>
+      <code><![CDATA[$stage]]></code>
+      <code><![CDATA[$type]]></code>
       <code><![CDATA[$typeMap['fieldPaths'][$fieldPath . '.' . $existingFieldPath]]]></code>
       <code><![CDATA[$typeMap['fieldPaths'][$fieldPath]]]></code>
-      <code>$value</code>
+      <code><![CDATA[$value]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>array|object|null</code>
-      <code>array|object|null</code>
+      <code><![CDATA[array|object|null]]></code>
+      <code><![CDATA[array|object|null]]></code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$collectionInfo['options']['encryptedFields'] ?? null]]></code>

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -19,6 +19,7 @@ namespace MongoDB;
 
 use Iterator;
 use MongoDB\BSON\Document;
+use MongoDB\BSON\Int64;
 use MongoDB\Codec\DocumentCodec;
 use MongoDB\Driver\CursorId;
 use MongoDB\Driver\Exception\ConnectionException;
@@ -32,6 +33,10 @@ use ReturnTypeWillChange;
 use function assert;
 use function call_user_func;
 use function in_array;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Iterator for a change stream.
@@ -105,10 +110,23 @@ class ChangeStream implements Iterator
         return $this->codec->decode($value);
     }
 
-    /** @return CursorId */
-    public function getCursorId()
+    /** @return CursorId|Int64 */
+    #[ReturnTypeWillChange]
+    public function getCursorId(bool $asInt64 = false)
     {
-        return $this->iterator->getInnerIterator()->getId();
+        if (! $asInt64) {
+            @trigger_error(
+                sprintf(
+                    'The method "%s" will no longer return a "%s" instance in the future. Pass "true" as argument to change to the new behavior and receive a "%s" instance instead.',
+                    __METHOD__,
+                    CursorId::class,
+                    Int64::class,
+                ),
+                E_USER_DEPRECATED,
+            );
+        }
+
+        return $this->iterator->getInnerIterator()->getId($asInt64);
     }
 
     /**

--- a/src/Model/CodecCursor.php
+++ b/src/Model/CodecCursor.php
@@ -19,17 +19,20 @@ namespace MongoDB\Model;
 
 use Iterator;
 use MongoDB\BSON\Document;
+use MongoDB\BSON\Int64;
 use MongoDB\Codec\DocumentCodec;
 use MongoDB\Driver\Cursor;
 use MongoDB\Driver\CursorId;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Server;
+use ReturnTypeWillChange;
 
 use function assert;
 use function iterator_to_array;
 use function sprintf;
 use function trigger_error;
 
+use const E_USER_DEPRECATED;
 use const E_USER_WARNING;
 
 /**
@@ -73,9 +76,23 @@ class CodecCursor implements CursorInterface, Iterator
         return new self($cursor, $codec);
     }
 
-    public function getId(): CursorId
+    /** @return CursorId|Int64 */
+    #[ReturnTypeWillChange]
+    public function getId(bool $asInt64 = false)
     {
-        return $this->cursor->getId();
+        if (! $asInt64) {
+            @trigger_error(
+                sprintf(
+                    'The method "%s" will no longer return a "%s" instance in the future. Pass "true" as argument to change to the new behavior and receive a "%s" instance instead.',
+                    __METHOD__,
+                    CursorId::class,
+                    Int64::class,
+                ),
+                E_USER_DEPRECATED,
+            );
+        }
+
+        return $this->cursor->getId($asInt64);
     }
 
     public function getServer(): Server

--- a/tests/Model/CodecCursorFunctionalTest.php
+++ b/tests/Model/CodecCursorFunctionalTest.php
@@ -2,9 +2,17 @@
 
 namespace MongoDB\Tests\Model;
 
+use MongoDB\BSON\Int64;
 use MongoDB\Codec\DocumentCodec;
+use MongoDB\Driver\CursorId;
 use MongoDB\Model\CodecCursor;
 use MongoDB\Tests\FunctionalTestCase;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_DEPRECATED;
+use const E_USER_DEPRECATED;
 
 class CodecCursorFunctionalTest extends FunctionalTestCase
 {
@@ -26,5 +34,71 @@ class CodecCursorFunctionalTest extends FunctionalTestCase
         $this->expectWarningMessage('Discarding type map for MongoDB\Model\CodecCursor::setTypeMap');
 
         $codecCursor->setTypeMap(['root' => 'array']);
+    }
+
+    public function testGetIdReturnTypeWithoutArgument(): void
+    {
+        $collection = self::createTestClient()->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+        $cursor = $collection->find();
+
+        $codecCursor = CodecCursor::fromCursor($cursor, $this->createMock(DocumentCodec::class));
+
+        $deprecations = [];
+
+        try {
+            $previousErrorHandler = set_error_handler(
+                function (...$args) use (&$previousErrorHandler, &$deprecations) {
+                    $deprecations[] = $args;
+
+                    return true;
+                },
+                E_USER_DEPRECATED | E_DEPRECATED,
+            );
+
+            $cursorId = $codecCursor->getId();
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertInstanceOf(CursorId::class, $cursorId);
+
+        // Expect 2 deprecations: 1 from CodecCursor, one from Cursor
+        self::assertCount(2, $deprecations);
+        self::assertSame(
+            'The method "MongoDB\Model\CodecCursor::getId" will no longer return a "MongoDB\Driver\CursorId" instance in the future. Pass "true" as argument to change to the new behavior and receive a "MongoDB\BSON\Int64" instance instead.',
+            $deprecations[0][1],
+        );
+        self::assertSame(
+            'MongoDB\Driver\Cursor::getId(): The method "MongoDB\Driver\Cursor::getId" will no longer return a "MongoDB\Driver\CursorId" instance in the future. Pass "true" as argument to change to the new behavior and receive a "MongoDB\BSON\Int64" instance instead.',
+            $deprecations[1][1],
+        );
+    }
+
+    public function testGetIdReturnTypeWithArgument(): void
+    {
+        $collection = self::createTestClient()->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+        $cursor = $collection->find();
+
+        $codecCursor = CodecCursor::fromCursor($cursor, $this->createMock(DocumentCodec::class));
+
+        $deprecations = [];
+
+        try {
+            $previousErrorHandler = set_error_handler(
+                function (...$args) use (&$previousErrorHandler, &$deprecations) {
+                    $deprecations[] = $args;
+
+                    return true;
+                },
+                E_USER_DEPRECATED | E_DEPRECATED,
+            );
+
+            $cursorId = $codecCursor->getId(true);
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertInstanceOf(Int64::class, $cursorId);
+        self::assertCount(0, $deprecations);
     }
 }


### PR DESCRIPTION
PHPLIB-1489

This PR complements https://github.com/mongodb/mongo-php-driver/pull/1616 by introducing the same `$asInt64` argument to all classes that implement `CursorInterface::getId` or wrap a cursor class. Not providing the argument or providing `false` as a value will trigger a deprecation warning to inform the user they need to update. In 2.0, we can deprecate the parameter and change the return type of the methods to `Int64`.