### PR TITLE
Fix `CursorId` and `Event::getServer()` deprecation in tests

### DIFF
--- a/tests/Model/CodecCursorFunctionalTest.php
+++ b/tests/Model/CodecCursorFunctionalTest.php
@@ -55,12 +55,15 @@ class CodecCursorFunctionalTest extends FunctionalTestCase
                 E_USER_DEPRECATED | E_DEPRECATED,
             );
 
-            $cursorId = $codecCursor->getId();
+            $cursorId = $codecCursor->getId(true);
         } finally {
             restore_error_handler();
         }
 
-        self::assertInstanceOf(CursorId::class, $cursorId);
+        self::logicalOr(
+            self::isInstanceOf(Int64::class),
+            self::isInstanceOf(CursorId::class),
+        )->matches($cursorId);
 
         // Expect 2 deprecations: 1 from CodecCursor, one from Cursor
         self::assertCount(2, $deprecations);

--- a/tests/Model/CodecCursorFunctionalTest.php
+++ b/tests/Model/CodecCursorFunctionalTest.php
@@ -55,15 +55,12 @@ class CodecCursorFunctionalTest extends FunctionalTestCase
                 E_USER_DEPRECATED | E_DEPRECATED,
             );
 
-            $cursorId = $codecCursor->getId(true);
+            $cursorId = $codecCursor->getId();
         } finally {
             restore_error_handler();
         }
 
-        self::logicalOr(
-            self::isInstanceOf(Int64::class),
-            self::isInstanceOf(CursorId::class),
-        )->matches($cursorId);
+        self::assertInstanceOf(CursorId::class, $cursorId);
 
         // Expect 2 deprecations: 1 from CodecCursor, one from Cursor
         self::assertCount(2, $deprecations);

--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -720,7 +720,7 @@ class WatchFunctionalTest extends FunctionalTestCase
          * reports the cursor as alive. While the cursor ID is accessed through
          * ChangeStream, we'll need to use reflection to access the internal
          * Cursor and call isDead(). */
-        $this->assertNotEquals('0', (string) $changeStream->getCursorId());
+        $this->assertNotEquals('0', (string) $changeStream->getCursorId(true));
 
         $rc = new ReflectionClass(ChangeStream::class);
         $rp = $rc->getProperty('iterator');
@@ -1370,11 +1370,11 @@ class WatchFunctionalTest extends FunctionalTestCase
         }
 
         $changeStream = $operation->execute($secondary);
-        $previousCursorId = $changeStream->getCursorId();
+        $previousCursorId = $changeStream->getCursorId(true);
         $this->forceChangeStreamResume();
 
         $changeStream->next();
