### PR TITLE
PHPLIB-1369 Upgrade to PHPUnit 10

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -43,7 +43,7 @@ if [ "${IS_MATRIX_TESTING}" = "true" ]; then
 fi
 
 # Enable verbose output to see skipped and incomplete tests
-PHPUNIT_OPTS="${PHPUNIT_OPTS} -v --configuration phpunit.evergreen.xml"
+PHPUNIT_OPTS="${PHPUNIT_OPTS} --configuration phpunit.evergreen.xml"
 
 if [ "$SSL" = "yes" ]; then
    SSL_OPTS="ssl=true&sslallowinvalidcertificates=true"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,6 @@ jobs:
           php-ini-values: "zend.assertions=1"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit -v"
+        run: "vendor/bin/phpunit"
         env:
-          SYMFONY_DEPRECATIONS_HELPER: 999999
           MONGODB_URI: ${{ steps.setup-mongodb.outputs.cluster-uri }}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
         "phpunit/phpunit": "^9.6.11",
-        "rector/rector": "^1.1",
+        "rector/rector": "^1.2",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "^5.13"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
-        "phpunit/phpunit": "^9.6.11",
+        "phpunit/phpunit": "^10.5",
         "rector/rector": "^1.2",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "^5.13"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "10.5.3",
         "rector/rector": "^1.2",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "^5.13"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
