### PR TITLE
PHPLIB-1522: Deprecate info iterators

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -150,6 +150,9 @@
     </TooManyArguments>
   </file>
   <file src="src/Model/CollectionInfoCommandIterator.php">
+    <DeprecatedInterface>
+      <code><![CDATA[CollectionInfoCommandIterator]]></code>
+    </DeprecatedInterface>
     <MixedArrayAssignment>
       <code><![CDATA[$info['idIndex']['ns']]]></code>
     </MixedArrayAssignment>
@@ -158,6 +161,9 @@
     </MixedOperand>
   </file>
   <file src="src/Model/DatabaseInfoLegacyIterator.php">
+    <DeprecatedInterface>
+      <code><![CDATA[DatabaseInfoLegacyIterator]]></code>
+    </DeprecatedInterface>
     <MixedArgument>
       <code><![CDATA[current($this->databases)]]></code>
     </MixedArgument>
@@ -165,6 +171,11 @@
       <code><![CDATA[int]]></code>
       <code><![CDATA[key($this->databases)]]></code>
     </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/Model/IndexInfoIteratorIterator.php">
+    <DeprecatedInterface>
+      <code><![CDATA[IndexInfoIteratorIterator]]></code>
+    </DeprecatedInterface>
   </file>
   <file src="src/Model/IndexInput.php">
     <LessSpecificReturnStatement>
@@ -553,7 +564,22 @@
       <code><![CDATA[$document]]></code>
     </PossiblyInvalidArgument>
   </file>
