### PR TITLE
PHPLIB-1518 `WriteResult::get*Count()` always return an int on acknowledged result

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -23,6 +23,7 @@
         <file name="stubs/BSON/PackedArray.stub.php"/>
         <file name="stubs/Driver/Cursor.stub.php"/>
         <file name="stubs/Driver/CursorInterface.stub.php"/>
+        <file name="stubs/Driver/WriteResult.stub.php"/>
     </stubs>
 
     <issueHandlers>

--- a/src/BulkWriteResult.php
+++ b/src/BulkWriteResult.php
@@ -17,19 +17,16 @@
 
 namespace MongoDB;
 
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteResult;
-use MongoDB\Exception\BadMethodCallException;
 
 /**
  * Result class for a bulk write operation.
  */
 class BulkWriteResult
 {
-    private bool $isAcknowledged;
-
     public function __construct(private WriteResult $writeResult, private array $insertedIds)
     {
-        $this->isAcknowledged = $writeResult->isAcknowledged();
     }
 
     /**
@@ -38,15 +35,11 @@ class BulkWriteResult
      * This method should only be called if the write was acknowledged.
      *
      * @see BulkWriteResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getDeletedCount(): ?int
+    public function getDeletedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getDeletedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getDeletedCount();
     }
 
     /**
@@ -55,15 +48,11 @@ class BulkWriteResult
      * This method should only be called if the write was acknowledged.
      *
      * @see BulkWriteResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getInsertedCount(): ?int
+    public function getInsertedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getInsertedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getInsertedCount();
     }
 
     /**
@@ -86,15 +75,11 @@ class BulkWriteResult
      * This method should only be called if the write was acknowledged.
      *
      * @see BulkWriteResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getMatchedCount(): ?int
+    public function getMatchedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getMatchedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getMatchedCount();
     }
 
     /**
@@ -106,15 +91,11 @@ class BulkWriteResult
      * This method should only be called if the write was acknowledged.
      *
      * @see BulkWriteResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getModifiedCount(): ?int
+    public function getModifiedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getModifiedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getModifiedCount();
     }
 
     /**
@@ -123,15 +104,11 @@ class BulkWriteResult
      * This method should only be called if the write was acknowledged.
      *
      * @see BulkWriteResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getUpsertedCount(): ?int
+    public function getUpsertedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getUpsertedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getUpsertedCount();
     }
 
     /**
@@ -145,15 +122,11 @@ class BulkWriteResult
      * This method should only be called if the write was acknowledged.
      *
      * @see BulkWriteResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
     public function getUpsertedIds(): array
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getUpsertedIds();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getUpsertedIds();
     }
 
     /**
@@ -164,6 +137,6 @@ class BulkWriteResult
      */
     public function isAcknowledged(): bool
     {
-        return $this->isAcknowledged;
+        return $this->writeResult->isAcknowledged();
     }
 }

--- a/src/DeleteResult.php
+++ b/src/DeleteResult.php
@@ -17,19 +17,16 @@
 
 namespace MongoDB;
 
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteResult;
-use MongoDB\Exception\BadMethodCallException;
 
 /**
  * Result class for a delete operation.
  */
 class DeleteResult
 {
-    private bool $isAcknowledged;
-
     public function __construct(private WriteResult $writeResult)
     {
-        $this->isAcknowledged = $writeResult->isAcknowledged();
     }
 
     /**
@@ -38,15 +35,11 @@ class DeleteResult
      * This method should only be called if the write was acknowledged.
      *
      * @see DeleteResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getDeletedCount(): ?int
+    public function getDeletedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getDeletedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getDeletedCount();
     }
 
     /**
@@ -57,6 +50,6 @@ class DeleteResult
      */
     public function isAcknowledged(): bool
     {
-        return $this->isAcknowledged;
+        return $this->writeResult->isAcknowledged();
     }
 }

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -33,15 +33,4 @@ class BadMethodCallException extends BaseBadMethodCallException implements Excep
     {
         return new self(sprintf('%s is immutable', $class));
     }
-
-    /**
-     * Thrown when accessing a result field on an unacknowledged write result.
-     *
-     * @param string $method Method name
-     * @internal
-     */
-    public static function unacknowledgedWriteResultAccess(string $method): self
-    {
-        return new self(sprintf('%s should not be called for an unacknowledged write result', $method));
-    }
 }

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -583,16 +583,9 @@ class Bucket
             return;
         }
 
-        /* If the update resulted in no modification, it's possible that the
-         * file did not exist, in which case we must raise an error. Checking
-         * the write result's matched count will be most efficient, but fall
-         * back to a findOne operation if necessary (i.e. legacy writes).
-         */
-        $found = $updateResult->getMatchedCount() !== null
-            ? $updateResult->getMatchedCount() === 1
-            : $this->collectionWrapper->findFileById($id) !== null;
-
-        if (! $found) {
+        // If the update resulted in no modification, it's possible that the
+        // file did not exist, in which case we must raise an error.
+        if ($updateResult->getMatchedCount() !== 1) {
             throw FileNotFoundException::byId($id, $this->getFilesNamespace());
         }
     }

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -73,7 +73,7 @@ final class CollectionWrapper
     /**
      * Delete all GridFS files and chunks for a given filename.
      */
