### PR TITLE
PHPLIB-1525 Removes dependency to Symfony PHPUnit bridge

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -83,30 +83,30 @@ export MONGODB_MULTI_MONGOS_LB_URI="${MONGODB_MULTI_MONGOS_LB_URI}"
 # Run the tests, and store the results in a junit result file
 case "$TESTS" in
    atlas)
-      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group atlas
+      php vendor/bin/phpunit $PHPUNIT_OPTS --group atlas
       ;;
 
    atlas-data-lake)
-      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group atlas-data-lake
+      php vendor/bin/phpunit $PHPUNIT_OPTS --group atlas-data-lake
       ;;
 
    csfle)
-      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group csfle
+      php vendor/bin/phpunit $PHPUNIT_OPTS --group csfle
       ;;
 
    csfle-without-aws-creds)
-      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group csfle-without-aws-creds
+      php vendor/bin/phpunit $PHPUNIT_OPTS --group csfle-without-aws-creds
       ;;
 
    versioned-api)
-      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group versioned-api
+      php vendor/bin/phpunit $PHPUNIT_OPTS --group versioned-api
       ;;
 
    serverless)
-      php vendor/bin/simple-phpunit $PHPUNIT_OPTS --group serverless
+      php vendor/bin/phpunit $PHPUNIT_OPTS --group serverless
       ;;
 
    *)
-      php vendor/bin/simple-phpunit $PHPUNIT_OPTS
+      php vendor/bin/phpunit $PHPUNIT_OPTS
       ;;
 esac

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           php-ini-values: "zend.assertions=1"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/simple-phpunit -v"
+        run: "vendor/bin/phpunit -v"
         env:
           SYMFONY_DEPRECATIONS_HELPER: 999999
           MONGODB_URI: ${{ steps.setup-mongodb.outputs.cluster-uri }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,6 @@ credentials in the connection string (i.e. `MONGODB_URI`) or set the
 Note that `MONGODB_USERNAME` and `MONGODB_PASSWORD` will override any
 credentials present in the connection string.
 
-To run tests use the `phpunit` executable installed by Composer:
-
-```console
-$ vendor/bin/phpunit
-```
-
 ### Environment Variables
 
 The test suite references the following environment variables:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,10 @@ credentials in the connection string (i.e. `MONGODB_URI`) or set the
 Note that `MONGODB_USERNAME` and `MONGODB_PASSWORD` will override any
 credentials present in the connection string.
 
-By default, the `simple-phpunit` binary chooses the correct PHPUnit version for
-the PHP version you are running. To run tests against a specific PHPUnit
-version, use the `SYMFONY_PHPUNIT_VERSION` environment variable:
+To run tests use the `phpunit` executable installed by Composer:
 
 ```console
-$ SYMFONY_PHPUNIT_VERSION=8.5 vendor/bin/simple-phpunit
+$ vendor/bin/phpunit
 ```
 
 ### Environment Variables

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
+        "phpunit/phpunit": "^9.6",
         "rector/rector": "^1.1",
         "squizlabs/php_codesniffer": "^3.7",
-        "symfony/phpunit-bridge": "^7.1",
         "vimeo/psalm": "^5.13"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "fix:cs": "phpcbf",
         "fix:psalm:baseline": "psalm --set-baseline=psalm-baseline.xml",
         "fix:rector": "rector process --ansi",
-        "test": "simple-phpunit"
+        "test": "phpunit"
     },
     "extra": {
         "branch-alias": {

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -5,10 +5,14 @@ namespace MongoDB\Tests;
 use Generator;
 
 use function bin2hex;
+use function error_reporting;
 use function getenv;
 use function putenv;
 use function random_bytes;
 use function sprintf;
+
+use const E_ALL;
+use const E_DEPRECATED;
 
 /** @runTestsInSeparateProcesses */
 final class ExamplesTest extends FunctionalTestCase
@@ -304,7 +308,14 @@ OUTPUT;
 
     private function assertExampleOutput(string $file, string $expectedOutput): void
     {
-        require $file;
+        // Hide deprecation messages
+        $level = error_reporting(E_ALL ^ E_DEPRECATED);
+
+        try {
+            require $file;
+        } finally {
+            error_reporting($level);
+        }
 
         $this->assertStringMatchesFormat($expectedOutput, $this->getActualOutputForAssertion());
     }

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -5,14 +5,10 @@ namespace MongoDB\Tests;
 use Generator;
 
 use function bin2hex;
-use function error_reporting;
 use function getenv;
 use function putenv;
 use function random_bytes;
 use function sprintf;
-
-use const E_ALL;
-use const E_DEPRECATED;
 
 /** @runTestsInSeparateProcesses */
 final class ExamplesTest extends FunctionalTestCase
@@ -308,14 +304,7 @@ OUTPUT;
 
     private function assertExampleOutput(string $file, string $expectedOutput): void
     {
-        // Hide deprecation messages
-        $level = error_reporting(E_ALL ^ E_DEPRECATED);
-
-        try {
-            require $file;
-        } finally {
-            error_reporting($level);
-        }
+        require $file;
 
         $this->assertStringMatchesFormat($expectedOutput, $this->getActualOutputForAssertion());
     }

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -872,7 +872,6 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $code = <<<'PHP'
             require '%s';
-            require '%s';
             $client = MongoDB\Tests\FunctionalTestCase::createTestClient();
             $database = $client->selectDatabase(getenv('MONGODB_DATABASE') ?: 'phplib_test');
             $gridfs = $database->selectGridFSBucket();
@@ -888,8 +887,6 @@ class BucketFunctionalTest extends FunctionalTestCase
                     sprintf(
                         $code,
                         __DIR__ . '/../../vendor/autoload.php',
-                        // Include the PHPUnit autoload file to ensure PHPUnit classes can be loaded
-                        __DIR__ . '/../../vendor/bin/.phpunit/phpunit/vendor/autoload.php',
                     ),
                 ),
                 '2>&1',
@@ -915,7 +912,6 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $code = <<<'PHP'
             require '%s';
-            require '%s';
             $client = MongoDB\Tests\FunctionalTestCase::createTestClient();
             $database = $client->selectDatabase(getenv('MONGODB_DATABASE') ?: 'phplib_test');
             $database->selectGridFSBucket()->registerGlobalStreamWrapperAlias('alias');
@@ -931,8 +927,6 @@ class BucketFunctionalTest extends FunctionalTestCase
                     sprintf(
                         $code,
                         __DIR__ . '/../../vendor/autoload.php',
-                        // Include the PHPUnit autoload file to ensure PHPUnit classes can be loaded
-                        __DIR__ . '/../../vendor/bin/.phpunit/phpunit/vendor/autoload.php',
                     ),
                 ),
                 '2>&1',

