### PR TITLE
Change dependabot to weekly runs for specifications submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Reverts mongodb/mongo-php-library#1497

With spec fest over, we can go back to weekly updates. Note that manual updates can be triggered anytime we deem necessary.