-    public function deleteFileAndChunksByFilename(string $filename): ?int
+    public function deleteFileAndChunksByFilename(string $filename): int
     {
         /** @var iterable<array{_id: mixed}> $files */
         $files = $this->findFiles(['filename' => $filename], [
@@ -262,7 +262,7 @@ final class CollectionWrapper
     /**
      * Updates the filename field in the file document for all the files with a given filename.
      */
-    public function updateFilenameForFilename(string $filename, string $newFilename): ?int
+    public function updateFilenameForFilename(string $filename, string $newFilename): int
     {
         return $this->filesCollection->updateMany(
             ['filename' => $filename],

--- a/src/InsertManyResult.php
+++ b/src/InsertManyResult.php
@@ -17,19 +17,16 @@
 
 namespace MongoDB;
 
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteResult;
-use MongoDB\Exception\BadMethodCallException;
 
 /**
  * Result class for a multi-document insert operation.
  */
 class InsertManyResult
 {
-    private bool $isAcknowledged;
-
     public function __construct(private WriteResult $writeResult, private array $insertedIds)
     {
-        $this->isAcknowledged = $writeResult->isAcknowledged();
     }
 
     /**
@@ -38,15 +35,11 @@ class InsertManyResult
      * This method should only be called if the write was acknowledged.
      *
      * @see InsertManyResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getInsertedCount(): ?int
+    public function getInsertedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getInsertedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getInsertedCount();
     }
 
     /**

--- a/src/InsertOneResult.php
+++ b/src/InsertOneResult.php
@@ -17,19 +17,16 @@
 
 namespace MongoDB;
 
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteResult;
-use MongoDB\Exception\BadMethodCallException;
 
 /**
  * Result class for a single-document insert operation.
  */
 class InsertOneResult
 {
-    private bool $isAcknowledged;
-
     public function __construct(private WriteResult $writeResult, private mixed $insertedId)
     {
-        $this->isAcknowledged = $writeResult->isAcknowledged();
     }
 
     /**
@@ -38,15 +35,11 @@ class InsertOneResult
      * This method should only be called if the write was acknowledged.
      *
      * @see InsertOneResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getInsertedCount(): ?int
+    public function getInsertedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getInsertedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getInsertedCount();
     }
 
     /**

--- a/src/UpdateResult.php
+++ b/src/UpdateResult.php
@@ -17,19 +17,16 @@
 
 namespace MongoDB;
 
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteResult;
-use MongoDB\Exception\BadMethodCallException;
 
 /**
  * Result class for an update operation.
  */
 class UpdateResult
 {
-    private bool $isAcknowledged;
-
     public function __construct(private WriteResult $writeResult)
     {
-        $this->isAcknowledged = $writeResult->isAcknowledged();
     }
 
     /**
@@ -38,15 +35,11 @@ class UpdateResult
      * This method should only be called if the write was acknowledged.
      *
      * @see UpdateResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getMatchedCount(): ?int
+    public function getMatchedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getMatchedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getMatchedCount();
     }
 
     /**
@@ -58,15 +51,11 @@ class UpdateResult
      * This method should only be called if the write was acknowledged.
      *
      * @see UpdateResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getModifiedCount(): ?int
+    public function getModifiedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getModifiedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getModifiedCount();
     }
 
     /**
@@ -75,15 +64,11 @@ class UpdateResult
      * This method should only be called if the write was acknowledged.
      *
      * @see UpdateResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
-    public function getUpsertedCount(): ?int
+    public function getUpsertedCount(): int
     {
-        if ($this->isAcknowledged) {
-            return $this->writeResult->getUpsertedCount();
-        }
-
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return $this->writeResult->getUpsertedCount();
     }
 
     /**
@@ -98,19 +83,15 @@ class UpdateResult
      * This method should only be called if the write was acknowledged.
      *
      * @see UpdateResult::isAcknowledged()
-     * @throws BadMethodCallException if the write result is unacknowledged
+     * @throws LogicException if the write result is unacknowledged
      */
     public function getUpsertedId(): mixed
     {
-        if ($this->isAcknowledged) {
-            foreach ($this->writeResult->getUpsertedIds() as $id) {
-                return $id;
-            }
-
-            return null;
+        foreach ($this->writeResult->getUpsertedIds() as $id) {
+            return $id;
         }
 
-        throw BadMethodCallException::unacknowledgedWriteResultAccess(__METHOD__);
+        return null;
     }
 
     /**
@@ -122,6 +103,6 @@ class UpdateResult
      */
     public function isAcknowledged(): bool
     {
-        return $this->isAcknowledged;
+        return $this->writeResult->isAcknowledged();
     }
 }

--- a/stubs/Driver/WriteResult.stub.php
+++ b/stubs/Driver/WriteResult.stub.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MongoDB\Driver;
+
+final class WriteResult
+{
+    final private function __construct()
+    {
+    }
+
+    final public function __wakeup(): void
+    {
+    }
+
+    final public function getDeletedCount(): int
+    {
+    }
+
+    final public function getInsertedCount(): int
+    {
+    }
+
+    final public function getMatchedCount(): int
+    {
+    }
+
+    final public function getModifiedCount(): int
+    {
+    }
+
+    final public function getServer(): Server
+    {
+    }
+
+    final public function getUpsertedCount(): int
+    {
+    }
+
+    final public function getUpsertedIds(): array
+    {
+    }
+
+    final public function getWriteConcernError(): ?WriteConcernError
+    {
+    }
+
+    final public function getWriteErrors(): array
+    {
+    }
+
+    final public function getErrorReplies(): array
+    {
+    }
+
+    final public function isAcknowledged(): bool
+    {
+    }
+}

--- a/stubs/Driver/WriteResult.stub.php
+++ b/stubs/Driver/WriteResult.stub.php
@@ -4,55 +4,29 @@ namespace MongoDB\Driver;
 
 final class WriteResult
 {
-    final private function __construct()
-    {
-    }
+    final private function __construct() {}
 
-    final public function __wakeup(): void
-    {
-    }
+    final public function __wakeup(): void {}
 
-    final public function getDeletedCount(): int
-    {
-    }
+    final public function getDeletedCount(): int {}
 
-    final public function getInsertedCount(): int
-    {
-    }
+    final public function getInsertedCount(): int {}
 
-    final public function getMatchedCount(): int
-    {
-    }
+    final public function getMatchedCount(): int {}
 
-    final public function getModifiedCount(): int
-    {
-    }
+    final public function getModifiedCount(): int {}
 
-    final public function getServer(): Server
-    {
-    }
+    final public function getServer(): Server {}
 
-    final public function getUpsertedCount(): int
-    {
-    }
+    final public function getUpsertedCount(): int {}
 
-    final public function getUpsertedIds(): array
-    {
-    }
+    final public function getUpsertedIds(): array {}
 
-    final public function getWriteConcernError(): ?WriteConcernError
-    {
-    }
+    final public function getWriteConcernError(): ?WriteConcernError {}
 
-    final public function getWriteErrors(): array
-    {
-    }
+    final public function getWriteErrors(): array {}
 
-    final public function getErrorReplies(): array
-    {
-    }
+    final public function getErrorReplies(): array {}
 
-    final public function isAcknowledged(): bool
-    {
-    }
+    final public function isAcknowledged(): bool {}
 }

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -7,8 +7,8 @@ use MongoDB\BSON\ObjectId;
 use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite as Bulk;
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\BulkWrite;
 use MongoDB\Tests\CommandObserver;
@@ -320,48 +320,48 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesDeletedCount(BulkWriteResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getDeletedCount();
     }
 
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesInsertCount(BulkWriteResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getInsertedCount();
     }
 
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesMatchedCount(BulkWriteResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getMatchedCount();
     }
 
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesModifiedCount(BulkWriteResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getModifiedCount();
     }
 
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesUpsertedCount(BulkWriteResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getUpsertedCount();
     }
 
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesUpsertedIds(BulkWriteResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getUpsertedIds();
     }
 

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -5,8 +5,8 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\Collection;
 use MongoDB\DeleteResult;
 use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\Operation\Delete;
 use MongoDB\Tests\CommandObserver;
@@ -136,8 +136,8 @@ class DeleteFunctionalTest extends FunctionalTestCase
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesDeletedCount(DeleteResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getDeletedCount();
     }
 

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -5,8 +5,8 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Exception\BadMethodCallException;
 use MongoDB\InsertManyResult;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertMany;
@@ -192,8 +192,8 @@ class InsertManyFunctionalTest extends FunctionalTestCase
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesInsertedCount(InsertManyResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getInsertedCount();
     }
 

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -5,8 +5,8 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Exception\BadMethodCallException;
 use MongoDB\InsertOneResult;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\InsertOne;
@@ -183,8 +183,8 @@ class InsertOneFunctionalTest extends FunctionalTestCase
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesInsertedCount(InsertOneResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getInsertedCount();
     }
 

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -5,8 +5,8 @@ namespace MongoDB\Tests\Operation;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\Exception\LogicException;
 use MongoDB\Driver\WriteConcern;
-use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\Operation\Update;
 use MongoDB\Tests\CommandObserver;
@@ -287,32 +287,32 @@ class UpdateFunctionalTest extends FunctionalTestCase
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesMatchedCount(UpdateResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getMatchedCount();
     }
 
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesModifiedCount(UpdateResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getModifiedCount();
     }
 
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesUpsertedCount(UpdateResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getUpsertedCount();
     }
 
     /** @depends testUnacknowledgedWriteConcern */
     public function testUnacknowledgedWriteConcernAccessesUpsertedId(UpdateResult $result): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessageMatches('/[\w:\\\\]+ should not be called for an unacknowledged write result/');
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageMatches('/[\w:\\\\\(\)]+ should not be called for an unacknowledged write result/');
         $result->getUpsertedId();
     }
 


### PR DESCRIPTION
Fix PHPLIB-1518

I chose to rely on the driver exception thrown by https://github.com/mongodb/mongo-php-driver/pull/1687