### PR TITLE
Configure automatic changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - mongodb-php-bot
+      - dependabot[bot]


### PR DESCRIPTION
Similar to https://github.com/mongodb/mongo-php-driver/pull/1757, we want to exclude merge ups and dependabot updates from appearing in release notes.