### PR TITLE
PHPLIB-1419 Encode Agg builder objects in Collection methods

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -890,6 +890,7 @@
     <MixedAssignment>
       <code><![CDATA[$element[$key]]]></code>
       <code><![CDATA[$stage]]></code>
+      <code><![CDATA[$stage]]></code>
       <code><![CDATA[$type]]></code>
       <code><![CDATA[$typeMap['fieldPaths'][$fieldPath . '.' . $existingFieldPath]]]></code>
       <code><![CDATA[$typeMap['fieldPaths'][$fieldPath]]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -223,6 +223,11 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$options['builderEncoder'] ?? new BuilderEncoder()]]></code>
     </MixedPropertyTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Command/ListCollections.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -191,6 +191,7 @@
   <file src="src/Client.php">
     <MixedArgument>
       <code><![CDATA[$driverOptions['driver'] ?? []]]></code>
+      <code><![CDATA[$pipeline]]></code>
     </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$mergedDriver['platform']]]></code>
@@ -198,6 +199,12 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$driverOptions['builderEncoder'] ?? new BuilderEncoder()]]></code>
     </MixedPropertyTypeCoercion>
+    <NamedArgumentNotAllowed>
+      <code><![CDATA[$pipeline]]></code>
+    </NamedArgumentNotAllowed>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$pipeline]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Codec/EncodeIfSupported.php">
     <ArgumentTypeCoercion>
@@ -220,9 +227,17 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/Collection.php">
+    <MixedArgument>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+    </MixedArgument>
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$options['builderEncoder'] ?? new BuilderEncoder()]]></code>
     </MixedPropertyTypeCoercion>
+    <NamedArgumentNotAllowed>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+    </NamedArgumentNotAllowed>
     <PossiblyInvalidArgument>
       <code><![CDATA[$pipeline]]></code>
       <code><![CDATA[$pipeline]]></code>
@@ -242,9 +257,22 @@
     </MixedAssignment>
   </file>
   <file src="src/Database.php">
+    <MixedArgument>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+    </MixedArgument>
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$options['builderEncoder'] ?? new BuilderEncoder()]]></code>
     </MixedPropertyTypeCoercion>
+    <NamedArgumentNotAllowed>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+    </NamedArgumentNotAllowed>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/GridFS/Bucket.php">
     <MixedArgument>

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,6 +22,7 @@ use Iterator;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Pipeline;
 use MongoDB\Codec\Encoder;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\InvalidArgumentException as DriverInvalidArgumentException;
@@ -391,6 +392,12 @@ class Client
      */
     public function watch(array $pipeline = [], array $options = [])
     {
+        if (is_builder_pipeline($pipeline)) {
+            $pipeline = new Pipeline(...$pipeline);
+        }
+
+        $pipeline = $this->builderEncoder->encodeIfSupported($pipeline);
+
         if (! isset($options['readPreference']) && ! is_in_transaction($options)) {
             $options['readPreference'] = $this->readPreference;
         }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1110,6 +1110,7 @@ class Collection
         }
 
         $pipeline = $this->builderEncoder->encodeIfSupported($pipeline);
+
         $options = $this->inheritReadOptions($options);
         $options = $this->inheritCodecOrTypeMap($options);
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -23,6 +23,7 @@ use MongoDB\BSON\Document;
 use MongoDB\BSON\JavascriptInterface;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Pipeline;
 use MongoDB\Codec\DocumentCodec;
 use MongoDB\Codec\Encoder;
 use MongoDB\Driver\CursorInterface;
