### PR TITLE
Run dependabot for spec tests daily during spec fest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
Since there will be a considerable influx of spec work during spec fest, running dependabot daily for spec updates will help us handle tests better and allow for more granular updates.