### PR TITLE
PHPLIB-1529 Remove usage of deprecated event getServer

### DIFF
--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -324,7 +324,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
         }
 
         if (
-            $this->shouldCaptureOperationTime($event->getServer()) &&
+            $this->shouldCaptureOperationTime() &&
             isset($reply->operationTime) && $reply->operationTime instanceof TimestampInterface
         ) {
             $this->operationTime = $reply->operationTime;
@@ -445,7 +445,7 @@ class Watch implements Executable, /* @internal */ CommandSubscriber
      *
      * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#startatoperationtime
      */
-    private function shouldCaptureOperationTime(Server $server): bool
+    private function shouldCaptureOperationTime(): bool
     {
         if ($this->hasResumed) {
             return false;


### PR DESCRIPTION
Fix PHPLIB-1529

The method `CommandSucceededEvent::getServer()` is deprecated by https://github.com/mongodb/mongo-php-driver/pull/1652

It is not used since https://github.com/mongodb/mongo-php-library/commit/de3aaf881dcf8a4807529bf9b1ad4d609d101107#diff-97711093784103ece28740e725cc6a5f44bba1a469d5dcb78ef94a85778b3549L473-L476