### PR TITLE
Higher phpunit version required for `assertObjectHasProperty`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^9.6.11",
         "rector/rector": "^1.1",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "^5.13"


### PR DESCRIPTION
Fix failing test with lower deps.
Caused by https://github.com/mongodb/mongo-php-library/pull/1432 and https://github.com/mongodb/mongo-php-library/pull/1405