### PR TITLE
Handle driver deprecation on `Cursor::getId` and `new UTCDateTime(string)`

### DIFF
--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -261,7 +261,7 @@ class ChangeStream implements Iterator
          * have been received in the last response. Therefore, we can unset the
          * resumeCallable. This will free any reference to Watch as well as the
          * only reference to any implicit session created therein. */
-        if ((string) $this->getCursorId() === '0') {
+        if ((string) $this->getCursorId(true) === '0') {
             $this->resumeCallable = null;
         }
 

--- a/tests/GridFS/StreamWrapperFunctionalTest.php
+++ b/tests/GridFS/StreamWrapperFunctionalTest.php
@@ -46,7 +46,7 @@ class StreamWrapperFunctionalTest extends FunctionalTestCase
         parent::setUp();
 
         $this->filesCollection->insertMany([
-            ['_id' => 'length-10', 'length' => 10, 'chunkSize' => 4, 'uploadDate' => new UTCDateTime('1484202200000')],
+            ['_id' => 'length-10', 'length' => 10, 'chunkSize' => 4, 'uploadDate' => new UTCDateTime(1484202200000)],
         ]);
 
         $this->chunksCollection->insertMany([


### PR DESCRIPTION
Handle deprecation from PHPC-2443 and PHPC-2412