### PR TITLE
PHPLIB-1568 Add `GridFS\Bucket::deleteByName(filename)` and `renameByName(filename, newFilename)`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -284,9 +284,18 @@
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/GridFS/CollectionWrapper.php">
+    <InvalidNullableReturnType>
+      <code><![CDATA[int]]></code>
+    </InvalidNullableReturnType>
     <MixedAssignment>
       <code><![CDATA[$ids[]]]></code>
     </MixedAssignment>
+    <NullableReturnStatement>
+      <code><![CDATA[$this->filesCollection->updateMany(
+            ['filename' => $filename],
+            ['$set' => ['filename' => $newFilename]],
+        )->getMatchedCount()]]></code>
+    </NullableReturnStatement>
   </file>
   <file src="src/GridFS/ReadableStream.php">
     <MixedArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -286,11 +286,13 @@
   <file src="src/GridFS/CollectionWrapper.php">
     <InvalidNullableReturnType>
       <code><![CDATA[int]]></code>
+      <code><![CDATA[int]]></code>
     </InvalidNullableReturnType>
     <MixedAssignment>
       <code><![CDATA[$ids[]]]></code>
     </MixedAssignment>
     <NullableReturnStatement>
+      <code><![CDATA[$count]]></code>
       <code><![CDATA[$this->filesCollection->updateMany(
             ['filename' => $filename],
             ['$set' => ['filename' => $newFilename]],

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -243,6 +243,19 @@ class Bucket
     }
 
     /**
+     * Delete all the revisions of a file name from the GridFS bucket.
+     *
+     * @param string $filename Filename
+     *
+     * @throws FileNotFoundException if no file could be selected
+     * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
+     */
+    public function deleteByName(string $filename): void
+    {
+        $this->collectionWrapper->deleteFileAndChunksByFilename($filename);
+    }
+
+    /**
      * Writes the contents of a GridFS file to a writable stream.
      *
      * @param mixed    $id          File ID

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -252,7 +252,11 @@ class Bucket
      */
     public function deleteByName(string $filename): void
     {
-        $this->collectionWrapper->deleteFileAndChunksByFilename($filename);
+        $count = $this->collectionWrapper->deleteFileAndChunksByFilename($filename);
+
+        if ($count === 0) {
+            throw FileNotFoundException::byFilename($filename);
+        }
     }
 
     /**
@@ -672,9 +676,9 @@ class Bucket
      */
     public function renameByName(string $filename, string $newFilename): void
     {
-        $matchedCount = $this->collectionWrapper->updateFilenameForFilename($filename, $newFilename);
+        $count = $this->collectionWrapper->updateFilenameForFilename($filename, $newFilename);
 
-        if (! $matchedCount) {
+        if ($count === 0) {
             throw FileNotFoundException::byFilename($filename);
         }
     }

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -662,6 +662,24 @@ class Bucket
     }
 
     /**
+     * Renames all the revisions of a file name in the GridFS bucket.
+     *
+     * @param string $filename    Filename
+     * @param string $newFilename New filename
+     *
+     * @throws FileNotFoundException if no file could be selected
+     * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
+     */
+    public function renameByName(string $filename, string $newFilename): void
+    {
+        $matchedCount = $this->collectionWrapper->updateFilenameForFilename($filename, $newFilename);
+
+        if (! $matchedCount) {
+            throw FileNotFoundException::byFilename($filename);
+        }
+    }
+
+    /**
      * Writes the contents of a readable stream to a GridFS file.
      *
      * Supported options:

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -150,9 +150,6 @@ class CollectionWrapper
      */
     public function findFileByFilenameAndRevision(string $filename, int $revision): ?object
     {
-        $filename = $filename;
-        $revision = $revision;
-
         if ($revision < 0) {
             $skip = abs($revision) - 1;
             $sortOrder = -1;
@@ -266,7 +263,7 @@ class CollectionWrapper
     /**
      * Updates the filename field in the file document for all the files with a given filename.
      */
-    public function updateFilenameForFilename(string $filename, string $newFilename): ?int
+    public function updateFilenameForFilename(string $filename, string $newFilename): int
     {
         return $this->filesCollection->updateMany(
             ['filename' => $filename],

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -74,7 +74,7 @@ class CollectionWrapper
     /**
      * Delete all GridFS files and chunks for a given filename.
      */
-    public function deleteFileAndChunksByFilename(string $filename): ?int
+    public function deleteFileAndChunksByFilename(string $filename): int
     {
         /** @var iterable<array{_id: mixed}> $files */
         $files = $this->findFiles(['filename' => $filename], [

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -160,6 +160,41 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertCollectionCount($this->chunksCollection, 0);
     }
 
+    public function testDeleteByName(): void
+    {
+        $this->bucket->uploadFromStream('filename', self::createStream('foobar1'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foobar2'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foobar3'));
+
+        $this->bucket->uploadFromStream('other', self::createStream('foobar'));
+
+        $this->assertCollectionCount($this->filesCollection, 4);
+        $this->assertCollectionCount($this->chunksCollection, 4);
+
+        $this->bucket->deleteByName('filename');
+
+        $this->assertCollectionCount($this->filesCollection, 1);
+        $this->assertCollectionCount($this->chunksCollection, 1);
+
+        $this->bucket->deleteByName('other');
+
+        $this->assertCollectionCount($this->filesCollection, 0);
+        $this->assertCollectionCount($this->chunksCollection, 0);
+    }
+
+    public function testDeleteByNameShouldIgnoreNonexistentFiles(): void
+    {
+        $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
+
+        $this->assertCollectionCount($this->filesCollection, 1);
+        $this->assertCollectionCount($this->chunksCollection, 1);
+
+        $this->bucket->deleteByName('nonexistent-filename');
+
+        $this->assertCollectionCount($this->filesCollection, 1);
+        $this->assertCollectionCount($this->chunksCollection, 1);
+    }
+
     public function testDownloadingFileWithMissingChunk(): void
     {
         $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -758,6 +758,24 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->rename('nonexistent-id', 'b');
     }
 
+    public function testRenameByName(): void
+    {
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
+        $this->bucket->uploadFromStream('filename', self::createStream('foo'));
+
+        $this->bucket->renameByName('filename', 'newname');
+
+        $this->assertNull($this->bucket->findOne(['filename' => 'filename']), 'No file has the old name');
+        $this->assertStreamContents('foo', $this->bucket->openDownloadStreamByName('newname'));
+    }
+
+    public function testRenameByNameShouldRequireFileToExist(): void
+    {
+        $this->expectException(FileNotFoundException::class);
+        $this->bucket->renameByName('nonexistent-name', 'b');
+    }
+
     public function testUploadFromStream(): void
     {
         $options = [

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -182,17 +182,10 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertCollectionCount($this->chunksCollection, 0);
     }
 
-    public function testDeleteByNameShouldIgnoreNonexistentFiles(): void
+    public function testDeleteByNameShouldRequireFileToExist(): void
     {
-        $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
-
-        $this->assertCollectionCount($this->filesCollection, 1);
-        $this->assertCollectionCount($this->chunksCollection, 1);
-
-        $this->bucket->deleteByName('nonexistent-filename');
-
-        $this->assertCollectionCount($this->filesCollection, 1);
-        $this->assertCollectionCount($this->chunksCollection, 1);
+        $this->expectException(FileNotFoundException::class);
+        $this->bucket->deleteByName('nonexistent-name');
     }
 
     public function testDownloadingFileWithMissingChunk(): void

--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -789,6 +789,12 @@ final class Operation
 
                 return $bucket->delete($args['id']);
 
+            case 'deleteByName':
+                assertArrayHasKey('filename', $args);
+                assertIsString($args['filename']);
+
+                return $bucket->deleteByName($args['filename']);
+
             case 'downloadByName':
                 assertArrayHasKey('filename', $args);
                 assertIsString($args['filename']);
@@ -811,6 +817,14 @@ final class Operation
                 $bucket->rename($args['id'], $args['newFilename']);
 
                 return null;
+
+            case 'renameByName':
+                assertArrayHasKey('filename', $args);
+                assertArrayHasKey('newFilename', $args);
+                assertIsString($args['filename']);
+                assertIsString($args['newFilename']);
+
+                return $bucket->renameByName($args['filename'], $args['newFilename']);
 
             case 'uploadWithId':
                 assertArrayHasKey('id', $args);

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -132,9 +132,11 @@ final class Util
         ],
         Bucket::class => [
             'delete' => ['id'],
+            'deleteByName' => ['filename'],
             'downloadByName' => ['filename', 'revision'],
             'download' => ['id'],
             'rename' => ['id', 'newFilename'],
+            'renameByName' => ['filename', 'newFilename'],
             'uploadWithId' => ['id', 'filename', 'source', 'chunkSizeBytes', 'disableMD5', 'contentType', 'metadata'],
             'upload' => ['filename', 'source', 'chunkSizeBytes', 'disableMD5', 'contentType', 'metadata'],
         ],


### PR DESCRIPTION
Fix PHPLIB-1568

## `GridFS\Bucket::deleteByName($filename)`
Use the `CollectionWrapper::deleteFileAndChunksByFilename()` introduced for the need of the `StreamWrapper::unlink()`. 
- https://github.com/mongodb/mongo-php-library/pull/1206

Implementation:

1. find file ids by file name
```js
db.files.find({filename: <filename>}, {projection: {_id: 1}})
```
3. delete files by ids
```js
db.files.deleteMany({_id: {$in: <ids>}})
```
5. delete chunks by file ids
```js
db.chunks.deleteMany({files_id: {$in: <ids>}})
```

If a DB error occurs during 1, nothing happened.
If a DB error occurs during 2 or 3, some chunks may become orphan and we cannot retry as the mapping chunks-id-to-file-name is missing.

There could be an issue if the list of ids is too big. In that case, we would have to work by batches.

## `GridFS\Bucket::renameByName($filename)`
Use the `CollectionWrapper::updateFilenameForFilename()` introduced for the need of `StreamWrapper::rename()`
- https://github.com/mongodb/mongo-php-library/pull/1207

Implementation:

1. update files with the file name, to set the new filename
```js
db.files.updateMany({filename: <filename>}, {$set: {filename: <newFilename>}})
```