+  <file src="src/Operation/ListCollections.php">
+    <DeprecatedClass>
+      <code><![CDATA[new CollectionInfoCommandIterator($this->listCollections->execute($server), $this->databaseName)]]></code>
+    </DeprecatedClass>
+  </file>
+  <file src="src/Operation/ListDatabases.php">
+    <DeprecatedClass>
+      <code><![CDATA[new DatabaseInfoLegacyIterator($this->listDatabases->execute($server))]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Operation/ListIndexes.php">
+    <DeprecatedClass>
+      <code><![CDATA[IndexInfoIteratorIterator]]></code>
+      <code><![CDATA[new IndexInfoIteratorIterator($iterator, $this->databaseName . '.' . $this->collectionName)]]></code>
+      <code><![CDATA[new IndexInfoIteratorIterator(new EmptyIterator())]]></code>
+    </DeprecatedClass>
     <MixedAssignment>
       <code><![CDATA[$cmd[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,7 +33,6 @@ use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
-use MongoDB\Model\DatabaseInfoIterator;
 use MongoDB\Operation\DropDatabase;
 use MongoDB\Operation\ListDatabaseNames;
 use MongoDB\Operation\ListDatabases;
@@ -294,7 +293,7 @@ class Client
      * List databases.
      *
      * @see ListDatabases::__construct() for supported options
-     * @return DatabaseInfoIterator
+     * @return Iterator
      * @throws UnexpectedValueException if the command response was malformed
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Client.php
+++ b/src/Client.php
@@ -33,6 +33,7 @@ use MongoDB\Exception\UnexpectedValueException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
+use MongoDB\Model\DatabaseInfo;
 use MongoDB\Operation\DropDatabase;
 use MongoDB\Operation\ListDatabaseNames;
 use MongoDB\Operation\ListDatabases;
@@ -293,7 +294,7 @@ class Client
      * List databases.
      *
      * @see ListDatabases::__construct() for supported options
-     * @return Iterator
+     * @return Iterator<int, DatabaseInfo>
      * @throws UnexpectedValueException if the command response was malformed
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -881,7 +881,7 @@ class Collection
      * Returns information for all indexes for the collection.
      *
      * @see ListIndexes::__construct() for supported options
-     * @return Iterator
+     * @return Iterator<int, IndexInfo>
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -33,7 +33,6 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Model\IndexInfo;
-use MongoDB\Model\IndexInfoIterator;
 use MongoDB\Operation\Aggregate;
 use MongoDB\Operation\BulkWrite;
 use MongoDB\Operation\Count;
@@ -882,7 +881,7 @@ class Collection
      * Returns information for all indexes for the collection.
      *
      * @see ListIndexes::__construct() for supported options
-     * @return IndexInfoIterator
+     * @return Iterator
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Database.php
+++ b/src/Database.php
@@ -32,7 +32,6 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\GridFS\Bucket;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
-use MongoDB\Model\CollectionInfoIterator;
 use MongoDB\Operation\Aggregate;
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\CreateEncryptedCollection;
@@ -473,7 +472,7 @@ class Database
      * Returns information for all collections in this database.
      *
      * @see ListCollections::__construct() for supported options
-     * @return CollectionInfoIterator
+     * @return Iterator
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Database.php
+++ b/src/Database.php
@@ -32,6 +32,7 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\GridFS\Bucket;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
+use MongoDB\Model\CollectionInfo;
 use MongoDB\Operation\Aggregate;
 use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\CreateEncryptedCollection;
@@ -472,7 +473,7 @@ class Database
      * Returns information for all collections in this database.
      *
      * @see ListCollections::__construct() for supported options
-     * @return Iterator
+     * @return Iterator<int, CollectionInfo>
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Model/CollectionInfoCommandIterator.php
+++ b/src/Model/CollectionInfoCommandIterator.php
@@ -30,6 +30,7 @@ use Traversable;
  * @see \MongoDB\Database::listCollections()
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-collections.rst
  * @see https://mongodb.com/docs/manual/reference/command/listCollections/
+ * @deprecated
  * @template-extends IteratorIterator<int, array, Traversable<int, array>>
  */
 class CollectionInfoCommandIterator extends IteratorIterator implements CollectionInfoIterator

--- a/src/Model/CollectionInfoIterator.php
+++ b/src/Model/CollectionInfoIterator.php
@@ -26,6 +26,7 @@ use ReturnTypeWillChange;
  * This iterator is used for enumerating collections in a database.
  *
  * @see \MongoDB\Database::listCollections()
+ * @deprecated
  * @template-extends Iterator<int, CollectionInfo>
  */
 interface CollectionInfoIterator extends Iterator

--- a/src/Model/DatabaseInfoIterator.php
+++ b/src/Model/DatabaseInfoIterator.php
@@ -26,6 +26,7 @@ use ReturnTypeWillChange;
  * This iterator is used for enumerating databases on a server.
  *
  * @see \MongoDB\Client::listDatabases()
+ * @deprecated
  * @template-extends Iterator<int, DatabaseInfo>
  */
 interface DatabaseInfoIterator extends Iterator

--- a/src/Model/DatabaseInfoLegacyIterator.php
+++ b/src/Model/DatabaseInfoLegacyIterator.php
@@ -31,6 +31,7 @@ use function reset;
  * @internal
  * @see \MongoDB\Client::listDatabases()
  * @see https://mongodb.com/docs/manual/reference/command/listDatabases/
+ * @deprecated
  */
 class DatabaseInfoLegacyIterator implements DatabaseInfoIterator
 {

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -96,10 +96,14 @@ class IndexInfo implements ArrayAccess
     /**
      * Return the index namespace (e.g. "db.collection").
      *
+     * @deprecated
+     *
      * @return string
      */
     public function getNamespace()
     {
+        @trigger_error('MongoDB 4.4 drops support for the namespace in indexes, the method "IndexInfo::getNamespace()" will be removed in a future release', E_USER_DEPRECATED);
+
         return (string) $this->info['ns'];
     }
 
@@ -131,7 +135,7 @@ class IndexInfo implements ArrayAccess
      */
     public function isGeoHaystack()
     {
-        trigger_error('MongoDB 5.0 removes support for "geoHaystack" indexes, the method "IndexInfo::isGeoHaystack()" will be removed in a future release', E_USER_DEPRECATED);
+        @trigger_error('MongoDB 5.0 removes support for "geoHaystack" indexes, the method "IndexInfo::isGeoHaystack()" will be removed in a future release', E_USER_DEPRECATED);
 
         return array_search('geoHaystack', $this->getKey(), true) !== false;
     }

--- a/src/Model/IndexInfoIterator.php
+++ b/src/Model/IndexInfoIterator.php
@@ -26,6 +26,7 @@ use ReturnTypeWillChange;
  * This iterator is used for enumerating indexes in a collection.
  *
  * @see \MongoDB\Collection::listIndexes()
+ * @deprecated
  * @template-extends Iterator<int, IndexInfo>
  */
 interface IndexInfoIterator extends Iterator

--- a/src/Model/IndexInfoIteratorIterator.php
+++ b/src/Model/IndexInfoIteratorIterator.php
@@ -34,6 +34,7 @@ use function array_key_exists;
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst
  * @see https://mongodb.com/docs/manual/reference/command/listIndexes/
  * @see https://mongodb.com/docs/manual/reference/system-collections/
+ * @deprecated
  * @template-extends IteratorIterator<int, array, Traversable<int, array>>
  */
 class IndexInfoIteratorIterator extends IteratorIterator implements IndexInfoIterator

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -17,12 +17,12 @@
 
 namespace MongoDB\Operation;
 
+use Iterator;
 use MongoDB\Command\ListCollections as ListCollectionsCommand;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\CollectionInfoCommandIterator;
-use MongoDB\Model\CollectionInfoIterator;
 
 /**
  * Operation for the listCollections command.
@@ -71,7 +71,7 @@ class ListCollections implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return CollectionInfoIterator
+     * @return Iterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)

--- a/src/Operation/ListCollections.php
+++ b/src/Operation/ListCollections.php
@@ -22,6 +22,7 @@ use MongoDB\Command\ListCollections as ListCollectionsCommand;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\CollectionInfo;
 use MongoDB\Model\CollectionInfoCommandIterator;
 
 /**
@@ -71,7 +72,7 @@ class ListCollections implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return Iterator
+     * @return Iterator<int, CollectionInfo>
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -17,12 +17,12 @@
 
 namespace MongoDB\Operation;
 
+use Iterator;
 use MongoDB\Command\ListDatabases as ListDatabasesCommand;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
-use MongoDB\Model\DatabaseInfoIterator;
 use MongoDB\Model\DatabaseInfoLegacyIterator;
 
 /**
@@ -68,7 +68,7 @@ class ListDatabases implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return DatabaseInfoIterator
+     * @return Iterator
      * @throws UnexpectedValueException if the command response was malformed
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Operation/ListDatabases.php
+++ b/src/Operation/ListDatabases.php
@@ -23,6 +23,7 @@ use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Model\DatabaseInfo;
 use MongoDB\Model\DatabaseInfoLegacyIterator;
 
 /**
@@ -68,7 +69,7 @@ class ListDatabases implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return Iterator
+     * @return Iterator<int, DatabaseInfo>
      * @throws UnexpectedValueException if the command response was malformed
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -26,6 +26,7 @@ use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\CachingIterator;
+use MongoDB\Model\IndexInfo;
 use MongoDB\Model\IndexInfoIteratorIterator;
 
 use function is_integer;
@@ -85,7 +86,7 @@ class ListIndexes implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return Iterator
+     * @return Iterator<int, IndexInfo>
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)

--- a/src/Operation/ListIndexes.php
+++ b/src/Operation/ListIndexes.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Operation;
 
 use EmptyIterator;
+use Iterator;
 use MongoDB\Driver\Command;
 use MongoDB\Driver\Exception\CommandException;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
@@ -25,7 +26,6 @@ use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\CachingIterator;
-use MongoDB\Model\IndexInfoIterator;
 use MongoDB\Model\IndexInfoIteratorIterator;
 
 use function is_integer;
@@ -85,7 +85,7 @@ class ListIndexes implements Executable
      * Execute the operation.
      *
      * @see Executable::execute()
-     * @return IndexInfoIterator
+     * @return Iterator
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
      */
     public function execute(Server $server)


### PR DESCRIPTION
PHPLIB-1522

This PR deprecates the `CollectionInfoIterator`, `DatabaseInfoIterator`, and `IndexInfoIterator` interfaces and implementing classes. These will be replaced with generic iterators in 2.0.

In addition to this change, this PR also deprecates `IndexInfo::getNamespace`. The `ns` field that feeds this method has been removed from output in MongoDB 4.4, and keeping the necessary code added in PHPLIB-499 around makes no sense going forward.