### PR TITLE
Remove compatibility layer for CursorId deprecation

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,11 +5,7 @@
       <code><![CDATA[$document['name']]]></code>
       <code><![CDATA[$index->name]]></code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$document['name']]]></code>
-    </MixedArrayAccess>
     <MixedAssignment>
-      <code><![CDATA[$document]]></code>
       <code><![CDATA[$index]]></code>
       <code><![CDATA[$index]]></code>
       <code><![CDATA[$index]]></code>
@@ -23,6 +19,9 @@
     <PossiblyFalseArgument>
       <code><![CDATA[$uri]]></code>
     </PossiblyFalseArgument>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[$document['name']]]></code>
+    </PossiblyInvalidArrayAccess>
   </file>
   <file src="examples/persistable.php">
     <LessSpecificReturnStatement>
@@ -184,9 +183,6 @@
     <DeprecatedConstant>
       <code><![CDATA[self::CURSOR_NOT_FOUND]]></code>
     </DeprecatedConstant>
-    <TooManyArguments>
-      <code><![CDATA[getId]]></code>
-    </TooManyArguments>
   </file>
   <file src="src/Client.php">
     <MixedArgument>
@@ -339,6 +335,15 @@
     </MixedArgument>
   </file>
   <file src="src/Model/ChangeStreamIterator.php">
+    <InvalidReturnStatement>
+      <code><![CDATA[$cursor]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[CursorInterface<TValue>]]></code>
+    </InvalidReturnType>
+    <LessSpecificImplementedReturnType>
+      <code><![CDATA[CursorInterface<TValue>]]></code>
+    </LessSpecificImplementedReturnType>
     <MixedArgument>
       <code><![CDATA[$reply->cursor->nextBatch]]></code>
     </MixedArgument>
@@ -353,11 +358,6 @@
     <PossiblyNullArgument>
       <code><![CDATA[$this->current()]]></code>
     </PossiblyNullArgument>
-  </file>
-  <file src="src/Model/CodecCursor.php">
-    <TooManyArguments>
-      <code><![CDATA[getId]]></code>
-    </TooManyArguments>
   </file>
   <file src="src/Model/CollectionInfoCommandIterator.php">
     <MixedArrayAssignment>
@@ -711,18 +711,6 @@
       <code><![CDATA[$value === null ? $value : $this->options['codec']->decode($value)]]></code>
       <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
       <code><![CDATA[is_object($result) ? ($result->value ?? null) : null]]></code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/Operation/FindOne.php">
-    <MixedAssignment>
-      <code><![CDATA[$document]]></code>
-    </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[array|object|null]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$document === false ? null : $document]]></code>
-      <code><![CDATA[$document === false ? null : $document]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Operation/FindOneAndDelete.php">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -21,6 +21,8 @@
         <file name="stubs/BSON/Document.stub.php"/>
         <file name="stubs/BSON/Iterator.stub.php"/>
         <file name="stubs/BSON/PackedArray.stub.php"/>
+        <file name="stubs/Driver/Cursor.stub.php"/>
+        <file name="stubs/Driver/CursorInterface.stub.php"/>
     </stubs>
 
     <issueHandlers>

--- a/src/Model/CodecCursor.php
+++ b/src/Model/CodecCursor.php
@@ -17,30 +17,24 @@
 
 namespace MongoDB\Model;
 
-use Iterator;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
 use MongoDB\Codec\DocumentCodec;
-use MongoDB\Driver\Cursor;
-use MongoDB\Driver\CursorId;
 use MongoDB\Driver\CursorInterface;
 use MongoDB\Driver\Server;
-use ReturnTypeWillChange;
 
 use function assert;
 use function iterator_to_array;
 use function sprintf;
 use function trigger_error;
 
-use const E_USER_DEPRECATED;
 use const E_USER_WARNING;
 
 /**
  * @template TValue of object
- * @template-implements CursorInterface<int, TValue>
- * @template-implements Iterator<int, TValue>
+ * @template-implements CursorInterface<TValue>
  */
-class CodecCursor implements CursorInterface, Iterator
+class CodecCursor implements CursorInterface
 {
     private const TYPEMAP = ['root' => 'bson'];
 
@@ -64,33 +58,16 @@ class CodecCursor implements CursorInterface, Iterator
      * @param DocumentCodec<NativeClass> $codec
      * @return self<NativeClass>
      */
-    public static function fromCursor(Cursor $cursor, DocumentCodec $codec): self
+    public static function fromCursor(CursorInterface $cursor, DocumentCodec $codec): self
     {
         $cursor->setTypeMap(self::TYPEMAP);
 
         return new self($cursor, $codec);
     }
 
-    /**
-     * @return CursorId|Int64
-     * @psalm-return ($asInt64 is true ? Int64 : CursorId)
-     */
-    #[ReturnTypeWillChange]
-    public function getId(bool $asInt64 = false)
+    public function getId(): Int64
     {
-        if (! $asInt64) {
-            @trigger_error(
-                sprintf(
-                    'The method "%s" will no longer return a "%s" instance in the future. Pass "true" as argument to change to the new behavior and receive a "%s" instance instead.',
-                    __METHOD__,
-                    CursorId::class,
-                    Int64::class,
-                ),
-                E_USER_DEPRECATED,
-            );
-        }
-
-        return $this->cursor->getId($asInt64);
+        return $this->cursor->getId();
     }
 
     public function getServer(): Server
@@ -138,7 +115,7 @@ class CodecCursor implements CursorInterface, Iterator
     }
 
     /** @param DocumentCodec<TValue> $codec */
-    private function __construct(private Cursor $cursor, private DocumentCodec $codec)
+    private function __construct(private CursorInterface $cursor, private DocumentCodec $codec)
     {
     }
 }