@@ -223,6 +224,12 @@ class Collection
      */
     public function aggregate(array $pipeline, array $options = [])
     {
+        if (is_builder_pipeline($pipeline)) {
+            $pipeline = new Pipeline(...$pipeline);
+        }
+
+        $pipeline = $this->builderEncoder->encodeIfSupported($pipeline);
+
         $hasWriteStage = is_last_pipeline_operator_write($pipeline);
 
         $options = $this->inheritReadPreference($options);
@@ -1098,6 +1105,11 @@ class Collection
      */
     public function watch(array $pipeline = [], array $options = [])
     {
+        if (is_builder_pipeline($pipeline)) {
+            $pipeline = new Pipeline(...$pipeline);
+        }
+
+        $pipeline = $this->builderEncoder->encodeIfSupported($pipeline);
         $options = $this->inheritReadOptions($options);
         $options = $this->inheritCodecOrTypeMap($options);
 

--- a/src/Database.php
+++ b/src/Database.php
@@ -21,6 +21,7 @@ use Iterator;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Builder\Pipeline;
 use MongoDB\Codec\Encoder;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Cursor;
@@ -202,6 +203,12 @@ class Database
      */
     public function aggregate(array $pipeline, array $options = [])
     {
+        if (is_builder_pipeline($pipeline)) {
+            $pipeline = new Pipeline(...$pipeline);
+        }
+
+        $pipeline = $this->builderEncoder->encodeIfSupported($pipeline);
+
         $hasWriteStage = is_last_pipeline_operator_write($pipeline);
 
         if (! isset($options['readPreference']) && ! is_in_transaction($options)) {
@@ -611,6 +618,12 @@ class Database
      */
     public function watch(array $pipeline = [], array $options = [])
     {
+        if (is_builder_pipeline($pipeline)) {
+            $pipeline = new Pipeline(...$pipeline);
+        }
+
+        $pipeline = $this->builderEncoder->encodeIfSupported($pipeline);
+
         if (! isset($options['readPreference']) && ! is_in_transaction($options)) {
             $options['readPreference'] = $this->readPreference;
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -336,28 +336,17 @@ function is_pipeline(array|object $pipeline, bool $allowEmpty = false): bool
  */
 function is_builder_pipeline(array $pipeline): bool
 {
-    if (! $pipeline) {
+    if (! $pipeline || ! array_is_list($pipeline)) {
         return false;
     }
 
-    if (! array_is_list($pipeline)) {
-        return false;
-    }
-
-    $result = false;
     foreach ($pipeline as $stage) {
-        if (! is_array($stage) && ! is_object($stage)) {
-            return false;
-        }
-
-        if ($stage instanceof StageInterface) {
-            $result = true;
-        } elseif (! is_first_key_operator($stage)) {
-            return false;
+        if (is_object($stage) && $stage instanceof StageInterface) {
+            return true;
         }
     }
 
-    return $result;
+    return false;
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -21,6 +21,7 @@ use Exception;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Serializable;
+use MongoDB\Builder\Type\StageInterface;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Manager;
 use MongoDB\Driver\ReadPreference;
@@ -325,6 +326,38 @@ function is_pipeline(array|object $pipeline, bool $allowEmpty = false): bool
     }
 
     return true;
+}
+
+/**
+ * Returns whether the argument is a list that contains at least one
+ * {@see StageInterface} object.
+ *
+ * @internal
+ */
+function is_builder_pipeline(array $pipeline): bool
+{
+    if (! $pipeline) {
+        return false;
+    }
+
+    if (! array_is_list($pipeline)) {
+        return false;
+    }
+
+    $result = false;
+    foreach ($pipeline as $stage) {
+        if (! is_array($stage) && ! is_object($stage)) {
+            return false;
+        }
+
+        if ($stage instanceof StageInterface) {
+            $result = true;
+        } elseif (! is_first_key_operator($stage)) {
+            return false;
+        }
+    }
+
+    return $result;
 }
 
 /**

--- a/tests/Collection/BuilderCollectionFunctionalTest.php
+++ b/tests/Collection/BuilderCollectionFunctionalTest.php
@@ -272,8 +272,6 @@ class BuilderCollectionFunctionalTest extends FunctionalTestCase
         $pipeline = iterator_to_array($pipeline);
 
         $changeStream = $this->collection->watch($pipeline);
-        $changeStream->rewind();
-        $this->assertNull($changeStream->current());
         $this->collection->insertOne(['x' => 3]);
         $changeStream->next();
         $this->assertTrue($changeStream->valid());

--- a/tests/Database/BuilderDatabaseFunctionalTest.php
+++ b/tests/Database/BuilderDatabaseFunctionalTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace MongoDB\Tests\Database;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+
+use function iterator_to_array;
+
+class BuilderDatabaseFunctionalTest extends FunctionalTestCase
+{
+    public function tearDown(): void
+    {
+        $this->dropCollection($this->getDatabaseName(), $this->getCollectionName());
+
+        parent::tearDown();
+    }
+
+    public function testAggregate(): void
+    {
+        $this->skipIfServerVersion('<', '6.0.0', '$documents stage is not supported');
+
+        $pipeline = new Pipeline(
+            Stage::documents([
+                ['x' => 1],
+                ['x' => 2],
+                ['x' => 3],
+            ]),
+            Stage::bucketAuto(
+                groupBy: Expression::intFieldPath('x'),
+                buckets: 2,
+            ),
+        );
+        // Extract the list of stages for arg type restriction
+        $pipeline = iterator_to_array($pipeline);
+
+        $results = $this->database->aggregate($pipeline)->toArray();
+        $this->assertCount(2, $results);
+    }
+
+    public function testWatch(): void
+    {
+        $this->skipIfChangeStreamIsNotSupported();
+
+        if ($this->isShardedCluster()) {
+            $this->markTestSkipped('Test does not apply on sharded clusters: need more than a single getMore call on the change stream.');
+        }
+
+        $pipeline = new Pipeline(
+            Stage::match(operationType: Query::eq('insert')),
+        );
+        // Extract the list of stages for arg type restriction
+        $pipeline = iterator_to_array($pipeline);
+
+        $changeStream = $this->database->watch($pipeline);
+        $this->database->selectCollection($this->getCollectionName())->insertOne(['x' => 3]);
+        $changeStream->next();
+        $this->assertTrue($changeStream->valid());
+        $this->assertEquals('insert', $changeStream->current()->operationType);
+    }
+}

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -327,7 +327,6 @@ class FunctionsTest extends TestCase
         yield 'map of stages' => [false, [1 => new MatchStage([])]];
         yield 'stages' => [true, [new MatchStage([]), new LimitStage(1)]];
         yield 'stages and operators' => [true, [new MatchStage([]), ['$limit' => 1]]];
-        yield 'stages and invalid' => [false, [new MatchStage([]), ['foo' => 'bar']]];
     }
 
     /** @dataProvider provideWriteConcerns */


### PR DESCRIPTION
Fix PHPLIB-1419

~Requires https://github.com/mongodb/mongo-php-library/pull/1382~

The encoding is done in the `Collection` methods, not in the various `Operation` classes:
- No option to validate in each Operation class
- Very little code duplicate in each method, whereas handling in operation classes would require the documentation and validation of the new option in each class.
- In the future, it is still possible to move the encoding and add an option to the methods without breaking change.

Only the `BulkWrite` operation has the option, because the processing of each operation is already organised in this operation class.

The Collection methods does not accept the `builderEncoder` option for now. If a specific encoder is necessary for an operation, if can be called just before the operation:

```php
$pipeline = new Pipeline(...);

// Required for now, as we could not change the argument type. In 2.0 this will not be necessary.
$pipeline = iterator_to_array($pipeline);

$pipeline = (new CustomBuilderEncoder)->encode($pipeline);
$collection->aggregate($pipeline);
```
