### PR TITLE
Use conditional return type for getId method in CursorInterface classes

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="examples/atlas_search.php">
     <MixedArgument>
       <code><![CDATA[$document['name']]]></code>
@@ -145,9 +145,6 @@
     </PossiblyNullArgument>
   </file>
   <file src="src/Model/CodecCursor.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[CursorId|Int64]]></code>
-    </ImplementedReturnTypeMismatch>
     <TooManyArguments>
       <code><![CDATA[getId]]></code>
     </TooManyArguments>

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -110,7 +110,10 @@ class ChangeStream implements Iterator
         return $this->codec->decode($value);
     }
 
-    /** @return CursorId|Int64 */
+    /**
+     * @return CursorId|Int64
+     * @psalm-return ($asInt64 is true ? Int64 : CursorId)
+     */
     #[ReturnTypeWillChange]
     public function getCursorId(bool $asInt64 = false)
     {

--- a/src/Model/CodecCursor.php
+++ b/src/Model/CodecCursor.php
@@ -76,7 +76,10 @@ class CodecCursor implements CursorInterface, Iterator
         return new self($cursor, $codec);
     }
 
-    /** @return CursorId|Int64 */
+    /**
+     * @return CursorId|Int64
+     * @psalm-return ($asInt64 is true ? Int64 : CursorId)
+     */
     #[ReturnTypeWillChange]
     public function getId(bool $asInt64 = false)
     {


### PR DESCRIPTION
This improves type detection so that users don't need additional type checks because of the union return type.