### PR TITLE
PHPLIB-1444 Unskip failCommand+appName tests on MongoDB 4.4.7+

### DIFF
--- a/tests/UnifiedSpecTests/load-balancers/sdam-error-handling.json
+++ b/tests/UnifiedSpecTests/load-balancers/sdam-error-handling.json
@@ -263,7 +263,7 @@
       "description": "errors during the initial connection hello are ignored",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.9"
+          "minServerVersion": "4.4.7"
         }
       ],
       "operations": [


### PR DESCRIPTION
Fix PHPLIB-1444

Sync https://github.com/mongodb/specifications/commit/a35de873621a244b88cad01aa3cd7c8da31a5ecd

Skipped this files, because they are missing:
```
source/client-side-operations-timeout/tests/command-execution.json
source/server-discovery-and-monitoring/tests/unified/hello-command-error.json
source/server-discovery-and-monitoring/tests/unified/hello-network-error.json
source/server-discovery-and-monitoring/tests/unified/interruptInUse-pool-clear.json
source/server-discovery-and-monitoring/tests/unified/minPoolSize-error.json
```

