### PR TITLE
PHPLIB-1514 Make data providers static

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -18,6 +19,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([LevelSetList::UP_TO_PHP_74]);
 
     $rectorConfig->rule(ChangeSwitchToMatchRector::class);
+    $rectorConfig->rule(StaticDataProviderClassMethodRector::class);
 
     // phpcs:disable Squiz.Arrays.ArrayDeclaration.KeySpecified
     $rectorConfig->skip([

--- a/tests/Builder/FieldPathTest.php
+++ b/tests/Builder/FieldPathTest.php
@@ -35,7 +35,7 @@ class FieldPathTest extends TestCase
         Expression::{$fieldPathClass}('$foo');
     }
 
-    public function provideFieldPath(): Generator
+    public static function provideFieldPath(): Generator
     {
         yield 'double' => ['doubleFieldPath', Expression\ResolvesToDouble::class];
         yield 'string' => ['stringFieldPath', Expression\ResolvesToString::class];

--- a/tests/Builder/Type/CombinedFieldQueryTest.php
+++ b/tests/Builder/Type/CombinedFieldQueryTest.php
@@ -87,7 +87,7 @@ class CombinedFieldQueryTest extends TestCase
         ]);
     }
 
-    public function provideDuplicateOperator(): Generator
+    public static function provideDuplicateOperator(): Generator
     {
         yield 'array and FieldQuery' => [
             [

--- a/tests/Builder/Type/OutputWindowTest.php
+++ b/tests/Builder/Type/OutputWindowTest.php
@@ -73,7 +73,7 @@ class OutputWindowTest extends TestCase
         );
     }
 
-    public function provideInvalidDocuments(): Generator
+    public static function provideInvalidDocuments(): Generator
     {
         yield 'too few' => [[1]];
         yield 'too many' => [[1, 2, 3]];
@@ -98,7 +98,7 @@ class OutputWindowTest extends TestCase
         );
     }
 
-    public function provideInvalidRange(): Generator
+    public static function provideInvalidRange(): Generator
     {
         yield 'too few' => [[1]];
         yield 'too many' => [[1, 2, 3]];

--- a/tests/Builder/Type/QueryObjectTest.php
+++ b/tests/Builder/Type/QueryObjectTest.php
@@ -57,7 +57,7 @@ class QueryObjectTest extends TestCase
         $this->assertCount($expectedCount, $queryObject->queries);
     }
 
-    public function provideQueryObjectValue(): Generator
+    public static function provideQueryObjectValue(): Generator
     {
         yield 'int' => [['foo' => 1]];
         yield 'float' => [['foo' => 1.1]];

--- a/tests/Builder/VariableTest.php
+++ b/tests/Builder/VariableTest.php
@@ -35,7 +35,7 @@ class VariableTest extends TestCase
         $this->assertStringStartsNotWith('$$', $variable->name);
     }
 
-    public function provideVariableBuilders(): Generator
+    public static function provideVariableBuilders(): Generator
     {
         yield 'now' => [fn () => Variable::now()];
         yield 'clusterTime' => [fn () => Variable::clusterTime()];

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -42,29 +42,29 @@ class ClientTest extends TestCase
         new Client(static::getUri(), [], $driverOptions);
     }
 
