### PR TITLE
PHPLIB-1528 Add traits to implement Command and SDAM subscriber methods

### DIFF
--- a/src/Monitoring/CommandEvents.php
+++ b/src/Monitoring/CommandEvents.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MongoDB\Monitoring;
+
+use MongoDB\Driver\Monitoring\CommandFailedEvent;
+use MongoDB\Driver\Monitoring\CommandStartedEvent;
+use MongoDB\Driver\Monitoring\CommandSubscriber;
+use MongoDB\Driver\Monitoring\CommandSucceededEvent;
+
+/** @see CommandSubscriber */
+trait CommandEvents
+{
+    public function commandFailed(CommandFailedEvent $event): void
+    {
+    }
+
+    public function commandStarted(CommandStartedEvent $event): void
+    {
+    }
+
+    public function commandSucceeded(CommandSucceededEvent $event): void
+    {
+    }
+}

--- a/src/Monitoring/SDAMEvents.php
+++ b/src/Monitoring/SDAMEvents.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace MongoDB\Monitoring;
+
+use MongoDB\Driver\Monitoring\SDAMSubscriber;
+use MongoDB\Driver\Monitoring\ServerChangedEvent;
+use MongoDB\Driver\Monitoring\ServerClosedEvent;
+use MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent;
+use MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent;
+use MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent;
+use MongoDB\Driver\Monitoring\ServerOpeningEvent;
+use MongoDB\Driver\Monitoring\TopologyChangedEvent;
+use MongoDB\Driver\Monitoring\TopologyClosedEvent;
+use MongoDB\Driver\Monitoring\TopologyOpeningEvent;
+
+/** @see SDAMSubscriber */
+trait SDAMEvents
+{
+    public function serverChanged(ServerChangedEvent $event): void
+    {
+    }
+
+    public function serverClosed(ServerClosedEvent $event): void
+    {
+    }
+
+    public function serverHeartbeatFailed(ServerHeartbeatFailedEvent $event): void
+    {
+    }
+
+    public function serverHeartbeatStarted(ServerHeartbeatStartedEvent $event): void
+    {
+    }
+
+    public function serverHeartbeatSucceeded(ServerHeartbeatSucceededEvent $event): void
+    {
+    }
+
+    public function serverOpening(ServerOpeningEvent $event): void
+    {
+    }
+
+    public function topologyChanged(TopologyChangedEvent $event): void
+    {
+    }
+
+    public function topologyClosed(TopologyClosedEvent $event): void
+    {
+    }
+
+    public function topologyOpening(TopologyOpeningEvent $event): void
+    {
+    }
+}

--- a/tests/MonitoringTest.php
+++ b/tests/MonitoringTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace MongoDB\Tests;
+
+use MongoDB\Driver\Monitoring\CommandSubscriber;
+use MongoDB\Driver\Monitoring\SDAMSubscriber;
+use MongoDB\Driver\Monitoring\Subscriber;
+use MongoDB\Monitoring\CommandEvents;
+use MongoDB\Monitoring\SDAMEvents;
+
+use function MongoDB\Driver\Monitoring\addSubscriber;
+use function MongoDB\Driver\Monitoring\removeSubscriber;
+
+class MonitoringTest extends TestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     *
+     * @dataProvider provideSubscribers
+     */
+    public function testSubscriber(Subscriber $subscriber): void
+    {
+        // Fatal error if the trait does not implement all methods required by the interface
+        addSubscriber($subscriber);
+        removeSubscriber($subscriber);
+    }
+
+    public static function provideSubscribers(): iterable
+    {
+        yield 'Command' => [
+            new class implements CommandSubscriber {
+                use CommandEvents;
+            },
+        ];
+
+        yield 'SDAM' => [
+            new class implements SDAMSubscriber {
+                use SDAMEvents;
+            },
+        ];
+    }
+}


### PR DESCRIPTION
Fix PHPLIB-1528

Make it easier to write partial implementations of interfaces `CommandSubscriber` and `SDAMSubscriber`.

Not adding a trait for `LogSubscriber`, as this interface contains only 1 method.