### PR TITLE
Don't build with PHPC 1.x on legacy PHP versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -66,6 +66,7 @@ include:
 
   # Automatically generated files
   - filename: .evergreen/config/generated/build/build-extension.yml
+  - filename: .evergreen/config/generated/build/build-extension-next-minor.yml
   - filename: .evergreen/config/generated/test/local.yml
   - filename: .evergreen/config/generated/test/load-balanced.yml
   - filename: .evergreen/config/generated/test/require-api-version.yml

--- a/.evergreen/config/generate-config.php
+++ b/.evergreen/config/generate-config.php
@@ -51,6 +51,7 @@ $allFiles = [];
 
 // Build tasks
 $allFiles[] = generateConfigs('tasks', 'build', 'phpVersion', 'build-extension.yml', $supportedPhpVersions);
+$allFiles[] = generateConfigs('tasks', 'build', 'phpVersion', 'build-extension-next-minor.yml', $modernPhpVersions);
 
 // Test tasks
 $allFiles[] = generateConfigs('tasks', 'test', 'mongodbVersion', 'local.yml', $localServerVersions);

--- a/.evergreen/config/generated/build/build-extension-next-minor.yml
+++ b/.evergreen/config/generated/build/build-extension-next-minor.yml
@@ -1,0 +1,32 @@
+# This file is generated automatically - please edit the "templates/build/build-extension-next-minor.yml" template file instead.
+tasks:
+  - name: "build-php-8.3-next-minor"
+    tags: ["build", "php8.3", "next-minor"]
+    commands:
+      - func: "locate PHP binaries"
+        vars:
+          PHP_VERSION: "8.3"
+      - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.x"
+      - func: "upload extension"
+  - name: "build-php-8.2-next-minor"
+    tags: ["build", "php8.2", "next-minor"]
+    commands:
+      - func: "locate PHP binaries"
+        vars:
+          PHP_VERSION: "8.2"
+      - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.x"
+      - func: "upload extension"
+  - name: "build-php-8.1-next-minor"
+    tags: ["build", "php8.1", "next-minor"]
+    commands:
+      - func: "locate PHP binaries"
+        vars:
+          PHP_VERSION: "8.1"
+      - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.x"
+      - func: "upload extension"

--- a/.evergreen/config/generated/build/build-extension.yml
+++ b/.evergreen/config/generated/build/build-extension.yml
@@ -28,16 +28,6 @@ tasks:
         vars:
           EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
-  - name: "build-php-8.3-next-minor"
-    tags: ["build", "php8.3", "next-minor"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "8.3"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.x"
-      - func: "upload extension"
   - name: "build-php-8.2"
     tags: ["build", "php8.2", "stable", "pr", "tag"]
     commands:
@@ -65,16 +55,6 @@ tasks:
       - func: "compile extension"
         vars:
           EXTENSION_BRANCH: "v1.20"
-      - func: "upload extension"
-  - name: "build-php-8.2-next-minor"
-    tags: ["build", "php8.2", "next-minor"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "8.2"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.x"
       - func: "upload extension"
   - name: "build-php-8.1"
     tags: ["build", "php8.1", "stable", "pr", "tag"]
@@ -104,16 +84,6 @@ tasks:
         vars:
           EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
-  - name: "build-php-8.1-next-minor"
-    tags: ["build", "php8.1", "next-minor"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "8.1"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.x"
-      - func: "upload extension"
   - name: "build-php-8.0"
     tags: ["build", "php8.0", "stable", "pr", "tag"]
     commands:
@@ -142,16 +112,6 @@ tasks:
         vars:
           EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
-  - name: "build-php-8.0-next-minor"
-    tags: ["build", "php8.0", "next-minor"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "8.0"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.x"
-      - func: "upload extension"
   - name: "build-php-7.4"
     tags: ["build", "php7.4", "stable", "pr", "tag"]
     commands:
@@ -179,14 +139,4 @@ tasks:
       - func: "compile extension"
         vars:
           EXTENSION_BRANCH: "v1.20"
-      - func: "upload extension"
-  - name: "build-php-7.4-next-minor"
-    tags: ["build", "php7.4", "next-minor"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "7.4"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.x"
       - func: "upload extension"

--- a/.evergreen/config/templates/build/build-extension-next-minor.yml
+++ b/.evergreen/config/templates/build/build-extension-next-minor.yml
@@ -1,0 +1,10 @@
+  - name: "build-php-%phpVersion%-next-minor"
+    tags: ["build", "php%phpVersion%", "next-minor"]
+    commands:
+      - func: "locate PHP binaries"
+        vars:
+          PHP_VERSION: "%phpVersion%"
+      - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.x"
+      - func: "upload extension"

--- a/.evergreen/config/templates/build/build-extension.yml
+++ b/.evergreen/config/templates/build/build-extension.yml
@@ -26,13 +26,3 @@
         vars:
           EXTENSION_BRANCH: "v1.20"
       - func: "upload extension"
-  - name: "build-php-%phpVersion%-next-minor"
-    tags: ["build", "php%phpVersion%", "next-minor"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "%phpVersion%"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.x"
-      - func: "upload extension"


### PR DESCRIPTION
The next minor version of PHPC drops support for PHP 7.4 and 8.0, which means that those builds currently fail on evergreen. This PR ensures we only build with PHPC 1.x on PHP 8.1+. This PR can be ignored when merging up to v1.x (i.e., use the "ignoring changes" instructions in the merge-up pull request)