### PR TITLE
PHPLIB-1420 Integrate query builder for non-aggregation APIs

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -223,11 +223,6 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$options['builderEncoder'] ?? new BuilderEncoder()]]></code>
     </MixedPropertyTypeCoercion>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$pipeline]]></code>
-      <code><![CDATA[$pipeline]]></code>
-      <code><![CDATA[$pipeline]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/Command/ListCollections.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -223,6 +223,11 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$options['builderEncoder'] ?? new BuilderEncoder()]]></code>
     </MixedPropertyTypeCoercion>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+      <code><![CDATA[$pipeline]]></code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Command/ListCollections.php">
     <MixedAssignment>
@@ -417,8 +422,9 @@
       <code><![CDATA[$args[0]]]></code>
       <code><![CDATA[$args[0]]]></code>
       <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
       <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]]]></code>
@@ -448,6 +454,7 @@
       <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]['limit']]]></code>
       <code><![CDATA[$args[2]]]></code>
       <code><![CDATA[$args[2]]]></code>
@@ -458,6 +465,10 @@
       <code><![CDATA[$args[2]['multi']]]></code>
       <code><![CDATA[$args[2]['multi']]]></code>
       <code><![CDATA[$operations[$i][$type][0]]]></code>
+      <code><![CDATA[$operations[$i][$type][0]]]></code>
+      <code><![CDATA[$operations[$i][$type][0]]]></code>
+      <code><![CDATA[$operations[$i][$type][0]]]></code>
+      <code><![CDATA[$operations[$i][$type][1]]]></code>
       <code><![CDATA[$operations[$i][$type][1]]]></code>
       <code><![CDATA[$operations[$i][$type][1]]]></code>
       <code><![CDATA[$operations[$i][$type][2]]]></code>
@@ -466,9 +477,14 @@
     <MixedAssignment>
       <code><![CDATA[$args]]></code>
       <code><![CDATA[$args]]></code>
+      <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[2]]]></code>
       <code><![CDATA[$args[2]]]></code>
       <code><![CDATA[$insertedIds[$i]]]></code>
+      <code><![CDATA[$operations[$i][$type][0]]]></code>
+      <code><![CDATA[$operations[$i][$type][0]]]></code>
+      <code><![CDATA[$operations[$i][$type][0]]]></code>
+      <code><![CDATA[$operations[$i][$type][1]]]></code>
       <code><![CDATA[$operations[$i][$type][1]]]></code>
       <code><![CDATA[$operations[$i][$type][2]]]></code>
       <code><![CDATA[$operations[$i][$type][2]]]></code>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -23,7 +23,6 @@ use MongoDB\BSON\Document;
 use MongoDB\BSON\JavascriptInterface;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\BuilderEncoder;
-use MongoDB\Builder\Pipeline;
 use MongoDB\Codec\DocumentCodec;
 use MongoDB\Codec\Encoder;
 use MongoDB\Driver\CursorInterface;
