### PR TITLE
Test with 1.20 branch in CI

### DIFF
--- a/.evergreen/config/generated/build/build-extension.yml
+++ b/.evergreen/config/generated/build/build-extension.yml
@@ -9,7 +9,7 @@ tasks:
       - func: "compile extension"
         # TODO: remove once 1.20.0 is released
         vars:
-          EXTENSION_BRANCH: "master"
+          EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
   # TODO: re-enable once 1.20.0 is released
 #  - name: "build-php-8.3-lowest"
@@ -51,7 +51,7 @@ tasks:
       - func: "compile extension"
         # TODO: remove once 1.20.0 is released
         vars:
-          EXTENSION_BRANCH: "master"
+          EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
   # TODO: re-enable once 1.20.0 is released
 #  - name: "build-php-8.2-lowest"
@@ -93,7 +93,7 @@ tasks:
       - func: "compile extension"
         # TODO: remove once 1.20.0 is released
         vars:
-          EXTENSION_BRANCH: "master"
+          EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
   # TODO: re-enable once 1.20.0 is released
 #  - name: "build-php-8.1-lowest"
@@ -135,7 +135,7 @@ tasks:
       - func: "compile extension"
         # TODO: remove once 1.20.0 is released
         vars:
-          EXTENSION_BRANCH: "master"
+          EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
   # TODO: re-enable once 1.20.0 is released
 #  - name: "build-php-8.0-lowest"
@@ -177,7 +177,7 @@ tasks:
       - func: "compile extension"
         # TODO: remove once 1.20.0 is released
         vars:
-          EXTENSION_BRANCH: "master"
+          EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
   # TODO: re-enable once 1.20.0 is released
 #  - name: "build-php-7.4-lowest"

--- a/.evergreen/config/templates/build/build-extension.yml
+++ b/.evergreen/config/templates/build/build-extension.yml
@@ -7,7 +7,7 @@
       - func: "compile extension"
         # TODO: remove once 1.20.0 is released
         vars:
-          EXTENSION_BRANCH: "master"
+          EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
   # TODO: re-enable once 1.20.0 is released
 #  - name: "build-php-%phpVersion%-lowest"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -17,7 +17,7 @@ env:
   PHP_VERSION: "8.2"
   # TODO: change to "stable" once 1.20.0 is released
   # DRIVER_VERSION: "stable"
-  DRIVER_VERSION: "mongodb/mongo-php-driver@master"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.20"
 
 jobs:
   phpcs:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,7 +23,7 @@ env:
   PHP_VERSION: "8.2"
   # TODO: change to "stable" once 1.20.0 is released
   # DRIVER_VERSION: "stable"
-  DRIVER_VERSION: "mongodb/mongo-php-driver@master"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.20"
 
 jobs:
   psalm:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ on:
 env:
   # TODO: change to "stable" once 1.20.0 is released
   # DRIVER_VERSION: "stable"
-  DRIVER_VERSION: "mongodb/mongo-php-driver@master"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.20"
 
 jobs:
   phpunit:


### PR DESCRIPTION
When https://github.com/mongodb/mongo-php-driver/pull/1631 is merged to master, builds on PHP 7.4 and 8.0 will fail. This PR changes the PHPC branch to 1.20 until a stable release of 1.20 is available so the build keeps working.

Note: CSFLE failures will be fixed by #1373.