-    public function provideInvalidConstructorDriverOptions()
+    public static function provideInvalidConstructorDriverOptions()
     {
         $options = [];
 
-        foreach ($this->getInvalidObjectValues() as $value) {
+        foreach (self::getInvalidObjectValues() as $value) {
             $options[][] = ['builderEncoder' => $value];
         }
 
-        foreach ($this->getInvalidArrayValues(true) as $value) {
+        foreach (self::getInvalidArrayValues(true) as $value) {
             $options[][] = ['typeMap' => $value];
         }
 
         $options[][] = ['autoEncryption' => ['keyVaultClient' => 'foo']];
 
-        foreach ($this->getInvalidStringValues() as $value) {
+        foreach (self::getInvalidStringValues() as $value) {
             $options[][] = ['driver' => ['name' => $value]];
         }
 
-        foreach ($this->getInvalidStringValues() as $value) {
+        foreach (self::getInvalidStringValues() as $value) {
             $options[][] = ['driver' => ['version' => $value]];
         }
 
-        foreach ($this->getInvalidStringValues() as $value) {
+        foreach (self::getInvalidStringValues() as $value) {
             $options[] = [
                 'driverOptions' => ['driver' => ['platform' => $value]],
                 'exception' => DriverInvalidArgumentException::class,

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -151,7 +151,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideFindOneAndModifyOptions(): Generator
+    public static function provideFindOneAndModifyOptions(): Generator
     {
         yield 'Default codec' => [
             'expected' => TestObject::createDecodedForFixture(1),

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -49,7 +49,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         new Collection($this->manager, $this->getDatabaseName(), $collectionName);
     }
 
-    public function provideInvalidDatabaseAndCollectionNames()
+    public static function provideInvalidDatabaseAndCollectionNames()
     {
         return [
             [null, TypeError::class],
@@ -64,15 +64,15 @@ class CollectionFunctionalTest extends FunctionalTestCase
         new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions(): array
+    public static function provideInvalidConstructorOptions(): array
     {
-        return $this->createOptionDataProvider([
-            'builderEncoder' => $this->getInvalidObjectValues(),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'builderEncoder' => self::getInvalidObjectValues(),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 
@@ -210,7 +210,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $this->assertEquals($expectedDocuments, $values);
     }
 
-    public function provideTypeMapOptionsAndExpectedDocuments()
+    public static function provideTypeMapOptionsAndExpectedDocuments()
     {
         return [
             'No type map' => [
@@ -448,7 +448,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         }
     }
 
-    public function collectionMethodClosures()
+    public static function collectionMethodClosures()
     {
         return [
             'read-only aggregate' => [
@@ -716,18 +716,18 @@ class CollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    public function collectionReadMethodClosures(): array
+    public static function collectionReadMethodClosures(): array
     {
         return array_filter(
-            $this->collectionMethodClosures(),
+            self::collectionMethodClosures(),
             fn ($rw) => str_contains($rw[1], 'r'),
         );
     }
 
-    public function collectionWriteMethodClosures(): array
+    public static function collectionWriteMethodClosures(): array
     {
         return array_filter(
-            $this->collectionMethodClosures(),
+            self::collectionMethodClosures(),
             fn ($rw) => str_contains($rw[1], 'w'),
         );
     }

--- a/tests/Command/ListCollectionsTest.php
+++ b/tests/Command/ListCollectionsTest.php
@@ -15,13 +15,13 @@ class ListCollectionsTest extends TestCase
         new ListCollections($this->getDatabaseName(), $options);
     }
 
-    public function provideInvalidConstructorOptions(): array
+    public static function provideInvalidConstructorOptions(): array
     {
-        return $this->createOptionDataProvider([
-            'authorizedCollections' => $this->getInvalidBooleanValues(),
-            'filter' => $this->getInvalidDocumentValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'session' => $this->getInvalidSessionValues(),
+        return self::createOptionDataProvider([
+            'authorizedCollections' => self::getInvalidBooleanValues(),
+            'filter' => self::getInvalidDocumentValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'session' => self::getInvalidSessionValues(),
         ]);
     }
 }

--- a/tests/Command/ListDatabasesTest.php
+++ b/tests/Command/ListDatabasesTest.php
@@ -15,14 +15,14 @@ class ListDatabasesTest extends TestCase
         new ListDatabases($options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'authorizedDatabases' => $this->getInvalidBooleanValues(),
-            'filter' => $this->getInvalidDocumentValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'nameOnly' => $this->getInvalidBooleanValues(),
-            'session' => $this->getInvalidSessionValues(),
+        return self::createOptionDataProvider([
+            'authorizedDatabases' => self::getInvalidBooleanValues(),
+            'filter' => self::getInvalidDocumentValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'nameOnly' => self::getInvalidBooleanValues(),
+            'session' => self::getInvalidSessionValues(),
         ]);
     }
 }

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -30,7 +30,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         new Database($this->manager, $databaseName);
     }
 
-    public function provideInvalidDatabaseNames()
+    public static function provideInvalidDatabaseNames()
     {
         return [
             [null, TypeError::class],
@@ -45,13 +45,13 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         new Database($this->manager, $this->getDatabaseName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -15,7 +15,7 @@ class InvalidArgumentExceptionTest extends TestCase
         $this->assertStringContainsString($typeString, $e->getMessage());
     }
 
-    public function provideExpectedTypes()
+    public static function provideExpectedTypes()
     {
         yield 'expectedType is a string' => [
             'array',

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -32,7 +32,7 @@ class FunctionsTest extends TestCase
         $this->assertEquals($expectedDocument, apply_type_map_to_document($document, $typeMap));
     }
 
-    public function provideDocumentAndTypeMap()
+    public static function provideDocumentAndTypeMap()
     {
         return [
             [
@@ -102,7 +102,7 @@ class FunctionsTest extends TestCase
         $this->assertSame($expectedArray, document_to_array($document));
     }
 
-    public function provideDocumentsAndExpectedArrays(): array
+    public static function provideDocumentsAndExpectedArrays(): array
     {
         return [
             'array' => [['x' => 1], ['x' => 1]],
@@ -122,13 +122,13 @@ class FunctionsTest extends TestCase
         document_to_array($document);
     }
 
-    public function provideInvalidDocumentValuesForChecks(): array
+    public static function provideInvalidDocumentValuesForChecks(): array
     {
         // PackedArray is intentionally left out, as document_to_array is used to convert aggregation pipelines
-        return $this->wrapValuesForDataProvider([123, 3.14, 'foo', true]);
+        return self::wrapValuesForDataProvider([123, 3.14, 'foo', true]);
     }
 
-    public function provideDocumentCasts(): array
+    public static function provideDocumentCasts(): array
     {
         // phpcs:disable SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing
         // phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration
@@ -180,7 +180,7 @@ class FunctionsTest extends TestCase
         $this->assertEquals($expected, create_field_path_type_map($typeMap, $fieldPath));
     }
 
-    public function provideTypeMapValues()
+    public static function provideTypeMapValues()
     {
         return [
             'No root type' => [
@@ -256,7 +256,7 @@ class FunctionsTest extends TestCase
         $this->assertSame($expected, is_pipeline($pipeline, $allowEmpty));
     }
 
-    public function providePipelines(): array
+    public static function providePipelines(): array
     {
         $valid = [
             ['$match' => ['foo' => 'bar']],
@@ -320,7 +320,7 @@ class FunctionsTest extends TestCase
         $this->assertSame($expected, is_builder_pipeline($pipeline));
     }
 
-    public function provideStagePipelines(): iterable
+    public static function provideStagePipelines(): iterable
     {
         yield 'empty array' => [false, []];
         yield 'array of arrays' => [false, [['$match' => ['x' => 1]]]];
@@ -335,7 +335,7 @@ class FunctionsTest extends TestCase
         $this->assertSame($expected, is_write_concern_acknowledged($writeConcern));
     }
 
-    public function provideWriteConcerns(): array
+    public static function provideWriteConcerns(): array
     {
         // Note: WriteConcern constructor prohibits w=-1 or w=0 and journal=true
         return [

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -214,7 +214,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->downloadToStream('id', $destination);
     }
 
-    public static function provideInvalidStreamValues()
+    public static function provideInvalidStreamValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidStreamValues());
     }
@@ -1029,7 +1029,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     /**
      * Return a list of invalid stream values.
      */
-    private function getInvalidStreamValues(): array
+    private static function getInvalidStreamValues(): array
     {
         return [null, 123, 'foo', [], hash_init('md5')];
     }

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -106,7 +106,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     /** @dataProvider provideInputDataAndExpectedChunks */
     public function testDelete($input, $expectedChunks): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream($input));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
 
         $this->assertCollectionCount($this->filesCollection, 1);
         $this->assertCollectionCount($this->chunksCollection, $expectedChunks);
@@ -142,7 +142,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     /** @dataProvider provideInputDataAndExpectedChunks */
     public function testDeleteStillRemovesChunksIfFileDoesNotExist($input, $expectedChunks): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream($input));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
 
         $this->assertCollectionCount($this->filesCollection, 1);
         $this->assertCollectionCount($this->chunksCollection, $expectedChunks);
@@ -160,7 +160,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDownloadingFileWithMissingChunk(): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
 
         $this->chunksCollection->deleteOne(['files_id' => $id, 'n' => 0]);
 
@@ -171,7 +171,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDownloadingFileWithUnexpectedChunkIndex(): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
 
         $this->chunksCollection->updateOne(
             ['files_id' => $id, 'n' => 0],
@@ -185,7 +185,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDownloadingFileWithUnexpectedChunkSize(): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
 
         $this->chunksCollection->updateOne(
             ['files_id' => $id, 'n' => 0],
@@ -200,8 +200,8 @@ class BucketFunctionalTest extends FunctionalTestCase
     /** @dataProvider provideInputDataAndExpectedChunks */
     public function testDownloadToStream($input): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream($input));
-        $destination = $this->createStream();
+        $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
+        $destination = self::createStream();
         $this->bucket->downloadToStream($id, $destination);
 
         $this->assertStreamContents($input, $destination);
@@ -222,40 +222,40 @@ class BucketFunctionalTest extends FunctionalTestCase
     public function testDownloadToStreamShouldRequireFileToExist(): void
     {
         $this->expectException(FileNotFoundException::class);
-        $this->bucket->downloadToStream('nonexistent-id', $this->createStream());
+        $this->bucket->downloadToStream('nonexistent-id', self::createStream());
     }
 
     public function testDownloadToStreamByName(): void
     {
-        $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
-        $this->bucket->uploadFromStream('filename', $this->createStream('bar'));
-        $this->bucket->uploadFromStream('filename', $this->createStream('baz'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('bar'));
+        $this->bucket->uploadFromStream('filename', self::createStream('baz'));
 
-        $destination = $this->createStream();
+        $destination = self::createStream();
         $this->bucket->downloadToStreamByName('filename', $destination);
         $this->assertStreamContents('baz', $destination);
 
-        $destination = $this->createStream();
+        $destination = self::createStream();
         $this->bucket->downloadToStreamByName('filename', $destination, ['revision' => -3]);
         $this->assertStreamContents('foo', $destination);
 
-        $destination = $this->createStream();
+        $destination = self::createStream();
         $this->bucket->downloadToStreamByName('filename', $destination, ['revision' => -2]);
         $this->assertStreamContents('bar', $destination);
 
-        $destination = $this->createStream();
+        $destination = self::createStream();
         $this->bucket->downloadToStreamByName('filename', $destination, ['revision' => -1]);
         $this->assertStreamContents('baz', $destination);
 
-        $destination = $this->createStream();
+        $destination = self::createStream();
         $this->bucket->downloadToStreamByName('filename', $destination, ['revision' => 0]);
         $this->assertStreamContents('foo', $destination);
 
-        $destination = $this->createStream();
+        $destination = self::createStream();
         $this->bucket->downloadToStreamByName('filename', $destination, ['revision' => 1]);
         $this->assertStreamContents('bar', $destination);
 
-        $destination = $this->createStream();
+        $destination = self::createStream();
         $this->bucket->downloadToStreamByName('filename', $destination, ['revision' => 2]);
         $this->assertStreamContents('baz', $destination);
     }
@@ -270,10 +270,10 @@ class BucketFunctionalTest extends FunctionalTestCase
     /** @dataProvider provideNonexistentFilenameAndRevision */
     public function testDownloadToStreamByNameShouldRequireFilenameAndRevisionToExist($filename, $revision): void
     {
-        $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
-        $this->bucket->uploadFromStream('filename', $this->createStream('bar'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('bar'));
 
-        $destination = $this->createStream();
+        $destination = self::createStream();
         $this->expectException(FileNotFoundException::class);
         $this->bucket->downloadToStreamByName($filename, $destination, ['revision' => $revision]);
     }
@@ -290,7 +290,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDrop(): void
     {
-        $this->bucket->uploadFromStream('filename', $this->createStream('foobar'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
 
         $this->assertCollectionCount($this->filesCollection, 1);
         $this->assertCollectionCount($this->chunksCollection, 1);
@@ -303,9 +303,9 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testFind(): void
     {
-        $this->bucket->uploadFromStream('a', $this->createStream('foo'));
-        $this->bucket->uploadFromStream('b', $this->createStream('foobar'));
-        $this->bucket->uploadFromStream('c', $this->createStream('foobarbaz'));
+        $this->bucket->uploadFromStream('a', self::createStream('foo'));
+        $this->bucket->uploadFromStream('b', self::createStream('foobar'));
+        $this->bucket->uploadFromStream('c', self::createStream('foobarbaz'));
 
         $cursor = $this->bucket->find(
             ['length' => ['$lte' => 6]],
@@ -329,7 +329,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testFindUsesTypeMap(): void
     {
-        $this->bucket->uploadFromStream('a', $this->createStream('foo'));
+        $this->bucket->uploadFromStream('a', self::createStream('foo'));
 
         $cursor = $this->bucket->find();
         $fileDocument = current($cursor->toArray());
@@ -339,7 +339,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testFindUsesCodec(): void
     {
-        $this->bucket->uploadFromStream('a', $this->createStream('foo'));
+        $this->bucket->uploadFromStream('a', self::createStream('foo'));
 
         $cursor = $this->bucket->find([], ['codec' => new TestFileCodec()]);
         $fileDocument = current($cursor->toArray());
@@ -351,7 +351,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     public function testFindInheritsBucketCodec(): void
     {
         $bucket = new Bucket($this->manager, $this->getDatabaseName(), ['codec' => new TestFileCodec()]);
-        $bucket->uploadFromStream('a', $this->createStream('foo'));
+        $bucket->uploadFromStream('a', self::createStream('foo'));
 
         $cursor = $bucket->find();
         $fileDocument = current($cursor->toArray());
@@ -363,7 +363,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     public function testFindResetsInheritedBucketCodec(): void
     {
         $bucket = new Bucket($this->manager, $this->getDatabaseName(), ['codec' => new TestFileCodec()]);
-        $bucket->uploadFromStream('a', $this->createStream('foo'));
+        $bucket->uploadFromStream('a', self::createStream('foo'));
 
         $cursor = $bucket->find([], ['codec' => null]);
         $fileDocument = current($cursor->toArray());
@@ -374,9 +374,9 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testFindOne(): void
     {
-        $this->bucket->uploadFromStream('a', $this->createStream('foo'));
-        $this->bucket->uploadFromStream('b', $this->createStream('foobar'));
-        $this->bucket->uploadFromStream('c', $this->createStream('foobarbaz'));
+        $this->bucket->uploadFromStream('a', self::createStream('foo'));
+        $this->bucket->uploadFromStream('b', self::createStream('foobar'));
+        $this->bucket->uploadFromStream('c', self::createStream('foobarbaz'));
 
         $fileDocument = $this->bucket->findOne(
             ['length' => ['$lte' => 6]],
@@ -396,9 +396,9 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testFindOneUsesCodec(): void
     {
-        $this->bucket->uploadFromStream('a', $this->createStream('foo'));
-        $this->bucket->uploadFromStream('b', $this->createStream('foobar'));
-        $this->bucket->uploadFromStream('c', $this->createStream('foobarbaz'));
+        $this->bucket->uploadFromStream('a', self::createStream('foo'));
+        $this->bucket->uploadFromStream('b', self::createStream('foobar'));
+        $this->bucket->uploadFromStream('c', self::createStream('foobarbaz'));
 
         $fileDocument = $this->bucket->findOne(
             ['length' => ['$lte' => 6]],
@@ -417,9 +417,9 @@ class BucketFunctionalTest extends FunctionalTestCase
     {
         $bucket = new Bucket($this->manager, $this->getDatabaseName(), ['codec' => new TestFileCodec()]);
 
-        $bucket->uploadFromStream('a', $this->createStream('foo'));
-        $bucket->uploadFromStream('b', $this->createStream('foobar'));
-        $bucket->uploadFromStream('c', $this->createStream('foobarbaz'));
+        $bucket->uploadFromStream('a', self::createStream('foo'));
+        $bucket->uploadFromStream('b', self::createStream('foobar'));
+        $bucket->uploadFromStream('c', self::createStream('foobarbaz'));
 
         $fileDocument = $bucket->findOne(
             ['length' => ['$lte' => 6]],
@@ -435,9 +435,9 @@ class BucketFunctionalTest extends FunctionalTestCase
     {
         $bucket = new Bucket($this->manager, $this->getDatabaseName(), ['codec' => new TestFileCodec()]);
 
-        $bucket->uploadFromStream('a', $this->createStream('foo'));
-        $bucket->uploadFromStream('b', $this->createStream('foobar'));
-        $bucket->uploadFromStream('c', $this->createStream('foobarbaz'));
+        $bucket->uploadFromStream('a', self::createStream('foo'));
+        $bucket->uploadFromStream('b', self::createStream('foobar'));
+        $bucket->uploadFromStream('c', self::createStream('foobarbaz'));
 
         $fileDocument = $bucket->findOne(
             ['length' => ['$lte' => 6]],
@@ -520,7 +520,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     public function testGetFileDocumentForStreamWithReadableStream(): void
     {
         $metadata = ['foo' => 'bar'];
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'), ['metadata' => $metadata]);
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'), ['metadata' => $metadata]);
         $stream = $this->bucket->openDownloadStream($id);
 
         $fileDocument = $this->bucket->getFileDocumentForStream($stream);
@@ -550,9 +550,9 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->getFileDocumentForStream($stream);
     }
 
-    public function provideInvalidGridFSStreamValues()
+    public static function provideInvalidGridFSStreamValues(): array
     {
-        return self::wrapValuesForDataProvider(array_merge(self::getInvalidStreamValues(), [$this->createStream()]));
+        return self::wrapValuesForDataProvider(array_merge(self::getInvalidStreamValues(), [self::createStream()]));
     }
 
     public function testGetFileIdForStreamUsesTypeMap(): void
@@ -567,7 +567,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testGetFileIdForStreamWithReadableStream(): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
         $stream = $this->bucket->openDownloadStream($id);
 
         $this->assertSameObjectId($id, $this->bucket->getFileIdForStream($stream));
@@ -598,7 +598,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     /** @dataProvider provideInputDataAndExpectedChunks */
     public function testOpenDownloadStream($input): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream($input));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
 
         $this->assertStreamContents($input, $this->bucket->openDownloadStream($id));
     }
@@ -606,7 +606,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     /** @dataProvider provideInputDataAndExpectedChunks */
     public function testOpenDownloadStreamAndMultipleReadOperations($input): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream($input));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
         $stream = $this->bucket->openDownloadStream($id);
         $buffer = '';
 
@@ -636,9 +636,9 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testOpenDownloadStreamByName(): void
     {
-        $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
-        $this->bucket->uploadFromStream('filename', $this->createStream('bar'));
-        $this->bucket->uploadFromStream('filename', $this->createStream('baz'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('bar'));
+        $this->bucket->uploadFromStream('filename', self::createStream('baz'));
 
         $this->assertStreamContents('baz', $this->bucket->openDownloadStreamByName('filename'));
         $this->assertStreamContents('foo', $this->bucket->openDownloadStreamByName('filename', ['revision' => -3]));
@@ -652,8 +652,8 @@ class BucketFunctionalTest extends FunctionalTestCase
     /** @dataProvider provideNonexistentFilenameAndRevision */
     public function testOpenDownloadStreamByNameShouldRequireFilenameAndRevisionToExist($filename, $revision): void
     {
-        $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
-        $this->bucket->uploadFromStream('filename', $this->createStream('bar'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('bar'));
 
         $this->expectException(FileNotFoundException::class);
         $this->bucket->openDownloadStreamByName($filename, ['revision' => $revision]);
@@ -689,7 +689,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testRename(): void
     {
-        $id = $this->bucket->uploadFromStream('a', $this->createStream('foo'));
+        $id = $this->bucket->uploadFromStream('a', self::createStream('foo'));
         $this->bucket->rename($id, 'b');
 
         $fileDocument = $this->filesCollection->findOne(
@@ -703,7 +703,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testRenameShouldNotRequireFileToBeModified(): void
     {
-        $id = $this->bucket->uploadFromStream('a', $this->createStream('foo'));
+        $id = $this->bucket->uploadFromStream('a', self::createStream('foo'));
         $this->bucket->rename($id, 'a');
 
         $fileDocument = $this->filesCollection->findOne(
@@ -729,7 +729,7 @@ class BucketFunctionalTest extends FunctionalTestCase
             'metadata' => ['foo' => 'bar'],
         ];
 
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream('foobar'), $options);
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'), $options);
 
         $this->assertCollectionCount($this->filesCollection, 1);
         $this->assertCollectionCount($this->chunksCollection, 3);
@@ -749,8 +749,8 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testUploadingAnEmptyFile(): void
     {
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream(''));
-        $destination = $this->createStream();
+        $id = $this->bucket->uploadFromStream('filename', self::createStream(''));
+        $destination = self::createStream();
         $this->bucket->downloadToStream($id, $destination);
 
         $this->assertStreamContents('', $destination);
@@ -779,7 +779,7 @@ class BucketFunctionalTest extends FunctionalTestCase
     public function testDisableMD5(): void
     {
         $options = ['disableMD5' => true];
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream('data'), $options);
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('data'), $options);
 
         $fileDocument = $this->filesCollection->findOne(
             ['_id' => $id],
@@ -793,7 +793,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $options = ['disableMD5' => true];
 
         $this->bucket = new Bucket($this->manager, $this->getDatabaseName(), $options);
-        $id = $this->bucket->uploadFromStream('filename', $this->createStream('data'));
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('data'));
 
         $fileDocument = $this->filesCollection->findOne(
             ['_id' => $id],
@@ -804,7 +804,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testUploadingFirstFileCreatesIndexes(): void
     {
-        $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
 
         $this->assertIndexExists($this->filesCollection->getCollectionName(), 'filename_1_uploadDate_1');
         $this->assertIndexExists($this->chunksCollection->getCollectionName(), 'files_id_1_n_1', function (IndexInfo $info): void {
@@ -817,7 +817,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->filesCollection->createIndex(['filename' => 1.0, 'uploadDate' => 1], ['name' => 'test']);
         $this->chunksCollection->createIndex(['files_id' => 1.0, 'n' => 1], ['name' => 'test', 'unique' => true]);
 
-        $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
 
         $this->assertIndexNotExists($this->filesCollection->getCollectionName(), 'filename_1_uploadDate_1');
         $this->assertIndexNotExists($this->chunksCollection->getCollectionName(), 'files_id_1_n_1');
@@ -825,7 +825,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDownloadToStreamFails(): void
     {
-        $this->bucket->uploadFromStream('filename', $this->createStream('foo'), ['_id' => ['foo' => 'bar']]);
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'), ['_id' => ['foo' => 'bar']]);
 
         $this->expectException(StreamException::class);
         $this->expectExceptionMessageMatches('#^Downloading file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS identifier: "{ "_id" : { "foo" : "bar" } }"$#');
@@ -834,7 +834,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDownloadToStreamByNameFails(): void
     {
-        $this->bucket->uploadFromStream('filename', $this->createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
 
         $this->expectException(StreamException::class);
         $this->expectExceptionMessageMatches('#^Downloading file from "gridfs://.*/.*/.*" to "php://temp" failed. GridFS filename: "filename"$#');

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -71,17 +71,17 @@ class BucketFunctionalTest extends FunctionalTestCase
         new Bucket($this->manager, $this->getDatabaseName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'bucketName' => $this->getInvalidStringValues(true),
-            'chunkSizeBytes' => $this->getInvalidIntegerValues(true),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'disableMD5' => $this->getInvalidBooleanValues(true),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'bucketName' => self::getInvalidStringValues(true),
+            'chunkSizeBytes' => self::getInvalidIntegerValues(true),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'disableMD5' => self::getInvalidBooleanValues(true),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 
@@ -117,7 +117,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertCollectionCount($this->chunksCollection, 0);
     }
 
-    public function provideInputDataAndExpectedChunks()
+    public static function provideInputDataAndExpectedChunks()
     {
         return [
             ['', 0],
@@ -214,9 +214,9 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->downloadToStream('id', $destination);
     }
 
-    public function provideInvalidStreamValues()
+    public static function provideInvalidStreamValues()
     {
-        return $this->wrapValuesForDataProvider($this->getInvalidStreamValues());
+        return self::wrapValuesForDataProvider(self::getInvalidStreamValues());
     }
 
     public function testDownloadToStreamShouldRequireFileToExist(): void
@@ -278,7 +278,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->downloadToStreamByName($filename, $destination, ['revision' => $revision]);
     }
 
-    public function provideNonexistentFilenameAndRevision()
+    public static function provideNonexistentFilenameAndRevision()
     {
         return [
             ['filename', 2],
@@ -552,7 +552,7 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function provideInvalidGridFSStreamValues()
     {
-        return $this->wrapValuesForDataProvider(array_merge($this->getInvalidStreamValues(), [$this->createStream()]));
+        return self::wrapValuesForDataProvider(array_merge(self::getInvalidStreamValues(), [$this->createStream()]));
     }
 
     public function testGetFileIdForStreamUsesTypeMap(): void

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -53,7 +53,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
      *
      * @return resource
      */
-    protected function createStream(string $data = '')
+    protected static function createStream(string $data = '')
     {
         $stream = fopen('php://temp', 'w+b');
         fwrite($stream, $data);

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -57,15 +57,15 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         new ReadableStream($this->collectionWrapper, $file);
     }
 
-    public function provideInvalidConstructorFileDocuments()
+    public static function provideInvalidConstructorFileDocuments()
     {
         $options = [];
 
-        foreach ($this->getInvalidIntegerValues() as $value) {
+        foreach (self::getInvalidIntegerValues() as $value) {
             $options[][] = (object) ['_id' => 1, 'chunkSize' => $value, 'length' => 0];
         }
 
-        foreach ($this->getInvalidIntegerValues() as $value) {
+        foreach (self::getInvalidIntegerValues() as $value) {
             $options[][] = (object) ['_id' => 1, 'chunkSize' => 1, 'length' => $value];
         }
 
@@ -85,7 +85,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         $this->assertSame($expectedBytes, $stream->readBytes($length));
     }
 
-    public function provideFileIdAndExpectedBytes()
+    public static function provideFileIdAndExpectedBytes()
     {
         return [
             ['length-0', 0, ''],
@@ -221,7 +221,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         $this->assertSame(['find'], $commands);
     }
 
-    public function providePreviousChunkSeekOffsetAndBytes()
+    public static function providePreviousChunkSeekOffsetAndBytes()
     {
         return [
             [0, 4, 'abcd'],
@@ -255,7 +255,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         $this->assertSame([], $commands);
     }
 
-    public function provideSameChunkSeekOffsetAndBytes()
+    public static function provideSameChunkSeekOffsetAndBytes()
     {
         return [
             [4, 4, 'efgh'],
@@ -287,7 +287,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         $this->assertSame([], $commands);
     }
 
-    public function provideSubsequentChunkSeekOffsetAndBytes()
+    public static function provideSubsequentChunkSeekOffsetAndBytes()
     {
         return [
             [4, 4, 'efgh'],

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -111,10 +111,10 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    public function provideFilteredFileIdAndExpectedBytes()
+    public static function provideFilteredFileIdAndExpectedBytes()
     {
         return array_filter(
-            $this->provideFileIdAndExpectedBytes(),
+            self::provideFileIdAndExpectedBytes(),
             fn (array $args) => $args[1] > 0,
         );
     }

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -39,12 +39,12 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
         new WritableStream($this->collectionWrapper, 'filename', $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'chunkSizeBytes' => $this->getInvalidIntegerValues(true),
-            'disableMD5' => $this->getInvalidBooleanValues(true),
-            'metadata' => $this->getInvalidDocumentValues(),
+        return self::createOptionDataProvider([
+            'chunkSizeBytes' => self::getInvalidIntegerValues(true),
+            'disableMD5' => self::getInvalidBooleanValues(true),
+            'metadata' => self::getInvalidDocumentValues(),
         ]);
     }
 
@@ -86,7 +86,7 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
         $this->assertSameDocument(['md5' => $expectedMD5], $fileDocument);
     }
 
-    public function provideInputDataAndExpectedMD5()
+    public static function provideInputDataAndExpectedMD5()
     {
         return [
             ['', 'd41d8cd98f00b204e9800998ecf8427e'],

--- a/tests/Model/BSONIteratorTest.php
+++ b/tests/Model/BSONIteratorTest.php
@@ -33,7 +33,7 @@ class BSONIteratorTest extends TestCase
         $this->assertEquals($expectedDocuments, $results);
     }
 
-    public function provideTypeMapOptionsAndExpectedDocuments(): Generator
+    public static function provideTypeMapOptionsAndExpectedDocuments(): Generator
     {
         yield 'No type map' => [
             'typeMap' => null,

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -64,9 +64,9 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
         new ChangeStreamIterator($this->collection->find(), 0, null, $postBatchResumeToken);
     }
 
-    public function provideInvalidObjectValues()
+    public static function provideInvalidObjectValues()
     {
-        return $this->wrapValuesForDataProvider([123, 3.14, 'foo', true, []]);
+        return self::wrapValuesForDataProvider([123, 3.14, 'foo', true, []]);
     }
 
     public function testPostBatchResumeTokenIsReturnedForLastElementInFirstBatch(): void

--- a/tests/Model/IndexInputTest.php
+++ b/tests/Model/IndexInputTest.php
@@ -35,9 +35,9 @@ class IndexInputTest extends TestCase
         new IndexInput(['key' => ['x' => $order]]);
     }
 
-    public function provideInvalidFieldOrderValues()
+    public static function provideInvalidFieldOrderValues()
     {
-        return $this->wrapValuesForDataProvider([true, [], new stdClass()]);
+        return self::wrapValuesForDataProvider([true, [], new stdClass()]);
     }
 
     /** @dataProvider provideInvalidStringValues */
@@ -54,7 +54,7 @@ class IndexInputTest extends TestCase
         $this->assertSame($expectedName, (string) new IndexInput(['key' => $key]));
     }
 
-    public function provideExpectedNameAndKey(): array
+    public static function provideExpectedNameAndKey(): array
     {
         return [
             ['x_1', ['x' => 1]],

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -271,7 +271,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideTypeMapOptionsAndExpectedDocuments()
+    public static function provideTypeMapOptionsAndExpectedDocuments()
     {
         return [
             [

--- a/tests/Operation/AggregateTest.php
+++ b/tests/Operation/AggregateTest.php
@@ -24,24 +24,24 @@ class AggregateTest extends TestCase
         new Aggregate($this->getDatabaseName(), $this->getCollectionName(), [['$match' => ['x' => 1]]], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'allowDiskUse' => $this->getInvalidBooleanValues(),
-            'batchSize' => $this->getInvalidIntegerValues(),
-            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'collation' => $this->getInvalidDocumentValues(),
-            'hint' => $this->getInvalidHintValues(),
-            'let' => $this->getInvalidDocumentValues(),
-            'explain' => $this->getInvalidBooleanValues(),
-            'maxAwaitTimeMS' => $this->getInvalidIntegerValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'allowDiskUse' => self::getInvalidBooleanValues(),
+            'batchSize' => self::getInvalidIntegerValues(),
+            'bypassDocumentValidation' => self::getInvalidBooleanValues(),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'collation' => self::getInvalidDocumentValues(),
+            'hint' => self::getInvalidHintValues(),
+            'let' => self::getInvalidDocumentValues(),
+            'explain' => self::getInvalidBooleanValues(),
+            'maxAwaitTimeMS' => self::getInvalidIntegerValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -87,7 +87,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideDocumentsWithIds(): array
+    public static function provideDocumentsWithIds(): array
     {
         $expectedDocument = (object) ['_id' => 1];
 
@@ -99,7 +99,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    public function provideDocumentsWithoutIds(): array
+    public static function provideDocumentsWithoutIds(): array
     {
         /* Note: _id placeholders must be replaced with generated ObjectIds. We
          * also clone the value for each data set since tests may need to modify

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -229,9 +229,9 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    public function provideInvalidBooleanValues()
+    public static function provideInvalidBooleanValues()
     {
-        return $this->wrapValuesForDataProvider($this->getInvalidBooleanValues());
+        return self::wrapValuesForDataProvider(self::getInvalidBooleanValues());
     }
 
     public function testReplaceOneWithCodecRejectsInvalidDocuments(): void
@@ -442,14 +442,14 @@ class BulkWriteTest extends TestCase
         );
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'ordered' => $this->getInvalidBooleanValues(true),
-            'session' => $this->getInvalidSessionValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'bypassDocumentValidation' => self::getInvalidBooleanValues(),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'ordered' => self::getInvalidBooleanValues(true),
+            'session' => self::getInvalidSessionValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 }

--- a/tests/Operation/CountDocumentsTest.php
+++ b/tests/Operation/CountDocumentsTest.php
@@ -23,17 +23,17 @@ class CountDocumentsTest extends TestCase
         new CountDocuments($this->getDatabaseName(), $this->getCollectionName(), [], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'collation' => $this->getInvalidDocumentValues(),
-            'hint' => $this->getInvalidHintValues(),
-            'limit' => $this->getInvalidIntegerValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'skip' => $this->getInvalidIntegerValues(),
+        return self::createOptionDataProvider([
+            'collation' => self::getInvalidDocumentValues(),
+            'hint' => self::getInvalidHintValues(),
+            'limit' => self::getInvalidIntegerValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'session' => self::getInvalidSessionValues(),
+            'skip' => self::getInvalidIntegerValues(),
         ]);
     }
 }

--- a/tests/Operation/CountTest.php
+++ b/tests/Operation/CountTest.php
@@ -24,17 +24,17 @@ class CountTest extends TestCase
         new Count($this->getDatabaseName(), $this->getCollectionName(), [], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'collation' => $this->getInvalidDocumentValues(),
-            'hint' => $this->getInvalidHintValues(),
-            'limit' => $this->getInvalidIntegerValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'skip' => $this->getInvalidIntegerValues(),
+        return self::createOptionDataProvider([
+            'collation' => self::getInvalidDocumentValues(),
+            'hint' => self::getInvalidHintValues(),
+            'limit' => self::getInvalidIntegerValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'session' => self::getInvalidSessionValues(),
+            'skip' => self::getInvalidIntegerValues(),
         ]);
     }
 

--- a/tests/Operation/CreateCollectionTest.php
+++ b/tests/Operation/CreateCollectionTest.php
@@ -21,31 +21,31 @@ class CreateCollectionTest extends TestCase
         new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'autoIndexId' => $this->getInvalidBooleanValues(),
-            'capped' => $this->getInvalidBooleanValues(),
-            'changeStreamPreAndPostImages' => $this->getInvalidDocumentValues(),
-            'clusteredIndex' => $this->getInvalidDocumentValues(),
-            'collation' => $this->getInvalidDocumentValues(),
-            'encryptedFields' => $this->getInvalidDocumentValues(),
-            'expireAfterSeconds' => $this->getInvalidIntegerValues(),
-            'flags' => $this->getInvalidIntegerValues(),
-            'indexOptionDefaults' => $this->getInvalidDocumentValues(),
-            'max' => $this->getInvalidIntegerValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'pipeline' => $this->getInvalidArrayValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'size' => $this->getInvalidIntegerValues(),
-            'storageEngine' => $this->getInvalidDocumentValues(),
-            'timeseries' => $this->getInvalidDocumentValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'validationAction' => $this->getInvalidStringValues(),
-            'validationLevel' => $this->getInvalidStringValues(),
-            'validator' => $this->getInvalidDocumentValues(),
-            'viewOn' => $this->getInvalidStringValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'autoIndexId' => self::getInvalidBooleanValues(),
+            'capped' => self::getInvalidBooleanValues(),
+            'changeStreamPreAndPostImages' => self::getInvalidDocumentValues(),
+            'clusteredIndex' => self::getInvalidDocumentValues(),
+            'collation' => self::getInvalidDocumentValues(),
+            'encryptedFields' => self::getInvalidDocumentValues(),
+            'expireAfterSeconds' => self::getInvalidIntegerValues(),
+            'flags' => self::getInvalidIntegerValues(),
+            'indexOptionDefaults' => self::getInvalidDocumentValues(),
+            'max' => self::getInvalidIntegerValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'pipeline' => self::getInvalidArrayValues(),
+            'session' => self::getInvalidSessionValues(),
+            'size' => self::getInvalidIntegerValues(),
+            'storageEngine' => self::getInvalidDocumentValues(),
+            'timeseries' => self::getInvalidDocumentValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'validationAction' => self::getInvalidStringValues(),
+            'validationLevel' => self::getInvalidStringValues(),
+            'validator' => self::getInvalidDocumentValues(),
+            'viewOn' => self::getInvalidStringValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
+++ b/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
@@ -73,7 +73,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame($expectedOutput, $encryptedFieldsOutput);
     }
 
-    public function provideEncryptedFieldsAndFieldsIsMissing(): array
+    public static function provideEncryptedFieldsAndFieldsIsMissing(): array
     {
         $ef = [];
 
@@ -104,7 +104,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame($expectedOutput, $encryptedFieldsOutput);
     }
 
-    public function provideEncryptedFieldsAndFieldsHasInvalidType(): array
+    public static function provideEncryptedFieldsAndFieldsHasInvalidType(): array
     {
         $ef = ['fields' => 'not-an-array'];
 
@@ -135,7 +135,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame($expectedOutput, $encryptedFieldsOutput);
     }
 
-    public function provideEncryptedFieldsElementHasInvalidType(): array
+    public static function provideEncryptedFieldsElementHasInvalidType(): array
     {
         $ef = ['fields' => ['not-an-array-or-object']];
 
@@ -190,7 +190,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $this->assertInstanceOf(Binary::class, $modifiedEncryptedFields['fields'][0]['keyId'] ?? null);
     }
 
-    public function provideEncryptedFields(): array
+    public static function provideEncryptedFields(): array
     {
         $ef = ['fields' => [['path' => 'ssn', 'bsonType' => 'string', 'keyId' => null]]];
 

--- a/tests/Operation/CreateEncryptedCollectionTest.php
+++ b/tests/Operation/CreateEncryptedCollectionTest.php
@@ -15,14 +15,14 @@ class CreateEncryptedCollectionTest extends TestCase
         new CreateEncryptedCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions(): Generator
+    public static function provideInvalidConstructorOptions(): Generator
     {
         yield 'encryptedFields is required' => [
             [],
         ];
 
-        yield from $this->createOptionDataProvider([
-            'encryptedFields' => $this->getInvalidDocumentValues(),
+        yield from self::createOptionDataProvider([
+            'encryptedFields' => self::getInvalidDocumentValues(),
         ]);
     }
 }

--- a/tests/Operation/CreateIndexesFunctionalTest.php
+++ b/tests/Operation/CreateIndexesFunctionalTest.php
@@ -121,7 +121,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
         });
     }
 
-    public function provideKeyCasts(): array
+    public static function provideKeyCasts(): array
     {
         // phpcs:disable SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing
         // phpcs:disable Squiz.Functions.MultiLineFunctionDeclaration

--- a/tests/Operation/CreateIndexesTest.php
+++ b/tests/Operation/CreateIndexesTest.php
@@ -25,14 +25,14 @@ class CreateIndexesTest extends TestCase
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => ['x' => 1]]], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
+        return self::createOptionDataProvider([
             // commitQuorum is int|string, for which no helper exists
             'commitQuorum' => ['float' => 3.14, 'bool' => true, 'array' => [], 'object' => new stdClass()],
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'session' => self::getInvalidSessionValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 
@@ -51,9 +51,9 @@ class CreateIndexesTest extends TestCase
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [$index]);
     }
 
-    public function provideInvalidIndexSpecificationTypes()
+    public static function provideInvalidIndexSpecificationTypes()
     {
-        return $this->wrapValuesForDataProvider($this->getInvalidArrayValues());
+        return self::wrapValuesForDataProvider(self::getInvalidArrayValues());
     }
 
     public function testConstructorRequiresIndexSpecificationKey(): void
@@ -79,7 +79,7 @@ class CreateIndexesTest extends TestCase
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => $key]]);
     }
 
-    public function provideKeyDocumentsWithInvalidOrder(): Generator
+    public static function provideKeyDocumentsWithInvalidOrder(): Generator
     {
         $invalidOrderValues = [true, [], new stdClass(), null];
 

--- a/tests/Operation/DatabaseCommandFunctionalTest.php
+++ b/tests/Operation/DatabaseCommandFunctionalTest.php
@@ -28,7 +28,7 @@ class DatabaseCommandFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideCommandDocuments(): array
+    public static function provideCommandDocuments(): array
     {
         return [
             'array' => [['ping' => 1]],

--- a/tests/Operation/DatabaseCommandTest.php
+++ b/tests/Operation/DatabaseCommandTest.php
@@ -23,12 +23,12 @@ class DatabaseCommandTest extends TestCase
         new DatabaseCommand($this->getDatabaseName(), ['ping' => 1], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
+        return self::createOptionDataProvider([
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
         ]);
     }
 }

--- a/tests/Operation/DeleteTest.php
+++ b/tests/Operation/DeleteTest.php
@@ -37,9 +37,9 @@ class DeleteTest extends TestCase
         new Delete($this->getDatabaseName(), $this->getCollectionName(), [], $limit);
     }
 
-    public function provideInvalidLimitValues()
+    public static function provideInvalidLimitValues()
     {
-        return $this->wrapValuesForDataProvider([-1, 2]);
+        return self::wrapValuesForDataProvider([-1, 2]);
     }
 
     /** @dataProvider provideInvalidConstructorOptions */
@@ -49,14 +49,14 @@ class DeleteTest extends TestCase
         new Delete($this->getDatabaseName(), $this->getCollectionName(), [], 1, $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'collation' => $this->getInvalidDocumentValues(),
-            'hint' => $this->getInvalidHintValues(),
-            'let' => $this->getInvalidDocumentValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'collation' => self::getInvalidDocumentValues(),
+            'hint' => self::getInvalidHintValues(),
+            'let' => self::getInvalidDocumentValues(),
+            'session' => self::getInvalidSessionValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Operation/DistinctFunctionalTest.php
+++ b/tests/Operation/DistinctFunctionalTest.php
@@ -118,7 +118,7 @@ class DistinctFunctionalTest extends FunctionalTestCase
         $this->assertEquals($expectedDocuments, $values);
     }
 
-    public function provideTypeMapOptionsAndExpectedDocuments()
+    public static function provideTypeMapOptionsAndExpectedDocuments()
     {
         return [
             'No type map' => [

--- a/tests/Operation/DistinctTest.php
+++ b/tests/Operation/DistinctTest.php
@@ -25,15 +25,15 @@ class DistinctTest extends TestCase
         new Distinct($this->getDatabaseName(), $this->getCollectionName(), 'x', [], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'collation' => $this->getInvalidDocumentValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
+        return self::createOptionDataProvider([
+            'collation' => self::getInvalidDocumentValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
         ]);
     }
 

--- a/tests/Operation/DropCollectionTest.php
+++ b/tests/Operation/DropCollectionTest.php
@@ -14,12 +14,12 @@ class DropCollectionTest extends TestCase
         new DropCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 }

--- a/tests/Operation/DropDatabaseTest.php
+++ b/tests/Operation/DropDatabaseTest.php
@@ -14,12 +14,12 @@ class DropDatabaseTest extends TestCase
         new DropDatabase($this->getDatabaseName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 }

--- a/tests/Operation/DropEncryptedCollectionTest.php
+++ b/tests/Operation/DropEncryptedCollectionTest.php
@@ -15,14 +15,14 @@ class DropEncryptedCollectionTest extends TestCase
         new DropEncryptedCollection($this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions(): Generator
+    public static function provideInvalidConstructorOptions(): Generator
     {
         yield 'encryptedFields is required' => [
             [],
         ];
 
-        yield from $this->createOptionDataProvider([
-            'encryptedFields' => $this->getInvalidDocumentValues(),
+        yield from self::createOptionDataProvider([
+            'encryptedFields' => self::getInvalidDocumentValues(),
         ]);
     }
 }

--- a/tests/Operation/DropIndexesTest.php
+++ b/tests/Operation/DropIndexesTest.php
@@ -20,13 +20,13 @@ class DropIndexesTest extends TestCase
         new DropIndexes($this->getDatabaseName(), $this->getCollectionName(), '*', $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 }

--- a/tests/Operation/EstimatedDocumentCountTest.php
+++ b/tests/Operation/EstimatedDocumentCountTest.php
@@ -14,13 +14,13 @@ class EstimatedDocumentCountTest extends TestCase
         new EstimatedDocumentCount($this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'session' => $this->getInvalidSessionValues(),
+        return self::createOptionDataProvider([
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'session' => self::getInvalidSessionValues(),
         ]);
     }
 }

--- a/tests/Operation/ExplainFunctionalTest.php
+++ b/tests/Operation/ExplainFunctionalTest.php
@@ -360,7 +360,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    public function provideVerbosityInformation()
+    public static function provideVerbosityInformation()
     {
         return [
             [Explain::VERBOSITY_ALL_PLANS, true, true],

--- a/tests/Operation/ExplainTest.php
+++ b/tests/Operation/ExplainTest.php
@@ -16,13 +16,13 @@ class ExplainTest extends TestCase
         new Explain($this->getDatabaseName(), $explainable, $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'verbosity' => $this->getInvalidStringValues(),
+        return self::createOptionDataProvider([
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'verbosity' => self::getInvalidStringValues(),
         ]);
     }
 }

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -35,7 +35,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideQueryDocuments(): array
+    public static function provideQueryDocuments(): array
     {
         $expected = (object) ['x' => 1];
 
@@ -74,7 +74,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideReplacementDocumentLikePipeline(): array
+    public static function provideReplacementDocumentLikePipeline(): array
     {
         /* Note: this expected value differs from UpdateFunctionalTest because
          * FindAndModify is not affected by libmongoc's pipeline detection for
@@ -251,7 +251,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         $this->assertEquals($expectedDocument, $document);
     }
 
-    public function provideTypeMapOptionsAndExpectedDocument()
+    public static function provideTypeMapOptionsAndExpectedDocument()
     {
         return [
             [

--- a/tests/Operation/FindAndModifyTest.php
+++ b/tests/Operation/FindAndModifyTest.php
@@ -15,24 +15,24 @@ class FindAndModifyTest extends TestCase
         new FindAndModify($this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'arrayFilters' => $this->getInvalidArrayValues(),
-            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'collation' => $this->getInvalidDocumentValues(),
-            'fields' => $this->getInvalidDocumentValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'new' => $this->getInvalidBooleanValues(),
-            'query' => $this->getInvalidDocumentValues(),
-            'remove' => $this->getInvalidBooleanValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'sort' => $this->getInvalidDocumentValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'update' => $this->getInvalidUpdateValues(),
-            'upsert' => $this->getInvalidBooleanValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'arrayFilters' => self::getInvalidArrayValues(),
+            'bypassDocumentValidation' => self::getInvalidBooleanValues(),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'collation' => self::getInvalidDocumentValues(),
+            'fields' => self::getInvalidDocumentValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'new' => self::getInvalidBooleanValues(),
+            'query' => self::getInvalidDocumentValues(),
+            'remove' => self::getInvalidBooleanValues(),
+            'session' => self::getInvalidSessionValues(),
+            'sort' => self::getInvalidDocumentValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'update' => self::getInvalidUpdateValues(),
+            'upsert' => self::getInvalidBooleanValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -56,7 +56,7 @@ class FindFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideModifierDocuments(): array
+    public static function provideModifierDocuments(): array
     {
         $expectedSort = (object) ['x' => 1];
 
@@ -168,7 +168,7 @@ class FindFunctionalTest extends FunctionalTestCase
         $this->assertEquals($expectedDocuments, $cursor->toArray());
     }
 
-    public function provideTypeMapOptionsAndExpectedDocuments()
+    public static function provideTypeMapOptionsAndExpectedDocuments()
     {
         return [
             [

--- a/tests/Operation/FindOneAndDeleteTest.php
+++ b/tests/Operation/FindOneAndDeleteTest.php
@@ -24,10 +24,10 @@ class FindOneAndDeleteTest extends TestCase
         new FindOneAndDelete($this->getDatabaseName(), $this->getCollectionName(), [], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'projection' => $this->getInvalidDocumentValues(),
+        return self::createOptionDataProvider([
+            'projection' => self::getInvalidDocumentValues(),
         ]);
     }
 

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -59,12 +59,12 @@ class FindOneAndReplaceTest extends TestCase
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], [], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'projection' => $this->getInvalidDocumentValues(),
-            'returnDocument' => $this->getInvalidIntegerValues(true),
+        return self::createOptionDataProvider([
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'projection' => self::getInvalidDocumentValues(),
+            'returnDocument' => self::getInvalidIntegerValues(true),
         ]);
     }
 
@@ -75,9 +75,9 @@ class FindOneAndReplaceTest extends TestCase
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], [], ['returnDocument' => $returnDocument]);
     }
 
-    public function provideInvalidConstructorReturnDocumentOptions()
+    public static function provideInvalidConstructorReturnDocumentOptions()
     {
-        return $this->wrapValuesForDataProvider([-1, 0, 3]);
+        return self::wrapValuesForDataProvider([-1, 0, 3]);
     }
 
     public function testExplainableCommandDocument(): void

--- a/tests/Operation/FindOneAndUpdateTest.php
+++ b/tests/Operation/FindOneAndUpdateTest.php
@@ -42,11 +42,11 @@ class FindOneAndUpdateTest extends TestCase
         new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], ['$set' => ['x' => 1]], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'projection' => $this->getInvalidDocumentValues(),
-            'returnDocument' => $this->getInvalidIntegerValues(),
+        return self::createOptionDataProvider([
+            'projection' => self::getInvalidDocumentValues(),
+            'returnDocument' => self::getInvalidIntegerValues(),
         ]);
     }
 
@@ -57,9 +57,9 @@ class FindOneAndUpdateTest extends TestCase
         new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], [], ['returnDocument' => $returnDocument]);
     }
 
-    public function provideInvalidConstructorReturnDocumentOptions()
+    public static function provideInvalidConstructorReturnDocumentOptions()
     {
-        return $this->wrapValuesForDataProvider([-1, 0, 3]);
+        return self::wrapValuesForDataProvider([-1, 0, 3]);
     }
 
     public function testExplainableCommandDocument(): void

--- a/tests/Operation/FindOneFunctionalTest.php
+++ b/tests/Operation/FindOneFunctionalTest.php
@@ -20,7 +20,7 @@ class FindOneFunctionalTest extends FunctionalTestCase
         $this->assertEquals($expectedDocument, $document);
     }
 
-    public function provideTypeMapOptionsAndExpectedDocument()
+    public static function provideTypeMapOptionsAndExpectedDocument()
     {
         return [
             [

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -25,33 +25,33 @@ class FindTest extends TestCase
         new Find($this->getDatabaseName(), $this->getCollectionName(), [], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'allowPartialResults' => $this->getInvalidBooleanValues(),
-            'batchSize' => $this->getInvalidIntegerValues(),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'collation' => $this->getInvalidDocumentValues(),
-            'cursorType' => $this->getInvalidIntegerValues(),
-            'hint' => $this->getInvalidHintValues(),
-            'limit' => $this->getInvalidIntegerValues(),
-            'max' => $this->getInvalidDocumentValues(),
-            'maxAwaitTimeMS' => $this->getInvalidIntegerValues(),
-            'maxScan' => $this->getInvalidIntegerValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'min' => $this->getInvalidDocumentValues(),
-            'modifiers' => $this->getInvalidDocumentValues(),
-            'oplogReplay' => $this->getInvalidBooleanValues(),
-            'projection' => $this->getInvalidDocumentValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'returnKey' => $this->getInvalidBooleanValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'showRecordId' => $this->getInvalidBooleanValues(),
-            'skip' => $this->getInvalidIntegerValues(),
-            'snapshot' => $this->getInvalidBooleanValues(),
-            'sort' => $this->getInvalidDocumentValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
+        return self::createOptionDataProvider([
+            'allowPartialResults' => self::getInvalidBooleanValues(),
+            'batchSize' => self::getInvalidIntegerValues(),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'collation' => self::getInvalidDocumentValues(),
+            'cursorType' => self::getInvalidIntegerValues(),
+            'hint' => self::getInvalidHintValues(),
+            'limit' => self::getInvalidIntegerValues(),
+            'max' => self::getInvalidDocumentValues(),
+            'maxAwaitTimeMS' => self::getInvalidIntegerValues(),
+            'maxScan' => self::getInvalidIntegerValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'min' => self::getInvalidDocumentValues(),
+            'modifiers' => self::getInvalidDocumentValues(),
+            'oplogReplay' => self::getInvalidBooleanValues(),
+            'projection' => self::getInvalidDocumentValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'returnKey' => self::getInvalidBooleanValues(),
+            'session' => self::getInvalidSessionValues(),
+            'showRecordId' => self::getInvalidBooleanValues(),
+            'skip' => self::getInvalidIntegerValues(),
+            'snapshot' => self::getInvalidBooleanValues(),
+            'sort' => self::getInvalidDocumentValues(),
+            'typeMap' => self::getInvalidArrayValues(),
         ]);
     }
 
@@ -80,9 +80,9 @@ class FindTest extends TestCase
         new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['cursorType' => $cursorType]);
     }
 
-    public function provideInvalidConstructorCursorTypeOptions()
+    public static function provideInvalidConstructorCursorTypeOptions()
     {
-        return $this->wrapValuesForDataProvider([-1, 0, 4]);
+        return self::wrapValuesForDataProvider([-1, 0, 4]);
     }
 
     public function testExplainableCommandDocument(): void

--- a/tests/Operation/FunctionalTestCase.php
+++ b/tests/Operation/FunctionalTestCase.php
@@ -22,7 +22,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         $this->dropCollection($this->getDatabaseName(), $this->getCollectionName());
     }
 
-    public function provideFilterDocuments(): array
+    public static function provideFilterDocuments(): array
     {
         $expected = (object) ['x' => 1];
 
@@ -34,7 +34,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         ];
     }
 
-    public function provideReplacementDocuments(): array
+    public static function provideReplacementDocuments(): array
     {
         $expected = (object) ['x' => 1];
         $expectedEmpty = (object) [];
@@ -53,7 +53,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         ];
     }
 
-    public function provideUpdateDocuments(): array
+    public static function provideUpdateDocuments(): array
     {
         $expected = (object) ['$set' => (object) ['x' => 1]];
 
@@ -65,7 +65,7 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         ];
     }
 
-    public function provideUpdatePipelines(): array
+    public static function provideUpdatePipelines(): array
     {
         $expected = [(object) ['$set' => (object) ['x' => 1]]];
 

--- a/tests/Operation/InsertManyTest.php
+++ b/tests/Operation/InsertManyTest.php
@@ -38,14 +38,14 @@ class InsertManyTest extends TestCase
         new InsertMany($this->getDatabaseName(), $this->getCollectionName(), [['x' => 1]], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'ordered' => $this->getInvalidBooleanValues(true),
-            'session' => $this->getInvalidSessionValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'bypassDocumentValidation' => self::getInvalidBooleanValues(),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'ordered' => self::getInvalidBooleanValues(true),
+            'session' => self::getInvalidSessionValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -53,7 +53,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideDocumentsWithIds(): array
+    public static function provideDocumentsWithIds(): array
     {
         $expectedDocument = (object) ['_id' => 1];
 
@@ -65,7 +65,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    public function provideDocumentsWithoutIds(): array
+    public static function provideDocumentsWithoutIds(): array
     {
         /* Note: _id placeholders must be replaced with generated ObjectIds. We
          * also clone the value for each data set since tests may need to modify

--- a/tests/Operation/InsertOneTest.php
+++ b/tests/Operation/InsertOneTest.php
@@ -25,13 +25,13 @@ class InsertOneTest extends TestCase
         new InsertOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'bypassDocumentValidation' => self::getInvalidBooleanValues(),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'session' => self::getInvalidSessionValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Operation/ListIndexesTest.php
+++ b/tests/Operation/ListIndexesTest.php
@@ -14,11 +14,11 @@ class ListIndexesTest extends TestCase
         new ListIndexes($this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'session' => $this->getInvalidSessionValues(),
+        return self::createOptionDataProvider([
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'session' => self::getInvalidSessionValues(),
         ]);
     }
 }

--- a/tests/Operation/ListSearchIndexesTest.php
+++ b/tests/Operation/ListSearchIndexesTest.php
@@ -20,11 +20,11 @@ class ListSearchIndexesTest extends TestCase
         new ListSearchIndexes($this->getDatabaseName(), $this->getCollectionName(), $options);
     }
 
-    public function provideInvalidConstructorOptions(): array
+    public static function provideInvalidConstructorOptions(): array
     {
         $options = [];
 
-        foreach ($this->getInvalidIntegerValues() as $value) {
+        foreach (self::getInvalidIntegerValues() as $value) {
             $options[][] = ['batchSize' => $value];
         }
 

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -228,7 +228,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         $this->assertEquals($this->sortResults($expectedDocuments), $this->sortResults($results));
     }
 
-    public function provideTypeMapOptionsAndExpectedDocuments()
+    public static function provideTypeMapOptionsAndExpectedDocuments()
     {
         return [
             [

--- a/tests/Operation/MapReduceTest.php
+++ b/tests/Operation/MapReduceTest.php
@@ -87,7 +87,7 @@ class MapReduceTest extends TestCase
         ]);
     }
 
-    private function getInvalidJavascriptValues()
+    private static function getInvalidJavascriptValues()
     {
         return [123, 3.14, 'foo', true, [], new stdClass(), new ObjectId()];
     }

--- a/tests/Operation/MapReduceTest.php
+++ b/tests/Operation/MapReduceTest.php
@@ -25,9 +25,9 @@ class MapReduceTest extends TestCase
         new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out);
     }
 
-    public function provideInvalidOutValues()
+    public static function provideInvalidOutValues()
     {
-        return $this->wrapValuesForDataProvider([123, 3.14, true]);
+        return self::wrapValuesForDataProvider([123, 3.14, true]);
     }
 
     /** @dataProvider provideDeprecatedOutValues */
@@ -41,7 +41,7 @@ class MapReduceTest extends TestCase
         });
     }
 
-    public function provideDeprecatedOutValues(): array
+    public static function provideDeprecatedOutValues(): array
     {
         return [
             'nonAtomic:array' => [['nonAtomic' => false]],
@@ -66,24 +66,24 @@ class MapReduceTest extends TestCase
         new MapReduce($this->getDatabaseName(), $this->getCollectionName(), $map, $reduce, $out, $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
-            'collation' => $this->getInvalidDocumentValues(),
-            'finalize' => $this->getInvalidJavascriptValues(),
-            'jsMode' => $this->getInvalidBooleanValues(),
-            'limit' => $this->getInvalidIntegerValues(),
-            'maxTimeMS' => $this->getInvalidIntegerValues(),
-            'query' => $this->getInvalidDocumentValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(),
-            'scope' => $this->getInvalidDocumentValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'sort' => $this->getInvalidDocumentValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'verbose' => $this->getInvalidBooleanValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'bypassDocumentValidation' => self::getInvalidBooleanValues(),
+            'collation' => self::getInvalidDocumentValues(),
+            'finalize' => self::getInvalidJavascriptValues(),
+            'jsMode' => self::getInvalidBooleanValues(),
+            'limit' => self::getInvalidIntegerValues(),
+            'maxTimeMS' => self::getInvalidIntegerValues(),
+            'query' => self::getInvalidDocumentValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(),
+            'scope' => self::getInvalidDocumentValues(),
+            'session' => self::getInvalidSessionValues(),
+            'sort' => self::getInvalidDocumentValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'verbose' => self::getInvalidBooleanValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Operation/ModifyCollectionTest.php
+++ b/tests/Operation/ModifyCollectionTest.php
@@ -21,12 +21,12 @@ class ModifyCollectionTest extends TestCase
         new ModifyCollection($this->getDatabaseName(), $this->getCollectionName(), [], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 }

--- a/tests/Operation/RenameCollectionTest.php
+++ b/tests/Operation/RenameCollectionTest.php
@@ -20,13 +20,13 @@ class RenameCollectionTest extends TestCase
         );
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'dropTarget' => $this->getInvalidBooleanValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'dropTarget' => self::getInvalidBooleanValues(),
+            'session' => self::getInvalidSessionValues(),
+            'typeMap' => self::getInvalidArrayValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 }

--- a/tests/Operation/ReplaceOneTest.php
+++ b/tests/Operation/ReplaceOneTest.php
@@ -60,10 +60,10 @@ class ReplaceOneTest extends TestCase
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], ['y' => 1], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'codec' => $this->getInvalidDocumentCodecValues(),
+        return self::createOptionDataProvider([
+            'codec' => self::getInvalidDocumentCodecValues(),
         ]);
     }
 

--- a/tests/Operation/TestCase.php
+++ b/tests/Operation/TestCase.php
@@ -77,7 +77,7 @@ abstract class TestCase extends BaseTestCase
 
     public function provideInvalidUpdateValues(): array
     {
-        return $this->wrapValuesForDataProvider($this->getInvalidUpdateValues());
+        return self::wrapValuesForDataProvider(self::getInvalidUpdateValues());
     }
 
     protected function getInvalidUpdateValues(): array

--- a/tests/Operation/TestCase.php
+++ b/tests/Operation/TestCase.php
@@ -13,7 +13,7 @@ use MongoDB\Tests\TestCase as BaseTestCase;
  */
 abstract class TestCase extends BaseTestCase
 {
-    public function provideReplacementDocuments(): array
+    public static function provideReplacementDocuments(): array
     {
         return [
             'replacement:array' => [['x' => 1]],
@@ -29,7 +29,7 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
-    public function provideUpdateDocuments(): array
+    public static function provideUpdateDocuments(): array
     {
         return [
             'update:array' => [['$set' => ['x' => 1]]],
@@ -39,7 +39,7 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
-    public function provideUpdatePipelines(): array
+    public static function provideUpdatePipelines(): array
     {
         return [
             'pipeline:array' => [[['$set' => ['x' => 1]]]],
@@ -48,7 +48,7 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
-    public function provideEmptyUpdatePipelines(): array
+    public static function provideEmptyUpdatePipelines(): array
     {
         /* Empty update pipelines are accepted by the update and findAndModify
          * commands (as NOPs); however, they are not supported for updates in
@@ -65,7 +65,7 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
-    public function provideEmptyUpdatePipelinesExcludingArray(): array
+    public static function provideEmptyUpdatePipelinesExcludingArray(): array
     {
         /* This data provider is used for replace operations, which accept empty
          * arrays as replacement documents for BC. */
@@ -75,12 +75,12 @@ abstract class TestCase extends BaseTestCase
         ];
     }
 
-    public function provideInvalidUpdateValues(): array
+    public static function provideInvalidUpdateValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidUpdateValues());
     }
 
-    protected function getInvalidUpdateValues(): array
+    protected static function getInvalidUpdateValues(): array
     {
         return [123, 3.14, 'foo', true];
     }

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -75,7 +75,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         );
     }
 
-    public function provideReplacementDocumentLikePipeline(): array
+    public static function provideReplacementDocumentLikePipeline(): array
     {
         /* Note: libmongoc encodes this replacement document as a BSON array
          * because it resembles an update pipeline (see: CDRIVER-4658). */

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -31,17 +31,17 @@ class UpdateTest extends TestCase
         new Update($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], ['y' => 1], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'arrayFilters' => $this->getInvalidArrayValues(),
-            'bypassDocumentValidation' => $this->getInvalidBooleanValues(),
-            'collation' => $this->getInvalidDocumentValues(),
-            'hint' => $this->getInvalidHintValues(),
-            'multi' => $this->getInvalidBooleanValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'upsert' => $this->getInvalidBooleanValues(),
-            'writeConcern' => $this->getInvalidWriteConcernValues(),
+        return self::createOptionDataProvider([
+            'arrayFilters' => self::getInvalidArrayValues(),
+            'bypassDocumentValidation' => self::getInvalidBooleanValues(),
+            'collation' => self::getInvalidDocumentValues(),
+            'hint' => self::getInvalidHintValues(),
+            'multi' => self::getInvalidBooleanValues(),
+            'session' => self::getInvalidSessionValues(),
+            'upsert' => self::getInvalidBooleanValues(),
+            'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
 

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -1064,7 +1064,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->assertMatchesDocument($expectedChangeDocument, $changeStream->current());
     }
 
-    public function provideTypeMapOptionsAndExpectedChangeDocument()
+    public static function provideTypeMapOptionsAndExpectedChangeDocument()
     {
         /* Note: the "_id" and "ns" fields are purposefully omitted because the
          * resume token's value cannot be anticipated and the collection name,

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -66,7 +66,7 @@ class WatchTest extends FunctionalTestCase
         new Watch($this->manager, $this->getDatabaseName(), $this->getCollectionName(), [], $options);
     }
 
-    private function getInvalidTimestampValues()
+    private static function getInvalidTimestampValues()
     {
         return [123, 3.14, 'foo', true, [], new stdClass()];
     }

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -39,22 +39,22 @@ class WatchTest extends FunctionalTestCase
         new Watch($this->manager, $this->getDatabaseName(), $this->getCollectionName(), [], $options);
     }
 
-    public function provideInvalidConstructorOptions()
+    public static function provideInvalidConstructorOptions()
     {
-        return $this->createOptionDataProvider([
-            'batchSize' => $this->getInvalidIntegerValues(),
-            'codec' => $this->getInvalidDocumentCodecValues(),
-            'collation' => $this->getInvalidDocumentValues(),
-            'fullDocument' => $this->getInvalidStringValues(true),
-            'fullDocumentBeforeChange' => $this->getInvalidStringValues(),
-            'maxAwaitTimeMS' => $this->getInvalidIntegerValues(),
-            'readConcern' => $this->getInvalidReadConcernValues(),
-            'readPreference' => $this->getInvalidReadPreferenceValues(true),
-            'resumeAfter' => $this->getInvalidDocumentValues(),
-            'session' => $this->getInvalidSessionValues(),
-            'startAfter' => $this->getInvalidDocumentValues(),
-            'startAtOperationTime' => $this->getInvalidTimestampValues(),
-            'typeMap' => $this->getInvalidArrayValues(),
+        return self::createOptionDataProvider([
+            'batchSize' => self::getInvalidIntegerValues(),
+            'codec' => self::getInvalidDocumentCodecValues(),
+            'collation' => self::getInvalidDocumentValues(),
+            'fullDocument' => self::getInvalidStringValues(true),
+            'fullDocumentBeforeChange' => self::getInvalidStringValues(),
+            'maxAwaitTimeMS' => self::getInvalidIntegerValues(),
+            'readConcern' => self::getInvalidReadConcernValues(),
+            'readPreference' => self::getInvalidReadPreferenceValues(true),
+            'resumeAfter' => self::getInvalidDocumentValues(),
+            'session' => self::getInvalidSessionValues(),
+            'startAfter' => self::getInvalidDocumentValues(),
+            'startAtOperationTime' => self::getInvalidTimestampValues(),
+            'typeMap' => self::getInvalidArrayValues(),
         ]);
     }
 

--- a/tests/PedantryTest.php
+++ b/tests/PedantryTest.php
@@ -63,7 +63,7 @@ class PedantryTest extends TestCase
         $this->assertEquals($sortedMethods, $methods);
     }
 
-    public function provideProjectClassNames()
+    public static function provideProjectClassNames()
     {
         $classNames = [];
         $srcDir = realpath(__DIR__ . '/../src/');

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -215,7 +215,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         }
     }
 
-    public function provideTests()
+    public static function provideTests()
     {
         $testArgs = [];
 

--- a/tests/SpecTests/DocumentsMatchConstraintTest.php
+++ b/tests/SpecTests/DocumentsMatchConstraintTest.php
@@ -78,7 +78,7 @@ class DocumentsMatchConstraintTest extends TestCase
         $this->assertResult(true, $constraint, ['x' => $value], 'Type matches');
     }
 
-    public function provideBSONTypes()
+    public static function provideBSONTypes()
     {
         $undefined = Document::fromJSON('{ "x": {"$undefined": true} }')->toPHP()->x;
         $symbol = Document::fromJSON('{ "x": {"$symbol": "test"} }')->toPHP()->x;
@@ -144,7 +144,7 @@ class DocumentsMatchConstraintTest extends TestCase
         }
     }
 
-    public function errorMessageProvider()
+    public static function errorMessageProvider()
     {
         return [
             'Root type mismatch' => [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -140,22 +140,22 @@ OUTPUT;
         return is_string($dataName) ? $dataName : '';
     }
 
-    public function provideInvalidArrayValues(): array
+    final public function provideInvalidArrayValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidArrayValues());
     }
 
-    public function provideInvalidDocumentValues(): array
+    final public function provideInvalidDocumentValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidDocumentValues());
     }
 
-    public function provideInvalidIntegerValues(): array
+    final public function provideInvalidIntegerValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidIntegerValues());
     }
 
-    public function provideInvalidStringValues(): array
+    final public function provideInvalidStringValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidStringValues());
     }
@@ -269,7 +269,7 @@ OUTPUT;
     /**
      * Return a list of invalid hint values.
      */
-    protected static function getInvalidHintValues()
+    protected static function getInvalidHintValues(): array
     {
         return [123, 3.14, true];
     }
@@ -376,7 +376,7 @@ OUTPUT;
      *
      * @param array $values List of values
      */
-    protected function wrapValuesForDataProvider(array $values): array
+    final protected static function wrapValuesForDataProvider(array $values): array
     {
         return array_map(fn ($value) => [$value], $values);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -140,22 +140,22 @@ OUTPUT;
 
     public function provideInvalidArrayValues(): array
     {
-        return $this->wrapValuesForDataProvider($this->getInvalidArrayValues());
+        return self::wrapValuesForDataProvider(self::getInvalidArrayValues());
     }
 
     public function provideInvalidDocumentValues(): array
     {
-        return $this->wrapValuesForDataProvider($this->getInvalidDocumentValues());
+        return self::wrapValuesForDataProvider(self::getInvalidDocumentValues());
     }
 
     public function provideInvalidIntegerValues(): array
     {
-        return $this->wrapValuesForDataProvider($this->getInvalidIntegerValues());
+        return self::wrapValuesForDataProvider(self::getInvalidIntegerValues());
     }
 
     public function provideInvalidStringValues(): array
     {
-        return $this->wrapValuesForDataProvider($this->getInvalidStringValues());
+        return self::wrapValuesForDataProvider(self::getInvalidStringValues());
     }
 
     protected function assertDeprecated(callable $execution): void
@@ -175,7 +175,7 @@ OUTPUT;
         $this->assertCount(1, $errors);
     }
 
-    protected function createOptionDataProvider(array $options): array
+    protected static function createOptionDataProvider(array $options): array
     {
         $data = [];
 
@@ -206,7 +206,7 @@ OUTPUT;
     /**
      * Return a list of invalid array values.
      */
-    protected function getInvalidArrayValues(bool $includeNull = false): array
+    protected static function getInvalidArrayValues(bool $includeNull = false): array
     {
         return [123, 3.14, 'foo', true, new stdClass(), ...($includeNull ? [null] : [])];
     }
@@ -214,7 +214,7 @@ OUTPUT;
     /**
      * Return a list of invalid boolean values.
      */
-    protected function getInvalidBooleanValues(bool $includeNull = false): array
+    protected static function getInvalidBooleanValues(bool $includeNull = false): array
     {
         return [123, 3.14, 'foo', [], new stdClass(), ...($includeNull ? [null] : [])];
     }
@@ -222,25 +222,25 @@ OUTPUT;
     /**
      * Return a list of invalid document values.
      */
-    protected function getInvalidDocumentValues(bool $includeNull = false): array
+    protected static function getInvalidDocumentValues(bool $includeNull = false): array
     {
         return [123, 3.14, 'foo', true, PackedArray::fromPHP([]), ...($includeNull ? [null] : [])];
     }
 
-    protected function getInvalidObjectValues(bool $includeNull = false): array
+    protected static function getInvalidObjectValues(bool $includeNull = false): array
     {
         return [123, 3.14, 'foo', true, [], new stdClass(), ...($includeNull ? [null] : [])];
     }
 
-    protected function getInvalidDocumentCodecValues(): array
+    protected static function getInvalidDocumentCodecValues(): array
     {
-        return [123, 3.14, 'foo', true, [], new stdClass(), $this->createMock(Codec::class)];
+        return [123, 3.14, 'foo', true, [], new stdClass(), self::createStub(Codec::class)];
     }
 
     /**
      * Return a list of invalid hint values.
      */
-    protected function getInvalidHintValues()
+    protected static function getInvalidHintValues()
     {
         return [123, 3.14, true];
     }
@@ -248,7 +248,7 @@ OUTPUT;
     /**
      * Return a list of invalid integer values.
      */
-    protected function getInvalidIntegerValues(bool $includeNull = false): array
+    protected static function getInvalidIntegerValues(bool $includeNull = false): array
     {
         return [3.14, 'foo', true, [], new stdClass(), ...($includeNull ? [null] : [])];
     }
@@ -256,7 +256,7 @@ OUTPUT;
     /**
      * Return a list of invalid ReadPreference values.
      */
-    protected function getInvalidReadConcernValues(bool $includeNull = false): array
+    protected static function getInvalidReadConcernValues(bool $includeNull = false): array
     {
         return [
             123,
@@ -274,7 +274,7 @@ OUTPUT;
     /**
      * Return a list of invalid ReadPreference values.
      */
-    protected function getInvalidReadPreferenceValues(bool $includeNull = false): array
+    protected static function getInvalidReadPreferenceValues(bool $includeNull = false): array
     {
         return [
             123,
@@ -292,7 +292,7 @@ OUTPUT;
     /**
      * Return a list of invalid Session values.
      */
-    protected function getInvalidSessionValues(bool $includeNull = false): array
+    protected static function getInvalidSessionValues(bool $includeNull = false): array
     {
         return [
             123,
@@ -311,7 +311,7 @@ OUTPUT;
     /**
      * Return a list of invalid string values.
      */
-    protected function getInvalidStringValues(bool $includeNull = false): array
+    protected static function getInvalidStringValues(bool $includeNull = false): array
     {
         return [123, 3.14, true, [], new stdClass(), ...($includeNull ? [null] : [])];
     }
@@ -319,7 +319,7 @@ OUTPUT;
     /**
      * Return a list of invalid WriteConcern values.
      */
-    protected function getInvalidWriteConcernValues(bool $includeNull = false): array
+    protected static function getInvalidWriteConcernValues(bool $includeNull = false): array
     {
         return [
             123,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,8 @@ use InvalidArgumentException;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Codec\Codec;
+use MongoDB\Codec\DecodeIfSupported;
+use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
@@ -234,7 +236,34 @@ OUTPUT;
 
     protected static function getInvalidDocumentCodecValues(): array
     {
-        return [123, 3.14, 'foo', true, [], new stdClass(), self::createStub(Codec::class)];
+        $codec = new class implements Codec {
+            use DecodeIfSupported;
+            use EncodeIfSupported;
+
+            public function canDecode(mixed $value): bool
+            {
+                return true;
+            }
+
+            public function decode(mixed $value): mixed
+            {
+                return $value;
+            }
+
+            public function canEncode(mixed $value): bool
+            {
+                return true;
+            }
+
+            public function encode(mixed $value): mixed
+            {
+                return $value;
+            }
+        };
+        // @fixme: createStub can be called statically in PHPUnit 10
+        // $codec = self::createStub(Codec::class);
+
+        return [123, 3.14, 'foo', true, [], new stdClass(), $codec];
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -140,22 +140,22 @@ OUTPUT;
         return is_string($dataName) ? $dataName : '';
     }
 
-    final public function provideInvalidArrayValues(): array
+    final public static function provideInvalidArrayValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidArrayValues());
     }
 
-    final public function provideInvalidDocumentValues(): array
+    final public static function provideInvalidDocumentValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidDocumentValues());
     }
 
-    final public function provideInvalidIntegerValues(): array
+    final public static function provideInvalidIntegerValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidIntegerValues());
     }
 
-    final public function provideInvalidStringValues(): array
+    final public static function provideInvalidStringValues(): array
     {
         return self::wrapValuesForDataProvider(self::getInvalidStringValues());
     }

--- a/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
+++ b/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
@@ -33,7 +33,7 @@ class IsBsonTypeTest extends TestCase
         $this->assertResult(true, new IsBsonType($type), $value, $this->dataName() . ' is ' . $type);
     }
 
-    public function provideTypes()
+    public static function provideTypes()
     {
         $undefined = Document::fromJSON('{ "x": {"$undefined": true} }')->toPHP()->x;
         $symbol = Document::fromJSON('{ "x": {"$symbol": "test"} }')->toPHP()->x;

--- a/tests/UnifiedSpecTests/Constraint/MatchesTest.php
+++ b/tests/UnifiedSpecTests/Constraint/MatchesTest.php
@@ -182,7 +182,7 @@ class MatchesTest extends FunctionalTestCase
         }
     }
 
-    public function errorMessageProvider()
+    public static function errorMessageProvider()
     {
         return [
             'assertEquals: type check (root-level)' => [
@@ -262,7 +262,7 @@ class MatchesTest extends FunctionalTestCase
         $constraint->evaluate(['x' => 1], '', true);
     }
 
-    public function operatorErrorMessageProvider()
+    public static function operatorErrorMessageProvider()
     {
         return [
             '$$exists type' => [

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -234,9 +234,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideAtlasDataLakeTests()
+    public static function provideAtlasDataLakeTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/atlas-data-lake/*.json');
+        return self::provideTests(__DIR__ . '/atlas-data-lake/*.json');
     }
 
     /**
@@ -248,9 +248,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideChangeStreamsTests()
+    public static function provideChangeStreamsTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/change-streams/*.json');
+        return self::provideTests(__DIR__ . '/change-streams/*.json');
     }
 
     /**
@@ -263,9 +263,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideClientSideEncryptionTests()
+    public static function provideClientSideEncryptionTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/client-side-encryption/*.json');
+        return self::provideTests(__DIR__ . '/client-side-encryption/*.json');
     }
 
     /**
@@ -277,9 +277,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideCollectionManagementTests()
+    public static function provideCollectionManagementTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/collection-management/*.json');
+        return self::provideTests(__DIR__ . '/collection-management/*.json');
     }
 
     /**
@@ -291,9 +291,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideCommandMonitoringTests()
+    public static function provideCommandMonitoringTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/command-monitoring/*.json');
+        return self::provideTests(__DIR__ . '/command-monitoring/*.json');
     }
 
     /**
@@ -305,9 +305,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideCrudTests()
+    public static function provideCrudTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/crud/*.json');
+        return self::provideTests(__DIR__ . '/crud/*.json');
     }
 
     /**
@@ -319,9 +319,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideGridFSTests()
+    public static function provideGridFSTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/gridfs/*.json');
+        return self::provideTests(__DIR__ . '/gridfs/*.json');
     }
 
     /**
@@ -333,9 +333,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideLoadBalancers()
+    public static function provideLoadBalancers(): Generator
     {
-        return $this->provideTests(__DIR__ . '/load-balancers/*.json');
+        return self::provideTests(__DIR__ . '/load-balancers/*.json');
     }
 
     /** @dataProvider provideReadWriteConcernTests */
@@ -344,9 +344,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideReadWriteConcernTests()
+    public static function provideReadWriteConcernTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/read-write-concern/*.json');
+        return self::provideTests(__DIR__ . '/read-write-concern/*.json');
     }
 
     /**
@@ -358,9 +358,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideRetryableReadsTests()
+    public static function provideRetryableReadsTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/retryable-reads/*.json');
+        return self::provideTests(__DIR__ . '/retryable-reads/*.json');
     }
 
     /**
@@ -372,9 +372,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideRetryableWritesTests()
+    public static function provideRetryableWritesTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/retryable-writes/*.json');
+        return self::provideTests(__DIR__ . '/retryable-writes/*.json');
     }
 
     /**
@@ -386,9 +386,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideRunCommandTests()
+    public static function provideRunCommandTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/run-command/*.json');
+        return self::provideTests(__DIR__ . '/run-command/*.json');
     }
 
     /**
@@ -400,9 +400,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideSessionsTests()
+    public static function provideSessionsTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/sessions/*.json');
+        return self::provideTests(__DIR__ . '/sessions/*.json');
     }
 
     /**
@@ -414,9 +414,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideTransactionsTests()
+    public static function provideTransactionsTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/transactions/*.json');
+        return self::provideTests(__DIR__ . '/transactions/*.json');
     }
 
     /** @dataProvider provideTransactionsConvenientApiTests */
@@ -425,9 +425,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideTransactionsConvenientApiTests()
+    public static function provideTransactionsConvenientApiTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/transactions-convenient-api/*.json');
+        return self::provideTests(__DIR__ . '/transactions-convenient-api/*.json');
     }
 
     /**
@@ -440,9 +440,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideVersionedApiTests()
+    public static function provideVersionedApiTests(): Generator
     {
-        return $this->provideTests(__DIR__ . '/versioned-api/*.json');
+        return self::provideTests(__DIR__ . '/versioned-api/*.json');
     }
 
     /** @dataProvider providePassingTests */
@@ -451,9 +451,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function providePassingTests()
+    public static function providePassingTests(): Generator
     {
-        yield from $this->provideTests(__DIR__ . '/valid-pass/*.json');
+        yield from self::provideTests(__DIR__ . '/valid-pass/*.json');
     }
 
     /** @dataProvider provideFailingTests */
@@ -489,9 +489,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         $this->assertTrue($failed, 'Expected test to throw an exception');
     }
 
-    public function provideFailingTests()
+    public static function provideFailingTests(): Generator
     {
-        yield from $this->provideTests(__DIR__ . '/valid-fail/*.json');
+        yield from self::provideTests(__DIR__ . '/valid-fail/*.json');
     }
 
     /** @dataProvider provideIndexManagementTests */
@@ -508,12 +508,12 @@ class UnifiedSpecTest extends FunctionalTestCase
         self::$runner->run($test);
     }
 
-    public function provideIndexManagementTests()
+    public static function provideIndexManagementTests(): Generator
     {
-        yield from $this->provideTests(__DIR__ . '/index-management/*.json');
+        yield from self::provideTests(__DIR__ . '/index-management/*.json');
     }
 
-    private function provideTests(string $pattern): Generator
+    private static function provideTests(string $pattern): Generator
     {
         foreach (glob($pattern) as $filename) {
             $group = basename(dirname($filename));


### PR DESCRIPTION
Fix PHPLIB-1514

In order to upgrade to PHPUnit 10+, we need to make all data provider static.