### PR TITLE
Change deprecated `assertObjectHasAttribute` to `assertObjectHasProperty`

### DIFF
--- a/tests/UnifiedSpecTests/ManagesFailPointsTrait.php
+++ b/tests/UnifiedSpecTests/ManagesFailPointsTrait.php
@@ -7,7 +7,7 @@ use MongoDB\Operation\DatabaseCommand;
 use stdClass;
 
 use function PHPUnit\Framework\assertIsString;
-use function PHPUnit\Framework\assertObjectHasAttribute;
+use function PHPUnit\Framework\assertObjectHasProperty;
 
 trait ManagesFailPointsTrait
 {
@@ -16,9 +16,9 @@ trait ManagesFailPointsTrait
 
     public function configureFailPoint(stdClass $failPoint, Server $server): void
     {
-        assertObjectHasAttribute('configureFailPoint', $failPoint);
+        assertObjectHasProperty('configureFailPoint', $failPoint);
         assertIsString($failPoint->configureFailPoint);
-        assertObjectHasAttribute('mode', $failPoint);
+        assertObjectHasProperty('mode', $failPoint);
 
         $operation = new DatabaseCommand('admin', $failPoint);
         $operation->execute($server);


### PR DESCRIPTION
Same as https://github.com/mongodb/mongo-php-library/pull/1405

This one was added by https://github.com/mongodb/mongo-php-library/commit/90dcf186c8664a2cdd57314122d46b16234555c2#diff-d75f68825f84c12ffab0646e1c1f085cf762f0ee3054e0e4f76f600d6114bc27R10