### PR TITLE
Update branch names for GHA workflows

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -5,12 +5,10 @@ on:
   pull_request:
     branches:
       - "v*.*"
-      - "master"
       - "feature/*"
   push:
     branches:
       - "v*.*"
-      - "master"
       - "feature/*"
 
 env:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -5,12 +5,10 @@ on:
   pull_request:
     branches:
       - "v*.*"
-      - "master"
       - "feature/*"
   push:
     branches:
       - "v*.*"
-      - "master"
       - "feature/*"
 
 env:

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -3,7 +3,7 @@ name: Merge up
 on:
   push:
     branches:
-      - "v[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9x]+"
 
 env:
   GH_TOKEN: ${{ secrets.MERGE_UP_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,12 +5,10 @@ on:
   pull_request:
     branches:
       - "v*.*"
-      - "master"
       - "feature/*"
   push:
     branches:
       - "v*.*"
-      - "master"
       - "feature/*"
   workflow_call:
     inputs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,10 @@ on:
   pull_request:
     branches:
       - "v*.*"
-      - "master"
       - "feature/*"
   push:
     branches:
       - "v*.*"
-      - "master"
       - "feature/*"
 
 env:


### PR DESCRIPTION
We can remove the `master` branch as it no longer exists. On top, the `merge-up` workflow also needs to be active on branches matching the `v1.x` pattern in order to work properly.