### PR TITLE
Fix junit logging

### DIFF
--- a/phpunit.evergreen.xml
+++ b/phpunit.evergreen.xml
@@ -26,6 +26,6 @@
     </testsuites>
 
     <logging>
-        <log type="junit" target="test-results.xml" />
+        <junit outputFile="test-results.xml" />
     </logging>
 </phpunit>


### PR DESCRIPTION
PHPUnit 10 has a different configuration format to enable junit logging, which was missed in #1412. As a result, Evergreen no longer shows the full list of tests. This PR fixes the wrong configuration.