### PR TITLE
PHPLIB-1185: Add new methods to get database and collection instances

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -174,7 +174,7 @@ class Client
      */
     public function __get(string $databaseName)
     {
-        return $this->selectDatabase($databaseName);
+        return $this->getDatabase($databaseName);
     }
 
     /**
@@ -245,6 +245,43 @@ class Client
         $operation = new DropDatabase($databaseName, $options);
 
         return $operation->execute($server);
+    }
+
+    /**
+     * Returns a collection instance.
+     *
+     * If the collection does not exist in the database, it is not created when
+     * invoking this method.
+     *
+     * @see Collection::__construct() for supported options
+     * @param string $databaseName   Name of the database containing the collection
+     * @param string $collectionName Name of the collection to select
+     * @param array  $options        Collection constructor options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     */
+    public function getCollection(string $databaseName, string $collectionName, array $options = []): Collection
+    {
+        $options += ['typeMap' => $this->typeMap, 'builderEncoder' => $this->builderEncoder];
+
+        return new Collection($this->manager, $databaseName, $collectionName, $options);
+    }
+
+    /**
+     * Returns a database instance.
+     *
+     * If the database does not exist on the server, it is not created when
+     * invoking this method.
+     *
+     * @param string $databaseName Name of the database to select
+     * @param array  $options      Database constructor options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     * @see Database::__construct() for supported options
+     */
+    public function getDatabase(string $databaseName, array $options = []): Database
+    {
+        $options += ['typeMap' => $this->typeMap, 'builderEncoder' => $this->builderEncoder];
+
+        return new Database($this->manager, $databaseName, $options);
     }
 
     /**
@@ -354,9 +391,7 @@ class Client
      */
     public function selectCollection(string $databaseName, string $collectionName, array $options = [])
     {
-        $options += ['typeMap' => $this->typeMap, 'builderEncoder' => $this->builderEncoder];
-
-        return new Collection($this->manager, $databaseName, $collectionName, $options);
+        return $this->getCollection($databaseName, $collectionName, $options);
     }
 
     /**
@@ -370,9 +405,7 @@ class Client
      */
     public function selectDatabase(string $databaseName, array $options = [])
     {
-        $options += ['typeMap' => $this->typeMap, 'builderEncoder' => $this->builderEncoder];
-
-        return new Database($this->manager, $databaseName, $options);
+        return $this->getDatabase($databaseName, $options);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -254,9 +254,6 @@ class Client
      * invoking this method.
      *
      * @see Collection::__construct() for supported options
-     * @param string $databaseName   Name of the database containing the collection
-     * @param string $collectionName Name of the collection to select
-     * @param array  $options        Collection constructor options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function getCollection(string $databaseName, string $collectionName, array $options = []): Collection
@@ -272,9 +269,6 @@ class Client
      * If the database does not exist on the server, it is not created when
      * invoking this method.
      *
-     * @param string $databaseName Name of the database to select
-     * @param array  $options      Database constructor options
-     * @throws InvalidArgumentException for parameter/option parsing errors
      * @see Database::__construct() for supported options
      */
     public function getDatabase(string $databaseName, array $options = []): Database

--- a/src/Database.php
+++ b/src/Database.php
@@ -178,7 +178,7 @@ class Database
      */
     public function __get(string $collectionName)
     {
-        return $this->selectCollection($collectionName);
+        return $this->getCollection($collectionName);
     }
 
     /**
@@ -423,6 +423,30 @@ class Database
     }
 
     /**
+     * Returns a collection instance.
+     *
+     * If the collection does not exist in the database, it is not created when
+     * invoking this method.
+     *
+     * @param string $collectionName Name of the collection to select
+     * @param array  $options        Collection constructor options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     * @see Collection::__construct() for supported options
+     */
+    public function getCollection(string $collectionName, array $options = []): Collection
+    {
+        $options += [
+            'builderEncoder' => $this->builderEncoder,
+            'readConcern' => $this->readConcern,
+            'readPreference' => $this->readPreference,
+            'typeMap' => $this->typeMap,
+            'writeConcern' => $this->writeConcern,
+        ];
+
+        return new Collection($this->manager, $this->databaseName, $collectionName, $options);
+    }
+
+    /**
      * Returns the database name.
      *
      * @return string
@@ -588,15 +612,7 @@ class Database
      */
     public function selectCollection(string $collectionName, array $options = [])
     {
-        $options += [
-            'builderEncoder' => $this->builderEncoder,
-            'readConcern' => $this->readConcern,
-            'readPreference' => $this->readPreference,
-            'typeMap' => $this->typeMap,
-            'writeConcern' => $this->writeConcern,
-        ];
-
-        return new Collection($this->manager, $this->databaseName, $collectionName, $options);
+        return $this->getCollection($collectionName, $options);
     }
 
     /**

--- a/src/Database.php
+++ b/src/Database.php
@@ -428,10 +428,8 @@ class Database
      * If the collection does not exist in the database, it is not created when
      * invoking this method.
      *
-     * @param string $collectionName Name of the collection to select
-     * @param array  $options        Collection constructor options
-     * @throws InvalidArgumentException for parameter/option parsing errors
      * @see Collection::__construct() for supported options
+     * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function getCollection(string $collectionName, array $options = []): Collection
     {


### PR DESCRIPTION
PHPLIB-1185

This PR adds the following new methods:
* `Client::getDatabase`, changed `Client::selectDatabase` and `Client::__get` to proxy to this method
* `Client::getCollection`, changed `Client::selectCollection` to proxy to this method
* `Database::getCollection`, changed `Database::selectCollection` and `Database::__get` to proxy to this method

Since they are widely used, I did not add any deprecation warnings, nor did I add any language to the documentation to indicate that they are deprecated. I left the tests as they are, as the old methods were changed to proxy to the new methods, so we are implicitly testing them. I can duplicate the existing tests, but I don't think this is necessary.

As a follow-up to this PR, we should update the documentation to use the new `get(Database|Collection)` methods, starting in 2.0 (as we only maintain a single documentation for 1.x, so users would have to figure out which method is correct for their version).