### PR TITLE
Deprecate functionality to be removed

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -956,7 +956,7 @@ class Collection
      */
     public function mapReduce(JavascriptInterface $map, JavascriptInterface $reduce, string|array|object $out, array $options = [])
     {
-        @trigger_error(sprintf('The %s method is deprecated and will be removed in a future release.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s method is deprecated and will be removed in a version 2.0.', __METHOD__), E_USER_DEPRECATED);
 
         $hasOutputCollection = ! is_mapreduce_output_inline($out);
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -77,7 +77,11 @@ use function array_intersect_key;
 use function array_key_exists;
 use function current;
 use function is_array;
+use function sprintf;
 use function strlen;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class Collection
 {
@@ -952,6 +956,8 @@ class Collection
      */
     public function mapReduce(JavascriptInterface $map, JavascriptInterface $reduce, string|array|object $out, array $options = [])
     {
+        @trigger_error(sprintf('The %s method is deprecated and will be removed in a future release.', __METHOD__), E_USER_DEPRECATED);
+
         $hasOutputCollection = ! is_mapreduce_output_inline($out);
 
         // Check if the out option is inline because we will want to coerce a primary read preference if not

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -99,7 +99,7 @@ class IndexInfo implements ArrayAccess
      */
     public function getNamespace()
     {
-        @trigger_error('MongoDB 4.4 drops support for the namespace in indexes, the method "IndexInfo::getNamespace()" will be removed in a future release', E_USER_DEPRECATED);
+        @trigger_error('MongoDB 4.4 drops support for the namespace in indexes, the method "IndexInfo::getNamespace()" will be removed in version 2.0', E_USER_DEPRECATED);
 
         return (string) $this->info['ns'];
     }
@@ -132,7 +132,7 @@ class IndexInfo implements ArrayAccess
      */
     public function isGeoHaystack()
     {
-        @trigger_error('MongoDB 5.0 removes support for "geoHaystack" indexes, the method "IndexInfo::isGeoHaystack()" will be removed in a future release', E_USER_DEPRECATED);
+        @trigger_error('MongoDB 5.0 removes support for "geoHaystack" indexes, the method "IndexInfo::isGeoHaystack()" will be removed in version 2.0', E_USER_DEPRECATED);
 
         return array_search('geoHaystack', $this->getKey(), true) !== false;
     }

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -230,7 +230,7 @@ class CreateCollection implements Executable
         }
 
         if (isset($this->options['autoIndexId'])) {
-            trigger_error('The "autoIndexId" option is deprecated and will be removed in a future release', E_USER_DEPRECATED);
+            trigger_error('The "autoIndexId" option is deprecated and will be removed in version 2.0', E_USER_DEPRECATED);
         }
 
         if (isset($this->options['pipeline']) && ! is_pipeline($this->options['pipeline'], true /* allowEmpty */)) {

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -37,9 +37,6 @@ use function is_object;
 use function is_string;
 use function MongoDB\document_to_array;
 use function MongoDB\is_document;
-use function trigger_error;
-
-use const E_USER_DEPRECATED;
 
 /**
  * Operation for the find command.
@@ -283,14 +280,6 @@ class Find implements Executable, Explainable
 
         if (isset($this->options['readConcern']) && $this->options['readConcern']->isDefault()) {
             unset($this->options['readConcern']);
-        }
-
-        if (isset($this->options['snapshot'])) {
-            trigger_error('The "snapshot" option is deprecated and will be removed in a future release', E_USER_DEPRECATED);
-        }
-
-        if (isset($this->options['maxScan'])) {
-            trigger_error('The "maxScan" option is deprecated and will be removed in a future release', E_USER_DEPRECATED);
         }
 
         if (isset($this->options['codec']) && isset($this->options['typeMap'])) {

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -433,7 +433,9 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $reduce = new Javascript('function(key, values) { return Array.sum(values); }');
         $out = ['inline' => 1];
 
-        $result = $this->collection->mapReduce($map, $reduce, $out);
+        $result = $this->assertDeprecated(
+            fn () => $this->collection->mapReduce($map, $reduce, $out),
+        );
 
         $this->assertInstanceOf(MapReduceResult::class, $result);
         $expected = [

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -55,24 +55,6 @@ class FindTest extends TestCase
         ]);
     }
 
-    public function testSnapshotOptionIsDeprecated(): void
-    {
-        $this->assertDeprecated(function (): void {
-            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['snapshot' => true]);
-        });
-
-        $this->assertDeprecated(function (): void {
-            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['snapshot' => false]);
-        });
-    }
-
-    public function testMaxScanOptionIsDeprecated(): void
-    {
-        $this->assertDeprecated(function (): void {
-            new Find($this->getDatabaseName(), $this->getCollectionName(), [], ['maxScan' => 1]);
-        });
-    }
-
     /** @dataProvider provideInvalidConstructorCursorTypeOptions */
     public function testConstructorCursorTypeOption($cursorType): void
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -160,7 +160,7 @@ OUTPUT;
         return self::wrapValuesForDataProvider(self::getInvalidStringValues());
     }
 
-    protected function assertDeprecated(callable $execution): void
+    protected function assertDeprecated(callable $execution)
     {
         $errors = [];
 
@@ -169,12 +169,14 @@ OUTPUT;
         }, E_USER_DEPRECATED);
 
         try {
-            call_user_func($execution);
+            $result = call_user_func($execution);
         } finally {
             restore_error_handler();
         }
 
         $this->assertCount(1, $errors);
+
+        return $result;
     }
 
     protected static function createOptionDataProvider(array $options): array


### PR DESCRIPTION
This PR deprecates the `Collection::mapReduce` method (PHPLIB-1533). Duplicated deprecation notices for deprecated query options have been removed.