### PR TITLE
PHPLIB-1538 Deprecate typeMap on operations without meaningful result

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -49,6 +49,10 @@ use Throwable;
 use function array_diff_key;
 use function is_array;
 use function is_string;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class Client
 {
@@ -228,6 +232,8 @@ class Client
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
+        } else {
+            @trigger_error(sprintf('The function %s() will return nothing in mongodb/mongodb v2.0, the "typeMap" option is deprecated', __FUNCTION__), E_USER_DEPRECATED);
         }
 
         $server = select_server_for_write($this->manager, $options);

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -524,7 +524,7 @@ class Collection
     public function drop(array $options = [])
     {
         $options = $this->inheritWriteOptions($options);
-        $options = $this->inheritTypeMap($options);
+        $options = $this->inheritTypeMap($options, __FUNCTION__);
 
         $server = select_server_for_write($this->manager, $options);
 
@@ -560,7 +560,7 @@ class Collection
         }
 
         $options = $this->inheritWriteOptions($options);
-        $options = $this->inheritTypeMap($options);
+        $options = $this->inheritTypeMap($options, __FUNCTION__);
 
         $operation = new DropIndexes($this->databaseName, $this->collectionName, $indexName, $options);
 
@@ -580,7 +580,7 @@ class Collection
     public function dropIndexes(array $options = [])
     {
         $options = $this->inheritWriteOptions($options);
-        $options = $this->inheritTypeMap($options);
+        $options = $this->inheritTypeMap($options, __FUNCTION__);
 
         $operation = new DropIndexes($this->databaseName, $this->collectionName, '*', $options);
 
@@ -1212,8 +1212,12 @@ class Collection
         return $options;
     }
 
-    private function inheritTypeMap(array $options): array
+    private function inheritTypeMap(array $options, ?string $deprecatedFunction = null): array
     {
+        if ($deprecatedFunction !== null && isset($options['typeMap'])) {
+            @trigger_error(sprintf('The function %s() will return nothing in mongodb/mongodb v2.0, the "typeMap" option is deprecated', $deprecatedFunction), E_USER_DEPRECATED);
+        }
+
         // Only inherit the type map if no codec is used
         if (! isset($options['typeMap']) && ! isset($options['codec'])) {
             $options['typeMap'] = $this->typeMap;

--- a/src/Database.php
+++ b/src/Database.php
@@ -55,7 +55,11 @@ use Throwable;
 use Traversable;
 
 use function is_array;
+use function sprintf;
 use function strlen;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 class Database
 {
@@ -286,6 +290,8 @@ class Database
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
+        } else {
+            @trigger_error(sprintf('The function %s() will return nothing in mongodb/mongodb v2.0, the "typeMap" option is deprecated', __FUNCTION__), E_USER_DEPRECATED);
         }
 
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
@@ -329,6 +335,8 @@ class Database
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
+        } else {
+            @trigger_error(sprintf('The function %s() will return nothing in mongodb/mongodb v2.0, the "typeMap" option is deprecated', __FUNCTION__), E_USER_DEPRECATED);
         }
 
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
@@ -362,6 +370,8 @@ class Database
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
+        } else {
+            @trigger_error(sprintf('The function %s() will return nothing in mongodb/mongodb v2.0, the "typeMap" option is deprecated', __FUNCTION__), E_USER_DEPRECATED);
         }
 
         $server = select_server_for_write($this->manager, $options);
@@ -390,6 +400,8 @@ class Database
     {
         if (! isset($options['typeMap'])) {
             $options['typeMap'] = $this->typeMap;
+        } else {
+            @trigger_error(sprintf('The function %s() will return nothing in mongodb/mongodb v2.0, the "typeMap" option is deprecated', __FUNCTION__), E_USER_DEPRECATED);
         }
 
         $server = select_server_for_write($this->manager, $options);


### PR DESCRIPTION
Fix PHPLIB-1538

Detecting the typeMap is used is a way to inform that the return document will be removed by https://github.com/mongodb/mongo-php-library/pull/1468