--- a/stubs/Driver/Cursor.stub.php
+++ b/stubs/Driver/Cursor.stub.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace MongoDB\Driver;
+
+/**
+ * @template-covariant TValue of array|object
+ *
+ * @template-implements CursorInterface<TValue>
+ */
+final class Cursor implements CursorInterface
+{
+    /**
+     * @return TValue|null
+     * @psalm-ignore-nullable-return
+     */
+    public function current(): array|object|null
+    {
+    }
+
+    public function next(): void
+    {
+    }
+
+    /** @psalm-ignore-nullable-return */
+    public function key(): ?int
+    {
+    }
+
+    public function valid(): bool
+    {
+    }
+
+    public function rewind(): void
+    {
+    }
+
+    /** @return array<TValue> */
+    public function toArray(): array
+    {
+    }
+}

--- a/stubs/Driver/CursorInterface.stub.php
+++ b/stubs/Driver/CursorInterface.stub.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MongoDB\Driver;
+
+use Iterator;
+
+/**
+ * @template TValue of array|object
+ * @template-implements Iterator<int, TValue>
+ */
+interface CursorInterface extends Iterator
+{
+    /**
+     * @return TValue|null
+     * @psalm-ignore-nullable-return
+     */
+    public function current(): array|object|null;
+
+    public function getId(): \MongoDB\BSON\Int64;
+
+    public function getServer(): Server;
+
+    public function isDead(): bool;
+
+    /** @psalm-ignore-nullable-return */
+    public function key(): ?int;
+
+    public function setTypeMap(array $typemap): void;
+
+    /** @return array<TValue> */
+    public function toArray(): array;
+}

--- a/tests/Model/CodecCursorFunctionalTest.php
+++ b/tests/Model/CodecCursorFunctionalTest.php
@@ -4,15 +4,8 @@ namespace MongoDB\Tests\Model;
 
 use MongoDB\BSON\Int64;
 use MongoDB\Codec\DocumentCodec;
-use MongoDB\Driver\CursorId;
 use MongoDB\Model\CodecCursor;
 use MongoDB\Tests\FunctionalTestCase;
-
-use function restore_error_handler;
-use function set_error_handler;
-
-use const E_DEPRECATED;
-use const E_USER_DEPRECATED;
 
 class CodecCursorFunctionalTest extends FunctionalTestCase
 {
@@ -36,44 +29,6 @@ class CodecCursorFunctionalTest extends FunctionalTestCase
         $codecCursor->setTypeMap(['root' => 'array']);
     }
 
-    public function testGetIdReturnTypeWithoutArgument(): void
-    {
-        $collection = self::createTestClient()->selectCollection($this->getDatabaseName(), $this->getCollectionName());
-        $cursor = $collection->find();
-
-        $codecCursor = CodecCursor::fromCursor($cursor, $this->createMock(DocumentCodec::class));
-
-        $deprecations = [];
-
-        try {
-            $previousErrorHandler = set_error_handler(
-                function (...$args) use (&$previousErrorHandler, &$deprecations) {
-                    $deprecations[] = $args;
-
-                    return true;
-                },
-                E_USER_DEPRECATED | E_DEPRECATED,
-            );
-
-            $cursorId = $codecCursor->getId();
-        } finally {
-            restore_error_handler();
-        }
-
-        self::assertInstanceOf(CursorId::class, $cursorId);
-
-        // Expect 2 deprecations: 1 from CodecCursor, one from Cursor
-        self::assertCount(2, $deprecations);
-        self::assertSame(
-            'The method "MongoDB\Model\CodecCursor::getId" will no longer return a "MongoDB\Driver\CursorId" instance in the future. Pass "true" as argument to change to the new behavior and receive a "MongoDB\BSON\Int64" instance instead.',
-            $deprecations[0][1],
-        );
-        self::assertSame(
-            'MongoDB\Driver\Cursor::getId(): The method "MongoDB\Driver\Cursor::getId" will no longer return a "MongoDB\Driver\CursorId" instance in the future. Pass "true" as argument to change to the new behavior and receive a "MongoDB\BSON\Int64" instance instead.',
-            $deprecations[1][1],
-        );
-    }
-
     public function testGetIdReturnTypeWithArgument(): void
     {
         $collection = self::createTestClient()->selectCollection($this->getDatabaseName(), $this->getCollectionName());
@@ -81,24 +36,6 @@ class CodecCursorFunctionalTest extends FunctionalTestCase
 
         $codecCursor = CodecCursor::fromCursor($cursor, $this->createMock(DocumentCodec::class));
 
-        $deprecations = [];
-
-        try {
-            $previousErrorHandler = set_error_handler(
-                function (...$args) use (&$previousErrorHandler, &$deprecations) {
-                    $deprecations[] = $args;
-
-                    return true;
-                },
-                E_USER_DEPRECATED | E_DEPRECATED,
-            );
-
-            $cursorId = $codecCursor->getId(true);
-        } finally {
-            restore_error_handler();
-        }
-
-        self::assertInstanceOf(Int64::class, $cursorId);
-        self::assertCount(0, $deprecations);
+        self::assertInstanceOf(Int64::class, $codecCursor->getId());
     }
 }


### PR DESCRIPTION
This pull request removes the compatibility layer introduced to handle the deprecation of `MongoDB\Driver\CursorId`. To work around psalm not having updated stubs, we introduce stubs temporarily until the stubs are properly updated.

Note that due to an issue in psalm, we still need a workaround for `ChangeStreamIterator::getInnerIterator`. I've created https://github.com/vimeo/psalm/pull/11100 to fix this issue, and the errors are suppressed in the baseline until a fix is released.