### PR TITLE
PHPLIB-797: Remove unused methods in UnsupportedException

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -28,3 +28,18 @@ GridFS
    ```php
    $bucket->openUploadStream($fileId, ['metadata' => ['contentType' => 'image/png']]);
    ```
+
+UnsupportedException method removals
+------------------------------------
+
+The following methods have been removed from the
+`MongoDB\Exception\UnsupportedException` class:
+ * `allowDiskUseNotSupported`
+ * `arrayFiltersNotSupported`
+ * `collationNotSupported`
+ * `explainNotSupported`
+ * `readConcernNotSupported`
+ * `writeConcernNotSupported`
+
+The remaining methods have been marked as internal and may be removed in a
+future minor version. Only the class itself is covered by the BC promise.

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -28,6 +28,7 @@ class BadMethodCallException extends BaseBadMethodCallException implements Excep
      *
      * @param string $class Class name
      * @return self
+     * @internal
      */
     public static function classIsImmutable(string $class)
     {
@@ -39,6 +40,7 @@ class BadMethodCallException extends BaseBadMethodCallException implements Excep
      *
      * @param string $method Method name
      * @return self
+     * @internal
      */
     public static function unacknowledgedWriteResultAccess(string $method)
     {

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -29,6 +29,7 @@ use function sprintf;
 
 class InvalidArgumentException extends DriverInvalidArgumentException implements Exception
 {
+    /** @internal */
     public static function cannotCombineCodecAndTypeMap(): self
     {
         return new self('Cannot provide both "codec" and "typeMap" options');
@@ -39,6 +40,7 @@ class InvalidArgumentException extends DriverInvalidArgumentException implements
      *
      * @param string $name  Name of the argument or option
      * @param mixed  $value Actual value (used to derive the type)
+     * @internal
      */
     public static function expectedDocumentType(string $name, mixed $value): self
     {
@@ -52,6 +54,7 @@ class InvalidArgumentException extends DriverInvalidArgumentException implements
      * @param mixed               $value        Actual value (used to derive the type)
      * @param string|list<string> $expectedType Expected type as a string or an array containing one or more strings
      * @return self
+     * @internal
      */
     public static function invalidType(string $name, mixed $value, string|array $expectedType)
     {

--- a/src/Exception/ResumeTokenException.php
+++ b/src/Exception/ResumeTokenException.php
@@ -27,6 +27,7 @@ class ResumeTokenException extends RuntimeException
      *
      * @param mixed $value Actual value (used to derive the type)
      * @return self
+     * @internal
      */
     public static function invalidType(mixed $value)
     {
@@ -37,6 +38,7 @@ class ResumeTokenException extends RuntimeException
      * Thrown when a resume token is not found in a change document.
      *
      * @return self
+     * @internal
      */
     public static function notFound()
     {

--- a/src/Exception/UnsupportedException.php
+++ b/src/Exception/UnsupportedException.php
@@ -24,6 +24,7 @@ class UnsupportedException extends RuntimeException
      * by a server.
      *
      * @return self
+     * @internal
      */
     public static function commitQuorumNotSupported()
     {
@@ -34,6 +35,7 @@ class UnsupportedException extends RuntimeException
      * Thrown when a command's hint option is not supported by a server.
      *
      * @return self
+     * @internal
      */
     public static function hintNotSupported()
     {
@@ -44,6 +46,7 @@ class UnsupportedException extends RuntimeException
      * Thrown when a readConcern is used with a read operation in a transaction.
      *
      * @return self
+     * @internal
      */
     public static function readConcernNotSupportedInTransaction()
     {
@@ -54,6 +57,7 @@ class UnsupportedException extends RuntimeException
      * Thrown when a writeConcern is used with a write operation in a transaction.
      *
      * @return self
+     * @internal
      */
     public static function writeConcernNotSupportedInTransaction()
     {

--- a/src/Exception/UnsupportedException.php
+++ b/src/Exception/UnsupportedException.php
@@ -20,42 +20,6 @@ namespace MongoDB\Exception;
 class UnsupportedException extends RuntimeException
 {
     /**
-     * Thrown when a command's allowDiskUse option is not supported by a server.
-     *
-     * @return self
-     */
-    public static function allowDiskUseNotSupported()
-    {
-        return new self('The "allowDiskUse" option is not supported by the server executing this operation');
-    }
-
-    /**
-     * Thrown when array filters are not supported by a server.
-     *
-     * @deprecated 1.12
-     * @todo Remove this in 2.0 (see: PHPLIB-797)
-     *
-     * @return self
-     */
-    public static function arrayFiltersNotSupported()
-    {
-        return new self('Array filters are not supported by the server executing this operation');
-    }
-
-    /**
-     * Thrown when collations are not supported by a server.
-     *
-     * @deprecated 1.12
-     * @todo Remove this in 2.0 (see: PHPLIB-797)
-     *
-     * @return self
-     */
-    public static function collationNotSupported()
-    {
-        return new self('Collations are not supported by the server executing this operation');
-    }
-
-    /**
      * Thrown when the commitQuorum option for createIndexes is not supported
      * by a server.
      *
@@ -64,16 +28,6 @@ class UnsupportedException extends RuntimeException
     public static function commitQuorumNotSupported()
     {
         return new self('The "commitQuorum" option is not supported by the server executing this operation');
-    }
-
-    /**
-     * Thrown when explain is not supported by a server.
-     *
-     * @return self
-     */
-    public static function explainNotSupported()
-    {
-        return new self('Explain is not supported by the server executing this operation');
     }
 
     /**
@@ -87,16 +41,6 @@ class UnsupportedException extends RuntimeException
     }
 
     /**
-     * Thrown when a command's readConcern option is not supported by a server.
-     *
-     * @return self
-     */
-    public static function readConcernNotSupported()
-    {
-        return new self('Read concern is not supported by the server executing this command');
-    }
-
-    /**
      * Thrown when a readConcern is used with a read operation in a transaction.
      *
      * @return self
@@ -104,16 +48,6 @@ class UnsupportedException extends RuntimeException
     public static function readConcernNotSupportedInTransaction()
     {
         return new self('The "readConcern" option cannot be specified within a transaction. Instead, specify it when starting the transaction.');
-    }
-
-    /**
-     * Thrown when a command's writeConcern option is not supported by a server.
-     *
-     * @return self
-     */
-    public static function writeConcernNotSupported()
-    {
-        return new self('Write concern is not supported by the server executing this command');
     }
 
     /**

--- a/src/GridFS/Exception/CorruptFileException.php
+++ b/src/GridFS/Exception/CorruptFileException.php
@@ -25,6 +25,8 @@ class CorruptFileException extends RuntimeException
 {
     /**
      * Thrown when a chunk doesn't contain valid data.
+     *
+     * @internal
      */
     public static function invalidChunkData(int $chunkIndex): self
     {
@@ -36,6 +38,7 @@ class CorruptFileException extends RuntimeException
      *
      * @param integer $expectedIndex Expected index number
      * @return self
+     * @internal
      */
     public static function missingChunk(int $expectedIndex)
     {
@@ -48,6 +51,7 @@ class CorruptFileException extends RuntimeException
      * @param integer $index         Actual index number (i.e. "n" field)
      * @param integer $expectedIndex Expected index number
      * @return self
+     * @internal
      */
     public static function unexpectedIndex(int $index, int $expectedIndex)
     {
@@ -60,6 +64,7 @@ class CorruptFileException extends RuntimeException
      * @param integer $size         Actual size (i.e. "data" field length)
      * @param integer $expectedSize Expected size
      * @return self
+     * @internal
      */
     public static function unexpectedSize(int $size, int $expectedSize)
     {

--- a/src/GridFS/Exception/FileNotFoundException.php
+++ b/src/GridFS/Exception/FileNotFoundException.php
@@ -29,6 +29,7 @@ class FileNotFoundException extends RuntimeException
      *
      * @param string $filename Filename
      * @return self
+     * @internal
      */
     public static function byFilename(string $filename)
     {
@@ -42,6 +43,7 @@ class FileNotFoundException extends RuntimeException
      * @param integer $revision  Revision
      * @param string  $namespace Namespace for the files collection
      * @return self
+     * @internal
      */
     public static function byFilenameAndRevision(string $filename, int $revision, string $namespace)
     {
@@ -54,6 +56,7 @@ class FileNotFoundException extends RuntimeException
      * @param mixed  $id        File ID
      * @param string $namespace Namespace for the files collection
      * @return self
+     * @internal
      */
     public static function byId(mixed $id, string $namespace)
     {

--- a/src/GridFS/Exception/StreamException.php
+++ b/src/GridFS/Exception/StreamException.php
@@ -13,6 +13,7 @@ class StreamException extends RuntimeException
     /**
      * @param resource $source
      * @param resource $destination
+     * @internal
      */
     public static function downloadFromFilenameFailed(string $filename, $source, $destination): self
     {
@@ -25,6 +26,7 @@ class StreamException extends RuntimeException
     /**
      * @param resource $source
      * @param resource $destination
+     * @internal
      */
     public static function downloadFromIdFailed(mixed $id, $source, $destination): self
     {
@@ -35,7 +37,10 @@ class StreamException extends RuntimeException
         return new self(sprintf('Downloading file from "%s" to "%s" failed. GridFS identifier: "%s"', $sourceMetadata['uri'], $destinationMetadata['uri'], $idString));
     }
 
-    /** @param resource $source */
+    /**
+     * @param resource $source
+     * @internal
+     */
     public static function uploadFailed(string $filename, $source, string $destinationUri): self
     {
         $sourceMetadata = stream_get_meta_data($source);


### PR DESCRIPTION
PHPLIB-797

In addition to the ask in the ticket, I've marked the remaining factory methods in the class as internal, meaning that we can remove them in a future minor version once they are no longer necessary. The class itself is covered by the BC promise, but the factories are only for internal use and shouldn't be called by users.

I can revert that change if there's disagreement.