### PR TITLE
PHPLIB-1569: Implement $$matchAsDocument and $$matchAsRoot

### DIFF
--- a/tests/UnifiedSpecTests/Constraint/MatchesTest.php
+++ b/tests/UnifiedSpecTests/Constraint/MatchesTest.php
@@ -30,6 +30,12 @@ class MatchesTest extends FunctionalTestCase
         $this->assertResult(true, $c, ['x' => 1.0, 'y' => 1.0], 'Float instead of expected int matches');
         $this->assertResult(true, $c, ['x' => 1, 'y' => 1], 'Int instead of expected float matches');
         $this->assertResult(false, $c, ['x' => 'foo', 'y' => 1.0], 'Different type does not match');
+
+        /* Matches uses PHPUnit's comparators, which follow PHP behavior. This
+         * is more liberal than the comparison logic called for by the unified
+         * test format. This test can be removed when PHPLIB-1577 is addressed.
+         */
+        $this->assertResult(true, $c, ['x' => '1.0', 'y' => '1'], 'Numeric strings may match ints and floats');
     }
 
     public function testDoNotAllowExtraRootKeys(): void

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -60,7 +60,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         'valid-pass/expectedEventsForClient-eventType: eventType defaults to command if unset' => 'PHPC does not implement CMAP',
         // CSOT is not yet implemented (PHPC-1760)
         'valid-pass/collectionData-createOptions: collection is created with the correct options' => 'CSOT is not yet implemented (PHPC-1760)',
-        'valid-pass/matches-lte-operator: special lte matching operator' => 'CSOT is not yet implemented (PHPC-1760)',
+        'valid-pass/operator-lte: special lte matching operator' => 'CSOT is not yet implemented (PHPC-1760)',
         // libmongoc always adds readConcern to aggregate command
         'index-management/search index operations ignore read and write concern: listSearchIndexes ignores read and write concern' => 'libmongoc appends readConcern to aggregate command',
         // Uses an invalid object name

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -43,6 +43,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         'crud/replaceOne-sort' => 'Sort for replace operations is not supported (PHPLIB-1492)',
         'crud/updateOne-sort' => 'Sort for update operations is not supported (PHPLIB-1492)',
         'crud/bypassDocumentValidation' => 'bypassDocumentValidation is handled by libmongoc (PHPLIB-1576)',
+        'crud/distinct-hint' => 'Hint for distinct operations is not supported (PHPLIB-1582)',
     ];
 
     /** @var array<string, string> */

--- a/tests/UnifiedSpecTests/UnifiedTestRunner.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunner.php
@@ -61,7 +61,7 @@ final class UnifiedTestRunner
      *   - 1.9: Only createEntities operation is implemented
      *   - 1.10: Not implemented
      *   - 1.11: Not implemented, but CMAP is not applicable
-     *   - 1.13: Not implemented
+     *   - 1.13: Only $$matchAsDocument and $$matchAsRoot is implemented
      *   - 1.14: Not implemented
      */
     public const MAX_SCHEMA_VERSION = '1.15';


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1569
https://jira.mongodb.org/browse/PHPLIB-1577

POC for https://github.com/mongodb/specifications/pull/1706

Includes an extra test for numeric comparisons, which can be removed when PHPLIB-1577 is addressed.