### PR TITLE
Ignore `disableMD5` option as `md5` field is removed from the spec

### DIFF
--- a/tests/UnifiedSpecTests/Context.php
+++ b/tests/UnifiedSpecTests/Context.php
@@ -463,7 +463,7 @@ final class Context
 
     private function createBucket(string $id, stdClass $o): void
     {
-        Util::assertHasOnlyKeys($o, ['id', 'database', 'bucketOptions', 'disableMD5']);
+        Util::assertHasOnlyKeys($o, ['id', 'database', 'bucketOptions']);
 
         $databaseId = $o->database ?? null;
         assertIsString($databaseId);

--- a/tests/UnifiedSpecTests/Context.php
+++ b/tests/UnifiedSpecTests/Context.php
@@ -463,7 +463,7 @@ final class Context
 
     private function createBucket(string $id, stdClass $o): void
     {
-        Util::assertHasOnlyKeys($o, ['id', 'database', 'bucketOptions']);
+        Util::assertHasOnlyKeys($o, ['id', 'database', 'bucketOptions', 'disableMD5']);
 
         $databaseId = $o->database ?? null;
         assertIsString($databaseId);
@@ -499,7 +499,7 @@ final class Context
 
     private static function prepareBucketOptions(array $options): array
     {
-        Util::assertHasOnlyKeys($options, ['bucketName', 'chunkSizeBytes', 'readConcern', 'readPreference', 'writeConcern']);
+        Util::assertHasOnlyKeys($options, ['bucketName', 'chunkSizeBytes', 'disableMD5', 'readConcern', 'readPreference', 'writeConcern']);
 
         if (array_key_exists('bucketName', $options)) {
             assertIsString($options['bucketName']);

--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -769,10 +769,6 @@ final class Operation
     private function executeForBucket(Bucket $bucket)
     {
         $args = $this->prepareArguments();
-
-        // "md5" field is removed from the spec, option "disableMD5" is ignored
-        unset($args['disableMD5']);
-
         Util::assertArgumentsBySchema(Bucket::class, $this->name, $args);
 
         switch ($this->name) {

--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -769,6 +769,10 @@ final class Operation
     private function executeForBucket(Bucket $bucket)
     {
         $args = $this->prepareArguments();
+
+        // "md5" field is removed from the spec, option "disableMD5" is ignored
+        unset($args['disableMD5']);
+
         Util::assertArgumentsBySchema(Bucket::class, $this->name, $args);
 
         switch ($this->name) {

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -64,10 +64,6 @@ class UnifiedSpecTest extends FunctionalTestCase
         'index-management/search index operations ignore read and write concern: listSearchIndexes ignores read and write concern' => 'libmongoc appends readConcern to aggregate command',
         // Uses an invalid object name
         'run-command/runCursorCommand: does not close the cursor when receiving an empty batch' => 'Uses an invalid object name',
-        // GridFS deprecated fields are removed
-        'gridfs/gridfs-upload-disableMD5: upload when length is 0 sans MD5' => 'Deprecated fields are removed',
-        'gridfs/gridfs-upload-disableMD5: upload when length is 1 sans MD5' => 'Deprecated fields are removed',
-        'gridfs/gridfs-upload: upload when contentType is provided' => 'Deprecated fields are removed',
     ];
 
     /**

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -134,6 +134,7 @@ final class Util
             'delete' => ['id'],
             'downloadByName' => ['filename', 'revision'],
             'download' => ['id'],
+            // "disableMD5" is ignored but allowed for backward compatibility
             'uploadWithId' => ['id', 'filename', 'source', 'chunkSizeBytes', 'disableMD5', 'metadata'],
             'upload' => ['filename', 'source', 'chunkSizeBytes', 'disableMD5', 'metadata'],
         ],

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -134,8 +134,8 @@ final class Util
             'delete' => ['id'],
             'downloadByName' => ['filename', 'revision'],
             'download' => ['id'],
-            'uploadWithId' => ['id', 'filename', 'source', 'chunkSizeBytes', 'metadata'],
-            'upload' => ['filename', 'source', 'chunkSizeBytes', 'metadata'],
+            'uploadWithId' => ['id', 'filename', 'source', 'chunkSizeBytes', 'disableMD5', 'metadata'],
+            'upload' => ['filename', 'source', 'chunkSizeBytes', 'disableMD5', 'metadata'],
         ],
     ];
 


### PR DESCRIPTION
The `disableMD5` option is ignored. The behavior is to never write the `md5` field, which is [supported by upload tests](https://github.com/mongodb/specifications/blob/04560fc74c823732c693e89a63027bc1453e6dc3/source/gridfs/tests/upload.yml#L55-L56). 

Related to
- https://github.com/mongodb/specifications/pull/1683 Removed test on `contentType` option
- https://github.com/mongodb/mongo-php-library/pull/1398 Removed `md5` field from the library