-        $this->assertNotSame($previousCursorId, $changeStream->getCursorId());
+        $this->assertNotSame($previousCursorId, $changeStream->getCursorId(true));
 
         $getCursor = Closure::bind(
             fn () => $this->iterator->getInnerIterator(),

--- a/tests/SpecTests/RetryableReads/Prose2_RetryOnMongosTest.php
+++ b/tests/SpecTests/RetryableReads/Prose2_RetryOnMongosTest.php
@@ -65,7 +65,8 @@ class Prose2_RetryOnMongosTest extends FunctionalTestCase
 
         // Step 4: Enable failed command event monitoring for client
         $subscriber = new class implements CommandSubscriber {
-            public $commandFailedServers = [];
+            /** @var int[] */
+            public array $commandFailedServers = [];
 
             public function commandStarted(CommandStartedEvent $event): void
             {
@@ -77,7 +78,7 @@ class Prose2_RetryOnMongosTest extends FunctionalTestCase
 
             public function commandFailed(CommandFailedEvent $event): void
             {
-                $this->commandFailedServers[] = $event->getServer();
+                $this->commandFailedServers[] = $event->getServerConnectionId();
             }
         };
 
@@ -130,8 +131,8 @@ class Prose2_RetryOnMongosTest extends FunctionalTestCase
 
         // Step 4: Enable succeeded and failed command event monitoring
         $subscriber = new class implements CommandSubscriber {
-            public Server $commandSucceededServer;
-            public Server $commandFailedServer;
+            public ?int $commandSucceededServer = null;
+            public ?int $commandFailedServer = null;
 
             public function commandStarted(CommandStartedEvent $event): void
             {
@@ -139,12 +140,12 @@ class Prose2_RetryOnMongosTest extends FunctionalTestCase
 
             public function commandSucceeded(CommandSucceededEvent $event): void
             {
-                $this->commandSucceededServer = $event->getServer();
+                $this->commandSucceededServer = $event->getServerConnectionId();
             }
 
             public function commandFailed(CommandFailedEvent $event): void
             {
-                $this->commandFailedServer = $event->getServer();
+                $this->commandFailedServer = $event->getServerConnectionId();
             }
         };
 

--- a/tests/SpecTests/RetryableReads/Prose2_RetryOnMongosTest.php
+++ b/tests/SpecTests/RetryableReads/Prose2_RetryOnMongosTest.php
@@ -7,7 +7,6 @@ use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
-use MongoDB\Driver\Server;
 use MongoDB\Tests\SpecTests\FunctionalTestCase;
 
 use function assert;

--- a/tests/SpecTests/RetryableWrites/Prose4_RetryOnDifferentMongosTest.php
+++ b/tests/SpecTests/RetryableWrites/Prose4_RetryOnDifferentMongosTest.php
@@ -67,7 +67,8 @@ class Prose4_RetryOnDifferentMongosTest extends FunctionalTestCase
 
         // Step 4: Enable failed command event monitoring for client
         $subscriber = new class implements CommandSubscriber {
-            public $commandFailedServers = [];
+            /** @var int[]  */
+            public array $commandFailedServers = [];
 
             public function commandStarted(CommandStartedEvent $event): void
             {
@@ -79,7 +80,7 @@ class Prose4_RetryOnDifferentMongosTest extends FunctionalTestCase
 
             public function commandFailed(CommandFailedEvent $event): void
             {
-                $this->commandFailedServers[] = $event->getServer();
+                $this->commandFailedServers[] = $event->getServerConnectionId();
             }
         };
 

--- a/tests/SpecTests/RetryableWrites/Prose5_RetryOnSameMongosTest.php
+++ b/tests/SpecTests/RetryableWrites/Prose5_RetryOnSameMongosTest.php
@@ -6,7 +6,6 @@ use MongoDB\Driver\Monitoring\CommandFailedEvent;
 use MongoDB\Driver\Monitoring\CommandStartedEvent;
 use MongoDB\Driver\Monitoring\CommandSubscriber;
 use MongoDB\Driver\Monitoring\CommandSucceededEvent;
-use MongoDB\Driver\Server;
 use MongoDB\Tests\SpecTests\FunctionalTestCase;
 
 /**

--- a/tests/SpecTests/RetryableWrites/Prose5_RetryOnSameMongosTest.php
+++ b/tests/SpecTests/RetryableWrites/Prose5_RetryOnSameMongosTest.php
@@ -50,8 +50,8 @@ class Prose5_RetryOnSameMongosTest extends FunctionalTestCase
 
         // Step 4: Enable succeeded and failed command event monitoring
         $subscriber = new class implements CommandSubscriber {
-            public Server $commandSucceededServer;
-            public Server $commandFailedServer;
+            public ?int $commandSucceededServer = null;
+            public ?int $commandFailedServer = null;
 
             public function commandStarted(CommandStartedEvent $event): void
             {
@@ -59,12 +59,12 @@ class Prose5_RetryOnSameMongosTest extends FunctionalTestCase
 
             public function commandSucceeded(CommandSucceededEvent $event): void
             {
-                $this->commandSucceededServer = $event->getServer();
+                $this->commandSucceededServer = $event->getServerConnectionId();
             }
 
             public function commandFailed(CommandFailedEvent $event): void
             {
-                $this->commandFailedServer = $event->getServer();
+                $this->commandFailedServer = $event->getServerConnectionId();
             }
         };
 
@@ -78,7 +78,7 @@ class Prose5_RetryOnSameMongosTest extends FunctionalTestCase
 
         /* Step 6: Assert that exactly one failed command event and one
          * succeeded command event occurred. Assert that both events occurred on
-         * the same mongos. */
+         * the same mongos connection. */
         $this->assertNotNull($subscriber->commandSucceededServer);
         $this->assertNotNull($subscriber->commandFailedServer);
         $this->assertEquals($subscriber->commandSucceededServer, $subscriber->commandFailedServer);

--- a/tests/UnifiedSpecTests/EventCollector.php
+++ b/tests/UnifiedSpecTests/EventCollector.php
@@ -120,7 +120,7 @@ final class EventCollector implements CommandSubscriber
             'name' => self::getEventName($event),
             'observedAt' => microtime(true),
             'commandName' => $event->getCommandName(),
-            'connectionId' => self::getConnectionId($event),
+            'connectionId' => $event->getServerConnectionId(),
             'requestId' => $event->getRequestId(),
             'operationId' => $event->getOperationId(),
         ];
@@ -142,14 +142,6 @@ final class EventCollector implements CommandSubscriber
         }
 
         $this->eventList[] = $log;
-    }
-
-    /** @param CommandStartedEvent|CommandSucceededEvent|CommandFailedEvent $event */
-    private static function getConnectionId($event): string
-    {
-        $server = $event->getServer();
-
-        return sprintf('%s:%d', $server->getHost(), $server->getPort());
     }
 
     private static function getEventName(object $event): string

--- a/tests/UnifiedSpecTests/EventCollector.php
+++ b/tests/UnifiedSpecTests/EventCollector.php
@@ -18,7 +18,6 @@ use function PHPUnit\Framework\assertArrayHasKey;
 use function PHPUnit\Framework\assertIsObject;
 use function PHPUnit\Framework\assertIsString;
 use function PHPUnit\Framework\assertNotEmpty;
-use function sprintf;
 
 /**
  * EventCollector handles "storeEventsAsEntities" for client entities.


### PR DESCRIPTION
Related to https://github.com/mongodb/mongo-php-library/pull/1366