-        "phpunit/phpunit": "10.5.3",
+        "phpunit/phpunit": "^10.5.35",
         "rector/rector": "^1.2",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "^5.13"

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -16,7 +17,10 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     // Modernize code
-    $rectorConfig->sets([LevelSetList::UP_TO_PHP_74]);
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_74,
+        PHPUnitSetList::PHPUNIT_100,
+    ]);
 
     $rectorConfig->rule(ChangeSwitchToMatchRector::class);
     $rectorConfig->rule(StaticDataProviderClassMethodRector::class);

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
+use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
@@ -27,6 +28,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // phpcs:disable Squiz.Arrays.ArrayDeclaration.KeySpecified
     $rectorConfig->skip([
+        RemoveExtraParametersRector::class,
         // Do not use ternaries extensively
         IfIssetToCoalescingRector::class,
         ChangeSwitchToMatchRector::class => [

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -14,6 +14,7 @@ use MongoDB\Builder\Query;
 use MongoDB\Builder\Stage;
 use MongoDB\Builder\Type\Sort;
 use MongoDB\Builder\Variable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_merge;
@@ -153,9 +154,8 @@ class BuilderEncoderTest extends TestCase
      *
      * @param list<int>          $limit
      * @param array<string, int> $expectedLimit
-     *
-     * @dataProvider provideExpressionFilterLimit
      */
+    #[DataProvider('provideExpressionFilterLimit')]
     public function testExpressionFilter(array $limit, array $expectedLimit): void
     {
         $pipeline = new Pipeline(

--- a/tests/Builder/FieldPathTest.php
+++ b/tests/Builder/FieldPathTest.php
@@ -8,6 +8,7 @@ use Generator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Type\FieldPathInterface;
 use MongoDB\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function is_subclass_of;
@@ -15,7 +16,7 @@ use function sprintf;
 
 class FieldPathTest extends TestCase
 {
-    /** @dataProvider provideFieldPath */
+    #[DataProvider('provideFieldPath')]
     public function testFieldPath(string $fieldPathClass, string $resolveClass): void
     {
         $fieldPath = Expression::{$fieldPathClass}('foo');
@@ -27,7 +28,7 @@ class FieldPathTest extends TestCase
         $this->assertTrue(is_subclass_of(Expression\FieldPath::class, $resolveClass), sprintf('%s instanceof %s', Expression\FieldPath::class, $resolveClass));
     }
 
-    /** @dataProvider provideFieldPath */
+    #[DataProvider('provideFieldPath')]
     public function testRejectDollarPrefix(string $fieldPathClass): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Builder/Type/CombinedFieldQueryTest.php
+++ b/tests/Builder/Type/CombinedFieldQueryTest.php
@@ -9,6 +9,7 @@ use MongoDB\Builder\Query\EqOperator;
 use MongoDB\Builder\Query\GtOperator;
 use MongoDB\Builder\Type\CombinedFieldQuery;
 use MongoDB\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class CombinedFieldQueryTest extends TestCase
@@ -47,7 +48,7 @@ class CombinedFieldQueryTest extends TestCase
         $this->assertCount(3, $fieldQueries->fieldQueries);
     }
 
-    /** @dataProvider provideInvalidFieldQuery */
+    #[DataProvider('provideInvalidFieldQuery')]
     public function testRejectInvalidFieldQueries(mixed $invalidQuery, string $message = '-'): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -71,11 +72,8 @@ class CombinedFieldQueryTest extends TestCase
         yield 'object key without $' => [(object) ['eq' => 1], 'Operator must contain exactly one key starting with $, "eq" given'];
     }
 
-    /**
-     * @param array<mixed> $fieldQueries
-     *
-     * @dataProvider provideDuplicateOperator
-     */
+    /** @param array<mixed> $fieldQueries */
+    #[DataProvider('provideDuplicateOperator')]
     public function testRejectDuplicateOperator(array $fieldQueries): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Builder/Type/OutputWindowTest.php
+++ b/tests/Builder/Type/OutputWindowTest.php
@@ -10,6 +10,7 @@ use MongoDB\Builder\Type\OutputWindow;
 use MongoDB\Builder\Type\TimeUnit;
 use MongoDB\Builder\Type\WindowInterface;
 use MongoDB\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class OutputWindowTest extends TestCase
@@ -57,11 +58,8 @@ class OutputWindowTest extends TestCase
         $this->assertEquals((object) ['unit' => TimeUnit::Day], $outputWindow->window);
     }
 
-    /**
-     * @param array<mixed> $documents
-     *
-     * @dataProvider provideInvalidDocuments
-     */
+    /** @param array<mixed> $documents */
+    #[DataProvider('provideInvalidDocuments')]
     public function testRejectInvalidDocuments(array $documents): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -82,11 +80,8 @@ class OutputWindowTest extends TestCase
         yield 'not a list' => [['foo' => 1, 'bar' => 2]];
     }
 
-    /**
-     * @param array<mixed> $range
-     *
-     * @dataProvider provideInvalidRange
-     */
+    /** @param array<mixed> $range */
+    #[DataProvider('provideInvalidRange')]
     public function testRejectInvalidRange(array $range): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Builder/Type/QueryObjectTest.php
+++ b/tests/Builder/Type/QueryObjectTest.php
@@ -13,6 +13,7 @@ use MongoDB\Builder\Query\LtOperator;
 use MongoDB\Builder\Type\CombinedFieldQuery;
 use MongoDB\Builder\Type\QueryInterface;
 use MongoDB\Builder\Type\QueryObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class QueryObjectTest extends TestCase
@@ -32,11 +33,8 @@ class QueryObjectTest extends TestCase
         $this->assertSame($query, $queryObject);
     }
 
-    /**
-     * @param array<array-key, mixed> $value
-     *
-     * @dataProvider provideQueryObjectValue
-     */
+    /** @param array<array-key, mixed> $value */
+    #[DataProvider('provideQueryObjectValue')]
     public function testCreateQueryObject(array $value, int $expectedCount = 1): void
     {
         $queryObject = QueryObject::create($value);
@@ -44,11 +42,8 @@ class QueryObjectTest extends TestCase
         $this->assertCount($expectedCount, $queryObject->queries);
     }
 
-    /**
-     * @param array<array-key, mixed> $value
-     *
-     * @dataProvider provideQueryObjectValue
-     */
+    /** @param array<array-key, mixed> $value */
+    #[DataProvider('provideQueryObjectValue')]
     public function testCreateQueryObjectFromArray(array $value, int $expectedCount = 1): void
     {
         // $value is wrapped in an array as if the user used an array instead of variadic arguments

--- a/tests/Builder/VariableTest.php
+++ b/tests/Builder/VariableTest.php
@@ -8,6 +8,7 @@ use Generator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Variable;
 use MongoDB\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class VariableTest extends TestCase
@@ -27,7 +28,7 @@ class VariableTest extends TestCase
         new Expression\Variable('$$foo');
     }
 
-    /** @dataProvider provideVariableBuilders */
+    #[DataProvider('provideVariableBuilders')]
     public function testSystemVariables($factory): void
     {
         $variable = $factory();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,6 +10,8 @@ use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * Unit tests for the Client class.
@@ -23,7 +25,7 @@ class ClientTest extends TestCase
         $this->assertEquals('mongodb://127.0.0.1/', (string) $client);
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testConstructorAutoEncryptionOpts(): void
     {
         $autoEncryptionOpts = [
@@ -35,7 +37,7 @@ class ClientTest extends TestCase
         new Client(static::getUri(), [], ['autoEncryption' => $autoEncryptionOpts]);
     }
 
-    /** @dataProvider provideInvalidConstructorDriverOptions */
+    #[DataProvider('provideInvalidConstructorDriverOptions')]
     public function testConstructorDriverOptionTypeChecks(array $driverOptions, string $exception = InvalidArgumentException::class): void
     {
         $this->expectException($exception);

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -12,6 +12,7 @@ use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindOneAndReplace;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Document\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CodecCollectionFunctionalTest extends FunctionalTestCase
 {
@@ -54,7 +55,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideAggregateOptions */
+    #[DataProvider('provideAggregateOptions')]
     public function testAggregate($expected, $options): void
     {
         $this->createFixtures(3);
@@ -114,7 +115,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideBulkWriteOptions */
+    #[DataProvider('provideBulkWriteOptions')]
     public function testBulkWrite($expected, $options): void
     {
         $this->createFixtures(3);
@@ -169,7 +170,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideFindOneAndModifyOptions */
+    #[DataProvider('provideFindOneAndModifyOptions')]
     public function testFindOneAndDelete($expected, $options): void
     {
         $this->createFixtures(1);
@@ -190,7 +191,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $this->collection->findOneAndDelete(['_id' => 1], $options);
     }
 
-    /** @dataProvider provideFindOneAndModifyOptions */
+    #[DataProvider('provideFindOneAndModifyOptions')]
     public function testFindOneAndUpdate($expected, $options): void
     {
         $this->createFixtures(1);
@@ -235,7 +236,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideFindOneAndReplaceOptions */
+    #[DataProvider('provideFindOneAndReplaceOptions')]
     public function testFindOneAndReplace($expected, $options): void
     {
         $this->createFixtures(1);
@@ -293,7 +294,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideFindOptions */
+    #[DataProvider('provideFindOptions')]
     public function testFind($expected, $options): void
     {
         $this->createFixtures(3);
@@ -332,7 +333,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideFindOneOptions */
+    #[DataProvider('provideFindOneOptions')]
     public function testFindOne($expected, $options): void
     {
         $this->createFixtures(1);
@@ -383,7 +384,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideInsertManyOptions */
+    #[DataProvider('provideInsertManyOptions')]
     public function testInsertMany($expected, $options): void
     {
         $documents = [
@@ -430,7 +431,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideInsertOneOptions */
+    #[DataProvider('provideInsertOneOptions')]
     public function testInsertOne($expected, $options): void
     {
         $result = $this->collection->insertOne(TestObject::createForFixture(1), $options);
@@ -475,7 +476,7 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideReplaceOneOptions */
+    #[DataProvider('provideReplaceOneOptions')]
     public function testReplaceOne($expected, $options): void
     {
         $this->createFixtures(1);

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -16,6 +16,8 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\MapReduceResult;
 use MongoDB\Operation\Count;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use TypeError;
 
 use function array_filter;
@@ -33,7 +35,7 @@ use const JSON_THROW_ON_ERROR;
  */
 class CollectionFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideInvalidDatabaseAndCollectionNames */
+    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
     public function testConstructorDatabaseNameArgument($databaseName, string $expectedExceptionClass): void
     {
         $this->expectException($expectedExceptionClass);
@@ -41,7 +43,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         new Collection($this->manager, $databaseName, $this->getCollectionName());
     }
 
-    /** @dataProvider provideInvalidDatabaseAndCollectionNames */
+    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
     public function testConstructorCollectionNameArgument($collectionName, string $expectedExceptionClass): void
     {
         $this->expectException($expectedExceptionClass);
@@ -57,7 +59,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -168,7 +170,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocuments */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocuments')]
     public function testDistinctWithTypeMap(array $typeMap, array $expectedDocuments): void
     {
         $bulkWrite = new BulkWrite(['ordered' => true]);
@@ -419,12 +421,10 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
-    /**
-     * @group matrix-testing-exclude-server-4.4-driver-4.0
-     * @group matrix-testing-exclude-server-4.4-driver-4.2
-     * @group matrix-testing-exclude-server-5.0-driver-4.0
-     * @group matrix-testing-exclude-server-5.0-driver-4.2
-     */
+    #[Group('matrix-testing-exclude-server-4.4-driver-4.0')]
+    #[Group('matrix-testing-exclude-server-4.4-driver-4.2')]
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.0')]
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.2')]
     public function testMapReduce(): void
     {
         $this->createFixtures(3);
@@ -734,7 +734,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider collectionMethodClosures */
+    #[DataProvider('collectionMethodClosures')]
     public function testMethodDoesNotInheritReadWriteConcernInTransaction(Closure $method): void
     {
         $this->skipIfTransactionsAreNotSupported();
@@ -760,7 +760,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider collectionWriteMethodClosures */
+    #[DataProvider('collectionWriteMethodClosures')]
     public function testMethodInTransactionWithWriteConcernOption($method): void
     {
         $this->skipIfTransactionsAreNotSupported();
@@ -780,7 +780,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         }
     }
 
-    /** @dataProvider collectionReadMethodClosures */
+    #[DataProvider('collectionReadMethodClosures')]
     public function testMethodInTransactionWithReadConcernOption($method): void
     {
         $this->skipIfTransactionsAreNotSupported();

--- a/tests/Command/ListCollectionsTest.php
+++ b/tests/Command/ListCollectionsTest.php
@@ -5,10 +5,11 @@ namespace MongoDB\Tests\Command;
 use MongoDB\Command\ListCollections;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ListCollectionsTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Command/ListDatabasesTest.php
+++ b/tests/Command/ListDatabasesTest.php
@@ -5,10 +5,11 @@ namespace MongoDB\Tests\Command;
 use MongoDB\Command\ListDatabases;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ListDatabasesTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Comparator/Int64Comparator.php
+++ b/tests/Comparator/Int64Comparator.php
@@ -5,13 +5,14 @@ namespace MongoDB\Tests\Comparator;
 use MongoDB\BSON\Int64;
 use SebastianBergmann\Comparator\Comparator;
 use SebastianBergmann\Comparator\ComparisonFailure;
+use SebastianBergmann\Exporter\Exporter;
 
 use function is_numeric;
 use function sprintf;
 
 class Int64Comparator extends Comparator
 {
-    public function accepts($expected, $actual)
+    public function accepts($expected, $actual): bool
     {
         // Only compare if either value is an Int64 and the other value is numeric
         return ($expected instanceof Int64 && $this->isComparable($actual))
@@ -24,16 +25,17 @@ class Int64Comparator extends Comparator
             return;
         }
 
+        $exporter = new Exporter();
+
         throw new ComparisonFailure(
             $expected,
             $actual,
             '',
             '',
-            false,
             sprintf(
                 'Failed asserting that %s matches expected %s.',
-                $this->exporter->export($actual),
-                $this->exporter->export($expected),
+                $exporter->export($actual),
+                $exporter->export($expected),
             ),
         );
     }

--- a/tests/Comparator/Int64ComparatorTest.php
+++ b/tests/Comparator/Int64ComparatorTest.php
@@ -4,12 +4,14 @@ namespace MongoDB\Tests\Comparator;
 
 use Generator;
 use MongoDB\BSON\Int64;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use SebastianBergmann\Comparator\ComparisonFailure;
 
 class Int64ComparatorTest extends TestCase
 {
-    /** @dataProvider provideAcceptsValues */
+    #[DataProvider('provideAcceptsValues')]
     public function testAccepts(bool $expectedResult, $expectedValue, $actualValue): void
     {
         $this->assertSame($expectedResult, (new Int64Comparator())->accepts($expectedValue, $actualValue));
@@ -96,10 +98,8 @@ class Int64ComparatorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideMatchingAssertions
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('provideMatchingAssertions')]
+    #[DoesNotPerformAssertions]
     public function testMatchingAssertions($expected, $actual): void
     {
         (new Int64Comparator())->assertEquals($expected, $actual);
@@ -153,7 +153,7 @@ class Int64ComparatorTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideFailingValues */
+    #[DataProvider('provideFailingValues')]
     public function testFailingAssertions($expected, $actual): void
     {
         $this->expectException(ComparisonFailure::class);

--- a/tests/Comparator/ServerComparator.php
+++ b/tests/Comparator/ServerComparator.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 class ServerComparator extends Comparator
 {
-    public function accepts($expected, $actual)
+    public function accepts($expected, $actual): bool
     {
         return $expected instanceof Server && $actual instanceof Server;
     }
@@ -26,7 +26,6 @@ class ServerComparator extends Comparator
             $actual,
             '',
             '',
-            false,
             sprintf(
                 'Failed asserting that Server("%s:%d") matches expected Server("%s:%d").',
                 $actual->getHost(),

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -12,6 +12,8 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateIndexes;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use TypeError;
 
 use function array_key_exists;
@@ -22,7 +24,7 @@ use function current;
  */
 class DatabaseFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideInvalidDatabaseNames */
+    #[DataProvider('provideInvalidDatabaseNames')]
     public function testConstructorDatabaseNameArgument($databaseName, string $expectedExceptionClass): void
     {
         $this->expectException($expectedExceptionClass);
@@ -38,7 +40,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -122,7 +124,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame(1, (int) $commandResult['ok']);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testCommandCommandArgumentTypeCheck($command): void
     {
         $this->expectException($command instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
@@ -170,11 +172,9 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
-    /**
-     * @group matrix-testing-exclude-server-4.2-driver-4.0-topology-sharded_cluster
-     * @group matrix-testing-exclude-server-4.4-driver-4.0-topology-sharded_cluster
-     * @group matrix-testing-exclude-server-5.0-driver-4.0-topology-sharded_cluster
-     */
+    #[Group('matrix-testing-exclude-server-4.2-driver-4.0-topology-sharded_cluster')]
+    #[Group('matrix-testing-exclude-server-4.4-driver-4.0-topology-sharded_cluster')]
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.0-topology-sharded_cluster')]
     public function testModifyCollection(): void
     {
         $this->database->createCollection($this->getCollectionName());

--- a/tests/DocumentationExamplesTest.php
+++ b/tests/DocumentationExamplesTest.php
@@ -12,6 +12,8 @@ use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\Exception\Exception;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Tests\SpecTests\ClientSideEncryptionSpecTest;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
 
 use function base64_decode;
 use function in_array;
@@ -1009,7 +1011,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $this->assertInventoryCount(0);
     }
 
-    /** @group matrix-testing-exclude-server-5.0-driver-4.0-topology-sharded_cluster */
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.0-topology-sharded_cluster')]
     public function testChangeStreamExample_1_4(): void
     {
         $this->skipIfChangeStreamIsNotSupported();
@@ -1715,7 +1717,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         $this->assertSame(1, $totalDailySales);
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testVersionedApi(): void
     {
         $uriString = static::getUri(true);
@@ -1800,7 +1802,7 @@ class DocumentationExamplesTest extends FunctionalTestCase
         // phpcs:enable
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testWithTransactionExample(): void
     {
         $this->skipIfTransactionsAreNotSupported();

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -3,6 +3,9 @@
 namespace MongoDB\Tests;
 
 use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 use function bin2hex;
 use function getenv;
@@ -10,7 +13,7 @@ use function putenv;
 use function random_bytes;
 use function sprintf;
 
-/** @runTestsInSeparateProcesses */
+#[RunTestsInSeparateProcesses]
 final class ExamplesTest extends FunctionalTestCase
 {
     public function setUp(): void
@@ -26,7 +29,7 @@ final class ExamplesTest extends FunctionalTestCase
         }
     }
 
-    /** @dataProvider provideExamples */
+    #[DataProvider('provideExamples')]
     public function testExamples(string $file, string $expectedOutput): void
     {
         $this->assertExampleOutput($file, $expectedOutput);
@@ -223,9 +226,8 @@ OUTPUT;
     /**
      * MongoDB Atlas Search example requires a MongoDB Atlas M10+ cluster with MongoDB 7.0+
      * Tips for insiders: if using a cloud-dev server, append ".mongodb.net" to the MONGODB_URI.
-     *
-     * @group atlas
      */
+    #[Group('atlas')]
     public function testAtlasSearch(): void
     {
         $uri = getenv('MONGODB_URI') ?? '';

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -5,10 +5,11 @@ namespace MongoDB\Tests\Exception;
 use AssertionError;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class InvalidArgumentExceptionTest extends TestCase
 {
-    /** @dataProvider provideExpectedTypes */
+    #[DataProvider('provideExpectedTypes')]
     public function testExpectedTypeFormatting($expectedType, $typeString): void
     {
         $e = InvalidArgumentException::invalidType('$arg', null, $expectedType);

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -17,6 +17,7 @@ use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\DatabaseCommand;
 use MongoDB\Operation\ListCollections;
 use stdClass;
+use Throwable;
 use UnexpectedValueException;
 
 use function array_intersect_key;
@@ -69,12 +70,15 @@ abstract class FunctionalTestCase extends TestCase
         $this->configuredFailPoints = [];
     }
 
+    protected function onNotSuccessfulTest(Throwable $t): never
+    {
+        $this->cleanupCollections();
+
+        throw $t;
+    }
+
     public function tearDown(): void
     {
-        if (! $this->hasFailed()) {
-            $this->cleanupCollections();
-        }
-
         $this->disableFailPoints();
 
         parent::tearDown();

--- a/tests/Functions/SelectServerFunctionalTest.php
+++ b/tests/Functions/SelectServerFunctionalTest.php
@@ -5,12 +5,13 @@ namespace MongoDB\Tests\Functions;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 use MongoDB\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function MongoDB\select_server;
 
 class SelectServerFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider providePinnedOptions */
+    #[DataProvider('providePinnedOptions')]
     public function testSelectServerPrefersPinnedServer(array $options): void
     {
         $this->skipIfTransactionsAreNotSupported();

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -9,6 +9,7 @@ use MongoDB\Builder\Stage\MatchStage;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 use function MongoDB\apply_type_map_to_document;
@@ -26,7 +27,7 @@ use function MongoDB\is_write_concern_acknowledged;
  */
 class FunctionsTest extends TestCase
 {
-    /** @dataProvider provideDocumentAndTypeMap */
+    #[DataProvider('provideDocumentAndTypeMap')]
     public function testApplyTypeMapToDocument($document, array $typeMap, $expectedDocument): void
     {
         $this->assertEquals($expectedDocument, apply_type_map_to_document($document, $typeMap));
@@ -96,7 +97,7 @@ class FunctionsTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideDocumentsAndExpectedArrays */
+    #[DataProvider('provideDocumentsAndExpectedArrays')]
     public function testDocumentToArray($document, array $expectedArray): void
     {
         $this->assertSame($expectedArray, document_to_array($document));
@@ -115,7 +116,7 @@ class FunctionsTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideInvalidDocumentValuesForChecks */
+    #[DataProvider('provideInvalidDocumentValuesForChecks')]
     public function testDocumentToArrayArgumentTypeCheck($document): void
     {
         $this->expectException(TypeError::class);
@@ -142,7 +143,7 @@ class FunctionsTest extends TestCase
         // phpcs:enable
     }
 
-    /** @dataProvider provideDocumentCasts */
+    #[DataProvider('provideDocumentCasts')]
     public function testIsFirstKeyOperator(callable $cast): void
     {
         $this->assertFalse(is_first_key_operator($cast(['y' => 1])));
@@ -153,14 +154,14 @@ class FunctionsTest extends TestCase
         $this->assertFalse(is_first_key_operator($cast(['foo'])));
     }
 
-    /** @dataProvider provideInvalidDocumentValuesForChecks */
+    #[DataProvider('provideInvalidDocumentValuesForChecks')]
     public function testIsFirstKeyOperatorArgumentTypeCheck($document): void
     {
         $this->expectException(TypeError::class);
         is_first_key_operator($document);
     }
 
-    /** @dataProvider provideDocumentCasts */
+    #[DataProvider('provideDocumentCasts')]
     public function testIsMapReduceOutputInlineWithDocumentValues(callable $cast): void
     {
         $this->assertTrue(is_mapreduce_output_inline($cast(['inline' => 1])));
@@ -174,7 +175,7 @@ class FunctionsTest extends TestCase
         $this->assertFalse(is_mapreduce_output_inline('collectionName'));
     }
 
-    /** @dataProvider provideTypeMapValues */
+    #[DataProvider('provideTypeMapValues')]
     public function testCreateFieldPathTypeMap(array $expected, array $typeMap, $fieldPath = 'field'): void
     {
         $this->assertEquals($expected, create_field_path_type_map($typeMap, $fieldPath));
@@ -234,7 +235,7 @@ class FunctionsTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideDocumentCasts */
+    #[DataProvider('provideDocumentCasts')]
     public function testIsLastPipelineOperatorWrite(callable $cast): void
     {
         $match = ['$match' => ['x' => 1]];
@@ -250,7 +251,7 @@ class FunctionsTest extends TestCase
         $this->assertFalse(is_last_pipeline_operator_write([$cast($out), $cast($match)]));
     }
 
-    /** @dataProvider providePipelines */
+    #[DataProvider('providePipelines')]
     public function testIsPipeline($expected, $pipeline, $allowEmpty = false): void
     {
         $this->assertSame($expected, is_pipeline($pipeline, $allowEmpty));
@@ -314,7 +315,7 @@ class FunctionsTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideStagePipelines */
+    #[DataProvider('provideStagePipelines')]
     public function testIsBuilderPipeline($expected, $pipeline): void
     {
         $this->assertSame($expected, is_builder_pipeline($pipeline));
@@ -329,7 +330,7 @@ class FunctionsTest extends TestCase
         yield 'stages and operators' => [true, [new MatchStage([]), ['$limit' => 1]]];
     }
 
-    /** @dataProvider provideWriteConcerns */
+    #[DataProvider('provideWriteConcerns')]
     public function testIsWriteConcernAcknowledged($expected, WriteConcern $writeConcern): void
     {
         $this->assertSame($expected, is_write_concern_acknowledged($writeConcern));

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -20,6 +20,8 @@ use MongoDB\Operation\ListIndexes;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Codec\TestFileCodec;
 use MongoDB\Tests\Fixtures\Document\TestFile;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use ReflectionMethod;
 use stdClass;
 
@@ -51,7 +53,7 @@ use const PHP_OS;
  */
 class BucketFunctionalTest extends FunctionalTestCase
 {
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testValidConstructorOptions(): void
     {
         new Bucket($this->manager, $this->getDatabaseName(), [
@@ -64,7 +66,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -103,7 +105,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         new Bucket($this->manager, $this->getDatabaseName(), $options);
     }
 
-    /** @dataProvider provideInputDataAndExpectedChunks */
+    #[DataProvider('provideInputDataAndExpectedChunks')]
     public function testDelete($input, $expectedChunks): void
     {
         $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
@@ -139,7 +141,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->delete('nonexistent-id');
     }
 
-    /** @dataProvider provideInputDataAndExpectedChunks */
+    #[DataProvider('provideInputDataAndExpectedChunks')]
     public function testDeleteStillRemovesChunksIfFileDoesNotExist($input, $expectedChunks): void
     {
         $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
@@ -197,7 +199,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         stream_get_contents($this->bucket->openDownloadStream($id));
     }
 
-    /** @dataProvider provideInputDataAndExpectedChunks */
+    #[DataProvider('provideInputDataAndExpectedChunks')]
     public function testDownloadToStream($input): void
     {
         $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
@@ -207,7 +209,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertStreamContents($input, $destination);
     }
 
-    /** @dataProvider provideInvalidStreamValues */
+    #[DataProvider('provideInvalidStreamValues')]
     public function testDownloadToStreamShouldRequireDestinationStream($destination): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -260,14 +262,14 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertStreamContents('baz', $destination);
     }
 
-    /** @dataProvider provideInvalidStreamValues */
+    #[DataProvider('provideInvalidStreamValues')]
     public function testDownloadToStreamByNameShouldRequireDestinationStream($destination): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->bucket->downloadToStreamByName('filename', $destination);
     }
 
-    /** @dataProvider provideNonexistentFilenameAndRevision */
+    #[DataProvider('provideNonexistentFilenameAndRevision')]
     public function testDownloadToStreamByNameShouldRequireFilenameAndRevisionToExist($filename, $revision): void
     {
         $this->bucket->uploadFromStream('filename', self::createStream('foo'));
@@ -543,7 +545,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertSameDocument($metadata, $fileDocument->metadata);
     }
 
-    /** @dataProvider provideInvalidGridFSStreamValues */
+    #[DataProvider('provideInvalidGridFSStreamValues')]
     public function testGetFileDocumentForStreamShouldRequireGridFSStreamResource($stream): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -580,7 +582,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertEquals(1, $this->bucket->getFileIdForStream($stream));
     }
 
-    /** @dataProvider provideInvalidGridFSStreamValues */
+    #[DataProvider('provideInvalidGridFSStreamValues')]
     public function testGetFileIdForStreamShouldRequireGridFSStreamResource($stream): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -595,7 +597,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertEquals('fs.files', $filesCollection->getCollectionName());
     }
 
-    /** @dataProvider provideInputDataAndExpectedChunks */
+    #[DataProvider('provideInputDataAndExpectedChunks')]
     public function testOpenDownloadStream($input): void
     {
         $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
@@ -603,7 +605,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertStreamContents($input, $this->bucket->openDownloadStream($id));
     }
 
-    /** @dataProvider provideInputDataAndExpectedChunks */
+    #[DataProvider('provideInputDataAndExpectedChunks')]
     public function testOpenDownloadStreamAndMultipleReadOperations($input): void
     {
         $id = $this->bucket->uploadFromStream('filename', self::createStream($input));
@@ -649,7 +651,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertStreamContents('baz', $this->bucket->openDownloadStreamByName('filename', ['revision' => 2]));
     }
 
-    /** @dataProvider provideNonexistentFilenameAndRevision */
+    #[DataProvider('provideNonexistentFilenameAndRevision')]
     public function testOpenDownloadStreamByNameShouldRequireFilenameAndRevisionToExist($filename, $revision): void
     {
         $this->bucket->uploadFromStream('filename', self::createStream('foo'));
@@ -669,7 +671,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertStreamContents('foobar', $this->bucket->openDownloadStreamByName('filename'));
     }
 
-    /** @dataProvider provideInputDataAndExpectedChunks */
+    #[DataProvider('provideInputDataAndExpectedChunks')]
     public function testOpenUploadStreamAndMultipleWriteOperations($input): void
     {
         $stream = $this->bucket->openUploadStream('filename');
@@ -740,7 +742,7 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertSameDocument(['foo' => 'bar'], $fileDocument['metadata']);
     }
 
-    /** @dataProvider provideInvalidStreamValues */
+    #[DataProvider('provideInvalidStreamValues')]
     public function testUploadFromStreamShouldRequireSourceStream($source): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/GridFS/FunctionalTestCase.php
+++ b/tests/GridFS/FunctionalTestCase.php
@@ -6,6 +6,8 @@ use MongoDB\Collection;
 use MongoDB\GridFS\Bucket;
 use MongoDB\Operation\DropCollection;
 use MongoDB\Tests\FunctionalTestCase as BaseFunctionalTestCase;
+use PHPUnit\Framework\Attributes\AfterClass;
+use PHPUnit\Framework\Attributes\BeforeClass;
 
 use function fopen;
 use function fwrite;
@@ -46,10 +48,9 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
      * The bucket's collections are created by the first test that runs and
      * kept for all subsequent tests. This is done to avoid creating the
      * collections and their indexes for each test, which would be slow.
-     *
-     * @beforeClass
-     * @afterClass
      */
+    #[BeforeClass]
+    #[AfterClass]
     public static function dropCollectionsBeforeAfterClass(): void
     {
         $manager = static::createTestManager();

--- a/tests/GridFS/ReadableStreamFunctionalTest.php
+++ b/tests/GridFS/ReadableStreamFunctionalTest.php
@@ -8,6 +8,7 @@ use MongoDB\GridFS\CollectionWrapper;
 use MongoDB\GridFS\Exception\CorruptFileException;
 use MongoDB\GridFS\ReadableStream;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_filter;
 
@@ -50,7 +51,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         $this->assertSame($fileDocument, $stream->getFile());
     }
 
-    /** @dataProvider provideInvalidConstructorFileDocuments */
+    #[DataProvider('provideInvalidConstructorFileDocuments')]
     public function testConstructorFileDocumentChecks($file): void
     {
         $this->expectException(CorruptFileException::class);
@@ -76,7 +77,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         return $options;
     }
 
-    /** @dataProvider provideFileIdAndExpectedBytes */
+    #[DataProvider('provideFileIdAndExpectedBytes')]
     public function testReadBytes($fileId, $length, $expectedBytes): void
     {
         $fileDocument = $this->collectionWrapper->findFileById($fileId);
@@ -119,7 +120,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideFilteredFileIdAndExpectedBytes */
+    #[DataProvider('provideFilteredFileIdAndExpectedBytes')]
     public function testReadBytesCalledMultipleTimes($fileId, $length, $expectedBytes): void
     {
         $fileDocument = $this->collectionWrapper->findFileById($fileId);
@@ -197,7 +198,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         $stream->seek(11);
     }
 
-    /** @dataProvider providePreviousChunkSeekOffsetAndBytes */
+    #[DataProvider('providePreviousChunkSeekOffsetAndBytes')]
     public function testSeekPreviousChunk($offset, $length, $expectedBytes): void
     {
         $fileDocument = $this->collectionWrapper->findFileById('length-10');
@@ -231,7 +232,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideSameChunkSeekOffsetAndBytes */
+    #[DataProvider('provideSameChunkSeekOffsetAndBytes')]
     public function testSeekSameChunk($offset, $length, $expectedBytes): void
     {
         $fileDocument = $this->collectionWrapper->findFileById('length-10');
@@ -263,7 +264,7 @@ class ReadableStreamFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideSubsequentChunkSeekOffsetAndBytes */
+    #[DataProvider('provideSubsequentChunkSeekOffsetAndBytes')]
     public function testSeekSubsequentChunk($offset, $length, $expectedBytes): void
     {
         $fileDocument = $this->collectionWrapper->findFileById('length-10');

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -7,6 +7,7 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\GridFS\Exception\FileNotFoundException;
 use MongoDB\GridFS\Exception\LogicException;
 use MongoDB\GridFS\StreamWrapper;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function copy;
 use function fclose;
@@ -232,7 +233,7 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         $this->assertSame(6, fwrite($stream, 'foobar'));
     }
 
-    /** @dataProvider provideUrl */
+    #[DataProvider('provideUrl')]
     public function testStreamWithContextResolver(string $url, string $expectedFilename): void
     {
         $this->bucket->registerGlobalStreamWrapperAlias('bucket');

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -5,6 +5,8 @@ namespace MongoDB\Tests\GridFS;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\CollectionWrapper;
 use MongoDB\GridFS\WritableStream;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 use function str_repeat;
 
@@ -22,7 +24,7 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
         $this->collectionWrapper = new CollectionWrapper($this->manager, $this->getDatabaseName(), 'fs');
     }
 
-    /** @doesNotPerformAssertions */
+    #[DoesNotPerformAssertions]
     public function testValidConstructorOptions(): void
     {
         new WritableStream($this->collectionWrapper, 'filename', [
@@ -32,7 +34,7 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -71,7 +73,7 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
         $this->assertSame(1536, $stream->getSize());
     }
 
-    /** @dataProvider provideInputDataAndExpectedMD5 */
+    #[DataProvider('provideInputDataAndExpectedMD5')]
     public function testWriteBytesCalculatesMD5($input, $expectedMD5): void
     {
         $stream = new WritableStream($this->collectionWrapper, 'filename');

--- a/tests/LogNonGenuineHostTest.php
+++ b/tests/LogNonGenuineHostTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests;
 
 use MongoDB\Client;
 use MongoDB\Driver\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 
@@ -28,7 +29,7 @@ class LogNonGenuineHostTest extends TestCase
         remove_logger($this->logger);
     }
 
-    /** @dataProvider provideCosmosUris */
+    #[DataProvider('provideCosmosUris')]
     public function testCosmosUriLogsInfoMessage(string $uri): void
     {
         $this->createClientAndIgnoreSrvLookupError($uri);
@@ -54,7 +55,7 @@ class LogNonGenuineHostTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideDocumentDbUris */
+    #[DataProvider('provideDocumentDbUris')]
     public function testDocumentDbUriLogsInfoMessage(string $uri): void
     {
         $this->createClientAndIgnoreSrvLookupError($uri);
@@ -83,7 +84,7 @@ class LogNonGenuineHostTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideGenuineUris */
+    #[DataProvider('provideGenuineUris')]
     public function testGenuineUriDoesNotLog(string $uri): void
     {
         $this->createClientAndIgnoreSrvLookupError($uri);

--- a/tests/Model/BSONIteratorTest.php
+++ b/tests/Model/BSONIteratorTest.php
@@ -7,6 +7,7 @@ use MongoDB\BSON\Document;
 use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\Model\BSONIterator;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_map;
 use function implode;
@@ -15,7 +16,7 @@ use function substr;
 
 class BSONIteratorTest extends TestCase
 {
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocuments */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocuments')]
     public function testValidValues(?array $typeMap, array $expectedDocuments): void
     {
         $binaryString = implode(array_map(

--- a/tests/Model/CallbackIteratorTest.php
+++ b/tests/Model/CallbackIteratorTest.php
@@ -8,12 +8,13 @@ use Iterator;
 use IteratorAggregate;
 use MongoDB\Model\CallbackIterator;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function iterator_to_array;
 
 class CallbackIteratorTest extends TestCase
 {
-    /** @dataProvider provideTests */
+    #[DataProvider('provideTests')]
     public function testIteration($expected, $source, $callback): void
     {
         $callbackIterator = new CallbackIterator($source, $callback);

--- a/tests/Model/ChangeStreamIteratorTest.php
+++ b/tests/Model/ChangeStreamIteratorTest.php
@@ -15,6 +15,7 @@ use MongoDB\Model\ChangeStreamIterator;
 use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 use function sprintf;
@@ -31,7 +32,7 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
         $this->collection = $this->createCollection($this->getDatabaseName(), $this->getCollectionName(), ['capped' => true, 'size' => 8192]);
     }
 
-    /** @dataProvider provideInvalidIntegerValues */
+    #[DataProvider('provideInvalidIntegerValues')]
     public function testFirstBatchArgumentTypeCheck($firstBatchSize): void
     {
         $this->expectException(TypeError::class);
@@ -50,14 +51,14 @@ class ChangeStreamIteratorTest extends FunctionalTestCase
         $this->assertSameDocument((object) ['resumeToken' => 2], $iterator->getResumeToken());
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testInitialResumeTokenArgumentTypeCheck($initialResumeToken): void
     {
         $this->expectException($initialResumeToken instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new ChangeStreamIterator($this->collection->find(), 0, $initialResumeToken, null);
     }
 
-    /** @dataProvider provideInvalidObjectValues */
+    #[DataProvider('provideInvalidObjectValues')]
     public function testPostBatchResumeTokenArgumentTypeCheck($postBatchResumeToken): void
     {
         $this->expectException(TypeError::class);

--- a/tests/Model/CodecCursorFunctionalTest.php
+++ b/tests/Model/CodecCursorFunctionalTest.php
@@ -31,7 +31,7 @@ class CodecCursorFunctionalTest extends FunctionalTestCase
         $codecCursor = CodecCursor::fromCursor($cursor, $this->createMock(DocumentCodec::class));
 
         $this->expectWarning();
-        $this->expectWarningMessage('Discarding type map for MongoDB\Model\CodecCursor::setTypeMap');
+        $this->expectExceptionMessage('Discarding type map for MongoDB\Model\CodecCursor::setTypeMap');
 
         $codecCursor->setTypeMap(['root' => 'array']);
     }

--- a/tests/Model/CodecCursorFunctionalTest.php
+++ b/tests/Model/CodecCursorFunctionalTest.php
@@ -13,6 +13,7 @@ use function set_error_handler;
 
 use const E_DEPRECATED;
 use const E_USER_DEPRECATED;
+use const E_USER_WARNING;
 
 class CodecCursorFunctionalTest extends FunctionalTestCase
 {
@@ -30,10 +31,7 @@ class CodecCursorFunctionalTest extends FunctionalTestCase
 
         $codecCursor = CodecCursor::fromCursor($cursor, $this->createMock(DocumentCodec::class));
 
-        $this->expectWarning();
-        $this->expectExceptionMessage('Discarding type map for MongoDB\Model\CodecCursor::setTypeMap');
-
-        $codecCursor->setTypeMap(['root' => 'array']);
+        $this->assertError(E_USER_WARNING, fn () => $codecCursor->setTypeMap(['root' => 'array']));
     }
 
     public function testGetIdReturnTypeWithoutArgument(): void

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Model;
 
 use MongoDB\Collection;
 use MongoDB\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class IndexInfoFunctionalTest extends FunctionalTestCase
 {
@@ -32,11 +33,9 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
         $this->assertEquals(3, $index['2dsphereIndexVersion']);
     }
 
-    /**
-     * @group matrix-testing-exclude-server-5.0-driver-4.0
-     * @group matrix-testing-exclude-server-5.0-driver-4.2
-     * @group matrix-testing-exclude-server-5.0-driver-4.4
-     */
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.0')]
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.2')]
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.4')]
     public function testIsGeoHaystack(): void
     {
         $this->skipIfGeoHaystackIndexIsNotSupported();

--- a/tests/Model/IndexInputTest.php
+++ b/tests/Model/IndexInputTest.php
@@ -8,6 +8,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Model\IndexInput;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class IndexInputTest extends TestCase
@@ -19,7 +20,7 @@ class IndexInputTest extends TestCase
         new IndexInput([]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorShouldRequireKeyToBeArrayOrObject($key): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -27,7 +28,7 @@ class IndexInputTest extends TestCase
         new IndexInput(['key' => $key]);
     }
 
-    /** @dataProvider provideInvalidFieldOrderValues */
+    #[DataProvider('provideInvalidFieldOrderValues')]
     public function testConstructorShouldRequireKeyFieldOrderToBeNumericOrString($order): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -40,7 +41,7 @@ class IndexInputTest extends TestCase
         return self::wrapValuesForDataProvider([true, [], new stdClass()]);
     }
 
-    /** @dataProvider provideInvalidStringValues */
+    #[DataProvider('provideInvalidStringValues')]
     public function testConstructorShouldRequireNameToBeString($name): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -48,7 +49,7 @@ class IndexInputTest extends TestCase
         new IndexInput(['key' => ['x' => 1], 'name' => $name]);
     }
 
-    /** @dataProvider provideExpectedNameAndKey */
+    #[DataProvider('provideExpectedNameAndKey')]
     public function testNameGeneration($expectedName, array|object $key): void
     {
         $this->assertSame($expectedName, (string) new IndexInput(['key' => $key]));

--- a/tests/Model/SearchIndexInputTest.php
+++ b/tests/Model/SearchIndexInputTest.php
@@ -6,6 +6,7 @@ use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\SearchIndexInput;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SearchIndexInputTest extends TestCase
 {
@@ -16,7 +17,7 @@ class SearchIndexInputTest extends TestCase
         new SearchIndexInput([]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorIndexDefinitionMustBeADocument($definition): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -24,7 +25,7 @@ class SearchIndexInputTest extends TestCase
         new SearchIndexInput(['definition' => $definition]);
     }
 
-    /** @dataProvider provideInvalidStringValues */
+    #[DataProvider('provideInvalidStringValues')]
     public function testConstructorShouldRequireNameToBeString($name): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -32,7 +33,7 @@ class SearchIndexInputTest extends TestCase
         new SearchIndexInput(['definition' => ['mapping' => ['dynamic' => true]], 'name' => $name]);
     }
 
-    /** @dataProvider provideInvalidStringValues */
+    #[DataProvider('provideInvalidStringValues')]
     public function testConstructorShouldRequireTypeToBeString($type): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/AggregateFunctionalTest.php
+++ b/tests/Operation/AggregateFunctionalTest.php
@@ -11,6 +11,7 @@ use MongoDB\Operation\Aggregate;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Document\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 use function array_key_exists;
@@ -161,7 +162,7 @@ class AggregateFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocuments */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocuments')]
     public function testTypeMapOption(?array $typeMap, array $expectedDocuments): void
     {
         $this->createFixtures(3);

--- a/tests/Operation/AggregateTest.php
+++ b/tests/Operation/AggregateTest.php
@@ -7,6 +7,7 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Aggregate;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AggregateTest extends TestCase
 {
@@ -17,7 +18,7 @@ class AggregateTest extends TestCase
         new Aggregate($this->getDatabaseName(), $this->getCollectionName(), [1 => ['$match' => ['x' => 1]]]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -14,6 +14,8 @@ use MongoDB\Operation\BulkWrite;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Document\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use stdClass;
 
 use function is_array;
@@ -60,10 +62,8 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $this->assertSameDocuments($expected, $this->collection->find());
     }
 
-    /**
-     * @dataProvider provideDocumentsWithIds
-     * @dataProvider provideDocumentsWithoutIds
-     */
+    #[DataProvider('provideDocumentsWithIds')]
+    #[DataProvider('provideDocumentsWithoutIds')]
     public function testInsertDocumentEncoding($document, stdClass $expectedDocument): void
     {
         (new CommandObserver())->observe(
@@ -150,7 +150,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $this->assertSameDocuments($expected, $this->collection->find());
     }
 
-    /** @dataProvider provideFilterDocuments */
+    #[DataProvider('provideFilterDocuments')]
     public function testUpdateFilterDocuments($filter, stdClass $expectedFilter): void
     {
         (new CommandObserver())->observe(
@@ -175,7 +175,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideReplacementDocuments */
+    #[DataProvider('provideReplacementDocuments')]
     public function testReplacementDocuments($replacement, stdClass $expectedReplacement): void
     {
         (new CommandObserver())->observe(
@@ -194,10 +194,8 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @dataProvider provideUpdateDocuments
-     * @dataProvider provideUpdatePipelines
-     */
+    #[DataProvider('provideUpdateDocuments')]
+    #[DataProvider('provideUpdatePipelines')]
     public function testUpdateDocuments($update, $expectedUpdate): void
     {
         if (is_array($expectedUpdate)) {
@@ -246,7 +244,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $this->assertSameDocuments($expected, $this->collection->find());
     }
 
-    /** @dataProvider provideFilterDocuments */
+    #[DataProvider('provideFilterDocuments')]
     public function testDeleteFilterDocuments($filter, stdClass $expectedQuery): void
     {
         (new CommandObserver())->observe(
@@ -317,7 +315,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         return $result;
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesDeletedCount(BulkWriteResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -325,7 +323,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $result->getDeletedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesInsertCount(BulkWriteResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -333,7 +331,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $result->getInsertedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesMatchedCount(BulkWriteResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -341,7 +339,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $result->getMatchedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesModifiedCount(BulkWriteResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -349,7 +347,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $result->getModifiedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesUpsertedCount(BulkWriteResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -357,7 +355,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         $result->getUpsertedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesUpsertedIds(BulkWriteResult $result): void
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -7,6 +7,8 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\BulkWrite;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use TypeError;
 
 class BulkWriteTest extends TestCase
@@ -57,7 +59,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testInsertOneDocumentArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -88,7 +90,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testDeleteManyFilterArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -98,7 +100,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testDeleteManyCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -117,7 +119,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testDeleteOneFilterArgumentTypeCheck($document): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -127,7 +129,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testDeleteOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -146,7 +148,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testReplaceOneFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -156,10 +158,8 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DoesNotPerformAssertions]
     public function testReplaceOneReplacementArgument($replacement): void
     {
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
@@ -176,7 +176,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testReplaceOneReplacementArgumentTypeCheck($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -186,7 +186,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideUpdateDocuments */
+    #[DataProvider('provideUpdateDocuments')]
     public function testReplaceOneReplacementArgumentProhibitsUpdateDocument($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -196,10 +196,8 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /**
-     * @dataProvider provideUpdatePipelines
-     * @dataProvider provideEmptyUpdatePipelinesExcludingArray
-     */
+    #[DataProvider('provideUpdatePipelines')]
+    #[DataProvider('provideEmptyUpdatePipelinesExcludingArray')]
     public function testReplaceOneReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -209,7 +207,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testReplaceOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -219,7 +217,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidBooleanValues */
+    #[DataProvider('provideInvalidBooleanValues')]
     public function testReplaceOneUpsertOptionTypeCheck($upsert): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -255,7 +253,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testUpdateManyFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -265,11 +263,9 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /**
-     * @dataProvider provideUpdateDocuments
-     * @dataProvider provideUpdatePipelines
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('provideUpdateDocuments')]
+    #[DataProvider('provideUpdatePipelines')]
+    #[DoesNotPerformAssertions]
     public function testUpdateManyUpdateArgument($update): void
     {
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
@@ -286,7 +282,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testUpdateManyUpdateArgumentTypeCheck($update): void
     {
         $this->expectException($update instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
@@ -295,10 +291,8 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @dataProvider provideEmptyUpdatePipelines
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DataProvider('provideEmptyUpdatePipelines')]
     public function testUpdateManyUpdateArgumentProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -308,7 +302,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidArrayValues */
+    #[DataProvider('provideInvalidArrayValues')]
     public function testUpdateManyArrayFiltersOptionTypeCheck($arrayFilters): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -318,7 +312,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testUpdateManyCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -328,7 +322,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidBooleanValues */
+    #[DataProvider('provideInvalidBooleanValues')]
     public function testUpdateManyUpsertOptionTypeCheck($upsert): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -338,11 +332,9 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /**
-     * @dataProvider provideUpdateDocuments
-     * @dataProvider provideUpdatePipelines
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('provideUpdateDocuments')]
+    #[DataProvider('provideUpdatePipelines')]
+    #[DoesNotPerformAssertions]
     public function testUpdateOneUpdateArgument($update): void
     {
         new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
@@ -359,7 +351,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testUpdateOneFilterArgumentTypeCheck($filter): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -378,7 +370,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testUpdateOneUpdateArgumentTypeCheck($update): void
     {
         $this->expectException($update instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
@@ -387,10 +379,8 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @dataProvider provideEmptyUpdatePipelines
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DataProvider('provideEmptyUpdatePipelines')]
     public function testUpdateOneUpdateArgumentProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -400,7 +390,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidArrayValues */
+    #[DataProvider('provideInvalidArrayValues')]
     public function testUpdateOneArrayFiltersOptionTypeCheck($arrayFilters): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -410,7 +400,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testUpdateOneCollationOptionTypeCheck($collation): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -420,7 +410,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidBooleanValues */
+    #[DataProvider('provideInvalidBooleanValues')]
     public function testUpdateOneUpsertOptionTypeCheck($upsert): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -430,7 +420,7 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/CountDocumentsFunctionalTest.php
+++ b/tests/Operation/CountDocumentsFunctionalTest.php
@@ -5,11 +5,12 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Operation\CountDocuments;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class CountDocumentsFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideFilterDocuments */
+    #[DataProvider('provideFilterDocuments')]
     public function testFilterDocuments($filter, stdClass $expectedMatchStage): void
     {
         (new CommandObserver())->observe(

--- a/tests/Operation/CountDocumentsTest.php
+++ b/tests/Operation/CountDocumentsTest.php
@@ -5,18 +5,19 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CountDocuments;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class CountDocumentsTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new CountDocuments($this->getDatabaseName(), $this->getCollectionName(), $filter);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/CountFunctionalTest.php
+++ b/tests/Operation/CountFunctionalTest.php
@@ -6,11 +6,12 @@ use MongoDB\Operation\Count;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class CountFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideFilterDocuments */
+    #[DataProvider('provideFilterDocuments')]
     public function testFilterDocuments($filter, stdClass $expectedQuery): void
     {
         (new CommandObserver())->observe(

--- a/tests/Operation/CountTest.php
+++ b/tests/Operation/CountTest.php
@@ -6,18 +6,19 @@ use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Count;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class CountTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new Count($this->getDatabaseName(), $this->getCollectionName(), $filter);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/CreateCollectionTest.php
+++ b/tests/Operation/CreateCollectionTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CreateCollectionTest extends TestCase
 {
@@ -14,7 +15,7 @@ class CreateCollectionTest extends TestCase
         new CreateCollection($this->getDatabaseName(), $this->getCollectionName(), ['pipeline' => [1 => ['$match' => ['x' => 1]]]]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
+++ b/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
@@ -10,6 +10,7 @@ use MongoDB\Driver\WriteConcern;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\CreateEncryptedCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function base64_decode;
 use function getenv;
@@ -54,7 +55,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         ]);
     }
 
-    /** @dataProvider provideEncryptedFieldsAndFieldsIsMissing */
+    #[DataProvider('provideEncryptedFieldsAndFieldsIsMissing')]
     public function testCreateDataKeysNopIfFieldsIsMissing($input, array $expectedOutput): void
     {
         $operation = new CreateEncryptedCollection(
@@ -85,7 +86,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideEncryptedFieldsAndFieldsHasInvalidType */
+    #[DataProvider('provideEncryptedFieldsAndFieldsHasInvalidType')]
     public function testCreateDataKeysNopIfFieldsHasInvalidType($input, array $expectedOutput): void
     {
         $operation = new CreateEncryptedCollection(
@@ -116,7 +117,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideEncryptedFieldsElementHasInvalidType */
+    #[DataProvider('provideEncryptedFieldsElementHasInvalidType')]
     public function testCreateDataKeysSkipsNonDocumentFields($input, array $expectedOutput): void
     {
         $operation = new CreateEncryptedCollection(
@@ -171,7 +172,7 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
         $this->assertInstanceOf(Binary::class, $modifiedEncryptedFields['fields'][0]['keyId'] ?? null);
     }
 
-    /** @dataProvider provideEncryptedFields */
+    #[DataProvider('provideEncryptedFields')]
     public function testEncryptedFieldsDocuments($input): void
     {
         $operation = new CreateEncryptedCollection(

--- a/tests/Operation/CreateEncryptedCollectionTest.php
+++ b/tests/Operation/CreateEncryptedCollectionTest.php
@@ -5,10 +5,11 @@ namespace MongoDB\Tests\Operation;
 use Generator;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateEncryptedCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CreateEncryptedCollectionTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/CreateIndexesFunctionalTest.php
+++ b/tests/Operation/CreateIndexesFunctionalTest.php
@@ -12,6 +12,7 @@ use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\ListIndexes;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function call_user_func;
 use function is_callable;
@@ -79,7 +80,7 @@ class CreateIndexesFunctionalTest extends FunctionalTestCase
         });
     }
 
-    /** @dataProvider provideKeyCasts */
+    #[DataProvider('provideKeyCasts')]
     public function testCreateIndexes(callable $cast): void
     {
         $expectedNames = ['x_1', 'y_-1_z_1', 'g_2dsphere_z_1', 'my_ttl'];

--- a/tests/Operation/CreateIndexesTest.php
+++ b/tests/Operation/CreateIndexesTest.php
@@ -7,6 +7,7 @@ use MongoDB\BSON\Document;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\CreateIndexes;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class CreateIndexesTest extends TestCase
@@ -18,7 +19,7 @@ class CreateIndexesTest extends TestCase
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [1 => ['key' => ['x' => 1]]]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -43,7 +44,7 @@ class CreateIndexesTest extends TestCase
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), []);
     }
 
-    /** @dataProvider provideInvalidIndexSpecificationTypes */
+    #[DataProvider('provideInvalidIndexSpecificationTypes')]
     public function testConstructorRequiresIndexSpecificationsToBeAnArray($index): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -63,7 +64,7 @@ class CreateIndexesTest extends TestCase
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [[]]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorRequiresIndexSpecificationKeyToBeADocument($key): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -71,7 +72,7 @@ class CreateIndexesTest extends TestCase
         new CreateIndexes($this->getDatabaseName(), $this->getCollectionName(), [['key' => $key]]);
     }
 
-    /** @dataProvider provideKeyDocumentsWithInvalidOrder */
+    #[DataProvider('provideKeyDocumentsWithInvalidOrder')]
     public function testConstructorValidatesIndexSpecificationKeyOrder($key): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -91,7 +92,7 @@ class CreateIndexesTest extends TestCase
         }
     }
 
-    /** @dataProvider provideInvalidStringValues */
+    #[DataProvider('provideInvalidStringValues')]
     public function testConstructorRequiresIndexSpecificationNameToBeString($name): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/CreateSearchIndexesTest.php
+++ b/tests/Operation/CreateSearchIndexesTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateSearchIndexes;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CreateSearchIndexesTest extends TestCase
 {
@@ -14,7 +15,7 @@ class CreateSearchIndexesTest extends TestCase
         new CreateSearchIndexes($this->getDatabaseName(), $this->getCollectionName(), [1 => ['name' => 'index name', 'definition' => ['mappings' => ['dynamic' => true]]]], []);
     }
 
-    /** @dataProvider provideInvalidArrayValues */
+    #[DataProvider('provideInvalidArrayValues')]
     public function testConstructorIndexDefinitionMustBeADocument($index): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -22,7 +23,7 @@ class CreateSearchIndexesTest extends TestCase
         new CreateSearchIndexes($this->getDatabaseName(), $this->getCollectionName(), [$index], []);
     }
 
-    /** @dataProvider provideInvalidStringValues */
+    #[DataProvider('provideInvalidStringValues')]
     public function testConstructorIndexNameMustBeAString($name): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -30,7 +31,7 @@ class CreateSearchIndexesTest extends TestCase
         new CreateSearchIndexes($this->getDatabaseName(), $this->getCollectionName(), [['name' => $name, 'definition' => ['mappings' => ['dynamic' => true]]]], []);
     }
 
-    /** @dataProvider provideInvalidStringValues */
+    #[DataProvider('provideInvalidStringValues')]
     public function testConstructorIndexTypeMustBeAString($type): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -45,7 +46,7 @@ class CreateSearchIndexesTest extends TestCase
         new CreateSearchIndexes($this->getDatabaseName(), $this->getCollectionName(), [['name' => 'index name']], []);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorIndexDefinitionMustBeAnArray($definition): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/DatabaseCommandFunctionalTest.php
+++ b/tests/Operation/DatabaseCommandFunctionalTest.php
@@ -7,10 +7,11 @@ use MongoDB\Driver\Command;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\DatabaseCommand;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DatabaseCommandFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideCommandDocuments */
+    #[DataProvider('provideCommandDocuments')]
     public function testCommandDocuments($command): void
     {
         (new CommandObserver())->observe(

--- a/tests/Operation/DatabaseCommandTest.php
+++ b/tests/Operation/DatabaseCommandTest.php
@@ -5,18 +5,19 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\DatabaseCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class DatabaseCommandTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorCommandArgumentTypeCheck($command): void
     {
         $this->expectException($command instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new DatabaseCommand($this->getDatabaseName(), $command);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -10,6 +10,8 @@ use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\Operation\Delete;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use stdClass;
 
 class DeleteFunctionalTest extends FunctionalTestCase
@@ -23,7 +25,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
         $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
     }
 
-    /** @dataProvider provideFilterDocuments */
+    #[DataProvider('provideFilterDocuments')]
     public function testFilterDocuments($filter, stdClass $expectedQuery): void
     {
         (new CommandObserver())->observe(
@@ -133,7 +135,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
         return $result;
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesDeletedCount(DeleteResult $result): void
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/Operation/DeleteTest.php
+++ b/tests/Operation/DeleteTest.php
@@ -11,25 +11,26 @@ use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Delete;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class DeleteTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new Delete($this->getDatabaseName(), $this->getCollectionName(), $filter, 0);
     }
 
-    /** @dataProvider provideInvalidIntegerValues */
+    #[DataProvider('provideInvalidIntegerValues')]
     public function testConstructorLimitArgumentMustBeInt($limit): void
     {
         $this->expectException(TypeError::class);
         new Delete($this->getDatabaseName(), $this->getCollectionName(), [], $limit);
     }
 
-    /** @dataProvider provideInvalidLimitValues */
+    #[DataProvider('provideInvalidLimitValues')]
     public function testConstructorLimitArgumentMustBeOneOrZero($limit): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -42,7 +43,7 @@ class DeleteTest extends TestCase
         return self::wrapValuesForDataProvider([-1, 2]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/DistinctFunctionalTest.php
+++ b/tests/Operation/DistinctFunctionalTest.php
@@ -5,6 +5,7 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Operation\Distinct;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 use function is_scalar;
@@ -15,7 +16,7 @@ use const JSON_THROW_ON_ERROR;
 
 class DistinctFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideFilterDocuments */
+    #[DataProvider('provideFilterDocuments')]
     public function testFilterDocuments($filter, stdClass $expectedQuery): void
     {
         (new CommandObserver())->observe(
@@ -75,7 +76,7 @@ class DistinctFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocuments */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocuments')]
     public function testTypeMapOption(array $typeMap, array $expectedDocuments): void
     {
         $bulkWrite = new BulkWrite(['ordered' => true]);

--- a/tests/Operation/DistinctTest.php
+++ b/tests/Operation/DistinctTest.php
@@ -7,18 +7,19 @@ use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Distinct;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class DistinctTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new Distinct($this->getDatabaseName(), $this->getCollectionName(), 'x', $filter);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/DropCollectionFunctionalTest.php
+++ b/tests/Operation/DropCollectionFunctionalTest.php
@@ -5,6 +5,7 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Operation\DropCollection;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\Depends;
 
 class DropCollectionFunctionalTest extends FunctionalTestCase
 {
@@ -41,7 +42,7 @@ class DropCollectionFunctionalTest extends FunctionalTestCase
         $this->assertCollectionDoesNotExist($this->getCollectionName());
     }
 
-    /** @depends testDropExistingCollection */
+    #[Depends('testDropExistingCollection')]
     public function testDropNonexistentCollection(): void
     {
         $this->assertCollectionDoesNotExist($this->getCollectionName());

--- a/tests/Operation/DropCollectionTest.php
+++ b/tests/Operation/DropCollectionTest.php
@@ -4,10 +4,11 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\DropCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DropCollectionTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/DropDatabaseFunctionalTest.php
+++ b/tests/Operation/DropDatabaseFunctionalTest.php
@@ -7,6 +7,7 @@ use MongoDB\Operation\DropDatabase;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\ListDatabases;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\Depends;
 
 use function sprintf;
 
@@ -43,7 +44,7 @@ class DropDatabaseFunctionalTest extends FunctionalTestCase
         $this->assertDatabaseDoesNotExist($server, $this->getDatabaseName());
     }
 
-    /** @depends testDropExistingDatabase */
+    #[Depends('testDropExistingDatabase')]
     public function testDropNonexistentDatabase(): void
     {
         $server = $this->getPrimaryServer();

--- a/tests/Operation/DropDatabaseTest.php
+++ b/tests/Operation/DropDatabaseTest.php
@@ -4,10 +4,11 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\DropDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DropDatabaseTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/DropEncryptedCollectionTest.php
+++ b/tests/Operation/DropEncryptedCollectionTest.php
@@ -5,10 +5,11 @@ namespace MongoDB\Tests\Operation;
 use Generator;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\DropEncryptedCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DropEncryptedCollectionTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/DropIndexesTest.php
+++ b/tests/Operation/DropIndexesTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\DropIndexes;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DropIndexesTest extends TestCase
 {
@@ -13,7 +14,7 @@ class DropIndexesTest extends TestCase
         new DropIndexes($this->getDatabaseName(), $this->getCollectionName(), '');
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/EstimatedDocumentCountTest.php
+++ b/tests/Operation/EstimatedDocumentCountTest.php
@@ -4,10 +4,11 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\EstimatedDocumentCount;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class EstimatedDocumentCountTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/ExplainFunctionalTest.php
+++ b/tests/Operation/ExplainFunctionalTest.php
@@ -20,13 +20,14 @@ use MongoDB\Operation\Update;
 use MongoDB\Operation\UpdateMany;
 use MongoDB\Operation\UpdateOne;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function array_key_exists;
 use function array_key_first;
 
 class ExplainFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testCount($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(3);
@@ -39,7 +40,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testDelete($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(3);
@@ -54,7 +55,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testDeleteMany($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(3);
@@ -69,7 +70,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testDeleteOne($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(3);
@@ -84,7 +85,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testDistinct($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $operation = new Distinct($this->getDatabaseName(), $this->getCollectionName(), 'x', []);
@@ -95,7 +96,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testFindAndModify($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $operation = new FindAndModify($this->getDatabaseName(), $this->getCollectionName(), ['remove' => true]);
@@ -106,7 +107,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testFind($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(3);
@@ -181,7 +182,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testFindOne($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(1);
@@ -194,7 +195,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testFindOneAndDelete($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $operation = new FindOneAndDelete($this->getDatabaseName(), $this->getCollectionName(), []);
@@ -205,7 +206,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testFindOneAndReplace($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $operation = new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1.1], ['x' => 5]);
@@ -216,7 +217,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testFindOneAndUpdate($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $operation = new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], ['$rename' => ['x' => 'y']]);
@@ -227,7 +228,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testUpdate($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(3);
@@ -296,7 +297,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testUpdateMany($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(3);
@@ -312,7 +313,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, $executionStatsExpected, $allPlansExecutionExpected);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testUpdateOne($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->createFixtures(3);
@@ -344,7 +345,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         $this->assertExplainResult($result, false, false);
     }
 
-    /** @dataProvider provideVerbosityInformation */
+    #[DataProvider('provideVerbosityInformation')]
     public function testAggregateOptimizedToQuery($verbosity, $executionStatsExpected, $allPlansExecutionExpected): void
     {
         $this->skipIfServerVersion('<', '4.2.0', 'MongoDB < 4.2 does not optimize simple aggregation pipelines');

--- a/tests/Operation/ExplainTest.php
+++ b/tests/Operation/ExplainTest.php
@@ -5,10 +5,11 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Explain;
 use MongoDB\Operation\Explainable;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ExplainTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $explainable = $this->getMockBuilder(Explainable::class)->getMock();

--- a/tests/Operation/FindAndModifyFunctionalTest.php
+++ b/tests/Operation/FindAndModifyFunctionalTest.php
@@ -12,11 +12,12 @@ use MongoDB\Operation\FindAndModify;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Document\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 class FindAndModifyFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideQueryDocuments */
+    #[DataProvider('provideQueryDocuments')]
     public function testQueryDocuments($query, stdClass $expectedQuery): void
     {
         (new CommandObserver())->observe(
@@ -47,12 +48,10 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @dataProvider provideUpdateDocuments
-     * @dataProvider provideUpdatePipelines
-     * @dataProvider provideReplacementDocumentLikePipeline
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DataProvider('provideUpdateDocuments')]
+    #[DataProvider('provideUpdatePipelines')]
+    #[DataProvider('provideReplacementDocumentLikePipeline')]
     public function testUpdateDocuments($update, $expectedUpdate): void
     {
         (new CommandObserver())->observe(
@@ -233,7 +232,7 @@ class FindAndModifyFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocument */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocument')]
     public function testTypeMapOption(?array $typeMap, $expectedDocument): void
     {
         $this->createFixtures(1);

--- a/tests/Operation/FindAndModifyTest.php
+++ b/tests/Operation/FindAndModifyTest.php
@@ -5,10 +5,11 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\FindAndModify;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FindAndModifyTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -11,13 +11,14 @@ use MongoDB\Operation\Find;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Document\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 use function microtime;
 
 class FindFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideFilterDocuments */
+    #[DataProvider('provideFilterDocuments')]
     public function testFilterDocuments($filter, stdClass $expectedQuery): void
     {
         (new CommandObserver())->observe(
@@ -36,7 +37,7 @@ class FindFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideModifierDocuments */
+    #[DataProvider('provideModifierDocuments')]
     public function testModifierDocuments($modifiers, stdClass $expectedSort): void
     {
         (new CommandObserver())->observe(
@@ -159,7 +160,7 @@ class FindFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocuments */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocuments')]
     public function testTypeMapOption(array $typeMap, array $expectedDocuments): void
     {
         $this->createFixtures(3);

--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -14,6 +14,7 @@ use MongoDB\Tests\Fixtures\Document\TestObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
+use function is_array;
 use function microtime;
 
 class FindFunctionalTest extends FunctionalTestCase
@@ -42,6 +43,11 @@ class FindFunctionalTest extends FunctionalTestCase
     {
         (new CommandObserver())->observe(
             function () use ($modifiers): void {
+                // @todo revert this lines after PHPC-2457
+                if (is_array($modifiers)) {
+                    $modifiers = [...$modifiers];
+                }
+
                 $operation = new Find(
                     $this->getDatabaseName(),
                     $this->getCollectionName(),

--- a/tests/Operation/FindOneAndDeleteTest.php
+++ b/tests/Operation/FindOneAndDeleteTest.php
@@ -6,18 +6,19 @@ use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\FindOneAndDelete;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class FindOneAndDeleteTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new FindOneAndDelete($this->getDatabaseName(), $this->getCollectionName(), $filter);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/FindOneAndReplaceTest.php
+++ b/tests/Operation/FindOneAndReplaceTest.php
@@ -6,34 +6,34 @@ use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\FindOneAndReplace;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use TypeError;
 
 class FindOneAndReplaceTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), $filter, []);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorReplacementArgumentTypeCheck($replacement): void
     {
         $this->expectException($replacement instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DoesNotPerformAssertions]
     public function testConstructorReplacementArgument($replacement): void
     {
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 
-    /** @dataProvider provideUpdateDocuments */
+    #[DataProvider('provideUpdateDocuments')]
     public function testConstructorReplacementArgumentProhibitsUpdateDocument($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -41,10 +41,8 @@ class FindOneAndReplaceTest extends TestCase
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 
-    /**
-     * @dataProvider provideUpdatePipelines
-     * @dataProvider provideEmptyUpdatePipelinesExcludingArray
-     */
+    #[DataProvider('provideUpdatePipelines')]
+    #[DataProvider('provideEmptyUpdatePipelinesExcludingArray')]
     public function testConstructorReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -52,7 +50,7 @@ class FindOneAndReplaceTest extends TestCase
         new FindOneAndReplace($this->getDatabaseName(), $this->getCollectionName(), [], $replacement);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -68,7 +66,7 @@ class FindOneAndReplaceTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidConstructorReturnDocumentOptions */
+    #[DataProvider('provideInvalidConstructorReturnDocumentOptions')]
     public function testConstructorReturnDocumentOption($returnDocument): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/FindOneAndUpdateTest.php
+++ b/tests/Operation/FindOneAndUpdateTest.php
@@ -6,28 +6,27 @@ use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\FindOneAndUpdate;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class FindOneAndUpdateTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), $filter, []);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorUpdateArgumentTypeCheck($update): void
     {
         $this->expectException($update instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], $update);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @dataProvider provideEmptyUpdatePipelines
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DataProvider('provideEmptyUpdatePipelines')]
     public function testConstructorUpdateArgumentProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -35,7 +34,7 @@ class FindOneAndUpdateTest extends TestCase
         new FindOneAndUpdate($this->getDatabaseName(), $this->getCollectionName(), [], $update);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -50,7 +49,7 @@ class FindOneAndUpdateTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidConstructorReturnDocumentOptions */
+    #[DataProvider('provideInvalidConstructorReturnDocumentOptions')]
     public function testConstructorReturnDocumentOption($returnDocument): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/FindOneFunctionalTest.php
+++ b/tests/Operation/FindOneFunctionalTest.php
@@ -6,10 +6,11 @@ use MongoDB\Driver\BulkWrite;
 use MongoDB\Operation\FindOne;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Document\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FindOneFunctionalTest extends FunctionalTestCase
 {
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocument */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocument')]
     public function testTypeMapOption(array $typeMap, $expectedDocument): void
     {
         $this->createFixtures(1);

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -7,18 +7,19 @@ use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Find;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class FindTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new Find($this->getDatabaseName(), $this->getCollectionName(), $filter);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -55,7 +56,26 @@ class FindTest extends TestCase
         ]);
     }
 
-    /** @dataProvider provideInvalidConstructorCursorTypeOptions */
+    #[DataProvider('provideInvalidConstructorCursorTypeOptions')]
+    public function testSnapshotOptionIsDeprecated(): void
+    {
+        $this->assertDeprecated(function (): void {
+            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['snapshot' => true]);
+        });
+
+        $this->assertDeprecated(function (): void {
+            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['snapshot' => false]);
+        });
+    }
+
+    public function testMaxScanOptionIsDeprecated(): void
+    {
+        $this->assertDeprecated(function (): void {
+            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['maxScan' => 1]);
+        });
+    }
+
+    #[DataProvider('provideInvalidConstructorCursorTypeOptions')]
     public function testConstructorCursorTypeOption($cursorType): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -57,25 +57,6 @@ class FindTest extends TestCase
     }
 
     #[DataProvider('provideInvalidConstructorCursorTypeOptions')]
-    public function testSnapshotOptionIsDeprecated(): void
-    {
-        $this->assertDeprecated(function (): void {
-            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['snapshot' => true]);
-        });
-
-        $this->assertDeprecated(function (): void {
-            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['snapshot' => false]);
-        });
-    }
-
-    public function testMaxScanOptionIsDeprecated(): void
-    {
-        $this->assertDeprecated(function (): void {
-            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['maxScan' => 1]);
-        });
-    }
-
-    #[DataProvider('provideInvalidConstructorCursorTypeOptions')]
     public function testConstructorCursorTypeOption($cursorType): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -13,6 +13,7 @@ use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Document\TestObject;
+use PHPUnit\Framework\Attributes\Depends;
 
 class InsertManyFunctionalTest extends FunctionalTestCase
 {
@@ -189,7 +190,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
         return $result;
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesInsertedCount(InsertManyResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -197,7 +198,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
         $result->getInsertedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesInsertedId(InsertManyResult $result): void
     {
         $this->assertInstanceOf(ObjectId::class, $result->getInsertedIds()[0]);

--- a/tests/Operation/InsertManyTest.php
+++ b/tests/Operation/InsertManyTest.php
@@ -6,6 +6,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\InsertMany;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class InsertManyTest extends TestCase
 {
@@ -23,7 +24,7 @@ class InsertManyTest extends TestCase
         new InsertMany($this->getDatabaseName(), $this->getCollectionName(), [1 => ['x' => 1]]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorDocumentsArgumentElementTypeChecks($document): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -31,7 +32,7 @@ class InsertManyTest extends TestCase
         new InsertMany($this->getDatabaseName(), $this->getCollectionName(), [$document]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -13,6 +13,8 @@ use MongoDB\Operation\InsertOne;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Document\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use stdClass;
 
 class InsertOneFunctionalTest extends FunctionalTestCase
@@ -26,10 +28,8 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
     }
 
-    /**
-     * @dataProvider provideDocumentsWithIds
-     * @dataProvider provideDocumentsWithoutIds
-     */
+    #[DataProvider('provideDocumentsWithIds')]
+    #[DataProvider('provideDocumentsWithoutIds')]
     public function testDocumentEncoding($document, stdClass $expectedDocument): void
     {
         (new CommandObserver())->observe(
@@ -80,7 +80,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideDocumentsWithIds */
+    #[DataProvider('provideDocumentsWithIds')]
     public function testInsertOneWithExistingId($document, stdClass $expectedDocument): void
     {
         $operation = new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
@@ -93,7 +93,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $this->assertSameDocuments([$expectedDocument], $this->collection->find());
     }
 
-    /** @dataProvider provideDocumentsWithoutIds */
+    #[DataProvider('provideDocumentsWithoutIds')]
     public function testInsertOneWithGeneratedId($document, stdClass $expectedDocument): void
     {
         $operation = new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
@@ -180,7 +180,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         return $result;
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesInsertedCount(InsertOneResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -188,7 +188,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
         $result->getInsertedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesInsertedId(InsertOneResult $result): void
     {
         $this->assertInstanceOf(ObjectId::class, $result->getInsertedId());

--- a/tests/Operation/InsertOneTest.php
+++ b/tests/Operation/InsertOneTest.php
@@ -7,18 +7,19 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class InsertOneTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorDocumentArgumentTypeCheck($document): void
     {
         $this->expectException($document instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new InsertOne($this->getDatabaseName(), $this->getCollectionName(), $document);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/ListCollectionsFunctionalTest.php
+++ b/tests/Operation/ListCollectionsFunctionalTest.php
@@ -8,6 +8,7 @@ use MongoDB\Operation\DropDatabase;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\ListCollections;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\Group;
 
 class ListCollectionsFunctionalTest extends FunctionalTestCase
 {
@@ -35,12 +36,10 @@ class ListCollectionsFunctionalTest extends FunctionalTestCase
         }
     }
 
-    /**
-     * @group matrix-testing-exclude-server-4.4-driver-4.0
-     * @group matrix-testing-exclude-server-4.4-driver-4.2
-     * @group matrix-testing-exclude-server-5.0-driver-4.0
-     * @group matrix-testing-exclude-server-5.0-driver-4.2
-     */
+    #[Group('matrix-testing-exclude-server-4.4-driver-4.0')]
+    #[Group('matrix-testing-exclude-server-4.4-driver-4.2')]
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.0')]
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.2')]
     public function testIdIndexAndInfo(): void
     {
         $server = $this->getPrimaryServer();

--- a/tests/Operation/ListIndexesTest.php
+++ b/tests/Operation/ListIndexesTest.php
@@ -4,10 +4,11 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\ListIndexes;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ListIndexesTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/ListSearchIndexesTest.php
+++ b/tests/Operation/ListSearchIndexesTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\ListSearchIndexes;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ListSearchIndexesTest extends TestCase
 {
@@ -13,7 +14,7 @@ class ListSearchIndexesTest extends TestCase
         new ListSearchIndexes($this->getDatabaseName(), $this->getCollectionName(), ['name' => '']);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/MapReduceFunctionalTest.php
+++ b/tests/Operation/MapReduceFunctionalTest.php
@@ -8,18 +8,18 @@ use MongoDB\MapReduceResult;
 use MongoDB\Operation\Find;
 use MongoDB\Operation\MapReduce;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 use function is_object;
 use function iterator_to_array;
 use function usort;
 use function version_compare;
 
-/**
- * @group matrix-testing-exclude-server-4.4-driver-4.0
- * @group matrix-testing-exclude-server-4.4-driver-4.2
- * @group matrix-testing-exclude-server-5.0-driver-4.0
- * @group matrix-testing-exclude-server-5.0-driver-4.2
- */
+#[Group('matrix-testing-exclude-server-4.4-driver-4.0')]
+#[Group('matrix-testing-exclude-server-4.4-driver-4.2')]
+#[Group('matrix-testing-exclude-server-5.0-driver-4.0')]
+#[Group('matrix-testing-exclude-server-5.0-driver-4.2')]
 class MapReduceFunctionalTest extends FunctionalTestCase
 {
     public function testDefaultReadConcernIsOmitted(): void
@@ -213,7 +213,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocuments */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocuments')]
     public function testTypeMapOptionWithInlineResults(?array $typeMap, array $expectedDocuments): void
     {
         $this->createFixtures(3);
@@ -258,7 +258,7 @@ class MapReduceFunctionalTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider provideTypeMapOptionsAndExpectedDocuments */
+    #[DataProvider('provideTypeMapOptionsAndExpectedDocuments')]
     public function testTypeMapOptionWithOutputCollection(?array $typeMap, array $expectedDocuments): void
     {
         $this->createFixtures(3);

--- a/tests/Operation/MapReduceTest.php
+++ b/tests/Operation/MapReduceTest.php
@@ -10,12 +10,13 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\MapReduce;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use TypeError;
 
 class MapReduceTest extends TestCase
 {
-    /** @dataProvider provideInvalidOutValues */
+    #[DataProvider('provideInvalidOutValues')]
     public function testConstructorOutArgumentTypeCheck($out): void
     {
         $map = new Javascript('function() { emit(this.x, this.y); }');
@@ -30,7 +31,7 @@ class MapReduceTest extends TestCase
         return self::wrapValuesForDataProvider([123, 3.14, true]);
     }
 
-    /** @dataProvider provideDeprecatedOutValues */
+    #[DataProvider('provideDeprecatedOutValues')]
     public function testConstructorOutArgumentDeprecations($out): void
     {
         $map = new Javascript('function() { emit(this.x, this.y); }');
@@ -55,7 +56,7 @@ class MapReduceTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $map = new Javascript('function() { emit(this.x, this.y); }');

--- a/tests/Operation/ModifyCollectionFunctionalTest.php
+++ b/tests/Operation/ModifyCollectionFunctionalTest.php
@@ -4,14 +4,13 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Operation\CreateIndexes;
 use MongoDB\Operation\ModifyCollection;
+use PHPUnit\Framework\Attributes\Group;
 
 class ModifyCollectionFunctionalTest extends FunctionalTestCase
 {
-    /**
-     * @group matrix-testing-exclude-server-4.2-driver-4.0-topology-sharded_cluster
-     * @group matrix-testing-exclude-server-4.4-driver-4.0-topology-sharded_cluster
-     * @group matrix-testing-exclude-server-5.0-driver-4.0-topology-sharded_cluster
-     */
+    #[Group('matrix-testing-exclude-server-4.2-driver-4.0-topology-sharded_cluster')]
+    #[Group('matrix-testing-exclude-server-4.4-driver-4.0-topology-sharded_cluster')]
+    #[Group('matrix-testing-exclude-server-5.0-driver-4.0-topology-sharded_cluster')]
     public function testCollMod(): void
     {
         if ($this->isShardedCluster()) {

--- a/tests/Operation/ModifyCollectionTest.php
+++ b/tests/Operation/ModifyCollectionTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\ModifyCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ModifyCollectionTest extends TestCase
 {
@@ -14,7 +15,7 @@ class ModifyCollectionTest extends TestCase
         new ModifyCollection($this->getDatabaseName(), $this->getCollectionName(), []);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/RenameCollectionTest.php
+++ b/tests/Operation/RenameCollectionTest.php
@@ -4,10 +4,11 @@ namespace MongoDB\Tests\Operation;
 
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\RenameCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RenameCollectionTest extends TestCase
 {
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/ReplaceOneTest.php
+++ b/tests/Operation/ReplaceOneTest.php
@@ -7,34 +7,34 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\ReplaceOne;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use TypeError;
 
 class ReplaceOneTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), $filter, ['y' => 1]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorReplacementArgumentTypeCheck($replacement): void
     {
         $this->expectException($replacement instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DoesNotPerformAssertions]
     public function testConstructorReplacementArgument($replacement): void
     {
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 
-    /** @dataProvider provideUpdateDocuments */
+    #[DataProvider('provideUpdateDocuments')]
     public function testConstructorReplacementArgumentProhibitsUpdateDocument($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -42,10 +42,8 @@ class ReplaceOneTest extends TestCase
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 
-    /**
-     * @dataProvider provideUpdatePipelines
-     * @dataProvider provideEmptyUpdatePipelinesExcludingArray
-     */
+    #[DataProvider('provideUpdatePipelines')]
+    #[DataProvider('provideEmptyUpdatePipelinesExcludingArray')]
     public function testConstructorReplacementArgumentProhibitsUpdatePipeline($replacement): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -53,7 +51,7 @@ class ReplaceOneTest extends TestCase
         new ReplaceOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $replacement);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionsTypeCheck($options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -11,6 +11,8 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\Operation\Update;
 use MongoDB\Tests\CommandObserver;
 use MongoDB\UpdateResult;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use stdClass;
 
 use function is_array;
@@ -26,7 +28,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $this->collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName());
     }
 
-    /** @dataProvider provideFilterDocuments */
+    #[DataProvider('provideFilterDocuments')]
     public function testFilterDocuments($filter, stdClass $expectedFilter): void
     {
         (new CommandObserver())->observe(
@@ -46,12 +48,10 @@ class UpdateFunctionalTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @dataProvider provideUpdateDocuments
-     * @dataProvider provideUpdatePipelines
-     * @dataProvider provideReplacementDocumentLikePipeline
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DataProvider('provideUpdateDocuments')]
+    #[DataProvider('provideUpdatePipelines')]
+    #[DataProvider('provideReplacementDocumentLikePipeline')]
     public function testUpdateDocuments($update, $expectedUpdate): void
     {
         if (is_array($expectedUpdate)) {
@@ -284,7 +284,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         return $result;
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesMatchedCount(UpdateResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -292,7 +292,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $result->getMatchedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesModifiedCount(UpdateResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -300,7 +300,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $result->getModifiedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesUpsertedCount(UpdateResult $result): void
     {
         $this->expectException(BadMethodCallException::class);
@@ -308,7 +308,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         $result->getUpsertedCount();
     }
 
-    /** @depends testUnacknowledgedWriteConcern */
+    #[Depends('testUnacknowledgedWriteConcern')]
     public function testUnacknowledgedWriteConcernAccessesUpsertedId(UpdateResult $result): void
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/Operation/UpdateManyTest.php
+++ b/tests/Operation/UpdateManyTest.php
@@ -5,38 +5,36 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\UpdateMany;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use TypeError;
 
 class UpdateManyTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new UpdateMany($this->getDatabaseName(), $this->getCollectionName(), $filter, ['$set' => ['x' => 1]]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorUpdateArgumentTypeCheck($update): void
     {
         $this->expectException($update instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new UpdateMany($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
     }
 
-    /**
-     * @dataProvider provideUpdateDocuments
-     * @dataProvider provideUpdatePipelines
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('provideUpdateDocuments')]
+    #[DataProvider('provideUpdatePipelines')]
+    #[DoesNotPerformAssertions]
     public function testConstructorUpdateArgument($update): void
     {
         new UpdateMany($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @dataProvider provideEmptyUpdatePipelines
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DataProvider('provideEmptyUpdatePipelines')]
     public function testConstructorUpdateArgumentProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/UpdateOneTest.php
+++ b/tests/Operation/UpdateOneTest.php
@@ -5,38 +5,36 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\UpdateOne;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use TypeError;
 
 class UpdateOneTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new UpdateOne($this->getDatabaseName(), $this->getCollectionName(), $filter, ['$set' => ['x' => 1]]);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorUpdateArgumentTypeCheck($update): void
     {
         $this->expectException($update instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new UpdateOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
     }
 
-    /**
-     * @dataProvider provideUpdateDocuments
-     * @dataProvider provideUpdatePipelines
-     * @doesNotPerformAssertions
-     */
+    #[DataProvider('provideUpdateDocuments')]
+    #[DataProvider('provideUpdatePipelines')]
+    #[DoesNotPerformAssertions]
     public function testConstructorUpdateArgument($update): void
     {
         new UpdateOne($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @dataProvider provideEmptyUpdatePipelines
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DataProvider('provideEmptyUpdatePipelines')]
     public function testConstructorUpdateArgumentProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/UpdateSearchIndexTest.php
+++ b/tests/Operation/UpdateSearchIndexTest.php
@@ -5,6 +5,7 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\UpdateSearchIndex;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class UpdateSearchIndexTest extends TestCase
@@ -15,7 +16,7 @@ class UpdateSearchIndexTest extends TestCase
         new UpdateSearchIndex($this->getDatabaseName(), $this->getCollectionName(), '', []);
     }
 
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorIndexDefinitionMustBeADocument($definition): void
     {
         $this->expectException($definition instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -6,25 +6,26 @@ use MongoDB\BSON\PackedArray;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Update;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TypeError;
 
 class UpdateTest extends TestCase
 {
-    /** @dataProvider provideInvalidDocumentValues */
+    #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {
         $this->expectException($filter instanceof PackedArray ? InvalidArgumentException::class : TypeError::class);
         new Update($this->getDatabaseName(), $this->getCollectionName(), $filter, ['$set' => ['x' => 1]]);
     }
 
-    /** @dataProvider provideInvalidUpdateValues */
+    #[DataProvider('provideInvalidUpdateValues')]
     public function testConstructorUpdateArgumentTypeCheck($update): void
     {
         $this->expectException(TypeError::class);
         new Update($this->getDatabaseName(), $this->getCollectionName(), ['x' => 1], $update);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -45,10 +46,8 @@ class UpdateTest extends TestCase
         ]);
     }
 
-    /**
-     * @dataProvider provideReplacementDocuments
-     * @dataProvider provideEmptyUpdatePipelines
-     */
+    #[DataProvider('provideReplacementDocuments')]
+    #[DataProvider('provideEmptyUpdatePipelines')]
     public function testConstructorMultiOptionProhibitsReplacementDocumentOrEmptyPipeline($update): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -25,6 +25,8 @@ use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Operation\InsertOne;
 use MongoDB\Operation\Watch;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Constraint\ObjectHasProperty;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionClass;
@@ -37,11 +39,9 @@ use function bin2hex;
 use function microtime;
 use function sprintf;
 
-/**
- * @group matrix-testing-exclude-server-4.2-driver-4.0-topology-sharded_cluster
- * @group matrix-testing-exclude-server-4.4-driver-4.0-topology-sharded_cluster
- * @group matrix-testing-exclude-server-5.0-driver-4.0-topology-sharded_cluster
- */
+#[Group('matrix-testing-exclude-server-4.2-driver-4.0-topology-sharded_cluster')]
+#[Group('matrix-testing-exclude-server-4.4-driver-4.0-topology-sharded_cluster')]
+#[Group('matrix-testing-exclude-server-5.0-driver-4.0-topology-sharded_cluster')]
 class WatchFunctionalTest extends FunctionalTestCase
 {
     public const INTERRUPTED = 11601;
@@ -109,9 +109,8 @@ class WatchFunctionalTest extends FunctionalTestCase
     /**
      * Prose test 1: "ChangeStream must continuously track the last seen
      * resumeToken"
-     *
-     * @dataProvider provideCodecOptions
      */
+    #[DataProvider('provideCodecOptions')]
     public function testGetResumeToken(array $options, Closure $getIdentifier): void
     {
         $this->skipIfServerVersion('>=', '4.0.7', 'postBatchResumeToken is supported');
@@ -162,9 +161,8 @@ class WatchFunctionalTest extends FunctionalTestCase
      *  - The batch has been iterated up to but not including the last element.
      * Expected result: getResumeToken must return the _id of the previous
      * document returned.
-     *
-     * @dataProvider provideCodecOptions
      */
+    #[DataProvider('provideCodecOptions')]
     public function testGetResumeTokenWithPostBatchResumeToken(array $options, Closure $getIdentifier): void
     {
         $this->skipIfServerVersion('<', '4.0.7', 'postBatchResumeToken is not supported');
@@ -489,7 +487,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->assertNull($changeStream->current());
     }
 
-    /** @dataProvider provideCodecOptions */
+    #[DataProvider('provideCodecOptions')]
     public function testNoChangeAfterResumeBeforeInsert(array $options): void
     {
         $operation = new Watch(
@@ -895,7 +893,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         }
     }
 
-    /** @dataProvider provideCodecOptions */
+    #[DataProvider('provideCodecOptions')]
     public function testRewindExtractsResumeTokenAndNextResumes(array $options, Closure $getIdentifier): void
     {
         $operation = new Watch(
@@ -953,7 +951,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->assertMatchesDocument(['_id' => 3, 'x' => 'baz'], $changeStream->current()->fullDocument);
     }
 
-    /** @dataProvider provideCodecOptions */
+    #[DataProvider('provideCodecOptions')]
     public function testResumeAfterOption(array $options, Closure $getIdentifier): void
     {
         $operation = new Watch(
@@ -999,7 +997,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->assertMatchesDocument(['_id' => 2, 'x' => 'bar'], $changeStream->current()->fullDocument);
     }
 
-    /** @dataProvider provideCodecOptions */
+    #[DataProvider('provideCodecOptions')]
     public function testStartAfterOption(array $options, Closure $getIdentifier): void
     {
         $this->skipIfServerVersion('<', '4.1.1', 'startAfter is not supported');
@@ -1047,7 +1045,7 @@ class WatchFunctionalTest extends FunctionalTestCase
         $this->assertMatchesDocument(['_id' => 2, 'x' => 'bar'], $changeStream->current()->fullDocument);
     }
 
-    /** @dataProvider provideTypeMapOptionsAndExpectedChangeDocument */
+    #[DataProvider('provideTypeMapOptionsAndExpectedChangeDocument')]
     public function testTypeMapOption(array $typeMap, $expectedChangeDocument): void
     {
         $operation = new Watch($this->manager, $this->getDatabaseName(), $this->getCollectionName(), [], ['typeMap' => $typeMap] + $this->defaultOptions);
@@ -1427,9 +1425,8 @@ class WatchFunctionalTest extends FunctionalTestCase
      *  - getResumeToken must return startAfter from the initial aggregate if the option was specified.
      *  - getResumeToken must return resumeAfter from the initial aggregate if the option was specified.
      *  - If neither the startAfter nor resumeAfter options were specified, the getResumeToken result must be empty.
-     *
-     * @dataProvider provideCodecOptions
      */
+    #[DataProvider('provideCodecOptions')]
     public function testResumeTokenBehaviour(array $options): void
     {
         $this->skipIfServerVersion('<', '4.1.1', 'Testing resumeAfter and startAfter can only be tested on servers >= 4.1.1');

--- a/tests/Operation/WatchTest.php
+++ b/tests/Operation/WatchTest.php
@@ -5,6 +5,7 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\Watch;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
+use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
 /**
@@ -32,7 +33,7 @@ class WatchTest extends FunctionalTestCase
         new Watch($this->manager, $this->getDatabaseName(), $this->getCollectionName(), ['foo' => ['$match' => ['x' => 1]]]);
     }
 
-    /** @dataProvider provideInvalidConstructorOptions */
+    #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/PedantryTest.php
+++ b/tests/PedantryTest.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests;
 
 use MongoDB;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
@@ -32,7 +33,7 @@ class PedantryTest extends TestCase
         MongoDB\Builder\Stage\FluentFactoryTrait::class,
     ];
 
-    /** @dataProvider provideProjectClassNames */
+    #[DataProvider('provideProjectClassNames')]
     public function testMethodsAreOrderedAlphabeticallyByVisibility($className): void
     {
         $class = new ReflectionClass($className);

--- a/tests/PsrLogAdapterTest.php
+++ b/tests/PsrLogAdapterTest.php
@@ -5,6 +5,7 @@ namespace MongoDB\Tests;
 use MongoDB\Driver\Monitoring\LogSubscriber;
 use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\PsrLogAdapter;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
@@ -84,10 +85,8 @@ class PsrLogAdapterTest extends BaseTestCase
         $this->assertSame($expectedLogs, $this->logger->logs);
     }
 
-    /**
-     * @testWith [-1]
-     *           [9]
-     */
+    #[TestWith([-1])]
+    #[TestWith([9])]
     public function testWriteLogWithInvalidLevel(int $level): void
     {
         $this->expectException(UnexpectedValueException::class);

--- a/tests/SpecTests/AtlasDataLakeSpecTest.php
+++ b/tests/SpecTests/AtlasDataLakeSpecTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\SpecTests;
 
 use MongoDB\Driver\Cursor;
 use MongoDB\Tests\CommandObserver;
+use PHPUnit\Framework\Attributes\Group;
 
 use function current;
 use function explode;
@@ -13,8 +14,8 @@ use function parse_url;
  * Atlas Data Lake spec tests.
  *
  * @see https://github.com/mongodb/specifications/tree/master/source/atlas-data-lake-testing/tests
- * @group atlas-data-lake
  */
+#[Group('atlas-data-lake')]
 class AtlasDataLakeSpecTest extends FunctionalTestCase
 {
     public function setUp(): void

--- a/tests/SpecTests/ClientSideEncryption/Prose21_AutomaticDataEncryptionKeysTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose21_AutomaticDataEncryptionKeysTest.php
@@ -10,6 +10,8 @@ use MongoDB\Driver\Exception\BulkWriteException;
 use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Exception\CreateEncryptedCollectionException;
 use MongoDB\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 use function base64_decode;
 
@@ -17,9 +19,9 @@ use function base64_decode;
  * Prose test 21: Automatic Data Encryption Keys
  *
  * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#automatic-data-encryption-keys
- * @group csfle
- * @group serverless
  */
+#[Group('csfle')]
+#[Group('serverless')]
 class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
 {
     public const SERVER_ERROR_TYPEMISMATCH = 14;
@@ -63,10 +65,8 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
         $this->database = null;
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/bc37892f360cab9df4082922384e0f4d4233f6d3/source/client-side-encryption/tests/README.rst#case-1-simple-creation-and-validation
-     * @dataProvider provideKmsProviderAndMasterKey
-     */
+    /** @see https://github.com/mongodb/specifications/blob/bc37892f360cab9df4082922384e0f4d4233f6d3/source/client-side-encryption/tests/README.rst#case-1-simple-creation-and-validation */
+    #[DataProvider('provideKmsProviderAndMasterKey')]
     public function testCase1_SimpleCreationAndValidation(string $kmsProvider, ?array $masterKey): void
     {
         [$result, $encryptedFields] = $this->database->createEncryptedCollection(
@@ -98,10 +98,8 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/bc37892f360cab9df4082922384e0f4d4233f6d3/source/client-side-encryption/tests/README.rst#case-2-missing-encryptedfields
-     * @dataProvider provideKmsProviderAndMasterKey
-     */
+    /** @see https://github.com/mongodb/specifications/blob/bc37892f360cab9df4082922384e0f4d4233f6d3/source/client-side-encryption/tests/README.rst#case-2-missing-encryptedfields */
+    #[DataProvider('provideKmsProviderAndMasterKey')]
     public function testCase2_MissingEncryptedFields(string $kmsProvider, ?array $masterKey): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -115,10 +113,8 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
         );
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/bc37892f360cab9df4082922384e0f4d4233f6d3/source/client-side-encryption/tests/README.rst#case-3-invalid-keyid
-     * @dataProvider provideKmsProviderAndMasterKey
-     */
+    /** @see https://github.com/mongodb/specifications/blob/bc37892f360cab9df4082922384e0f4d4233f6d3/source/client-side-encryption/tests/README.rst#case-3-invalid-keyid */
+    #[DataProvider('provideKmsProviderAndMasterKey')]
     public function testCase3_InvalidKeyId(string $kmsProvider, ?array $masterKey): void
     {
         try {
@@ -140,10 +136,8 @@ class Prose21_AutomaticDataEncryptionKeysTest extends FunctionalTestCase
         }
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/bc37892f360cab9df4082922384e0f4d4233f6d3/source/client-side-encryption/tests/README.rst#case-4-insert-encrypted-value
-     * @dataProvider provideKmsProviderAndMasterKey
-     */
+    /** @see https://github.com/mongodb/specifications/blob/bc37892f360cab9df4082922384e0f4d4233f6d3/source/client-side-encryption/tests/README.rst#case-4-insert-encrypted-value */
+    #[DataProvider('provideKmsProviderAndMasterKey')]
     public function testCase4_InsertEncryptedValue(string $kmsProvider, ?array $masterKey): void
     {
         [$result, $encryptedFields] = $this->database->createEncryptedCollection(

--- a/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
@@ -16,6 +16,8 @@ use MongoDB\Collection;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\EncryptionException;
 use MultipleIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 use function base64_decode;
 use function file_get_contents;
@@ -26,9 +28,9 @@ use function is_int;
  * Prose test 22: Range Explicit Encryption
  *
  * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#22-range-explicit-encryption
- * @group csfle
- * @group serverless
  */
+#[Group('csfle')]
+#[Group('serverless')]
 class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
 {
     private ?ClientEncryption $clientEncryption = null;
@@ -178,10 +180,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         ];
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-1-can-decrypt-a-payload
-     * @dataProvider provideTypeAndRangeOpts
-     */
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-1-can-decrypt-a-payload */
+    #[DataProvider('provideTypeAndRangeOpts')]
     public function testCase1_CanDecryptAPayload(string $type, array $rangeOpts): void
     {
         $this->setUpWithTypeAndRangeOpts($type, $rangeOpts);
@@ -211,10 +211,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         $this->assertEquals($originalValue, $decryptedValue);
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-2-can-find-encrypted-range-and-return-the-maximum
-     * @dataProvider provideTypeAndRangeOpts
-     */
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-2-can-find-encrypted-range-and-return-the-maximum */
+    #[DataProvider('provideTypeAndRangeOpts')]
     public function testCase2_CanFindEncryptedRangeAndReturnTheMaximum(string $type, array $rangeOpts): void
     {
         $this->setUpWithTypeAndRangeOpts($type, $rangeOpts);
@@ -248,10 +246,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         $this->assertMultipleDocumentsMatch($expectedDocuments, $cursor);
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-3-can-find-encrypted-range-and-return-the-minimum
-     * @dataProvider provideTypeAndRangeOpts
-     */
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-3-can-find-encrypted-range-and-return-the-minimum */
+    #[DataProvider('provideTypeAndRangeOpts')]
     public function testCase3_CanFindEncryptedRangeAndReturnTheMinimum(string $type, array $rangeOpts): void
     {
         $this->setUpWithTypeAndRangeOpts($type, $rangeOpts);
@@ -284,10 +280,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         $this->assertMultipleDocumentsMatch($expectedDocuments, $cursor);
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-4-can-find-encrypted-range-with-an-open-range-query
-     * @dataProvider provideTypeAndRangeOpts
-     */
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-4-can-find-encrypted-range-with-an-open-range-query */
+    #[DataProvider('provideTypeAndRangeOpts')]
     public function testCase4_CanFindEncryptedRangeWithAnOpenRangeQuery(string $type, array $rangeOpts): void
     {
         $this->setUpWithTypeAndRangeOpts($type, $rangeOpts);
@@ -311,10 +305,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         $this->assertMultipleDocumentsMatch($expectedDocuments, $cursor);
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-5-can-run-an-aggregation-expression-inside-expr
-     * @dataProvider provideTypeAndRangeOpts
-     */
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-5-can-run-an-aggregation-expression-inside-expr */
+    #[DataProvider('provideTypeAndRangeOpts')]
     public function testCase5_CanRunAnAggregationExpressionInsideExpr(string $type, array $rangeOpts): void
     {
         $this->setUpWithTypeAndRangeOpts($type, $rangeOpts);
@@ -343,10 +335,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         $this->assertMultipleDocumentsMatch($expectedDocuments, $cursor);
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-6-encrypting-a-document-greater-than-the-maximum-errors
-     * @dataProvider provideTypeAndRangeOpts
-     */
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-6-encrypting-a-document-greater-than-the-maximum-errors */
+    #[DataProvider('provideTypeAndRangeOpts')]
     public function testCase6_EncryptingADocumentGreaterThanTheMaximumErrors(string $type, array $rangeOpts): void
     {
         if ($type === 'DecimalNoPrecision' || $type === 'DoubleNoPrecision') {
@@ -367,10 +357,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         $this->clientEncryption->encrypt(self::cast($type, 201), $encryptOpts);
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-7-encrypting-a-value-of-a-different-type-errors
-     * @dataProvider provideTypeAndRangeOpts
-     */
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-7-encrypting-a-value-of-a-different-type-errors */
+    #[DataProvider('provideTypeAndRangeOpts')]
     public function testCase7_EncryptingAValueOfADifferentTypeErrors(string $type, array $rangeOpts): void
     {
         if ($type === 'DecimalNoPrecision' || $type === 'DoubleNoPrecision') {
@@ -395,10 +383,8 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         $this->clientEncryption->encrypt($value, $encryptOpts);
     }
 
-    /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-8-setting-precision-errors-if-the-type-is-not-double-or-decimal128
-     * @dataProvider provideTypeAndRangeOpts
-     */
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-8-setting-precision-errors-if-the-type-is-not-double-or-decimal128 */
+    #[DataProvider('provideTypeAndRangeOpts')]
     public function testCase8_SettingPrecisionErrorsIfTheTypeIsNotDoubleOrDecimal128(string $type, array $rangeOpts): void
     {
         if ($type === 'DecimalNoPrecision' || $type === 'DecimalPrecision' || $type === 'DoubleNoPrecision' || $type === 'DoublePrecision') {

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -24,6 +24,9 @@ use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Tests\CommandObserver;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\SkippedTestError;
 use stdClass;
 use Throwable;
@@ -48,9 +51,9 @@ use const JSON_THROW_ON_ERROR;
  * Client-side encryption spec tests.
  *
  * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption
- * @group csfle
- * @group serverless
  */
+#[Group('csfle')]
+#[Group('serverless')]
 class ClientSideEncryptionSpecTest extends FunctionalTestCase
 {
     public const LOCAL_MASTERKEY = 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk';
@@ -149,7 +152,6 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     /**
      * Execute an individual test case from the specification.
      *
-     * @dataProvider provideTests
      * @param stdClass    $test           Individual "tests[]" document
      * @param array       $runOn          Top-level "runOn" array with server requirements
      * @param array       $data           Top-level "data" array to initialize collection
@@ -158,6 +160,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * @param string      $databaseName   Name of database under test
      * @param string      $collectionName Name of collection under test
      */
+    #[DataProvider('provideTests')]
     public function testClientSideEncryption(stdClass $test, ?array $runOn, array $data, ?stdClass $encryptedFields = null, ?array $keyVaultData = null, ?stdClass $jsonSchema = null, ?string $databaseName = null, ?string $collectionName = null): void
     {
         if (isset(self::$incompleteTests[$this->dataDescription()])) {
@@ -270,8 +273,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 2: Data Key and Double Encryption
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#data-key-and-double-encryption
-     * @dataProvider dataKeyProvider
      */
+    #[DataProvider('dataKeyProvider')]
     public function testDataKeyAndDoubleEncryption(string $providerName, $masterKey): void
     {
         $client = static::createTestClient();
@@ -409,9 +412,9 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 3: External Key Vault
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#external-key-vault-test
-     * @testWith [false]
-     *           [true]
      */
+    #[TestWith([false])]
+    #[TestWith([true])]
     public function testExternalKeyVault($withExternalKeyVault): void
     {
         $client = static::createTestClient();
@@ -557,8 +560,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 4: BSON Size Limits and Batch Splitting
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#bson-size-limits-and-batch-splitting
-     * @dataProvider provideBSONSizeLimitsAndBatchSplittingTests
      */
+    #[DataProvider('provideBSONSizeLimitsAndBatchSplittingTests')]
     public function testBSONSizeLimitsAndBatchSplitting(Closure $test): void
     {
         $client = static::createTestClient();
@@ -623,9 +626,9 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 6: BSON Corpus
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#corpus-test
-     * @testWith [true]
-     *           [false]
      */
+    #[TestWith([true])]
+    #[TestWith([false])]
     public function testCorpus($schemaMap = true): void
     {
         $client = static::createTestClient();
@@ -732,8 +735,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 7: Custom Endpoint
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#custom-endpoint-test
-     * @dataProvider customEndpointProvider
      */
+    #[DataProvider('customEndpointProvider')]
     public function testCustomEndpoint(Closure $test): void
     {
         $client = static::createTestClient();
@@ -1103,8 +1106,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 11: KMS TLS Options
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#kms-tls-options-tests
-     * @dataProvider provideKmsTlsOptionsTests
      */
+    #[DataProvider('provideKmsTlsOptionsTests')]
     public function testKmsTlsOptions(Closure $test): void
     {
         $client = static::createTestClient();
@@ -1321,8 +1324,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 12: Explicit Encryption
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#explicit-encryption
-     * @dataProvider provideExplicitEncryptionTests
      */
+    #[DataProvider('provideExplicitEncryptionTests')]
     public function testExplicitEncryption(Closure $test): void
     {
         if ($this->isStandalone()) {
@@ -1500,8 +1503,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 13: Unique Index on keyAltNames
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#unique-index-on-keyaltnames
-     * @dataProvider provideUniqueIndexOnKeyAltNamesTests
      */
+    #[DataProvider('provideUniqueIndexOnKeyAltNamesTests')]
     public function testUniqueIndexOnKeyAltNames(Closure $test): void
     {
         // Test setup
@@ -1587,8 +1590,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 14: Decryption Events
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#decryption-events
-     * @dataProvider provideDecryptionEventsTests
      */
+    #[DataProvider('provideDecryptionEventsTests')]
     public function testDecryptionEvents(Closure $test): void
     {
         // Test setup
@@ -1736,10 +1739,10 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 15: On-demand AWS Credentials
      *
      * @see https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#on-demand-aws-credentials
-     * @group csfle-without-aws-creds
-     * @testWith [true]
-     *           [false]
      */
+    #[TestWith([true])]
+    #[TestWith([false])]
+    #[Group('csfle-without-aws-creds')]
     public function testOnDemandAwsCredentials(bool $shouldSucceed): void
     {
         $hasCredentials = (getenv('AWS_ACCESS_KEY_ID') && getenv('AWS_SECRET_ACCESS_KEY'));
@@ -1779,8 +1782,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
      * Prose test 16: RewrapManyDataKey
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#rewrap
-     * @dataProvider provideRewrapManyDataKeySrcAndDstProviders
      */
+    #[DataProvider('provideRewrapManyDataKeySrcAndDstProviders')]
     public function testRewrapManyDataKey(string $srcProvider, string $dstProvider): void
     {
         $providerMasterKeys = [

--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 use RuntimeException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory;
+use SebastianBergmann\Exporter\Exporter;
 use stdClass;
 
 use function array_values;
@@ -80,12 +81,12 @@ class DocumentsMatchConstraint extends Constraint
             $this->assertEquals($this->value, $other, $this->ignoreExtraKeysInRoot);
             $success = true;
         } catch (RuntimeException $e) {
+            $exporter = new Exporter();
             $this->lastFailure = new ComparisonFailure(
                 $this->value,
                 $other,
-                $this->exporter()->export($this->value),
-                $this->exporter()->export($other),
-                false,
+                $exporter->export($this->value),
+                $exporter->export($other),
                 $e->getMessage(),
             );
         }
@@ -123,7 +124,7 @@ class DocumentsMatchConstraint extends Constraint
         if ($expected::class !== $actual::class) {
             throw new RuntimeException(sprintf(
                 '%s is not instance of expected class "%s"',
-                $this->exporter()->shortenedExport($actual),
+                (new Exporter())->shortenedExport($actual),
                 $expected::class,
             ));
         }
@@ -162,11 +163,10 @@ class DocumentsMatchConstraint extends Constraint
                     $actualValue,
                     '',
                     '',
-                    false,
                     sprintf(
                         'Field path "%s": %s is not instance of expected type "%s".',
                         $keyPrefix . $key,
-                        $this->exporter()->shortenedExport($actualValue),
+                        (new Exporter())->shortenedExport($actualValue),
                         $expectedType,
                     ),
                 );
@@ -180,7 +180,6 @@ class DocumentsMatchConstraint extends Constraint
                     $actualValue,
                     '',
                     '',
-                    false,
                     sprintf('Field path "%s": %s', $keyPrefix . $key, $failure->getMessage()),
                 );
             }
@@ -233,7 +232,7 @@ class DocumentsMatchConstraint extends Constraint
 
     public function toString(): string
     {
-        return 'matches ' . $this->exporter()->export($this->value);
+        return 'matches ' . (new Exporter())->export($this->value);
     }
 
     private static function isNumeric($value): bool

--- a/tests/SpecTests/DocumentsMatchConstraintTest.php
+++ b/tests/SpecTests/DocumentsMatchConstraintTest.php
@@ -16,6 +16,7 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\ExpectationFailedException;
 
 use const PHP_INT_SIZE;
@@ -70,7 +71,7 @@ class DocumentsMatchConstraintTest extends TestCase
         $this->assertResult(false, $c, [1, ['a' => 2]], 'Keys must have the correct value');
     }
 
-    /** @dataProvider provideBSONTypes */
+    #[DataProvider('provideBSONTypes')]
     public function testBSONTypeAssertions($type, $value): void
     {
         $constraint = new DocumentsMatchConstraint(['x' => ['$$type' => $type]]);
@@ -132,7 +133,7 @@ class DocumentsMatchConstraintTest extends TestCase
         $this->assertResult(false, $c2, ['x' => true], 'bool is not number or string');
     }
 
-    /** @dataProvider errorMessageProvider */
+    #[DataProvider('errorMessageProvider')]
     public function testErrorMessages($expectedMessagePart, DocumentsMatchConstraint $constraint, $actualValue): void
     {
         try {

--- a/tests/SpecTests/RetryableWrites/Prose3_ReturnOriginalErrorTest.php
+++ b/tests/SpecTests/RetryableWrites/Prose3_ReturnOriginalErrorTest.php
@@ -8,13 +8,14 @@ use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
 use MongoDB\Tests\SpecTests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Prose test 3: Return Original Error
  *
  * @see https://github.com/mongodb/specifications/blob/master/source/retryable-writes/tests/README.md
- * @group serverless
  */
+#[Group('serverless')]
 class Prose3_ReturnOriginalErrorTest extends FunctionalTestCase
 {
     public const NOT_WRITABLE_PRIMARY = 10107;

--- a/tests/SpecTests/SearchIndexSpecTest.php
+++ b/tests/SpecTests/SearchIndexSpecTest.php
@@ -6,6 +6,7 @@ use Closure;
 use MongoDB\Collection;
 use MongoDB\Model\CachingIterator;
 use MongoDB\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 use function bin2hex;
 use function count;
@@ -19,8 +20,8 @@ use function sprintf;
  * Functional tests for the Atlas Search index management.
  *
  * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.rst#search-index-management-helpers
- * @group atlas
  */
+#[Group('atlas')]
 class SearchIndexSpecTest extends FunctionalTestCase
 {
     private const WAIT_TIMEOUT_SEC = 300;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -161,11 +161,16 @@ OUTPUT;
 
     protected function assertDeprecated(callable $execution)
     {
+        $this->assertError(E_USER_DEPRECATED | E_DEPRECATED, $execution);
+    }
+
+    protected function assertError(int $levels, callable $execution): void
+    {
         $errors = [];
 
         set_error_handler(function ($errno, $errstr) use (&$errors): void {
             $errors[] = $errstr;
-        }, E_USER_DEPRECATED | E_DEPRECATED);
+        }, $levels);
 
         try {
             $result = call_user_func($execution);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,8 +6,6 @@ use InvalidArgumentException;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Codec\Codec;
-use MongoDB\Codec\DecodeIfSupported;
-use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -239,34 +239,7 @@ OUTPUT;
 
     protected static function getInvalidDocumentCodecValues(): array
     {
-        $codec = new class implements Codec {
-            use DecodeIfSupported;
-            use EncodeIfSupported;
-
-            public function canDecode(mixed $value): bool
-            {
-                return true;
-            }
-
-            public function decode(mixed $value): mixed
-            {
-                return $value;
-            }
-
-            public function canEncode(mixed $value): bool
-            {
-                return true;
-            }
-
-            public function encode(mixed $value): mixed
-            {
-                return $value;
-            }
-        };
-        // @fixme: createStub can be called statically in PHPUnit 10
-        // $codec = self::createStub(Codec::class);
-
-        return [123, 3.14, 'foo', true, [], new stdClass(), $codec];
+        return [123, 3.14, 'foo', true, [], new stdClass(), self::createStub(Codec::class)];
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -205,7 +205,7 @@ OUTPUT;
     {
         $class = new ReflectionClass($this);
 
-        return sprintf('%s.%s', $class->getShortName(), hash('crc32b', $this->getName()));
+        return sprintf('%s.%s', $class->getShortName(), hash('crc32b', $this->name()));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -203,7 +203,7 @@ OUTPUT;
     {
         $class = new ReflectionClass($this);
 
-        return sprintf('%s.%s', $class->getShortName(), hash('crc32b', $this->name()));
+        return sprintf('%s.%s', $class->getShortName(), hash('xxh3', $this->name()));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -159,12 +159,12 @@ OUTPUT;
         return self::wrapValuesForDataProvider(self::getInvalidStringValues());
     }
 
-    protected function assertDeprecated(callable $execution)
+    protected function assertDeprecated(callable $execution): mixed
     {
-        $this->assertError(E_USER_DEPRECATED | E_DEPRECATED, $execution);
+        return $this->assertError(E_USER_DEPRECATED | E_DEPRECATED, $execution);
     }
 
-    protected function assertError(int $levels, callable $execution): void
+    protected function assertError(int $levels, callable $execution): mixed
     {
         $errors = [];
 

--- a/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
+++ b/tests/UnifiedSpecTests/Constraint/IsBsonTypeTest.php
@@ -17,6 +17,7 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
 use stdClass;
@@ -27,7 +28,7 @@ use const PHP_INT_SIZE;
 
 class IsBsonTypeTest extends TestCase
 {
-    /** @dataProvider provideTypes */
+    #[DataProvider('provideTypes')]
     public function testConstraint($type, $value): void
     {
         $this->assertResult(true, new IsBsonType($type), $value, $this->dataName() . ' is ' . $type);
@@ -76,7 +77,7 @@ class IsBsonTypeTest extends TestCase
         ];
     }
 
-    /** @dataProvider provideTypes */
+    #[DataProvider('provideTypes')]
     public function testAny($type, $value): void
     {
         $this->assertResult(true, IsBsonType::any(), $value, $this->dataName() . ' is a BSON type');

--- a/tests/UnifiedSpecTests/Constraint/Matches.php
+++ b/tests/UnifiedSpecTests/Constraint/Matches.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use RuntimeException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory;
+use SebastianBergmann\Exporter\Exporter;
 
 use function array_keys;
 use function count;
@@ -82,14 +83,14 @@ class Matches extends Constraint
         } catch (RuntimeException $e) {
             /* This will generally catch internal errors from failAt(), which
              * include a key path to pinpoint the failure. */
+            $exporter = new Exporter();
             $this->lastFailure = new ComparisonFailure(
                 $this->value,
                 $other,
                 /* TODO: Improve the exporter to canonicalize documents by
                  * sorting keys and remove spl_object_hash from output. */
-                $this->exporter()->export($this->value),
-                $this->exporter()->export($other),
-                false,
+                $exporter->export($this->value),
+                $exporter->export($other),
                 $e->getMessage(),
             );
         }
@@ -256,7 +257,7 @@ class Matches extends Constraint
             $constraint = IsBsonType::anyOf(...(array) $operator['$$type']);
 
             if (! $constraint->evaluate($actual, '', true)) {
-                self::failAt(sprintf('%s is not an expected BSON type: %s', $this->exporter()->shortenedExport($actual), implode(', ', (array) $operator['$$type'])), $keyPath);
+                self::failAt(sprintf('%s is not an expected BSON type: %s', (new Exporter())->shortenedExport($actual), implode(', ', (array) $operator['$$type'])), $keyPath);
             }
 
             return;
@@ -284,7 +285,7 @@ class Matches extends Constraint
             assertIsString($actual);
 
             if ($actual !== hex2bin($operator['$$matchesHexBytes'])) {
-                self::failAt(sprintf('%s does not match expected hex bytes: %s', $this->exporter()->shortenedExport($actual), $operator['$$matchesHexBytes']), $keyPath);
+                self::failAt(sprintf('%s does not match expected hex bytes: %s', (new Exporter())->shortenedExport($actual), $operator['$$matchesHexBytes']), $keyPath);
             }
 
             return;
@@ -349,7 +350,7 @@ class Matches extends Constraint
 
     public function toString(): string
     {
-        return 'matches ' . $this->exporter()->export($this->value);
+        return 'matches ' . (new Exporter())->export($this->value);
     }
 
     /** @psalm-return never-return */

--- a/tests/UnifiedSpecTests/Constraint/Matches.php
+++ b/tests/UnifiedSpecTests/Constraint/Matches.php
@@ -256,7 +256,7 @@ class Matches extends Constraint
             $constraint = IsBsonType::anyOf(...(array) $operator['$$type']);
 
             if (! $constraint->evaluate($actual, '', true)) {
-                self::failAt(sprintf('%s is not an expected BSON type: %s', $this->exporter()->shortenedExport($actual), implode(', ', $types)), $keyPath);
+                self::failAt(sprintf('%s is not an expected BSON type: %s', $this->exporter()->shortenedExport($actual), implode(', ', (array) $operator['$$type'])), $keyPath);
             }
 
             return;

--- a/tests/UnifiedSpecTests/Constraint/MatchesTest.php
+++ b/tests/UnifiedSpecTests/Constraint/MatchesTest.php
@@ -5,6 +5,7 @@ namespace MongoDB\Tests\UnifiedSpecTests\Constraint;
 use MongoDB\BSON\Binary;
 use MongoDB\Tests\FunctionalTestCase;
 use MongoDB\Tests\UnifiedSpecTests\EntityMap;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\ExpectationFailedException;
 use stdClass;
 
@@ -170,7 +171,7 @@ class MatchesTest extends FunctionalTestCase
         $this->assertResult(false, $c, ['x' => 1], 'session LSID does not match (embedded)');
     }
 
-    /** @dataProvider errorMessageProvider */
+    #[DataProvider('errorMessageProvider')]
     public function testErrorMessages($expectedMessageRegex, Matches $constraint, $actualValue): void
     {
         try {
@@ -253,7 +254,7 @@ class MatchesTest extends FunctionalTestCase
         ];
     }
 
-    /** @dataProvider operatorErrorMessageProvider */
+    #[DataProvider('operatorErrorMessageProvider')]
     public function testOperatorSyntaxValidation($expectedMessage, Matches $constraint): void
     {
         $this->expectException(ExpectationFailedException::class);

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -5,6 +5,8 @@ namespace MongoDB\Tests\UnifiedSpecTests;
 use Exception;
 use Generator;
 use MongoDB\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\SkippedTest;
 use PHPUnit\Framework\Warning;
 
@@ -221,10 +223,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         }
     }
 
-    /**
-     * @dataProvider provideAtlasDataLakeTests
-     * @group atlas-data-lake
-     */
+    #[DataProvider('provideAtlasDataLakeTests')]
+    #[Group('atlas-data-lake')]
     public function testAtlasDataLake(UnifiedTestCase $test): void
     {
         if (! $this->isAtlasDataLake()) {
@@ -239,10 +239,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/atlas-data-lake/*.json');
     }
 
-    /**
-     * @dataProvider provideChangeStreamsTests
-     * @group serverless
-     */
+    #[DataProvider('provideChangeStreamsTests')]
+    #[Group('serverless')]
     public function testChangeStreams(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -253,11 +251,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/change-streams/*.json');
     }
 
-    /**
-     * @dataProvider provideClientSideEncryptionTests
-     * @group csfle
-     * @group serverless
-     */
+    #[DataProvider('provideClientSideEncryptionTests')]
+    #[Group('csfle')]
+    #[Group('serverless')]
     public function testClientSideEncryption(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -268,10 +264,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/client-side-encryption/*.json');
     }
 
-    /**
-     * @dataProvider provideCollectionManagementTests
-     * @group serverless
-     */
+    #[DataProvider('provideCollectionManagementTests')]
+    #[Group('serverless')]
     public function testCollectionManagement(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -282,10 +276,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/collection-management/*.json');
     }
 
-    /**
-     * @dataProvider provideCommandMonitoringTests
-     * @group serverless
-     */
+    #[DataProvider('provideCommandMonitoringTests')]
+    #[Group('serverless')]
     public function testCommandMonitoring(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -296,10 +288,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/command-monitoring/*.json');
     }
 
-    /**
-     * @dataProvider provideCrudTests
-     * @group serverless
-     */
+    #[DataProvider('provideCrudTests')]
+    #[Group('serverless')]
     public function testCrud(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -310,10 +300,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/crud/*.json');
     }
 
-    /**
-     * @dataProvider provideGridFSTests
-     * @group serverless
-     */
+    #[DataProvider('provideGridFSTests')]
+    #[Group('serverless')]
     public function testGridFS(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -324,10 +312,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/gridfs/*.json');
     }
 
-    /**
-     * @dataProvider provideLoadBalancers
-     * @group serverless
-     */
+    #[DataProvider('provideLoadBalancers')]
+    #[Group('serverless')]
     public function testLoadBalancers(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -338,7 +324,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/load-balancers/*.json');
     }
 
-    /** @dataProvider provideReadWriteConcernTests */
+    #[DataProvider('provideReadWriteConcernTests')]
     public function testReadWriteConcern(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -349,10 +335,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/read-write-concern/*.json');
     }
 
-    /**
-     * @dataProvider provideRetryableReadsTests
-     * @group serverless
-     */
+    #[DataProvider('provideRetryableReadsTests')]
+    #[Group('serverless')]
     public function testRetryableReads(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -363,10 +347,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/retryable-reads/*.json');
     }
 
-    /**
-     * @dataProvider provideRetryableWritesTests
-     * @group serverless
-     */
+    #[DataProvider('provideRetryableWritesTests')]
+    #[Group('serverless')]
     public function testRetryableWrites(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -377,10 +359,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/retryable-writes/*.json');
     }
 
-    /**
-     * @dataProvider provideRunCommandTests
-     * @group serverless
-     */
+    #[DataProvider('provideRunCommandTests')]
+    #[Group('serverless')]
     public function testRunCommand(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -391,10 +371,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/run-command/*.json');
     }
 
-    /**
-     * @dataProvider provideSessionsTests
-     * @group serverless
-     */
+    #[DataProvider('provideSessionsTests')]
+    #[Group('serverless')]
     public function testSessions(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -405,10 +383,8 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/sessions/*.json');
     }
 
-    /**
-     * @dataProvider provideTransactionsTests
-     * @group serverless
-     */
+    #[DataProvider('provideTransactionsTests')]
+    #[Group('serverless')]
     public function testTransactions(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -419,7 +395,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/transactions/*.json');
     }
 
-    /** @dataProvider provideTransactionsConvenientApiTests */
+    #[DataProvider('provideTransactionsConvenientApiTests')]
     public function testTransactionsConvenientApi(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -430,11 +406,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/transactions-convenient-api/*.json');
     }
 
-    /**
-     * @dataProvider provideVersionedApiTests
-     * @group serverless
-     * @group versioned-api
-     */
+    #[DataProvider('provideVersionedApiTests')]
+    #[Group('serverless')]
+    #[Group('versioned-api')]
     public function testVersionedApi(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -445,7 +419,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         return self::provideTests(__DIR__ . '/versioned-api/*.json');
     }
 
-    /** @dataProvider providePassingTests */
+    #[DataProvider('providePassingTests')]
     public function testPassingTests(UnifiedTestCase $test): void
     {
         self::$runner->run($test);
@@ -456,7 +430,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         yield from self::provideTests(__DIR__ . '/valid-pass/*.json');
     }
 
-    /** @dataProvider provideFailingTests */
+    #[DataProvider('provideFailingTests')]
     public function testFailingTests(UnifiedTestCase $test): void
     {
         // Cannot use expectException(), as it ignores PHPUnit Exceptions
@@ -494,7 +468,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         yield from self::provideTests(__DIR__ . '/valid-fail/*.json');
     }
 
-    /** @dataProvider provideIndexManagementTests */
+    #[DataProvider('provideIndexManagementTests')]
     public function testIndexManagement(UnifiedTestCase $test): void
     {
         if (self::isAtlas()) {


### PR DESCRIPTION
Fix PHPLIB-1369

- Migration from `@annotations` to `#[Attributes]`
- Replace `hasFailed` with the method `onNotSuccessfulTest` in `FunctionalTestCase`
- User `createStub` in `getInvalidDocumentCodecValues`
- Update custom constraints (`TestCase::exporter()` is deprecated and `ComparisonFailure` 5th argument was removed)