--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -97,6 +97,8 @@ class DocumentsMatchConstraint extends Constraint
         if (! $success) {
             $this->fail($other, $description, $this->lastFailure);
         }
+
+        return null;
     }
 
     /** @param string|BSONArray[] $expectedType */

--- a/tests/SpecTests/DocumentsMatchConstraint.php
+++ b/tests/SpecTests/DocumentsMatchConstraint.php
@@ -13,7 +13,6 @@ use RuntimeException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory;
 use stdClass;
-use Symfony\Bridge\PhpUnit\ConstraintTrait;
 
 use function array_values;
 use function get_debug_type;
@@ -36,8 +35,6 @@ use function sprintf;
  */
 class DocumentsMatchConstraint extends Constraint
 {
-    use ConstraintTrait;
-
     /**
      * TODO: This is not currently used, but was preserved from the design of
      * TestCase::assertMatchesDocument(), which would sort keys and then compare
@@ -65,7 +62,7 @@ class DocumentsMatchConstraint extends Constraint
         $this->comparatorFactory = Factory::getInstance();
     }
 
-    private function doEvaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         /* TODO: If ignoreExtraKeys and sortKeys are both false, then we may be
          * able to skip preparation, convert both documents to extended JSON,
@@ -198,7 +195,7 @@ class DocumentsMatchConstraint extends Constraint
         }
     }
 
-    private function doAdditionalFailureDescription($other)
+    protected function additionalFailureDescription($other): string
     {
         if ($this->lastFailure === null) {
             return '';
@@ -207,12 +204,12 @@ class DocumentsMatchConstraint extends Constraint
         return $this->lastFailure->getMessage();
     }
 
-    private function doFailureDescription($other)
+    protected function failureDescription($other): string
     {
         return 'two BSON objects are equal';
     }
 
-    private function doMatches($other)
+    protected function matches($other): bool
     {
         /* TODO: If ignoreExtraKeys and sortKeys are both false, then we may be
          * able to skip preparation, convert both documents to extended JSON,
@@ -232,7 +229,7 @@ class DocumentsMatchConstraint extends Constraint
         return true;
     }
 
-    private function doToString()
+    public function toString(): string
     {
         return 'matches ' . $this->exporter()->export($this->value);
     }

--- a/tests/UnifiedSpecTests/Constraint/IsBsonType.php
+++ b/tests/UnifiedSpecTests/Constraint/IsBsonType.php
@@ -23,7 +23,6 @@ use MongoDB\Model\BSONDocument;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\LogicalOr;
 use RuntimeException;
-use Symfony\Bridge\PhpUnit\ConstraintTrait;
 
 use function array_keys;
 use function array_map;
@@ -40,8 +39,6 @@ use function sprintf;
 
 final class IsBsonType extends Constraint
 {
-    use ConstraintTrait;
-
     private static array $types = [
         'double',
         'string',
@@ -88,7 +85,7 @@ final class IsBsonType extends Constraint
         return LogicalOr::fromConstraints(...array_map(fn ($type) => new self($type), $types));
     }
 
-    private function doMatches($other): bool
+    protected function matches($other): bool
     {
         return match ($this->type) {
             'double' => is_float($other),
@@ -118,7 +115,7 @@ final class IsBsonType extends Constraint
         };
     }
 
-    private function doToString(): string
+    public function toString(): string
     {
         return sprintf('is of BSON type "%s"', $this->type);
     }

--- a/tests/UnifiedSpecTests/Constraint/Matches.php
+++ b/tests/UnifiedSpecTests/Constraint/Matches.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\ExpectationFailedException;
 use RuntimeException;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\Comparator\Factory;
-use Symfony\Bridge\PhpUnit\ConstraintTrait;
 
 use function array_keys;
 use function count;
@@ -49,8 +48,6 @@ use function strrchr;
  */
 class Matches extends Constraint
 {
-    use ConstraintTrait;
-
     private mixed $value;
 
     private bool $allowExtraRootKeys;
@@ -69,7 +66,7 @@ class Matches extends Constraint
         $this->comparatorFactory = Factory::getInstance();
     }
 
-    private function doEvaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, $description = '', $returnResult = false): ?bool
     {
         $other = self::prepare($other);
         $success = false;
@@ -321,8 +318,7 @@ class Matches extends Constraint
         throw new LogicException('unsupported operator: ' . $name);
     }
 
