### PR TITLE
Fix array shape for `Collection::listSearchIndex($options)`

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -896,7 +896,7 @@ class Collection
      * Returns information for all Atlas Search indexes for the collection.
      * Only available when used against a 7.0+ Atlas cluster.
      *
-     * @param array{name?: string} $options Command options
+     * @param array{name?: string, ...} $options Command options
      * @return Countable&Iterator
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -896,7 +896,7 @@ class Collection
      * Returns information for all Atlas Search indexes for the collection.
      * Only available when used against a 7.0+ Atlas cluster.
      *
-     * @param array{name?: string, ...} $options Command options
+     * @param array $options Command options
      * @return Countable&Iterator
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Operation/ListSearchIndexes.php
+++ b/src/Operation/ListSearchIndexes.php
@@ -48,7 +48,7 @@ class ListSearchIndexes implements Executable
      *
      * @param string               $databaseName   Database name
      * @param string               $collectionName Collection name
-     * @param array{name?: string} $options        Command options
+     * @param array{name?: string, ...} $options        Command options
      */
     public function __construct(string $databaseName, string $collectionName, array $options = [])
     {

--- a/src/Operation/ListSearchIndexes.php
+++ b/src/Operation/ListSearchIndexes.php
@@ -46,9 +46,9 @@ class ListSearchIndexes implements Executable
     /**
      * Constructs an aggregate command for listing Atlas Search indexes
      *
-     * @param string               $databaseName   Database name
-     * @param string               $collectionName Collection name
-     * @param array{name?: string, ...} $options        Command options
+     * @param string $databaseName   Database name
+     * @param string $collectionName Collection name
+     * @param array  $options        Command options
      */
     public function __construct(string $databaseName, string $collectionName, array $options = [])
     {


### PR DESCRIPTION
The `@param` annotation only accept `name` option. Which is wrong since all the `aggregate` options are allowed. 

See https://github.com/doctrine/mongodb-odm/pull/2689#issuecomment-2410880675