@@ -222,9 +221,8 @@ class Collection
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
-    public function aggregate(array|Pipeline $pipeline, array $options = [])
+    public function aggregate(array $pipeline, array $options = [])
     {
-        $pipeline = $this->builderEncoder->encodeIfSupported($pipeline);
         $hasWriteStage = is_last_pipeline_operator_write($pipeline);
 
         $options = $this->inheritReadPreference($options);
@@ -1098,9 +1096,8 @@ class Collection
      * @return ChangeStream
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function watch(array|Pipeline $pipeline = [], array $options = [])
+    public function watch(array $pipeline = [], array $options = [])
     {
-        $pipeline = $this->builderEncoder->encodeIfSupported($pipeline);
         $options = $this->inheritReadOptions($options);
         $options = $this->inheritCodecOrTypeMap($options);
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1133,9 +1133,7 @@ class Collection
 
     private function inheritBuilderEncoder(array $options): array
     {
-        $options['builderEncoder'] = $this->builderEncoder;
-
-        return $options;
+        return ['builderEncoder' => $this->builderEncoder] + $options;
     }
 
     private function inheritCodec(array $options): array

--- a/tests/Collection/BuilderCollectionFunctionalTest.php
+++ b/tests/Collection/BuilderCollectionFunctionalTest.php
@@ -2,7 +2,6 @@
 
 namespace MongoDB\Tests\Collection;
 
-use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
@@ -18,15 +17,7 @@ class BuilderCollectionFunctionalTest extends FunctionalTestCase
 
     public function testAggregate(): void
     {
-        $this->collection->insertMany([['x' => 10], ['x' => 10], ['x' => 10]]);
-        $pipeline = new Pipeline(
-            Stage::bucketAuto(
-                groupBy: Expression::intFieldPath('x'),
-                buckets: 2,
-            ),
-        );
-        $results = $this->collection->aggregate($pipeline)->toArray();
-        $this->assertCount(2, $results);
+        $this->markTestSkipped('Not supported yet');
     }
 
     public function testBulkWriteDeleteMany(): void
@@ -254,21 +245,6 @@ class BuilderCollectionFunctionalTest extends FunctionalTestCase
 
     public function testWatch(): void
     {
-        $this->skipIfChangeStreamIsNotSupported();
-
-        if ($this->isShardedCluster()) {
-            $this->markTestSkipped('Test does not apply on sharded clusters: need more than a single getMore call on the change stream.');
-        }
-
-        $pipeline = new Pipeline(
-            Stage::match(operationType: Query::eq('insert')),
-        );
-        $changeStream = $this->collection->watch($pipeline);
-        $changeStream->rewind();
-        $this->assertNull($changeStream->current());
-        $this->collection->insertOne(['x' => 3]);
-        $changeStream->next();
-        $this->assertTrue($changeStream->valid());
-        $this->assertEquals('insert', $changeStream->current()->operationType);
+        $this->markTestSkipped('Not supported yet');
     }
 }

--- a/tests/Collection/BuilderCollectionFunctionalTest.php
+++ b/tests/Collection/BuilderCollectionFunctionalTest.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace MongoDB\Tests\Collection;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+
+class BuilderCollectionFunctionalTest extends FunctionalTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->collection->insertMany([['x' => 1], ['x' => 2], ['x' => 2]]);
+    }
+
+    public function testAggregate(): void
+    {
+        $this->collection->insertMany([['x' => 10], ['x' => 10], ['x' => 10]]);
+        $pipeline = new Pipeline(
+            Stage::bucketAuto(
+                groupBy: Expression::intFieldPath('x'),
+                buckets: 2,
+            ),
+        );
+        $results = $this->collection->aggregate($pipeline)->toArray();
+        $this->assertCount(2, $results);
+    }
+
+    public function testBulkWriteDeleteMany(): void
+    {
+        $result = $this->collection->bulkWrite([
+            [
+                'deleteMany' => [
+                    Query::query(x: Query::gt(1)),
+                ],
+            ],
+        ]);
+        $this->assertEquals(2, $result->getDeletedCount());
+    }
+
+    public function testBulkWriteDeleteOne(): void
+    {
+        $result = $this->collection->bulkWrite([
+            [
+                'deleteOne' => [
+                    Query::query(x: Query::eq(1)),
+                ],
+            ],
+        ]);
+        $this->assertEquals(1, $result->getDeletedCount());
+    }
+
+    public function testBulkWriteReplaceOne(): void
+    {
+        $result = $this->collection->bulkWrite([
+            [
+                'replaceOne' => [
+                    Query::query(x: Query::eq(1)),
+                    ['x' => 3],
+                ],
+            ],
+        ]);
+        $this->assertEquals(1, $result->getModifiedCount());
+
+        $result = $this->collection->findOne(Query::query(x: Query::eq(3)));
+        $this->assertEquals(3, $result->x);
+    }
+
+    public function testBulkWriteUpdateMany(): void
+    {
+        $result = $this->collection->bulkWrite([
+            [
+                'updateMany' => [
+                    Query::query(x: Query::gt(1)),
+                    // @todo Use Builder when update operators are supported by PHPLIB-1507
+                    ['$set' => ['x' => 3]],
+                ],
+            ],
+        ]);
+        $this->assertEquals(2, $result->getModifiedCount());
+
+        $result = $this->collection->find(Query::query(x: Query::eq(3)))->toArray();
+        $this->assertCount(2, $result);
+        $this->assertEquals(3, $result[0]->x);
+    }
+
+    public function testBulkWriteUpdateOne(): void
+    {
+        $result = $this->collection->bulkWrite([
+            [
+                'updateOne' => [
+                    Query::query(x: Query::eq(1)),
+                    // @todo Use Builder when update operators are supported by PHPLIB-1507
+                    ['$set' => ['x' => 3]],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(1, $result->getModifiedCount());
+
+        $result = $this->collection->findOne(Query::query(x: Query::eq(3)));
+        $this->assertEquals(3, $result->x);
+    }
+
+    public function testCountDocuments(): void
+    {
+        $result = $this->collection->countDocuments(Query::query(x: Query::gt(1)));
+        $this->assertEquals(2, $result);
+    }
+
+    public function testDeleteMany(): void
+    {
+        $result = $this->collection->deleteMany(Query::query(x: Query::gt(1)));
+        $this->assertEquals(2, $result->getDeletedCount());
+    }
+
+    public function testDeleteOne(): void
+    {
+        $result = $this->collection->deleteOne(Query::query(x: Query::gt(1)));
+        $this->assertEquals(1, $result->getDeletedCount());
+    }
+
+    public function testDistinct(): void
+    {
+        $result = $this->collection->distinct('x', Query::query(x: Query::gt(1)));
+        $this->assertEquals([2], $result);
+    }
+
+    public function testFind(): void
+    {
+        $results = $this->collection->find(Query::query(x: Query::gt(1)))->toArray();
+        $this->assertCount(2, $results);
+        $this->assertEquals(2, $results[0]->x);
+    }
+
+    public function testFindOne(): void
+    {
+        $result = $this->collection->findOne(Query::query(x: Query::eq(1)));
+        $this->assertEquals(1, $result->x);
+    }
+
+    public function testFindOneAndDelete(): void
+    {
+        $result = $this->collection->findOneAndDelete(Query::query(x: Query::eq(1)));
+        $this->assertEquals(1, $result->x);
+
+        $result = $this->collection->find()->toArray();
+        $this->assertCount(2, $result);
+    }
+
+    public function testFindOneAndReplace(): void
+    {
+        $this->collection->insertOne(['x' => 1]);
+
+        $result = $this->collection->findOneAndReplace(
+            Query::query(x: Query::lt(2)),
+            ['x' => 3],
+        );
+        $this->assertEquals(1, $result->x);
+
+        $result = $this->collection->findOne(Query::query(x: Query::eq(3)));
+        $this->assertEquals(3, $result->x);
+    }
+
+    public function testFindOneAndUpdate(): void
+    {
+        $result = $this->collection->findOneAndUpdate(
+            Query::query(x: Query::lt(2)),
+            // @todo Use Builder when update operators are supported by PHPLIB-1507
+            ['$set' => ['x' => 3]],
+        );
+        $this->assertEquals(1, $result->x);
+
+        $result = $this->collection->findOne(Query::query(x: Query::eq(3)));
+        $this->assertEquals(3, $result->x);
+    }
+
+    public function testReplaceOne(): void
+    {
+        $this->collection->insertOne(['x' => 1]);
+
+        $result = $this->collection->replaceOne(
+            Query::query(x: Query::lt(2)),
+            ['x' => 3],
+        );
+        $this->assertEquals(1, $result->getModifiedCount());
+
+        $result = $this->collection->findOne(Query::query(x: Query::eq(3)));
+        $this->assertEquals(3, $result->x);
+    }
+
+    public function testUpdateOne(): void
+    {
+        $this->collection->insertOne(['x' => 1]);
+
+        $result = $this->collection->updateOne(
+            Query::query(x: Query::lt(2)),
+            // @todo Use Builder when update operators are supported by PHPLIB-1507
+            ['$set' => ['x' => 3]],
+        );
+        $this->assertEquals(1, $result->getModifiedCount());
+
+        $result = $this->collection->findOne(Query::query(x: Query::eq(3)));
+        $this->assertEquals(3, $result->x);
+    }
+
+    public function testUpdateWithPipeline(): void
+    {
+        $result = $this->collection->updateOne(
+            Query::query(x: Query::lt(2)),
+            new Pipeline(
+                Stage::set(x: 3),
+            ),
+        );
+
+        $this->assertEquals(1, $result->getModifiedCount());
+    }
+
+    public function testUpdateMany(): void
+    {
+        $result = $this->collection->updateMany(
+            Query::query(x: Query::gt(1)),
+            // @todo Use Builder when update operators are supported by PHPLIB-1507
+            ['$set' => ['x' => 3]],
+        );
+        $this->assertEquals(2, $result->getModifiedCount());
+
+        $result = $this->collection->find(Query::query(x: Query::eq(3)))->toArray();
+        $this->assertCount(2, $result);
+        $this->assertEquals(3, $result[0]->x);
+    }
+
+    public function testUpdateManyWithPipeline(): void
+    {
+        $result = $this->collection->updateMany(
+            Query::query(x: Query::gt(1)),
+            new Pipeline(
+                Stage::set(x: 3),
+            ),
+        );
+        $this->assertEquals(2, $result->getModifiedCount());
+
+        $result = $this->collection->find(Query::query(x: Query::eq(3)))->toArray();
+        $this->assertCount(2, $result);
+        $this->assertEquals(3, $result[0]->x);
+    }
+
+    public function testWatch(): void
+    {
+        $this->skipIfChangeStreamIsNotSupported();
+
+        if ($this->isShardedCluster()) {
+            $this->markTestSkipped('Test does not apply on sharded clusters: need more than a single getMore call on the change stream.');
+        }
+
+        $pipeline = new Pipeline(
+            Stage::match(operationType: Query::eq('insert')),
+        );
+        $changeStream = $this->collection->watch($pipeline);
+        $changeStream->rewind();
+        $this->assertNull($changeStream->current());
+        $this->collection->insertOne(['x' => 3]);
+        $changeStream->next();
+        $this->assertTrue($changeStream->valid());
+        $this->assertEquals('insert', $changeStream->current()->operationType);
+    }
+}

--- a/tests/Collection/BuilderCollectionFunctionalTest.php
+++ b/tests/Collection/BuilderCollectionFunctionalTest.php
@@ -209,6 +209,8 @@ class BuilderCollectionFunctionalTest extends FunctionalTestCase
 
     public function testUpdateWithPipeline(): void
     {
+        $this->skipIfServerVersion('<', '4.2.0', 'Pipeline-style updates are not supported');
+
         $result = $this->collection->updateOne(
             Query::query(x: Query::lt(2)),
             new Pipeline(
@@ -235,6 +237,8 @@ class BuilderCollectionFunctionalTest extends FunctionalTestCase
 
     public function testUpdateManyWithPipeline(): void
     {
+        $this->skipIfServerVersion('<', '4.2.0', 'Pipeline-style updates are not supported');
+
         $result = $this->collection->updateMany(
             Query::query(x: Query::gt(1)),
             new Pipeline(


### PR DESCRIPTION
Fix PHPLIB-1420

Extracted from https://github.com/mongodb/mongo-php-library/pull/1383 without the [breaking changes on the methods Collection::aggregate() and Collection::watch()](https://github.com/mongodb/mongo-php-library/pull/1383#discussion_r1753314570).