### PR TITLE
Use RHEL 8 to test old server versions

### DIFF
--- a/.evergreen/config/build-variants.yml
+++ b/.evergreen/config/build-variants.yml
@@ -15,18 +15,6 @@ buildvariants:
     run_on: debian11-small
     tasks:
       - name: "build-all-php"
-  - name: build-debian10
-    display_name: "Build: Debian 10"
-    tags: ["build", "debian", "x64", "pr", "tag"]
-    run_on: debian10-small
-    tasks:
-      - name: "build-all-php"
-  - name: build-debian92
-    display_name: "Build: Debian 9.2"
-    tags: ["build", "debian", "x64", "pr", "tag"]
-    run_on: debian92-small
-    tasks:
-      - name: "build-all-php"
 
   # RHEL
   - name: build-rhel90

--- a/.evergreen/config/generated/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/generated/test-variant/legacy-php-full.yml
@@ -23,27 +23,8 @@ buildvariants:
       - "test-atlas-data-lake"
 
   # Test versions < 5.0
-  - name: test-debian92-php-8.0-local
-    tags: ["test", "debian", "x64", "php8.0", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 8.0"
-    run_on: debian92-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
-      FETCH_BUILD_TASK: "build-php-8.0"
-      PHP_VERSION: "8.0"
-    depends_on:
-      - variant: "build-debian92"
-        name: "build-php-8.0"
-    tasks:
-      # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-
-  # Test Atlas and CSFLE on RHEL 8
-  - name: test-rhel80-php-8.0-atlas
-    tags: ["test", "debian", "x64", "php8.0", "pr", "tag"]
+  - name: test-rhel80-php-8.0
+    tags: ["test", "rhel", "x64", "php8.0", "pr", "tag"]
     display_name: "Test: RHEL 8.0, PHP 8.0"
     run_on: rhel80-small
     expansions:
@@ -54,6 +35,11 @@ buildvariants:
       - variant: "build-rhel80"
         name: "build-php-8.0"
     tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"
 # TODO PHPLIB-955: This file can be removed when requiring PHP 8.1+
@@ -79,27 +65,8 @@ buildvariants:
       - "test-atlas-data-lake"
 
   # Test versions < 5.0
-  - name: test-debian92-php-7.4-local
-    tags: ["test", "debian", "x64", "php7.4", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 7.4"
-    run_on: debian92-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
-      FETCH_BUILD_TASK: "build-php-7.4"
-      PHP_VERSION: "7.4"
-    depends_on:
-      - variant: "build-debian92"
-        name: "build-php-7.4"
-    tasks:
-      # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-
-  # Test Atlas and CSFLE on RHEL 8
-  - name: test-rhel80-php-7.4-atlas
-    tags: ["test", "debian", "x64", "php7.4", "pr", "tag"]
+  - name: test-rhel80-php-7.4
+    tags: ["test", "rhel", "x64", "php7.4", "pr", "tag"]
     display_name: "Test: RHEL 8.0, PHP 7.4"
     run_on: rhel80-small
     expansions:
@@ -110,5 +77,10 @@ buildvariants:
       - variant: "build-rhel80"
         name: "build-php-7.4"
     tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"

--- a/.evergreen/config/generated/test-variant/lowest.yml
+++ b/.evergreen/config/generated/test-variant/lowest.yml
@@ -1,16 +1,16 @@
 # This file is generated automatically - please edit the "templates/test-variant/lowest.yml" template file instead.
 buildvariants:
-  - name: test-debian92-php-7.4-local-lowest
-    tags: ["test", "debian", "x64", "php7.4", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 7.4, Lowest Dependencies"
-    run_on: debian92-small
+  - name: test-rhel80-php-7.4-local-lowest
+    tags: ["test", "rhel", "x64", "php7.4", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP 7.4, Lowest Dependencies"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel80"
       FETCH_BUILD_TASK: "build-php-7.4-lowest"
       PHP_VERSION: "7.4"
       DEPENDENCIES: "lowest"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel80"
         name: "build-php-7.4-lowest"
     tasks:
       - ".replicaset .local .4.0 !.csfle"

--- a/.evergreen/config/generated/test-variant/modern-php-full.yml
+++ b/.evergreen/config/generated/test-variant/modern-php-full.yml
@@ -42,26 +42,7 @@ buildvariants:
       - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
 
   # Test versions < 5.0
-  - name: test-debian92-php-8.3-local
-    tags: ["test", "debian", "x64", "php8.3", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 8.3"
-    run_on: debian92-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
-      FETCH_BUILD_TASK: "build-php-8.3"
-      PHP_VERSION: "8.3"
-    depends_on:
-      - variant: "build-debian92"
-        name: "build-php-8.3"
-    tasks:
-      # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-
-  # Test Atlas and CSFLE on RHEL 8
-  - name: test-rhel80-php-8.3-atlas
+  - name: test-rhel80-php-8.3
     tags: ["test", "debian", "x64", "php8.3", "pr", "tag"]
     display_name: "Test: RHEL 8.0, PHP 8.3"
     run_on: rhel80-small
@@ -73,6 +54,11 @@ buildvariants:
       - variant: "build-rhel80"
         name: "build-php-8.3"
     tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"
   # Test MongoDB >= 7.0
@@ -117,26 +103,7 @@ buildvariants:
       - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
 
   # Test versions < 5.0
-  - name: test-debian92-php-8.2-local
-    tags: ["test", "debian", "x64", "php8.2", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 8.2"
-    run_on: debian92-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
-      FETCH_BUILD_TASK: "build-php-8.2"
-      PHP_VERSION: "8.2"
-    depends_on:
-      - variant: "build-debian92"
-        name: "build-php-8.2"
-    tasks:
-      # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-
-  # Test Atlas and CSFLE on RHEL 8
-  - name: test-rhel80-php-8.2-atlas
+  - name: test-rhel80-php-8.2
     tags: ["test", "debian", "x64", "php8.2", "pr", "tag"]
     display_name: "Test: RHEL 8.0, PHP 8.2"
     run_on: rhel80-small
@@ -148,6 +115,11 @@ buildvariants:
       - variant: "build-rhel80"
         name: "build-php-8.2"
     tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"
   # Test MongoDB >= 7.0
@@ -192,26 +164,7 @@ buildvariants:
       - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
 
   # Test versions < 5.0
-  - name: test-debian92-php-8.1-local
-    tags: ["test", "debian", "x64", "php8.1", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP 8.1"
-    run_on: debian92-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
-      FETCH_BUILD_TASK: "build-php-8.1"
-      PHP_VERSION: "8.1"
-    depends_on:
-      - variant: "build-debian92"
-        name: "build-php-8.1"
-    tasks:
-      # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-
-  # Test Atlas and CSFLE on RHEL 8
-  - name: test-rhel80-php-8.1-atlas
+  - name: test-rhel80-php-8.1
     tags: ["test", "debian", "x64", "php8.1", "pr", "tag"]
     display_name: "Test: RHEL 8.0, PHP 8.1"
     run_on: rhel80-small
@@ -223,5 +176,10 @@ buildvariants:
       - variant: "build-rhel80"
         name: "build-php-8.1"
     tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"

--- a/.evergreen/config/templates/test-variant/legacy-php-full.yml
+++ b/.evergreen/config/templates/test-variant/legacy-php-full.yml
@@ -21,27 +21,8 @@
       - "test-atlas-data-lake"
 
   # Test versions < 5.0
-  - name: test-debian92-php-%phpVersion%-local
-    tags: ["test", "debian", "x64", "php%phpVersion%", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP %phpVersion%"
-    run_on: debian92-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
-      FETCH_BUILD_TASK: "build-php-%phpVersion%"
-      PHP_VERSION: "%phpVersion%"
-    depends_on:
-      - variant: "build-debian92"
-        name: "build-php-%phpVersion%"
-    tasks:
-      # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-
-  # Test Atlas and CSFLE on RHEL 8
-  - name: test-rhel80-php-%phpVersion%-atlas
-    tags: ["test", "debian", "x64", "php%phpVersion%", "pr", "tag"]
+  - name: test-rhel80-php-%phpVersion%
+    tags: ["test", "rhel", "x64", "php%phpVersion%", "pr", "tag"]
     display_name: "Test: RHEL 8.0, PHP %phpVersion%"
     run_on: rhel80-small
     expansions:
@@ -52,5 +33,10 @@
       - variant: "build-rhel80"
         name: "build-php-%phpVersion%"
     tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"

--- a/.evergreen/config/templates/test-variant/lowest.yml
+++ b/.evergreen/config/templates/test-variant/lowest.yml
@@ -1,14 +1,14 @@
-  - name: test-debian92-php-%phpVersion%-local-lowest
-    tags: ["test", "debian", "x64", "php%phpVersion%", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP %phpVersion%, Lowest Dependencies"
-    run_on: debian92-small
+  - name: test-rhel80-php-%phpVersion%-local-lowest
+    tags: ["test", "rhel", "x64", "php%phpVersion%", "pr", "tag"]
+    display_name: "Test: RHEL 8.0, PHP %phpVersion%, Lowest Dependencies"
+    run_on: rhel80-small
     expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
+      FETCH_BUILD_VARIANT: "build-rhel80"
       FETCH_BUILD_TASK: "build-php-%phpVersion%-lowest"
       PHP_VERSION: "%phpVersion%"
       DEPENDENCIES: "lowest"
     depends_on:
-      - variant: "build-debian92"
+      - variant: "build-rhel80"
         name: "build-php-%phpVersion%-lowest"
     tasks:
       - ".replicaset .local .4.0 !.csfle"

--- a/.evergreen/config/templates/test-variant/modern-php-full.yml
+++ b/.evergreen/config/templates/test-variant/modern-php-full.yml
@@ -40,26 +40,7 @@
       - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
 
   # Test versions < 5.0
-  - name: test-debian92-php-%phpVersion%-local
-    tags: ["test", "debian", "x64", "php%phpVersion%", "pr", "tag"]
-    display_name: "Test: Debian 9.2, PHP %phpVersion%"
-    run_on: debian92-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian92"
-      FETCH_BUILD_TASK: "build-php-%phpVersion%"
-      PHP_VERSION: "%phpVersion%"
-    depends_on:
-      - variant: "build-debian92"
-        name: "build-php-%phpVersion%"
-    tasks:
-      # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-
-  # Test Atlas and CSFLE on RHEL 8
-  - name: test-rhel80-php-%phpVersion%-atlas
+  - name: test-rhel80-php-%phpVersion%
     tags: ["test", "debian", "x64", "php%phpVersion%", "pr", "tag"]
     display_name: "Test: RHEL 8.0, PHP %phpVersion%"
     run_on: rhel80-small
@@ -71,5 +52,10 @@
       - variant: "build-rhel80"
         name: "build-php-%phpVersion%"
     tasks:
+      # Remember to add new major versions here as they are released
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"


### PR DESCRIPTION
This PR drops Debian 10 and Debian 9.2 from our build pipeline. Debian 9.2 was used to test MongoDB < 5.0, which will be tested on RHEL 8 going forwards. Debian 10 isn't used at all, so we can safely drop it as well. This will make it easier to test with PHP 8.4 on Evergreen, which isn't available on Debian 9.2 due to an old openssl version.