### PR TITLE
Assert that the modifiers option is indeed deprecated

### DIFF
--- a/tests/Operation/FindFunctionalTest.php
+++ b/tests/Operation/FindFunctionalTest.php
@@ -48,7 +48,9 @@ class FindFunctionalTest extends FunctionalTestCase
                     ['modifiers' => $modifiers],
                 );
 
-                $operation->execute($this->getPrimaryServer());
+                $this->assertDeprecated(
+                    fn () => $operation->execute($this->getPrimaryServer()),
+                );
             },
             function (array $event) use ($expectedSort): void {
                 $this->assertEquals($expectedSort, $event['started']->getCommand()->sort ?? null);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,7 @@ use function set_error_handler;
 use function sprintf;
 use function strtr;
 
+use const E_DEPRECATED;
 use const E_USER_DEPRECATED;
 
 abstract class TestCase extends BaseTestCase
@@ -171,7 +172,7 @@ OUTPUT;
 
         set_error_handler(function ($errno, $errstr) use (&$errors): void {
             $errors[] = $errstr;
-        }, E_USER_DEPRECATED);
+        }, E_USER_DEPRECATED | E_DEPRECATED);
 
         try {
             call_user_func($execution);


### PR DESCRIPTION
This PR adds an assertion that the `modifiers` query option is deprecated. While this commit is not necessary in 1.20 due to our usage of Symfony's PHPUnit Bridge which handles deprecations, when running phpunit directly the deprecation creates test output which causes a test failure in later versions. For this reason, I figured it's best to include this in 1.20.