-    /** @see ConstraintTrait */
-    private function doAdditionalFailureDescription($other)
+    protected function additionalFailureDescription($other): string
     {
         if ($this->lastFailure === null) {
             return '';
@@ -331,14 +327,12 @@ class Matches extends Constraint
         return $this->lastFailure->getMessage();
     }
 
-    /** @see ConstraintTrait */
-    private function doFailureDescription($other)
+    protected function failureDescription($other): string
     {
         return 'expected value matches actual value';
     }
 
-    /** @see ConstraintTrait */
-    private function doMatches($other)
+    protected function matches($other): bool
     {
         $other = self::prepare($other);
 
@@ -351,8 +345,7 @@ class Matches extends Constraint
         return true;
     }
 
-    /** @see ConstraintTrait */
-    private function doToString()
+    public function toString(): string
     {
         return 'matches ' . $this->exporter()->export($this->value);
     }

--- a/tests/UnifiedSpecTests/Constraint/Matches.php
+++ b/tests/UnifiedSpecTests/Constraint/Matches.php
@@ -101,6 +101,8 @@ class Matches extends Constraint
         if (! $success) {
             $this->fail($other, $description, $this->lastFailure);
         }
+
+        return null;
     }
 
     private function assertEquals($expected, $actual, string $keyPath): void


### PR DESCRIPTION
Fix PHPLIB-1525


> The PHPUnit Bridge provides utilities to report legacy tests and usage of deprecated code and helpers for mocking native functions related to time, DNS and class existence.

We don't use any of this features.

The bridge also helps in maintaining custom constraints compatible with [multiple versions of PHPUnit](https://github.com/symfony/phpunit-bridge/blob/7.0/ConstraintTrait.php), due to type changes between versions 7, 8 and 9. This should longer be required as the [Constraint class](https://github.com/sebastianbergmann/phpunit/blob/9.6/src/Framework/Constraint/Constraint.php#L43) is fully typed.


drivers-atlas-testing will require an update:
- https://github.com/mongodb-labs/drivers-atlas-testing/blob/784b9e5e4656e207003cac7d6bc9dd7a551b800f/integrations/php/install-driver.sh#L85-L86
- https://github.com/mongodb-labs/drivers-atlas-testing/blob/784b9e5e4656e207003cac7d6bc9dd7a551b800f/integrations/php/workload-executor.php#L11