### PR TITLE
Remove specific encoder for `Group` and `DollarGroup`, use property name map

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -19,17 +19,18 @@ The `generator/config/*.yaml` files contains the list of operators and stages th
 
 ### Arguments
 
-| Field | Type | Description |
-| `name` | `string` | The name of the argument. It can start with `$` when the aggregation operator needs it, but it will be trimmed from the class property name. |
-| `type` | list of `string` | The list of accepted types |
-| `description` | `string` | The description of the argument from MongoDB's documentation. |
-| `optional` | `boolean` | Whether the argument is optional or not. |
-| `valueMin` | `number` | The minimum value for a numeric argument. |
-| `valueMax` | `number` | The maximum value for a numeric argument. |
-| `variadic` | `string` | If sent, the argument is variadic. Defines the format `array` for a list or `object` for a map |
-| `variadicMin` | `integer` | The minimum number of arguments for a variadic parameter. |
-| `default` | `scalar` or `array` | The default value for the argument. |
-| `mergeObject` | `bool` | Default `false`. If `true`, the value must be an object and the properties of the value object are merged into the parent operator. `$group` stage uses it for the fields. |
+| Field         | Type                | Description                                                                                                                                                               |
+|---------------|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`        | `string`            | The name of the argument. If it starts with `$`, the dollar is trimmed from the class property name                                                                       |
+| `type`        | list of `string`    | The list of accepted types                                                                                                                                                |
+| `description` | `string`            | The description of the argument from MongoDB's documentation                                                                                                              |
+| `optional`    | `boolean`           | Whether the argument is optional or not                                                                                                                                   |
+| `valueMin`    | `number`            | The minimum value for a numeric argument                                                                                                                                  |
+| `valueMax`    | `number`            | The maximum value for a numeric argument                                                                                                                                  |
+| `variadic`    | `string`            | If sent, the argument is variadic. Defines the format `array` for a list or `object` for a map                                                                            |
+| `variadicMin` | `integer`           | The minimum number of arguments for a variadic parameter                                                                                                                  |
+| `default`     | `scalar` or `array` | The default value for the argument                                                                                                                                        |
+| `mergeObject` | `bool`              | Default `false`. If `true`, the value must be an object and the properties of the value object are merged into the parent operator. `$group` stage uses it for the fields |
 
 ### Test pipelines
 

--- a/generator/README.md
+++ b/generator/README.md
@@ -20,7 +20,7 @@ The `generator/config/*.yaml` files contains the list of operators and stages th
 ### Arguments
 
 | Field | Type | Description |
-| `name` | `string` | The name of the argument. It can start with `$`. |
+| `name` | `string` | The name of the argument. It can start with `$` when the aggregation operator needs it, but it will be trimmed from the class property name. |
 | `type` | list of `string` | The list of accepted types |
 | `description` | `string` | The description of the argument from MongoDB's documentation. |
 | `optional` | `boolean` | Whether the argument is optional or not. |
@@ -29,7 +29,7 @@ The `generator/config/*.yaml` files contains the list of operators and stages th
 | `variadic` | `string` | If sent, the argument is variadic. Defines the format `array` for a list or `object` for a map |
 | `variadicMin` | `integer` | The minimum number of arguments for a variadic parameter. |
 | `default` | `scalar` or `array` | The default value for the argument. |
-| `noName` | `bool` | Default `false`. If `true`, the value must be an object and the properties of the value object are merged into the parent operator. `$group` stage uses it for the fields. |
+| `mergeObject` | `bool` | Default `false`. If `true`, the value must be an object and the properties of the value object are merged into the parent operator. `$group` stage uses it for the fields. |
 
 ### Test pipelines
 

--- a/generator/README.md
+++ b/generator/README.md
@@ -10,17 +10,30 @@ Updating the generated code can be done only by modifying the code generator, or
 To run the generator, you need to have PHP 8.1+ installed and Composer.
 
 1. Move to the `generator` directory: `cd generator`
-1. Install dependencies: `composer install`
-1. Run the generator: `./generate`
+2. Install dependencies: `composer install`
+3. Run the generator: `./generate`
 
 ## Configuration
 
 The `generator/config/*.yaml` files contains the list of operators and stages that are supported by the library.
 
+### Arguments
+
+| Field | Type | Description |
+| `name` | `string` | The name of the argument. It can start with `$`. |
+| `type` | list of `string` | The list of accepted types |
+| `description` | `string` | The description of the argument from MongoDB's documentation. |
+| `optional` | `boolean` | Whether the argument is optional or not. |
+| `valueMin` | `number` | The minimum value for a numeric argument. |
+| `valueMax` | `number` | The maximum value for a numeric argument. |
+| `variadic` | `string` | If sent, the argument is variadic. Defines the format `array` for a list or `object` for a map |
+| `variadicMin` | `integer` | The minimum number of arguments for a variadic parameter. |
+| `default` | `scalar` or `array` | The default value for the argument. |
+| `noName` | `bool` | Default `false`. If `true`, the value must be an object and the properties of the value object are merged into the parent operator. `$group` stage uses it for the fields. |
+
 ### Test pipelines
 
-Each operator can contain a `tests` section with a list if pipelines. To represent specific BSON objects,
-it is necessary to use Yaml tags:
+Each operator can contain a `tests` section with a list if pipelines. To represent specific BSON objects, it is necessary to use Yaml tags:
 
 | BSON Type   | Example                                                |
 |-------------|--------------------------------------------------------|
@@ -30,5 +43,4 @@ it is necessary to use Yaml tags:
 | UTCDateTime | `!bson_utcdatetime 0`                                  |
 | Binary      | `!bson_binary 'IA=='`                                  |
 
-To add new test cases to operators, you can get inspiration from the official MongoDB documentation and use
-the `generator/js2yaml.html` web page to manually convert a pipeline array from JS to Yaml.
+To add new test cases to operators, you can get inspiration from the official MongoDB documentation and use the `generator/js2yaml.html` web page to manually convert a pipeline array from JS to Yaml.

--- a/generator/config/query/geoIntersects.yaml
+++ b/generator/config/query/geoIntersects.yaml
@@ -3,12 +3,13 @@ name: $geoIntersects
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/geoIntersects/'
 type:
     - fieldQuery
-encode: single
+encode: object
 description: |
     Selects geometries that intersect with a GeoJSON geometry. The 2dsphere index supports $geoIntersects.
 arguments:
     -
         name: geometry
+        noName: true
         type:
             - geometry
 tests:

--- a/generator/config/query/geoIntersects.yaml
+++ b/generator/config/query/geoIntersects.yaml
@@ -9,7 +9,7 @@ description: |
 arguments:
     -
         name: geometry
-        noName: true
+        mergeObject: true
         type:
             - geometry
 tests:

--- a/generator/config/query/geoWithin.yaml
+++ b/generator/config/query/geoWithin.yaml
@@ -9,7 +9,7 @@ description: |
 arguments:
     -
         name: geometry
-        noName: true
+        mergeObject: true
         type:
             - geometry
 tests:

--- a/generator/config/query/geoWithin.yaml
+++ b/generator/config/query/geoWithin.yaml
@@ -3,12 +3,13 @@ name: $geoWithin
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/geoWithin/'
 type:
     - fieldQuery
-encode: single
+encode: object
 description: |
     Selects geometries within a bounding GeoJSON geometry. The 2dsphere and 2d indexes support $geoWithin.
 arguments:
     -
         name: geometry
+        noName: true
         type:
             - geometry
 tests:

--- a/generator/config/query/near.yaml
+++ b/generator/config/query/near.yaml
@@ -9,7 +9,7 @@ description: |
 arguments:
     -
         name: geometry
-        noName: true
+        mergeObject: true
         type:
             - geometry
     -

--- a/generator/config/query/near.yaml
+++ b/generator/config/query/near.yaml
@@ -3,23 +3,24 @@ name: $near
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/near/'
 type:
     - fieldQuery
-encode: dollar_object
+encode: object
 description: |
     Returns geospatial objects in proximity to a point. Requires a geospatial index. The 2dsphere and 2d indexes support $near.
 arguments:
     -
         name: geometry
+        noName: true
         type:
             - geometry
     -
-        name: maxDistance
+        name: $maxDistance
         type:
             - number
         optional: true
         description: |
             Distance in meters. Limits the results to those documents that are at most the specified distance from the center point.
     -
-        name: minDistance
+        name: $minDistance
         type:
             - number
         optional: true

--- a/generator/config/query/nearSphere.yaml
+++ b/generator/config/query/nearSphere.yaml
@@ -9,7 +9,7 @@ description: |
 arguments:
     -
         name: geometry
-        noName: true
+        mergeObject: true
         type:
             - geometry
     -

--- a/generator/config/query/nearSphere.yaml
+++ b/generator/config/query/nearSphere.yaml
@@ -3,23 +3,24 @@ name: $nearSphere
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/'
 type:
     - fieldQuery
-encode: dollar_object
+encode: object
 description: |
     Returns geospatial objects in proximity to a point on a sphere. Requires a geospatial index. The 2dsphere and 2d indexes support $nearSphere.
 arguments:
     -
         name: geometry
+        noName: true
         type:
             - geometry
     -
-        name: maxDistance
+        name: $maxDistance
         type:
             - number
         optional: true
         description: |
             Distance in meters.
     -
-        name: minDistance
+        name: $minDistance
         type:
             - number
         optional: true

--- a/generator/config/query/text.yaml
+++ b/generator/config/query/text.yaml
@@ -3,18 +3,18 @@ name: $text
 link: 'https://www.mongodb.com/docs/manual/reference/operator/query/text/'
 type:
     - query
-encode: dollar_object
+encode: object
 description: |
     Performs text search.
 arguments:
     -
-        name: search
+        name: $search
         type:
             - string
         description: |
             A string of terms that MongoDB parses and uses to query the text index. MongoDB performs a logical OR search of the terms unless specified as a phrase.
     -
-        name: language
+        name: $language
         type:
             - string
         optional: true
@@ -22,14 +22,14 @@ arguments:
             The language that determines the list of stop words for the search and the rules for the stemmer and tokenizer. If not specified, the search uses the default language of the index.
             If you specify a default_language value of none, then the text index parses through each word in the field, including stop words, and ignores suffix stemming.
     -
-        name: caseSensitive
+        name: $caseSensitive
         type:
             - bool
         optional: true
         description: |
             A boolean flag to enable or disable case sensitive search. Defaults to false; i.e. the search defers to the case insensitivity of the text index.
     -
-        name: diacriticSensitive
+        name: $diacriticSensitive
         type:
             - bool
         optional: true

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -168,8 +168,8 @@
                     "$comment": "The default value for the argument.",
                     "type": ["array", "boolean", "number", "string"]
                 },
-                "noName": {
-                    "$comment": "Skip the name in object encoding and merge the value object",
+                "mergeObject": {
+                    "$comment": "Skip the name in object encoding and merge the properties of the value into the operator",
                     "type": "boolean",
                     "default": false
                 }

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -61,9 +61,7 @@
                         "array",
                         "object",
                         "flat_object",
-                        "dollar_object",
-                        "single",
-                        "group"
+                        "single"
                     ]
                 },
                 "description": {
@@ -100,7 +98,7 @@
             "properties": {
                 "name": {
                     "type": "string",
-                    "pattern": "^(_?[a-z][a-zA-Z0-9]*|N)$"
+                    "pattern": "^([_$]?[a-z][a-zA-Z0-9]*|N)$"
                 },
                 "type": {
                     "type": "array",
@@ -150,7 +148,7 @@
                     "type": "number"
                 },
                 "valueMax": {
-                    "$comment": "The minimum value for a numeric argument.",
+                    "$comment": "The maximum value for a numeric argument.",
                     "type": "number"
                 },
                 "variadic": {
@@ -169,6 +167,11 @@
                 "default": {
                     "$comment": "The default value for the argument.",
                     "type": ["array", "boolean", "number", "string"]
+                },
+                "noName": {
+                    "$comment": "Skip the name in object encoding and merge the value object",
+                    "type": "boolean",
+                    "default": false
                 }
             },
             "required": [

--- a/generator/config/stage/group.yaml
+++ b/generator/config/stage/group.yaml
@@ -3,7 +3,7 @@ name: $group
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/'
 type:
     - stage
-encode: group
+encode: object
 description: |
     Groups input documents by a specified identifier expression and applies the accumulator expression(s), if specified, to each group. Consumes all input documents and outputs one document per each distinct group. The output documents only contain the identifier field and, if specified, accumulated fields.
 arguments:
@@ -15,6 +15,7 @@ arguments:
             The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents.
     -
         name: field
+        noName: true
         type:
             - accumulator
         variadic: object

--- a/generator/config/stage/group.yaml
+++ b/generator/config/stage/group.yaml
@@ -15,7 +15,7 @@ arguments:
             The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents.
     -
         name: field
-        noName: true
+        mergeObject: true
         type:
             - accumulator
         variadic: object

--- a/generator/src/Definition/ArgumentDefinition.php
+++ b/generator/src/Definition/ArgumentDefinition.php
@@ -25,6 +25,7 @@ final class ArgumentDefinition
         string|null $variadic = null,
         int|null $variadicMin = null,
         public mixed $default = null,
+        public bool $noName = false,
     ) {
         assert($this->optional === false || $this->default === null, 'Optional arguments cannot have a default value');
         if (is_array($type)) {

--- a/generator/src/Definition/ArgumentDefinition.php
+++ b/generator/src/Definition/ArgumentDefinition.php
@@ -9,10 +9,12 @@ use function assert;
 use function get_debug_type;
 use function is_array;
 use function is_string;
+use function ltrim;
 use function sprintf;
 
 final class ArgumentDefinition
 {
+    public string $propertyName;
     public VariadicType|null $variadic;
     public int|null $variadicMin;
 
@@ -25,7 +27,7 @@ final class ArgumentDefinition
         string|null $variadic = null,
         int|null $variadicMin = null,
         public mixed $default = null,
-        public bool $noName = false,
+        public bool $mergeObject = false,
     ) {
         assert($this->optional === false || $this->default === null, 'Optional arguments cannot have a default value');
         if (is_array($type)) {
@@ -34,6 +36,8 @@ final class ArgumentDefinition
                 assert(is_string($t), sprintf('Type must be a list of strings. Got %s', get_debug_type($type)));
             }
         }
+
+        $this->propertyName = ltrim($this->name, '$');
 
         if ($variadic) {
             $this->variadic = VariadicType::from($variadic);

--- a/generator/src/Definition/OperatorDefinition.php
+++ b/generator/src/Definition/OperatorDefinition.php
@@ -40,8 +40,6 @@ final class OperatorDefinition
             'array' => Encode::Array,
             'object' => Encode::Object,
             'flat_object' => Encode::FlatObject,
-            'dollar_object' => Encode::DollarObject,
-            'group' => Encode::Group,
             default => throw new UnexpectedValueException(sprintf('Unexpected "encode" value for operator "%s". Got "%s"', $name, $encode)),
         };
 

--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -20,6 +20,7 @@ use Throwable;
 
 use function assert;
 use function interface_exists;
+use function ltrim;
 use function rtrim;
 use function sprintf;
 use function var_export;
@@ -61,27 +62,32 @@ class OperatorClassGenerator extends OperatorGenerator
         $namespace->addUse(Encode::class);
         $class->addConstant('ENCODE', new Literal('Encode::' . $operator->encode->name));
 
-        $constuctor = $class->addMethod('__construct');
+        $encodeNames = [];
+        $constructor = $class->addMethod('__construct');
         foreach ($operator->arguments as $argument) {
+            // Remove the leading $ from the argument name
+            $argName = ltrim($argument->name, '$');
+            $encodeNames[$argName] = $argument->noName ? null : $argument->name;
+
             $type = $this->getAcceptedTypes($argument);
             foreach ($type->use as $use) {
                 $namespace->addUse($use);
             }
 
-            $property = $class->addProperty($argument->name);
+            $property = $class->addProperty($argName);
             $property->setReadOnly();
-            $constuctorParam = $constuctor->addParameter($argument->name);
-            $constuctorParam->setType($type->native);
+            $constructorParam = $constructor->addParameter($argName);
+            $constructorParam->setType($type->native);
 
             if ($argument->variadic) {
-                $constuctor->setVariadic();
-                $constuctor->addComment('@param ' . $type->doc . ' ...$' . $argument->name . rtrim(' ' . $argument->description));
+                $constructor->setVariadic();
+                $constructor->addComment('@param ' . $type->doc . ' ...$' . $argName . rtrim(' ' . $argument->description));
 
                 if ($argument->variadicMin > 0) {
                     $namespace->addUse(InvalidArgumentException::class);
-                    $constuctor->addBody(<<<PHP
-                    if (\count(\${$argument->name}) < {$argument->variadicMin}) {
-                        throw new InvalidArgumentException(\sprintf('Expected at least %d values for \${$argument->name}, got %d.', {$argument->variadicMin}, \count(\${$argument->name})));
+                    $constructor->addBody(<<<PHP
+                    if (\count(\${$argName}) < {$argument->variadicMin}) {
+                        throw new InvalidArgumentException(\sprintf('Expected at least %d values for \${$argName}, got %d.', {$argument->variadicMin}, \count(\${$argName})));
                     }
 
                     PHP);
@@ -89,45 +95,45 @@ class OperatorClassGenerator extends OperatorGenerator
 
                 if ($argument->variadic === VariadicType::Array) {
                     $property->setType('array');
-                    $property->addComment('@var list<' . $type->doc . '> $' . $argument->name . rtrim(' ' . $argument->description));
+                    $property->addComment('@var list<' . $type->doc . '> $' . $argName . rtrim(' ' . $argument->description));
                     // Warn that named arguments are not supported
                     // @see https://psalm.dev/docs/running_psalm/issues/NamedArgumentNotAllowed/
-                    $constuctor->addComment('@no-named-arguments');
+                    $constructor->addComment('@no-named-arguments');
                     $namespace->addUseFunction('array_is_list');
                     $namespace->addUse(InvalidArgumentException::class);
-                    $constuctor->addBody(<<<PHP
-                    if (! array_is_list(\${$argument->name})) {
-                        throw new InvalidArgumentException('Expected \${$argument->name} arguments to be a list (array), named arguments are not supported');
+                    $constructor->addBody(<<<PHP
+                    if (! array_is_list(\${$argName})) {
+                        throw new InvalidArgumentException('Expected \${$argName} arguments to be a list (array), named arguments are not supported');
                     }
 
                     PHP);
                 } elseif ($argument->variadic === VariadicType::Object) {
                     $namespace->addUse(stdClass::class);
                     $property->setType(stdClass::class);
-                    $property->addComment('@var stdClass<' . $type->doc . '> $' . $argument->name . rtrim(' ' . $argument->description));
+                    $property->addComment('@var stdClass<' . $type->doc . '> $' . $argName . rtrim(' ' . $argument->description));
                     $namespace->addUseFunction('is_string');
                     $namespace->addUse(InvalidArgumentException::class);
-                    $constuctor->addBody(<<<PHP
-                    foreach(\${$argument->name} as \$key => \$value) {
+                    $constructor->addBody(<<<PHP
+                    foreach(\${$argName} as \$key => \$value) {
                         if (! is_string(\$key)) {
-                            throw new InvalidArgumentException('Expected \${$argument->name} arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
+                            throw new InvalidArgumentException('Expected \${$argName} arguments to be a map (object), named arguments (<name>:<value>) or array unpacking ...[\'<name>\' => <value>] must be used');
                         }
                     }
 
-                    \${$argument->name} = (object) \${$argument->name};
+                    \${$argName} = (object) \${$argName};
                     PHP);
                 }
             } else {
                 // Non-variadic arguments
-                $property->addComment('@var ' . $type->doc . ' $' . $argument->name . rtrim(' ' . $argument->description));
+                $property->addComment('@var ' . $type->doc . ' $' . $argName . rtrim(' ' . $argument->description));
                 $property->setType($type->native);
-                $constuctor->addComment('@param ' . $type->doc . ' $' . $argument->name . rtrim(' ' . $argument->description));
+                $constructor->addComment('@param ' . $type->doc . ' $' . $argName . rtrim(' ' . $argument->description));
 
                 if ($argument->optional) {
                     // We use a special Optional::Undefined type to differentiate between null and undefined
-                    $constuctorParam->setDefaultValue(new Literal('Optional::Undefined'));
+                    $constructorParam->setDefaultValue(new Literal('Optional::Undefined'));
                 } elseif ($argument->default !== null) {
-                    $constuctorParam->setDefaultValue($argument->default);
+                    $constructorParam->setDefaultValue($argument->default);
                 }
 
                 // List type must be validated with array_is_list()
@@ -135,9 +141,9 @@ class OperatorClassGenerator extends OperatorGenerator
                     $namespace->addUseFunction('is_array');
                     $namespace->addUseFunction('array_is_list');
                     $namespace->addUse(InvalidArgumentException::class);
-                    $constuctor->addBody(<<<PHP
-                    if (is_array(\${$argument->name}) && ! array_is_list(\${$argument->name})) {
-                        throw new InvalidArgumentException('Expected \${$argument->name} argument to be a list, got an associative array.');
+                    $constructor->addBody(<<<PHP
+                    if (is_array(\${$argName}) && ! array_is_list(\${$argName})) {
+                        throw new InvalidArgumentException('Expected \${$argName} argument to be a list, got an associative array.');
                     }
 
                     PHP);
@@ -146,9 +152,9 @@ class OperatorClassGenerator extends OperatorGenerator
                 if ($type->query) {
                     $namespace->addUseFunction('is_array');
                     $namespace->addUse(QueryObject::class);
-                    $constuctor->addBody(<<<PHP
-                    if (is_array(\${$argument->name})) {
-                        \${$argument->name} = QueryObject::create(\${$argument->name});
+                    $constructor->addBody(<<<PHP
+                    if (is_array(\${$argName})) {
+                        \${$argName} = QueryObject::create(\${$argName});
                     }
 
                     PHP);
@@ -157,9 +163,9 @@ class OperatorClassGenerator extends OperatorGenerator
                 if ($type->javascript) {
                     $namespace->addUseFunction('is_string');
                     $namespace->addUse(Javascript::class);
-                    $constuctor->addBody(<<<PHP
-                    if (is_string(\${$argument->name})) {
-                        \${$argument->name} = new Javascript(\${$argument->name});
+                    $constructor->addBody(<<<PHP
+                    if (is_string(\${$argName})) {
+                        \${$argName} = new Javascript(\${$argName});
                     }
 
                     PHP);
@@ -167,7 +173,11 @@ class OperatorClassGenerator extends OperatorGenerator
             }
 
             // Set property from constructor argument
-            $constuctor->addBody('$this->' . $argument->name . ' = $' . $argument->name . ';');
+            $constructor->addBody('$this->' . $argName . ' = $' . $argName . ';');
+        }
+
+        if ($encodeNames !== []) {
+            $class->addConstant('PROPERTIES', $encodeNames);
         }
 
         $class->addMethod('getOperator')

--- a/generator/src/OperatorFactoryGenerator.php
+++ b/generator/src/OperatorFactoryGenerator.php
@@ -60,13 +60,12 @@ final class OperatorFactoryGenerator extends OperatorGenerator
         $method->addComment('@see ' . $operator->link);
         $args = [];
         foreach ($operator->arguments as $argument) {
-            $argName = ltrim($argument->name, '$');
             $type = $this->getAcceptedTypes($argument);
             foreach ($type->use as $use) {
                 $namespace->addUse($use);
             }
 
-            $parameter = $method->addParameter($argName);
+            $parameter = $method->addParameter($argument->propertyName);
             $parameter->setType($type->native);
             if ($argument->variadic) {
                 if ($argument->variadic === VariadicType::Array) {
@@ -76,8 +75,8 @@ final class OperatorFactoryGenerator extends OperatorGenerator
                 }
 
                 $method->setVariadic();
-                $method->addComment('@param ' . $type->doc . ' ...$' . $argName . rtrim(' ' . $argument->description));
-                $args[] = '...$' . $argName;
+                $method->addComment('@param ' . $type->doc . ' ...$' . $argument->propertyName . rtrim(' ' . $argument->description));
+                $args[] = '...$' . $argument->propertyName;
             } else {
                 if ($argument->optional) {
                     $parameter->setDefaultValue(new Literal('Optional::Undefined'));
@@ -85,8 +84,8 @@ final class OperatorFactoryGenerator extends OperatorGenerator
                     $parameter->setDefaultValue($argument->default);
                 }
 
-                $method->addComment('@param ' . $type->doc . ' $' . $argName . rtrim(' ' . $argument->description));
-                $args[] = '$' . $argName;
+                $method->addComment('@param ' . $type->doc . ' $' . $argument->propertyName . rtrim(' ' . $argument->description));
+                $args[] = '$' . $argument->propertyName;
             }
         }
 

--- a/generator/src/OperatorFactoryGenerator.php
+++ b/generator/src/OperatorFactoryGenerator.php
@@ -60,12 +60,13 @@ final class OperatorFactoryGenerator extends OperatorGenerator
         $method->addComment('@see ' . $operator->link);
         $args = [];
         foreach ($operator->arguments as $argument) {
+            $argName = ltrim($argument->name, '$');
             $type = $this->getAcceptedTypes($argument);
             foreach ($type->use as $use) {
                 $namespace->addUse($use);
             }
 
-            $parameter = $method->addParameter($argument->name);
+            $parameter = $method->addParameter($argName);
             $parameter->setType($type->native);
             if ($argument->variadic) {
                 if ($argument->variadic === VariadicType::Array) {
@@ -75,8 +76,8 @@ final class OperatorFactoryGenerator extends OperatorGenerator
                 }
 
                 $method->setVariadic();
-                $method->addComment('@param ' . $type->doc . ' ...$' . $argument->name . rtrim(' ' . $argument->description));
-                $args[] = '...$' . $argument->name;
+                $method->addComment('@param ' . $type->doc . ' ...$' . $argName . rtrim(' ' . $argument->description));
+                $args[] = '...$' . $argName;
             } else {
                 if ($argument->optional) {
                     $parameter->setDefaultValue(new Literal('Optional::Undefined'));
@@ -84,8 +85,8 @@ final class OperatorFactoryGenerator extends OperatorGenerator
                     $parameter->setDefaultValue($argument->default);
                 }
 
-                $method->addComment('@param ' . $type->doc . ' $' . $argument->name . rtrim(' ' . $argument->description));
-                $args[] = '$' . $argument->name;
+                $method->addComment('@param ' . $type->doc . ' $' . $argName . rtrim(' ' . $argument->description));
+                $args[] = '$' . $argName;
             }
         }
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -160,4 +160,7 @@
     <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
         <exclude-pattern>/tests/SpecTests/*/Prose*</exclude-pattern>
     </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint.UselessDocComment">
+        <exclude-pattern>src/Builder/Type/OperatorInterface.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -61,14 +61,23 @@
   </file>
   <file src="src/Builder/Encoder/OperatorEncoder.php">
     <MixedAssignment>
+      <code><![CDATA[$k]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$name]]></code>
+      <code><![CDATA[$prop]]></code>
+      <code><![CDATA[$prop]]></code>
+      <code><![CDATA[$prop]]></code>
       <code><![CDATA[$result]]></code>
       <code><![CDATA[$result[]]]></code>
-      <code><![CDATA[$val]]></code>
-      <code><![CDATA[$val]]></code>
+      <code><![CDATA[$v]]></code>
       <code><![CDATA[$val]]></code>
       <code><![CDATA[$val]]></code>
       <code><![CDATA[$val]]></code>
     </MixedAssignment>
+    <PossibleRawObjectIteration>
+      <code><![CDATA[$val]]></code>
+    </PossibleRawObjectIteration>
   </file>
   <file src="src/Builder/Encoder/OutputWindowEncoder.php">
     <MixedArgument>

--- a/src/Builder/Accumulator/AccumulatorAccumulator.php
+++ b/src/Builder/Accumulator/AccumulatorAccumulator.php
@@ -32,6 +32,16 @@ class AccumulatorAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'init' => 'init',
+        'accumulate' => 'accumulate',
+        'accumulateArgs' => 'accumulateArgs',
+        'merge' => 'merge',
+        'lang' => 'lang',
+        'initArgs' => 'initArgs',
+        'finalize' => 'finalize',
+    ];
+
     /** @var Javascript|string $init Function used to initialize the state. The init function receives its arguments from the initArgs array expression. You can specify the function definition as either BSON type Code or String. */
     public readonly Javascript|string $init;
 

--- a/src/Builder/Accumulator/AddToSetAccumulator.php
+++ b/src/Builder/Accumulator/AddToSetAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 class AddToSetAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Accumulator/AvgAccumulator.php
+++ b/src/Builder/Accumulator/AvgAccumulator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class AvgAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression;

--- a/src/Builder/Accumulator/BottomAccumulator.php
+++ b/src/Builder/Accumulator/BottomAccumulator.php
@@ -27,6 +27,7 @@ use stdClass;
 class BottomAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['sortBy' => 'sortBy', 'output' => 'output'];
 
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
     public readonly Document|Serializable|stdClass|array $sortBy;

--- a/src/Builder/Accumulator/BottomNAccumulator.php
+++ b/src/Builder/Accumulator/BottomNAccumulator.php
@@ -29,6 +29,7 @@ use stdClass;
 class BottomNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['n' => 'n', 'sortBy' => 'sortBy', 'output' => 'output'];
 
     /** @var ResolvesToInt|int $n Limits the number of results per group and has to be a positive integral expression that is either a constant or depends on the _id value for $group. */
     public readonly ResolvesToInt|int $n;

--- a/src/Builder/Accumulator/CovariancePopAccumulator.php
+++ b/src/Builder/Accumulator/CovariancePopAccumulator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class CovariancePopAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression1 */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression1;

--- a/src/Builder/Accumulator/CovarianceSampAccumulator.php
+++ b/src/Builder/Accumulator/CovarianceSampAccumulator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class CovarianceSampAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression1 */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression1;

--- a/src/Builder/Accumulator/DerivativeAccumulator.php
+++ b/src/Builder/Accumulator/DerivativeAccumulator.php
@@ -29,6 +29,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class DerivativeAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'unit' => 'unit'];
 
     /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $input */
     public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $input;

--- a/src/Builder/Accumulator/ExpMovingAvgAccumulator.php
+++ b/src/Builder/Accumulator/ExpMovingAvgAccumulator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class ExpMovingAvgAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'N' => 'N', 'alpha' => 'alpha'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $input */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $input;

--- a/src/Builder/Accumulator/FirstAccumulator.php
+++ b/src/Builder/Accumulator/FirstAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 class FirstAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Accumulator/FirstNAccumulator.php
+++ b/src/Builder/Accumulator/FirstNAccumulator.php
@@ -27,6 +27,7 @@ use stdClass;
 class FirstNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input An expression that resolves to the array from which to return n elements. */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;

--- a/src/Builder/Accumulator/IntegralAccumulator.php
+++ b/src/Builder/Accumulator/IntegralAccumulator.php
@@ -29,6 +29,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class IntegralAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'unit' => 'unit'];
 
     /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $input */
     public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $input;

--- a/src/Builder/Accumulator/LastAccumulator.php
+++ b/src/Builder/Accumulator/LastAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 class LastAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Accumulator/LastNAccumulator.php
+++ b/src/Builder/Accumulator/LastNAccumulator.php
@@ -31,6 +31,7 @@ use function is_array;
 class LastNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return n elements. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;

--- a/src/Builder/Accumulator/LinearFillAccumulator.php
+++ b/src/Builder/Accumulator/LinearFillAccumulator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class LinearFillAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression;

--- a/src/Builder/Accumulator/LocfAccumulator.php
+++ b/src/Builder/Accumulator/LocfAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 class LocfAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Accumulator/MaxAccumulator.php
+++ b/src/Builder/Accumulator/MaxAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 class MaxAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Accumulator/MaxNAccumulator.php
+++ b/src/Builder/Accumulator/MaxNAccumulator.php
@@ -29,6 +29,7 @@ use function is_array;
 class MaxNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return the maximal n elements. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;

--- a/src/Builder/Accumulator/MedianAccumulator.php
+++ b/src/Builder/Accumulator/MedianAccumulator.php
@@ -29,6 +29,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class MedianAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'method' => 'method'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $input;

--- a/src/Builder/Accumulator/MergeObjectsAccumulator.php
+++ b/src/Builder/Accumulator/MergeObjectsAccumulator.php
@@ -24,6 +24,7 @@ use stdClass;
 class MergeObjectsAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['document' => 'document'];
 
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $document Any valid expression that resolves to a document. */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array $document;

--- a/src/Builder/Accumulator/MinAccumulator.php
+++ b/src/Builder/Accumulator/MinAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 class MinAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Accumulator/MinNAccumulator.php
+++ b/src/Builder/Accumulator/MinNAccumulator.php
@@ -29,6 +29,7 @@ use function is_array;
 class MinNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return the maximal n elements. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;

--- a/src/Builder/Accumulator/PercentileAccumulator.php
+++ b/src/Builder/Accumulator/PercentileAccumulator.php
@@ -39,6 +39,7 @@ use function is_array;
 class PercentileAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'p' => 'p', 'method' => 'method'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $input;

--- a/src/Builder/Accumulator/PushAccumulator.php
+++ b/src/Builder/Accumulator/PushAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 class PushAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Accumulator/ShiftAccumulator.php
+++ b/src/Builder/Accumulator/ShiftAccumulator.php
@@ -24,6 +24,7 @@ use stdClass;
 class ShiftAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['output' => 'output', 'by' => 'by', 'default' => 'default'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Specifies an expression to evaluate and return in the output. */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;

--- a/src/Builder/Accumulator/StdDevPopAccumulator.php
+++ b/src/Builder/Accumulator/StdDevPopAccumulator.php
@@ -26,6 +26,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class StdDevPopAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression;

--- a/src/Builder/Accumulator/StdDevSampAccumulator.php
+++ b/src/Builder/Accumulator/StdDevSampAccumulator.php
@@ -26,6 +26,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class StdDevSampAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression;

--- a/src/Builder/Accumulator/SumAccumulator.php
+++ b/src/Builder/Accumulator/SumAccumulator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\WindowInterface;
 class SumAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression;

--- a/src/Builder/Accumulator/TopAccumulator.php
+++ b/src/Builder/Accumulator/TopAccumulator.php
@@ -28,6 +28,7 @@ use stdClass;
 class TopAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['sortBy' => 'sortBy', 'output' => 'output'];
 
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
     public readonly Document|Serializable|stdClass|array $sortBy;

--- a/src/Builder/Accumulator/TopNAccumulator.php
+++ b/src/Builder/Accumulator/TopNAccumulator.php
@@ -29,6 +29,7 @@ use stdClass;
 class TopNAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['n' => 'n', 'sortBy' => 'sortBy', 'output' => 'output'];
 
     /** @var ResolvesToInt|int $n limits the number of results per group and has to be a positive integral expression that is either a constant or depends on the _id value for $group. */
     public readonly ResolvesToInt|int $n;

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -74,6 +74,8 @@ class OperatorEncoder extends AbstractExpressionEncoder
                 continue;
             }
 
+            // The name is null for arguments with "mergeObject: true" in the YAML file,
+            // the value properties are merged into the parent object.
             if ($name === null) {
                 $val = $this->recursiveEncode($val);
                 foreach ($val as $k => $v) {

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Encoder;
 
 use LogicException;
-use MongoDB\Builder\Stage\GroupStage;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
@@ -13,12 +12,6 @@ use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 use stdClass;
 
-use function array_key_exists;
-use function assert;
-use function get_object_vars;
-use function is_array;
-use function is_object;
-use function property_exists;
 use function sprintf;
 
 /** @template-extends AbstractExpressionEncoder<stdClass, OperatorInterface> */
@@ -42,8 +35,6 @@ class OperatorEncoder extends AbstractExpressionEncoder
             Encode::Single => $this->encodeAsSingle($value),
             Encode::Array => $this->encodeAsArray($value),
             Encode::Object, Encode::FlatObject => $this->encodeAsObject($value),
-            Encode::DollarObject => $this->encodeAsDollarObject($value),
-            Encode::Group => $this->encodeAsGroup($value),
             default => throw new LogicException(sprintf('Class "%s" does not have a valid ENCODE constant.', $value::class)),
         };
     }
@@ -54,8 +45,8 @@ class OperatorEncoder extends AbstractExpressionEncoder
     private function encodeAsArray(OperatorInterface $value): stdClass
     {
         $result = [];
-        /** @var mixed $val */
-        foreach (get_object_vars($value) as $val) {
+        foreach ($value::PROPERTIES as $prop => $name) {
+            $val = $value->$prop;
             // Skip optional arguments. For example, the $slice expression operator has an optional <position> argument
             // in the middle of the array.
             if ($val === Optional::Undefined) {
@@ -68,60 +59,29 @@ class OperatorEncoder extends AbstractExpressionEncoder
         return $this->wrap($value, $result);
     }
 
-    private function encodeAsDollarObject(OperatorInterface $value): stdClass
-    {
-        $result = new stdClass();
-        foreach (get_object_vars($value) as $key => $val) {
-            // Skip optional arguments. If they have a default value, it is resolved by the server.
-            if ($val === Optional::Undefined) {
-                continue;
-            }
-
-            $val = $this->recursiveEncode($val);
-
-            if ($key === 'geometry') {
-                if (is_object($val) && property_exists($val, '$geometry')) {
-                    $result->{'$geometry'} = $val->{'$geometry'};
-                } elseif (is_array($val) && array_key_exists('$geometry', $val)) {
-                    $result->{'$geometry'} = $val['$geometry'];
-                } else {
-                    $result->{'$geometry'} = $val;
-                }
-            } else {
-                $result->{'$' . $key} = $val;
-            }
-        }
-
-        return $this->wrap($value, $result);
-    }
-
     /**
-     * $group stage have a specific encoding because the _id argument is required and others are variadic
+     * Encode the value as an object with properties. Property names are
+     * mapped by the PROPERTIES constant.
      */
-    private function encodeAsGroup(OperatorInterface $value): stdClass
-    {
-        assert($value instanceof GroupStage);
-
-        $result = new stdClass();
-        $result->_id = $this->recursiveEncode($value->_id);
-
-        foreach (get_object_vars($value->field) as $key => $val) {
-            $result->{$key} = $this->recursiveEncode($val);
-        }
-
-        return $this->wrap($value, $result);
-    }
-
     private function encodeAsObject(OperatorInterface $value): stdClass
     {
         $result = new stdClass();
-        foreach (get_object_vars($value) as $key => $val) {
+        foreach ($value::PROPERTIES as $prop => $name) {
+            $val = $value->$prop;
+
             // Skip optional arguments. If they have a default value, it is resolved by the server.
             if ($val === Optional::Undefined) {
                 continue;
             }
 
-            $result->{$key} = $this->recursiveEncode($val);
+            if ($name === null) {
+                $val = $this->recursiveEncode($val);
+                foreach ($val as $k => $v) {
+                    $result->{$k} = $v;
+                }
+            } else {
+                $result->{$name} = $this->recursiveEncode($val);
+            }
         }
 
         return $value::ENCODE === Encode::FlatObject
@@ -134,8 +94,8 @@ class OperatorEncoder extends AbstractExpressionEncoder
      */
     private function encodeAsSingle(OperatorInterface $value): stdClass
     {
-        foreach (get_object_vars($value) as $val) {
-            $result = $this->recursiveEncode($val);
+        foreach ($value::PROPERTIES as $prop => $name) {
+            $result = $this->recursiveEncode($value->$prop);
 
             return $this->wrap($value, $result);
         }

--- a/src/Builder/Expression/AbsOperator.php
+++ b/src/Builder/Expression/AbsOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class AbsOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $value */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $value;

--- a/src/Builder/Expression/AcosOperator.php
+++ b/src/Builder/Expression/AcosOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class AcosOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $acos takes any valid expression that resolves to a number between -1 and 1, e.g. -1 <= value <= 1.

--- a/src/Builder/Expression/AcoshOperator.php
+++ b/src/Builder/Expression/AcoshOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class AcoshOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $acosh takes any valid expression that resolves to a number between 1 and +Infinity, e.g. 1 <= value <= +Infinity.

--- a/src/Builder/Expression/AddOperator.php
+++ b/src/Builder/Expression/AddOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int> $expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date. */
     public readonly array $expression;

--- a/src/Builder/Expression/AllElementsTrueOperator.php
+++ b/src/Builder/Expression/AllElementsTrueOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class AllElementsTrueOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression;

--- a/src/Builder/Expression/AndOperator.php
+++ b/src/Builder/Expression/AndOperator.php
@@ -27,6 +27,7 @@ use function array_is_list;
 class AndOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/AnyElementTrueOperator.php
+++ b/src/Builder/Expression/AnyElementTrueOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class AnyElementTrueOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression;

--- a/src/Builder/Expression/ArrayElemAtOperator.php
+++ b/src/Builder/Expression/ArrayElemAtOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class ArrayElemAtOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['array' => 'array', 'idx' => 'idx'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $array */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $array;

--- a/src/Builder/Expression/ArrayToObjectOperator.php
+++ b/src/Builder/Expression/ArrayToObjectOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class ArrayToObjectOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['array' => 'array'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $array */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $array;

--- a/src/Builder/Expression/AsinOperator.php
+++ b/src/Builder/Expression/AsinOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class AsinOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $asin takes any valid expression that resolves to a number between -1 and 1, e.g. -1 <= value <= 1.

--- a/src/Builder/Expression/AsinhOperator.php
+++ b/src/Builder/Expression/AsinhOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class AsinhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $asinh takes any valid expression that resolves to a number.

--- a/src/Builder/Expression/Atan2Operator.php
+++ b/src/Builder/Expression/Atan2Operator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class Atan2Operator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['y' => 'y', 'x' => 'x'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $y $atan2 takes any valid expression that resolves to a number.

--- a/src/Builder/Expression/AtanOperator.php
+++ b/src/Builder/Expression/AtanOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class AtanOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $atan takes any valid expression that resolves to a number.

--- a/src/Builder/Expression/AtanhOperator.php
+++ b/src/Builder/Expression/AtanhOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class AtanhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $atanh takes any valid expression that resolves to a number between -1 and 1, e.g. -1 <= value <= 1.

--- a/src/Builder/Expression/AvgOperator.php
+++ b/src/Builder/Expression/AvgOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 class AvgOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|Int64|ResolvesToNumber|float|int> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/BinarySizeOperator.php
+++ b/src/Builder/Expression/BinarySizeOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class BinarySizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression */
     public readonly Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression;

--- a/src/Builder/Expression/BitAndOperator.php
+++ b/src/Builder/Expression/BitAndOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 class BitAndOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Int64|ResolvesToInt|ResolvesToLong|int> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/BitNotOperator.php
+++ b/src/Builder/Expression/BitNotOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class BitNotOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Int64|ResolvesToInt|ResolvesToLong|int $expression */
     public readonly Int64|ResolvesToInt|ResolvesToLong|int $expression;

--- a/src/Builder/Expression/BitOrOperator.php
+++ b/src/Builder/Expression/BitOrOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 class BitOrOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Int64|ResolvesToInt|ResolvesToLong|int> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/BitXorOperator.php
+++ b/src/Builder/Expression/BitXorOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 class BitXorOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Int64|ResolvesToInt|ResolvesToLong|int> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/BsonSizeOperator.php
+++ b/src/Builder/Expression/BsonSizeOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class BsonSizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['object' => 'object'];
 
     /** @var Document|ResolvesToNull|ResolvesToObject|Serializable|array|null|stdClass $object */
     public readonly Document|Serializable|ResolvesToNull|ResolvesToObject|stdClass|array|null $object;

--- a/src/Builder/Expression/CaseOperator.php
+++ b/src/Builder/Expression/CaseOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class CaseOperator implements SwitchBranchInterface, OperatorInterface
 {
     public const ENCODE = Encode::FlatObject;
+    public const PROPERTIES = ['case' => 'case', 'then' => 'then'];
 
     /** @var ResolvesToBool|bool $case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here. */
     public readonly ResolvesToBool|bool $case;

--- a/src/Builder/Expression/CeilOperator.php
+++ b/src/Builder/Expression/CeilOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class CeilOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression If the argument resolves to a value of null or refers to a field that is missing, $ceil returns null. If the argument resolves to NaN, $ceil returns NaN. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression;

--- a/src/Builder/Expression/CmpOperator.php
+++ b/src/Builder/Expression/CmpOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class CmpOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;

--- a/src/Builder/Expression/ConcatArraysOperator.php
+++ b/src/Builder/Expression/ConcatArraysOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 class ConcatArraysOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['array' => 'array'];
 
     /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $array */
     public readonly array $array;

--- a/src/Builder/Expression/ConcatOperator.php
+++ b/src/Builder/Expression/ConcatOperator.php
@@ -22,6 +22,7 @@ use function array_is_list;
 class ConcatOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ResolvesToString|string> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/CondOperator.php
+++ b/src/Builder/Expression/CondOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class CondOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['if' => 'if', 'then' => 'then', 'else' => 'else'];
 
     /** @var ResolvesToBool|bool $if */
     public readonly ResolvesToBool|bool $if;

--- a/src/Builder/Expression/ConvertOperator.php
+++ b/src/Builder/Expression/ConvertOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 class ConvertOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'to' => 'to', 'onError' => 'onError', 'onNull' => 'onNull'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;

--- a/src/Builder/Expression/CosOperator.php
+++ b/src/Builder/Expression/CosOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class CosOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $cos takes any valid expression that resolves to a number. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the result to radians.

--- a/src/Builder/Expression/CoshOperator.php
+++ b/src/Builder/Expression/CoshOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class CoshOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $cosh takes any valid expression that resolves to a number, measured in radians. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the value to radians.

--- a/src/Builder/Expression/DateAddOperator.php
+++ b/src/Builder/Expression/DateAddOperator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\TimeUnit;
 class DateAddOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['startDate' => 'startDate', 'unit' => 'unit', 'amount' => 'amount', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate;

--- a/src/Builder/Expression/DateDiffOperator.php
+++ b/src/Builder/Expression/DateDiffOperator.php
@@ -25,6 +25,14 @@ class DateDiffOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'startDate' => 'startDate',
+        'endDate' => 'endDate',
+        'unit' => 'unit',
+        'timezone' => 'timezone',
+        'startOfWeek' => 'startOfWeek',
+    ];
+
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate;
 

--- a/src/Builder/Expression/DateFromPartsOperator.php
+++ b/src/Builder/Expression/DateFromPartsOperator.php
@@ -23,6 +23,20 @@ class DateFromPartsOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'year' => 'year',
+        'isoWeekYear' => 'isoWeekYear',
+        'month' => 'month',
+        'isoWeek' => 'isoWeek',
+        'day' => 'day',
+        'isoDayOfWeek' => 'isoDayOfWeek',
+        'hour' => 'hour',
+        'minute' => 'minute',
+        'second' => 'second',
+        'millisecond' => 'millisecond',
+        'timezone' => 'timezone',
+    ];
+
     /** @var Optional|Decimal128|Int64|ResolvesToNumber|float|int $year Calendar year. Can be any expression that evaluates to a number. */
     public readonly Optional|Decimal128|Int64|ResolvesToNumber|float|int $year;
 

--- a/src/Builder/Expression/DateFromStringOperator.php
+++ b/src/Builder/Expression/DateFromStringOperator.php
@@ -24,6 +24,14 @@ class DateFromStringOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'dateString' => 'dateString',
+        'format' => 'format',
+        'timezone' => 'timezone',
+        'onError' => 'onError',
+        'onNull' => 'onNull',
+    ];
+
     /** @var ResolvesToString|string $dateString The date/time string to convert to a date object. */
     public readonly ResolvesToString|string $dateString;
 

--- a/src/Builder/Expression/DateSubtractOperator.php
+++ b/src/Builder/Expression/DateSubtractOperator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\TimeUnit;
 class DateSubtractOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['startDate' => 'startDate', 'unit' => 'unit', 'amount' => 'amount', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $startDate;

--- a/src/Builder/Expression/DateToPartsOperator.php
+++ b/src/Builder/Expression/DateToPartsOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class DateToPartsOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone', 'iso8601' => 'iso8601'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The input date for which to return parts. date can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/DateToStringOperator.php
+++ b/src/Builder/Expression/DateToStringOperator.php
@@ -26,6 +26,7 @@ use stdClass;
 class DateToStringOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'format' => 'format', 'timezone' => 'timezone', 'onNull' => 'onNull'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to convert to string. Must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/DateTruncOperator.php
+++ b/src/Builder/Expression/DateTruncOperator.php
@@ -27,6 +27,14 @@ class DateTruncOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'date' => 'date',
+        'unit' => 'unit',
+        'binSize' => 'binSize',
+        'timezone' => 'timezone',
+        'startOfWeek' => 'startOfWeek',
+    ];
+
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;
 

--- a/src/Builder/Expression/DayOfMonthOperator.php
+++ b/src/Builder/Expression/DayOfMonthOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class DayOfMonthOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/DayOfWeekOperator.php
+++ b/src/Builder/Expression/DayOfWeekOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class DayOfWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/DayOfYearOperator.php
+++ b/src/Builder/Expression/DayOfYearOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class DayOfYearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/DegreesToRadiansOperator.php
+++ b/src/Builder/Expression/DegreesToRadiansOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class DegreesToRadiansOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $degreesToRadians takes any valid expression that resolves to a number.

--- a/src/Builder/Expression/DivideOperator.php
+++ b/src/Builder/Expression/DivideOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class DivideOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['dividend' => 'dividend', 'divisor' => 'divisor'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $dividend The first argument is the dividend, and the second argument is the divisor; i.e. the first argument is divided by the second argument. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $dividend;

--- a/src/Builder/Expression/EqOperator.php
+++ b/src/Builder/Expression/EqOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class EqOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;

--- a/src/Builder/Expression/ExpOperator.php
+++ b/src/Builder/Expression/ExpOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class ExpOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['exponent' => 'exponent'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $exponent */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $exponent;

--- a/src/Builder/Expression/FilterOperator.php
+++ b/src/Builder/Expression/FilterOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class FilterOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'cond' => 'cond', 'as' => 'as', 'limit' => 'limit'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;

--- a/src/Builder/Expression/FirstNOperator.php
+++ b/src/Builder/Expression/FirstNOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class FirstNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['n' => 'n', 'input' => 'input'];
 
     /** @var ResolvesToInt|int $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $firstN returns. */
     public readonly ResolvesToInt|int $n;

--- a/src/Builder/Expression/FirstOperator.php
+++ b/src/Builder/Expression/FirstOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class FirstOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression;

--- a/src/Builder/Expression/FloorOperator.php
+++ b/src/Builder/Expression/FloorOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class FloorOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression;

--- a/src/Builder/Expression/FunctionOperator.php
+++ b/src/Builder/Expression/FunctionOperator.php
@@ -28,6 +28,7 @@ use function is_string;
 class FunctionOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['body' => 'body', 'args' => 'args', 'lang' => 'lang'];
 
     /**
      * @var Javascript|string $body The function definition. You can specify the function definition as either BSON\JavaScript or string.

--- a/src/Builder/Expression/GetFieldOperator.php
+++ b/src/Builder/Expression/GetFieldOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 class GetFieldOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['field' => 'field', 'input' => 'input'];
 
     /**
      * @var ResolvesToString|string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.

--- a/src/Builder/Expression/GtOperator.php
+++ b/src/Builder/Expression/GtOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class GtOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;

--- a/src/Builder/Expression/GteOperator.php
+++ b/src/Builder/Expression/GteOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class GteOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;

--- a/src/Builder/Expression/HourOperator.php
+++ b/src/Builder/Expression/HourOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class HourOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/IfNullOperator.php
+++ b/src/Builder/Expression/IfNullOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 class IfNullOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/InOperator.php
+++ b/src/Builder/Expression/InOperator.php
@@ -28,6 +28,7 @@ use function is_array;
 class InOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression' => 'expression', 'array' => 'array'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression Any valid expression expression. */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/IndexOfArrayOperator.php
+++ b/src/Builder/Expression/IndexOfArrayOperator.php
@@ -29,6 +29,7 @@ use function is_array;
 class IndexOfArrayOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['array' => 'array', 'search' => 'search', 'start' => 'start', 'end' => 'end'];
 
     /**
      * @var BSONArray|PackedArray|ResolvesToArray|array $array Can be any valid expression as long as it resolves to an array.

--- a/src/Builder/Expression/IndexOfBytesOperator.php
+++ b/src/Builder/Expression/IndexOfBytesOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\Optional;
 class IndexOfBytesOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['string' => 'string', 'substring' => 'substring', 'start' => 'start', 'end' => 'end'];
 
     /**
      * @var ResolvesToString|string $string Can be any valid expression as long as it resolves to a string.

--- a/src/Builder/Expression/IndexOfCPOperator.php
+++ b/src/Builder/Expression/IndexOfCPOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\Optional;
 class IndexOfCPOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['string' => 'string', 'substring' => 'substring', 'start' => 'start', 'end' => 'end'];
 
     /**
      * @var ResolvesToString|string $string Can be any valid expression as long as it resolves to a string.

--- a/src/Builder/Expression/IsArrayOperator.php
+++ b/src/Builder/Expression/IsArrayOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class IsArrayOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/IsNumberOperator.php
+++ b/src/Builder/Expression/IsNumberOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 class IsNumberOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/IsoDayOfWeekOperator.php
+++ b/src/Builder/Expression/IsoDayOfWeekOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class IsoDayOfWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/IsoWeekOperator.php
+++ b/src/Builder/Expression/IsoWeekOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class IsoWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/IsoWeekYearOperator.php
+++ b/src/Builder/Expression/IsoWeekYearOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class IsoWeekYearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/LastNOperator.php
+++ b/src/Builder/Expression/LastNOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class LastNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['n' => 'n', 'input' => 'input'];
 
     /** @var ResolvesToInt|int $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $firstN returns. */
     public readonly ResolvesToInt|int $n;

--- a/src/Builder/Expression/LastOperator.php
+++ b/src/Builder/Expression/LastOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class LastOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression;

--- a/src/Builder/Expression/LetOperator.php
+++ b/src/Builder/Expression/LetOperator.php
@@ -25,6 +25,7 @@ use stdClass;
 class LetOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['vars' => 'vars', 'in' => 'in'];
 
     /**
      * @var Document|Serializable|array|stdClass $vars Assignment block for the variables accessible in the in expression. To assign a variable, specify a string for the variable name and assign a valid expression for the value.

--- a/src/Builder/Expression/LiteralOperator.php
+++ b/src/Builder/Expression/LiteralOperator.php
@@ -21,6 +21,7 @@ use stdClass;
 class LiteralOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression. */
     public readonly Type|stdClass|array|bool|float|int|null|string $value;

--- a/src/Builder/Expression/LnOperator.php
+++ b/src/Builder/Expression/LnOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class LnOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['number' => 'number'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number Any valid expression as long as it resolves to a non-negative number. For more information on expressions, see Expressions. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $number;

--- a/src/Builder/Expression/Log10Operator.php
+++ b/src/Builder/Expression/Log10Operator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class Log10Operator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['number' => 'number'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number Any valid expression as long as it resolves to a non-negative number. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $number;

--- a/src/Builder/Expression/LogOperator.php
+++ b/src/Builder/Expression/LogOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class LogOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['number' => 'number', 'base' => 'base'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number Any valid expression as long as it resolves to a non-negative number. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $number;

--- a/src/Builder/Expression/LtOperator.php
+++ b/src/Builder/Expression/LtOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class LtOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;

--- a/src/Builder/Expression/LteOperator.php
+++ b/src/Builder/Expression/LteOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class LteOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;

--- a/src/Builder/Expression/LtrimOperator.php
+++ b/src/Builder/Expression/LtrimOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\Optional;
 class LtrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'chars' => 'chars'];
 
     /** @var ResolvesToString|string $input The string to trim. The argument can be any valid expression that resolves to a string. */
     public readonly ResolvesToString|string $input;

--- a/src/Builder/Expression/MapOperator.php
+++ b/src/Builder/Expression/MapOperator.php
@@ -29,6 +29,7 @@ use function is_array;
 class MapOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'in' => 'in', 'as' => 'as'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;

--- a/src/Builder/Expression/MaxNOperator.php
+++ b/src/Builder/Expression/MaxNOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class MaxNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return the maximal n elements. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;

--- a/src/Builder/Expression/MaxOperator.php
+++ b/src/Builder/Expression/MaxOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 class MaxOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/MedianOperator.php
+++ b/src/Builder/Expression/MedianOperator.php
@@ -32,6 +32,7 @@ use function is_array;
 class MedianOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'method' => 'method'];
 
     /** @var BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it. */
     public readonly Decimal128|Int64|PackedArray|ResolvesToNumber|BSONArray|array|float|int $input;

--- a/src/Builder/Expression/MergeObjectsOperator.php
+++ b/src/Builder/Expression/MergeObjectsOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 class MergeObjectsOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['document' => 'document'];
 
     /** @var list<Document|ResolvesToObject|Serializable|array|stdClass> $document Any valid expression that resolves to a document. */
     public readonly array $document;

--- a/src/Builder/Expression/MetaOperator.php
+++ b/src/Builder/Expression/MetaOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class MetaOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['keyword' => 'keyword'];
 
     /** @var string $keyword */
     public readonly string $keyword;

--- a/src/Builder/Expression/MillisecondOperator.php
+++ b/src/Builder/Expression/MillisecondOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class MillisecondOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/MinNOperator.php
+++ b/src/Builder/Expression/MinNOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class MinNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return the maximal n elements. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $input;

--- a/src/Builder/Expression/MinOperator.php
+++ b/src/Builder/Expression/MinOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 class MinOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/MinuteOperator.php
+++ b/src/Builder/Expression/MinuteOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class MinuteOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/ModOperator.php
+++ b/src/Builder/Expression/ModOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class ModOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['dividend' => 'dividend', 'divisor' => 'divisor'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $dividend The first argument is the dividend, and the second argument is the divisor; i.e. first argument is divided by the second argument. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $dividend;

--- a/src/Builder/Expression/MonthOperator.php
+++ b/src/Builder/Expression/MonthOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class MonthOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/MultiplyOperator.php
+++ b/src/Builder/Expression/MultiplyOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 class MultiplyOperator implements ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var list<Decimal128|Int64|ResolvesToNumber|float|int> $expression The arguments can be any valid expression as long as they resolve to numbers.

--- a/src/Builder/Expression/NeOperator.php
+++ b/src/Builder/Expression/NeOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class NeOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;

--- a/src/Builder/Expression/NotOperator.php
+++ b/src/Builder/Expression/NotOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class NotOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ObjectToArrayOperator.php
+++ b/src/Builder/Expression/ObjectToArrayOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class ObjectToArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['object' => 'object'];
 
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $object Any valid expression as long as it resolves to a document object. $objectToArray applies to the top-level fields of its argument. If the argument is a document that itself contains embedded document fields, the $objectToArray does not recursively apply to the embedded document fields. */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array $object;

--- a/src/Builder/Expression/OrOperator.php
+++ b/src/Builder/Expression/OrOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 class OrOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/PercentileOperator.php
+++ b/src/Builder/Expression/PercentileOperator.php
@@ -35,6 +35,7 @@ use function is_array;
 class PercentileOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'p' => 'p', 'method' => 'method'];
 
     /** @var BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it. */
     public readonly Decimal128|Int64|PackedArray|ResolvesToNumber|BSONArray|array|float|int $input;

--- a/src/Builder/Expression/PowOperator.php
+++ b/src/Builder/Expression/PowOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class PowOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['number' => 'number', 'exponent' => 'exponent'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $number;

--- a/src/Builder/Expression/RadiansToDegreesOperator.php
+++ b/src/Builder/Expression/RadiansToDegreesOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class RadiansToDegreesOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $expression;

--- a/src/Builder/Expression/RangeOperator.php
+++ b/src/Builder/Expression/RangeOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\Optional;
 class RangeOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['start' => 'start', 'end' => 'end', 'step' => 'step'];
 
     /** @var ResolvesToInt|int $start An integer that specifies the start of the sequence. Can be any valid expression that resolves to an integer. */
     public readonly ResolvesToInt|int $start;

--- a/src/Builder/Expression/ReduceOperator.php
+++ b/src/Builder/Expression/ReduceOperator.php
@@ -28,6 +28,7 @@ use function is_array;
 class ReduceOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'initialValue' => 'initialValue', 'in' => 'in'];
 
     /**
      * @var BSONArray|PackedArray|ResolvesToArray|array $input Can be any valid expression that resolves to an array.

--- a/src/Builder/Expression/RegexFindAllOperator.php
+++ b/src/Builder/Expression/RegexFindAllOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\Optional;
 class RegexFindAllOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'regex' => 'regex', 'options' => 'options'];
 
     /** @var ResolvesToString|string $input The string on which you wish to apply the regex pattern. Can be a string or any valid expression that resolves to a string. */
     public readonly ResolvesToString|string $input;

--- a/src/Builder/Expression/RegexFindOperator.php
+++ b/src/Builder/Expression/RegexFindOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\Optional;
 class RegexFindOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'regex' => 'regex', 'options' => 'options'];
 
     /** @var ResolvesToString|string $input The string on which you wish to apply the regex pattern. Can be a string or any valid expression that resolves to a string. */
     public readonly ResolvesToString|string $input;

--- a/src/Builder/Expression/RegexMatchOperator.php
+++ b/src/Builder/Expression/RegexMatchOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\Optional;
 class RegexMatchOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'regex' => 'regex', 'options' => 'options'];
 
     /** @var ResolvesToString|string $input The string on which you wish to apply the regex pattern. Can be a string or any valid expression that resolves to a string. */
     public readonly ResolvesToString|string $input;

--- a/src/Builder/Expression/ReplaceAllOperator.php
+++ b/src/Builder/Expression/ReplaceAllOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class ReplaceAllOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'find' => 'find', 'replacement' => 'replacement'];
 
     /** @var ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceAll returns null. */
     public readonly ResolvesToNull|ResolvesToString|null|string $input;

--- a/src/Builder/Expression/ReplaceOneOperator.php
+++ b/src/Builder/Expression/ReplaceOneOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class ReplaceOneOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'find' => 'find', 'replacement' => 'replacement'];
 
     /** @var ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceAll returns null. */
     public readonly ResolvesToNull|ResolvesToString|null|string $input;

--- a/src/Builder/Expression/ReverseArrayOperator.php
+++ b/src/Builder/Expression/ReverseArrayOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class ReverseArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression The argument can be any valid expression as long as it resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression;

--- a/src/Builder/Expression/RoundOperator.php
+++ b/src/Builder/Expression/RoundOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\Optional;
 class RoundOperator implements ResolvesToInt, ResolvesToDouble, ResolvesToDecimal, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['number' => 'number', 'place' => 'place'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $number Can be any valid expression that resolves to a number. Specifically, the expression must resolve to an integer, double, decimal, or long.

--- a/src/Builder/Expression/RtrimOperator.php
+++ b/src/Builder/Expression/RtrimOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\Optional;
 class RtrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'chars' => 'chars'];
 
     /** @var ResolvesToString|string $input The string to trim. The argument can be any valid expression that resolves to a string. */
     public readonly ResolvesToString|string $input;

--- a/src/Builder/Expression/SecondOperator.php
+++ b/src/Builder/Expression/SecondOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class SecondOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/SetDifferenceOperator.php
+++ b/src/Builder/Expression/SetDifferenceOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class SetDifferenceOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression1 The arguments can be any valid expression as long as they each resolve to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression1;

--- a/src/Builder/Expression/SetEqualsOperator.php
+++ b/src/Builder/Expression/SetEqualsOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 class SetEqualsOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/SetFieldOperator.php
+++ b/src/Builder/Expression/SetFieldOperator.php
@@ -25,6 +25,7 @@ use stdClass;
 class SetFieldOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['field' => 'field', 'input' => 'input', 'value' => 'value'];
 
     /** @var ResolvesToString|string $field Field in the input object that you want to add, update, or remove. field can be any valid expression that resolves to a string constant. */
     public readonly ResolvesToString|string $field;

--- a/src/Builder/Expression/SetIntersectionOperator.php
+++ b/src/Builder/Expression/SetIntersectionOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 class SetIntersectionOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/SetIsSubsetOperator.php
+++ b/src/Builder/Expression/SetIsSubsetOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class SetIsSubsetOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression1 */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression1;

--- a/src/Builder/Expression/SetUnionOperator.php
+++ b/src/Builder/Expression/SetUnionOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 class SetUnionOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/SinOperator.php
+++ b/src/Builder/Expression/SinOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SinOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $sin takes any valid expression that resolves to a number. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the result to radians.

--- a/src/Builder/Expression/SinhOperator.php
+++ b/src/Builder/Expression/SinhOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SinhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $sinh takes any valid expression that resolves to a number, measured in radians. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the value to radians.

--- a/src/Builder/Expression/SizeOperator.php
+++ b/src/Builder/Expression/SizeOperator.php
@@ -25,6 +25,7 @@ use function is_array;
 class SizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression The argument for $size can be any expression as long as it resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression;

--- a/src/Builder/Expression/SliceOperator.php
+++ b/src/Builder/Expression/SliceOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class SliceOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression' => 'expression', 'n' => 'n', 'position' => 'position'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression Any valid expression as long as it resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array $expression;

--- a/src/Builder/Expression/SortArrayOperator.php
+++ b/src/Builder/Expression/SortArrayOperator.php
@@ -29,6 +29,7 @@ use function is_array;
 class SortArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'sortBy' => 'sortBy'];
 
     /**
      * @var BSONArray|PackedArray|ResolvesToArray|array $input The array to be sorted.

--- a/src/Builder/Expression/SplitOperator.php
+++ b/src/Builder/Expression/SplitOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SplitOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['string' => 'string', 'delimiter' => 'delimiter'];
 
     /** @var ResolvesToString|string $string The string to be split. string expression can be any valid expression as long as it resolves to a string. */
     public readonly ResolvesToString|string $string;

--- a/src/Builder/Expression/SqrtOperator.php
+++ b/src/Builder/Expression/SqrtOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SqrtOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['number' => 'number'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number The argument can be any valid expression as long as it resolves to a non-negative number. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int $number;

--- a/src/Builder/Expression/StdDevPopOperator.php
+++ b/src/Builder/Expression/StdDevPopOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 class StdDevPopOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|Int64|ResolvesToNumber|float|int> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/StdDevSampOperator.php
+++ b/src/Builder/Expression/StdDevSampOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 class StdDevSampOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|Int64|ResolvesToNumber|float|int> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/StrLenBytesOperator.php
+++ b/src/Builder/Expression/StrLenBytesOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class StrLenBytesOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToString|string $expression */
     public readonly ResolvesToString|string $expression;

--- a/src/Builder/Expression/StrLenCPOperator.php
+++ b/src/Builder/Expression/StrLenCPOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class StrLenCPOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToString|string $expression */
     public readonly ResolvesToString|string $expression;

--- a/src/Builder/Expression/StrcasecmpOperator.php
+++ b/src/Builder/Expression/StrcasecmpOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class StrcasecmpOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ResolvesToString|string $expression1 */
     public readonly ResolvesToString|string $expression1;

--- a/src/Builder/Expression/SubstrBytesOperator.php
+++ b/src/Builder/Expression/SubstrBytesOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SubstrBytesOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['string' => 'string', 'start' => 'start', 'length' => 'length'];
 
     /** @var ResolvesToString|string $string */
     public readonly ResolvesToString|string $string;

--- a/src/Builder/Expression/SubstrCPOperator.php
+++ b/src/Builder/Expression/SubstrCPOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SubstrCPOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['string' => 'string', 'start' => 'start', 'length' => 'length'];
 
     /** @var ResolvesToString|string $string */
     public readonly ResolvesToString|string $string;

--- a/src/Builder/Expression/SubstrOperator.php
+++ b/src/Builder/Expression/SubstrOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SubstrOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['string' => 'string', 'start' => 'start', 'length' => 'length'];
 
     /** @var ResolvesToString|string $string */
     public readonly ResolvesToString|string $string;

--- a/src/Builder/Expression/SubtractOperator.php
+++ b/src/Builder/Expression/SubtractOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SubtractOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $expression1 */
     public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int $expression1;

--- a/src/Builder/Expression/SumOperator.php
+++ b/src/Builder/Expression/SumOperator.php
@@ -27,6 +27,7 @@ use function array_is_list;
 class SumOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<BSONArray|Decimal128|Int64|PackedArray|ResolvesToArray|ResolvesToNumber|array|float|int> $expression */
     public readonly array $expression;

--- a/src/Builder/Expression/SwitchOperator.php
+++ b/src/Builder/Expression/SwitchOperator.php
@@ -29,6 +29,7 @@ use function is_array;
 class SwitchOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['branches' => 'branches', 'default' => 'default'];
 
     /**
      * @var BSONArray|PackedArray|array $branches An array of control branch documents. Each branch is a document with the following fields:

--- a/src/Builder/Expression/TanOperator.php
+++ b/src/Builder/Expression/TanOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class TanOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $tan takes any valid expression that resolves to a number. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the result to radians.

--- a/src/Builder/Expression/TanhOperator.php
+++ b/src/Builder/Expression/TanhOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class TanhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $expression $tanh takes any valid expression that resolves to a number, measured in radians. If the expression returns a value in degrees, use the $degreesToRadians operator to convert the value to radians.

--- a/src/Builder/Expression/ToBoolOperator.php
+++ b/src/Builder/Expression/ToBoolOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ToBoolOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ToDateOperator.php
+++ b/src/Builder/Expression/ToDateOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ToDateOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ToDecimalOperator.php
+++ b/src/Builder/Expression/ToDecimalOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ToDecimalOperator implements ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ToDoubleOperator.php
+++ b/src/Builder/Expression/ToDoubleOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ToDoubleOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ToHashedIndexKeyOperator.php
+++ b/src/Builder/Expression/ToHashedIndexKeyOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class ToHashedIndexKeyOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value;

--- a/src/Builder/Expression/ToIntOperator.php
+++ b/src/Builder/Expression/ToIntOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ToIntOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ToLongOperator.php
+++ b/src/Builder/Expression/ToLongOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ToLongOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ToLowerOperator.php
+++ b/src/Builder/Expression/ToLowerOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class ToLowerOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToString|string $expression */
     public readonly ResolvesToString|string $expression;

--- a/src/Builder/Expression/ToObjectIdOperator.php
+++ b/src/Builder/Expression/ToObjectIdOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ToObjectIdOperator implements ResolvesToObjectId, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ToStringOperator.php
+++ b/src/Builder/Expression/ToStringOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ToStringOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/ToUpperOperator.php
+++ b/src/Builder/Expression/ToUpperOperator.php
@@ -19,6 +19,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class ToUpperOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToString|string $expression */
     public readonly ResolvesToString|string $expression;

--- a/src/Builder/Expression/TrimOperator.php
+++ b/src/Builder/Expression/TrimOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\Optional;
 class TrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['input' => 'input', 'chars' => 'chars'];
 
     /** @var ResolvesToString|string $input The string to trim. The argument can be any valid expression that resolves to a string. */
     public readonly ResolvesToString|string $input;

--- a/src/Builder/Expression/TruncOperator.php
+++ b/src/Builder/Expression/TruncOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\Optional;
 class TruncOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['number' => 'number', 'place' => 'place'];
 
     /**
      * @var Decimal128|Int64|ResolvesToNumber|float|int $number Can be any valid expression that resolves to a number. Specifically, the expression must resolve to an integer, double, decimal, or long.

--- a/src/Builder/Expression/TsIncrementOperator.php
+++ b/src/Builder/Expression/TsIncrementOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class TsIncrementOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToTimestamp|Timestamp|int $expression */
     public readonly Timestamp|ResolvesToTimestamp|int $expression;

--- a/src/Builder/Expression/TsSecondOperator.php
+++ b/src/Builder/Expression/TsSecondOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class TsSecondOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToTimestamp|Timestamp|int $expression */
     public readonly Timestamp|ResolvesToTimestamp|int $expression;

--- a/src/Builder/Expression/TypeOperator.php
+++ b/src/Builder/Expression/TypeOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class TypeOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Expression/UnsetFieldOperator.php
+++ b/src/Builder/Expression/UnsetFieldOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class UnsetFieldOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['field' => 'field', 'input' => 'input'];
 
     /** @var ResolvesToString|string $field Field in the input object that you want to add, update, or remove. field can be any valid expression that resolves to a string constant. */
     public readonly ResolvesToString|string $field;

--- a/src/Builder/Expression/WeekOperator.php
+++ b/src/Builder/Expression/WeekOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class WeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/YearOperator.php
+++ b/src/Builder/Expression/YearOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 class YearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
     public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int $date;

--- a/src/Builder/Expression/ZipOperator.php
+++ b/src/Builder/Expression/ZipOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class ZipOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['inputs' => 'inputs', 'useLongestLength' => 'useLongestLength', 'defaults' => 'defaults'];
 
     /**
      * @var BSONArray|PackedArray|ResolvesToArray|array $inputs An array of expressions that resolve to arrays. The elements of these input arrays combine to form the arrays of the output array.

--- a/src/Builder/Query/AllOperator.php
+++ b/src/Builder/Query/AllOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 class AllOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var list<FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string> $value */
     public readonly array $value;

--- a/src/Builder/Query/AndOperator.php
+++ b/src/Builder/Query/AndOperator.php
@@ -23,6 +23,7 @@ use function array_is_list;
 class AndOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['queries' => 'queries'];
 
     /** @var list<QueryInterface|array> $queries */
     public readonly array $queries;

--- a/src/Builder/Query/BitsAllClearOperator.php
+++ b/src/Builder/Query/BitsAllClearOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 class BitsAllClearOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['bitmask' => 'bitmask'];
 
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public readonly Binary|PackedArray|BSONArray|array|int|string $bitmask;

--- a/src/Builder/Query/BitsAllSetOperator.php
+++ b/src/Builder/Query/BitsAllSetOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 class BitsAllSetOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['bitmask' => 'bitmask'];
 
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public readonly Binary|PackedArray|BSONArray|array|int|string $bitmask;

--- a/src/Builder/Query/BitsAnyClearOperator.php
+++ b/src/Builder/Query/BitsAnyClearOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 class BitsAnyClearOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['bitmask' => 'bitmask'];
 
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public readonly Binary|PackedArray|BSONArray|array|int|string $bitmask;

--- a/src/Builder/Query/BitsAnySetOperator.php
+++ b/src/Builder/Query/BitsAnySetOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 class BitsAnySetOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['bitmask' => 'bitmask'];
 
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public readonly Binary|PackedArray|BSONArray|array|int|string $bitmask;

--- a/src/Builder/Query/BoxOperator.php
+++ b/src/Builder/Query/BoxOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class BoxOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;

--- a/src/Builder/Query/CenterOperator.php
+++ b/src/Builder/Query/CenterOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class CenterOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;

--- a/src/Builder/Query/CenterSphereOperator.php
+++ b/src/Builder/Query/CenterSphereOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class CenterSphereOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;

--- a/src/Builder/Query/CommentOperator.php
+++ b/src/Builder/Query/CommentOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\QueryInterface;
 class CommentOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['comment' => 'comment'];
 
     /** @var string $comment */
     public readonly string $comment;

--- a/src/Builder/Query/ElemMatchOperator.php
+++ b/src/Builder/Query/ElemMatchOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class ElemMatchOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['query' => 'query'];
 
     /** @var FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query */
     public readonly Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query;

--- a/src/Builder/Query/EqOperator.php
+++ b/src/Builder/Query/EqOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class EqOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
     public readonly Type|stdClass|array|bool|float|int|null|string $value;

--- a/src/Builder/Query/ExistsOperator.php
+++ b/src/Builder/Query/ExistsOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class ExistsOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['exists' => 'exists'];
 
     /** @var bool $exists */
     public readonly bool $exists;

--- a/src/Builder/Query/ExprOperator.php
+++ b/src/Builder/Query/ExprOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class ExprOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Query/GeoIntersectsOperator.php
+++ b/src/Builder/Query/GeoIntersectsOperator.php
@@ -23,7 +23,8 @@ use stdClass;
  */
 class GeoIntersectsOperator implements FieldQueryInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Single;
+    public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['geometry' => null];
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;

--- a/src/Builder/Query/GeoWithinOperator.php
+++ b/src/Builder/Query/GeoWithinOperator.php
@@ -23,7 +23,8 @@ use stdClass;
  */
 class GeoWithinOperator implements FieldQueryInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Single;
+    public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['geometry' => null];
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;

--- a/src/Builder/Query/GeometryOperator.php
+++ b/src/Builder/Query/GeometryOperator.php
@@ -30,6 +30,7 @@ use function is_array;
 class GeometryOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['type' => 'type', 'coordinates' => 'coordinates', 'crs' => 'crs'];
 
     /** @var string $type */
     public readonly string $type;

--- a/src/Builder/Query/GtOperator.php
+++ b/src/Builder/Query/GtOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class GtOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
     public readonly Type|stdClass|array|bool|float|int|null|string $value;

--- a/src/Builder/Query/GteOperator.php
+++ b/src/Builder/Query/GteOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class GteOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
     public readonly Type|stdClass|array|bool|float|int|null|string $value;

--- a/src/Builder/Query/InOperator.php
+++ b/src/Builder/Query/InOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class InOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;

--- a/src/Builder/Query/JsonSchemaOperator.php
+++ b/src/Builder/Query/JsonSchemaOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 class JsonSchemaOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['schema' => 'schema'];
 
     /** @var Document|Serializable|array|stdClass $schema */
     public readonly Document|Serializable|stdClass|array $schema;

--- a/src/Builder/Query/LtOperator.php
+++ b/src/Builder/Query/LtOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class LtOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
     public readonly Type|stdClass|array|bool|float|int|null|string $value;

--- a/src/Builder/Query/LteOperator.php
+++ b/src/Builder/Query/LteOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class LteOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
     public readonly Type|stdClass|array|bool|float|int|null|string $value;

--- a/src/Builder/Query/MaxDistanceOperator.php
+++ b/src/Builder/Query/MaxDistanceOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class MaxDistanceOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Decimal128|Int64|float|int $value */
     public readonly Decimal128|Int64|float|int $value;

--- a/src/Builder/Query/MinDistanceOperator.php
+++ b/src/Builder/Query/MinDistanceOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class MinDistanceOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Int64|float|int $value */
     public readonly Int64|float|int $value;

--- a/src/Builder/Query/ModOperator.php
+++ b/src/Builder/Query/ModOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class ModOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const PROPERTIES = ['divisor' => 'divisor', 'remainder' => 'remainder'];
 
     /** @var Decimal128|Int64|float|int $divisor */
     public readonly Decimal128|Int64|float|int $divisor;

--- a/src/Builder/Query/NeOperator.php
+++ b/src/Builder/Query/NeOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class NeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
     public readonly Type|stdClass|array|bool|float|int|null|string $value;

--- a/src/Builder/Query/NearOperator.php
+++ b/src/Builder/Query/NearOperator.php
@@ -26,7 +26,8 @@ use stdClass;
  */
 class NearOperator implements FieldQueryInterface, OperatorInterface
 {
-    public const ENCODE = Encode::DollarObject;
+    public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['geometry' => null, 'maxDistance' => '$maxDistance', 'minDistance' => '$minDistance'];
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;

--- a/src/Builder/Query/NearSphereOperator.php
+++ b/src/Builder/Query/NearSphereOperator.php
@@ -26,7 +26,8 @@ use stdClass;
  */
 class NearSphereOperator implements FieldQueryInterface, OperatorInterface
 {
-    public const ENCODE = Encode::DollarObject;
+    public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['geometry' => null, 'maxDistance' => '$maxDistance', 'minDistance' => '$minDistance'];
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;

--- a/src/Builder/Query/NinOperator.php
+++ b/src/Builder/Query/NinOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class NinOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;

--- a/src/Builder/Query/NorOperator.php
+++ b/src/Builder/Query/NorOperator.php
@@ -23,6 +23,7 @@ use function array_is_list;
 class NorOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['queries' => 'queries'];
 
     /** @var list<QueryInterface|array> $queries */
     public readonly array $queries;

--- a/src/Builder/Query/NotOperator.php
+++ b/src/Builder/Query/NotOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 class NotOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Query/OrOperator.php
+++ b/src/Builder/Query/OrOperator.php
@@ -23,6 +23,7 @@ use function array_is_list;
 class OrOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['queries' => 'queries'];
 
     /** @var list<QueryInterface|array> $queries */
     public readonly array $queries;

--- a/src/Builder/Query/PolygonOperator.php
+++ b/src/Builder/Query/PolygonOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 class PolygonOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['points' => 'points'];
 
     /** @var BSONArray|PackedArray|array $points */
     public readonly PackedArray|BSONArray|array $points;

--- a/src/Builder/Query/RegexOperator.php
+++ b/src/Builder/Query/RegexOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class RegexOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['regex' => 'regex'];
 
     /** @var Regex $regex */
     public readonly Regex $regex;

--- a/src/Builder/Query/SampleRateOperator.php
+++ b/src/Builder/Query/SampleRateOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\QueryInterface;
 class SampleRateOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['rate' => 'rate'];
 
     /**
      * @var Int64|ResolvesToDouble|float|int $rate The selection process uses a uniform random distribution. The sample rate is a floating point number between 0 and 1, inclusive, which represents the probability that a given document will be selected as it passes through the pipeline.

--- a/src/Builder/Query/SizeOperator.php
+++ b/src/Builder/Query/SizeOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 class SizeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['value' => 'value'];
 
     /** @var int $value */
     public readonly int $value;

--- a/src/Builder/Query/TextOperator.php
+++ b/src/Builder/Query/TextOperator.php
@@ -20,7 +20,14 @@ use MongoDB\Builder\Type\QueryInterface;
  */
 class TextOperator implements QueryInterface, OperatorInterface
 {
-    public const ENCODE = Encode::DollarObject;
+    public const ENCODE = Encode::Object;
+
+    public const PROPERTIES = [
+        'search' => '$search',
+        'language' => '$language',
+        'caseSensitive' => '$caseSensitive',
+        'diacriticSensitive' => '$diacriticSensitive',
+    ];
 
     /** @var string $search A string of terms that MongoDB parses and uses to query the text index. MongoDB performs a logical OR search of the terms unless specified as a phrase. */
     public readonly string $search;

--- a/src/Builder/Query/TypeOperator.php
+++ b/src/Builder/Query/TypeOperator.php
@@ -23,6 +23,7 @@ use function array_is_list;
 class TypeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['type' => 'type'];
 
     /** @var list<int|string> $type */
     public readonly array $type;

--- a/src/Builder/Query/WhereOperator.php
+++ b/src/Builder/Query/WhereOperator.php
@@ -23,6 +23,7 @@ use function is_string;
 class WhereOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['function' => 'function'];
 
     /** @var Javascript|string $function */
     public readonly Javascript|string $function;

--- a/src/Builder/Stage/AddFieldsStage.php
+++ b/src/Builder/Stage/AddFieldsStage.php
@@ -26,6 +26,7 @@ use function is_string;
 class AddFieldsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression Specify the name of each field to add and set its value to an aggregation expression or an empty object. */
     public readonly stdClass $expression;

--- a/src/Builder/Stage/BucketAutoStage.php
+++ b/src/Builder/Stage/BucketAutoStage.php
@@ -27,6 +27,13 @@ class BucketAutoStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'groupBy' => 'groupBy',
+        'buckets' => 'buckets',
+        'output' => 'output',
+        'granularity' => 'granularity',
+    ];
+
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes. */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy;
 

--- a/src/Builder/Stage/BucketStage.php
+++ b/src/Builder/Stage/BucketStage.php
@@ -33,6 +33,13 @@ class BucketStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'groupBy' => 'groupBy',
+        'boundaries' => 'boundaries',
+        'default' => 'default',
+        'output' => 'output',
+    ];
+
     /**
      * @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * Unless $bucket includes a default specification, each input document must resolve the groupBy field path or expression to a value that falls within one of the ranges specified by the boundaries.

--- a/src/Builder/Stage/ChangeStreamStage.php
+++ b/src/Builder/Stage/ChangeStreamStage.php
@@ -26,6 +26,16 @@ class ChangeStreamStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'allChangesForCluster' => 'allChangesForCluster',
+        'fullDocument' => 'fullDocument',
+        'fullDocumentBeforeChange' => 'fullDocumentBeforeChange',
+        'resumeAfter' => 'resumeAfter',
+        'showExpandedEvents' => 'showExpandedEvents',
+        'startAfter' => 'startAfter',
+        'startAtOperationTime' => 'startAtOperationTime',
+    ];
+
     /** @var Optional|bool $allChangesForCluster A flag indicating whether the stream should report all changes that occur on the deployment, aside from those on internal databases or collections. */
     public readonly Optional|bool $allChangesForCluster;
 

--- a/src/Builder/Stage/CollStatsStage.php
+++ b/src/Builder/Stage/CollStatsStage.php
@@ -25,6 +25,13 @@ class CollStatsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'latencyStats' => 'latencyStats',
+        'storageStats' => 'storageStats',
+        'count' => 'count',
+        'queryExecStats' => 'queryExecStats',
+    ];
+
     /** @var Optional|Document|Serializable|array|stdClass $latencyStats */
     public readonly Optional|Document|Serializable|stdClass|array $latencyStats;
 

--- a/src/Builder/Stage/CountStage.php
+++ b/src/Builder/Stage/CountStage.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\StageInterface;
 class CountStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['field' => 'field'];
 
     /** @var string $field Name of the output field which has the count as its value. It must be a non-empty string, must not start with $ and must not contain the . character. */
     public readonly string $field;

--- a/src/Builder/Stage/CurrentOpStage.php
+++ b/src/Builder/Stage/CurrentOpStage.php
@@ -22,6 +22,14 @@ class CurrentOpStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'allUsers' => 'allUsers',
+        'idleConnections' => 'idleConnections',
+        'idleCursors' => 'idleCursors',
+        'idleSessions' => 'idleSessions',
+        'localOps' => 'localOps',
+    ];
+
     /** @var Optional|bool $allUsers */
     public readonly Optional|bool $allUsers;
 

--- a/src/Builder/Stage/DensifyStage.php
+++ b/src/Builder/Stage/DensifyStage.php
@@ -30,6 +30,7 @@ use function is_array;
 class DensifyStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['field' => 'field', 'range' => 'range', 'partitionByFields' => 'partitionByFields'];
 
     /**
      * @var string $field The field to densify. The values of the specified field must either be all numeric values or all dates.

--- a/src/Builder/Stage/DocumentsStage.php
+++ b/src/Builder/Stage/DocumentsStage.php
@@ -27,6 +27,7 @@ use function is_array;
 class DocumentsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['documents' => 'documents'];
 
     /**
      * @var BSONArray|PackedArray|ResolvesToArray|array $documents $documents accepts any valid expression that resolves to an array of objects. This includes:

--- a/src/Builder/Stage/FacetStage.php
+++ b/src/Builder/Stage/FacetStage.php
@@ -27,6 +27,7 @@ use function is_string;
 class FacetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['facet' => 'facet'];
 
     /** @var stdClass<BSONArray|PackedArray|Pipeline|array> $facet */
     public readonly stdClass $facet;

--- a/src/Builder/Stage/FillStage.php
+++ b/src/Builder/Stage/FillStage.php
@@ -31,6 +31,13 @@ class FillStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'output' => 'output',
+        'partitionBy' => 'partitionBy',
+        'partitionByFields' => 'partitionByFields',
+        'sortBy' => 'sortBy',
+    ];
+
     /**
      * @var Document|Serializable|array|stdClass $output Specifies an object containing each field for which to fill missing values. You can specify multiple fields in the output object.
      * The object name is the name of the field to fill. The object value specifies how the field is filled.

--- a/src/Builder/Stage/GeoNearStage.php
+++ b/src/Builder/Stage/GeoNearStage.php
@@ -32,6 +32,18 @@ class GeoNearStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'distanceField' => 'distanceField',
+        'near' => 'near',
+        'distanceMultiplier' => 'distanceMultiplier',
+        'includeLocs' => 'includeLocs',
+        'key' => 'key',
+        'maxDistance' => 'maxDistance',
+        'minDistance' => 'minDistance',
+        'query' => 'query',
+        'spherical' => 'spherical',
+    ];
+
     /** @var string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation. */
     public readonly string $distanceField;
 

--- a/src/Builder/Stage/GraphLookupStage.php
+++ b/src/Builder/Stage/GraphLookupStage.php
@@ -33,6 +33,17 @@ class GraphLookupStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'from' => 'from',
+        'startWith' => 'startWith',
+        'connectFromField' => 'connectFromField',
+        'connectToField' => 'connectToField',
+        'as' => 'as',
+        'maxDepth' => 'maxDepth',
+        'depthField' => 'depthField',
+        'restrictSearchWithMatch' => 'restrictSearchWithMatch',
+    ];
+
     /**
      * @var string $from Target collection for the $graphLookup operation to search, recursively matching the connectFromField to the connectToField. The from collection must be in the same database as any other collections used in the operation.
      * Starting in MongoDB 5.1, the collection specified in the from parameter can be sharded.

--- a/src/Builder/Stage/GroupStage.php
+++ b/src/Builder/Stage/GroupStage.php
@@ -28,7 +28,8 @@ use function is_string;
  */
 class GroupStage implements StageInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Group;
+    public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['_id' => '_id', 'field' => null];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents. */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $_id;

--- a/src/Builder/Stage/LimitStage.php
+++ b/src/Builder/Stage/LimitStage.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\StageInterface;
 class LimitStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['limit' => 'limit'];
 
     /** @var int $limit */
     public readonly int $limit;

--- a/src/Builder/Stage/ListLocalSessionsStage.php
+++ b/src/Builder/Stage/ListLocalSessionsStage.php
@@ -27,6 +27,7 @@ use function is_array;
 class ListLocalSessionsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['users' => 'users', 'allUsers' => 'allUsers'];
 
     /** @var Optional|BSONArray|PackedArray|array $users Returns all sessions for the specified users. If running with access control, the authenticated user must have privileges with listSessions action on the cluster to list sessions for other users. */
     public readonly Optional|PackedArray|BSONArray|array $users;

--- a/src/Builder/Stage/ListSampledQueriesStage.php
+++ b/src/Builder/Stage/ListSampledQueriesStage.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\StageInterface;
 class ListSampledQueriesStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['namespace' => 'namespace'];
 
     /** @var Optional|string $namespace */
     public readonly Optional|string $namespace;

--- a/src/Builder/Stage/ListSearchIndexesStage.php
+++ b/src/Builder/Stage/ListSearchIndexesStage.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\StageInterface;
 class ListSearchIndexesStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['id' => 'id', 'name' => 'name'];
 
     /** @var Optional|string $id The id of the index to return information about. */
     public readonly Optional|string $id;

--- a/src/Builder/Stage/ListSessionsStage.php
+++ b/src/Builder/Stage/ListSessionsStage.php
@@ -27,6 +27,7 @@ use function is_array;
 class ListSessionsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['users' => 'users', 'allUsers' => 'allUsers'];
 
     /** @var Optional|BSONArray|PackedArray|array $users Returns all sessions for the specified users. If running with access control, the authenticated user must have privileges with listSessions action on the cluster to list sessions for other users. */
     public readonly Optional|PackedArray|BSONArray|array $users;

--- a/src/Builder/Stage/LookupStage.php
+++ b/src/Builder/Stage/LookupStage.php
@@ -32,6 +32,15 @@ class LookupStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'as' => 'as',
+        'from' => 'from',
+        'localField' => 'localField',
+        'foreignField' => 'foreignField',
+        'let' => 'let',
+        'pipeline' => 'pipeline',
+    ];
+
     /** @var string $as Specifies the name of the new array field to add to the input documents. The new array field contains the matching documents from the from collection. If the specified name already exists in the input document, the existing field is overwritten. */
     public readonly string $as;
 

--- a/src/Builder/Stage/MatchStage.php
+++ b/src/Builder/Stage/MatchStage.php
@@ -24,6 +24,7 @@ use function is_array;
 class MatchStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['query' => 'query'];
 
     /** @var QueryInterface|array $query */
     public readonly QueryInterface|array $query;

--- a/src/Builder/Stage/MergeStage.php
+++ b/src/Builder/Stage/MergeStage.php
@@ -33,6 +33,14 @@ class MergeStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'into' => 'into',
+        'on' => 'on',
+        'let' => 'let',
+        'whenMatched' => 'whenMatched',
+        'whenNotMatched' => 'whenNotMatched',
+    ];
+
     /** @var Document|Serializable|array|stdClass|string $into The output collection. */
     public readonly Document|Serializable|stdClass|array|string $into;
 

--- a/src/Builder/Stage/OutStage.php
+++ b/src/Builder/Stage/OutStage.php
@@ -23,6 +23,7 @@ use stdClass;
 class OutStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['coll' => 'coll'];
 
     /** @var Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to. */
     public readonly Document|Serializable|stdClass|array|string $coll;

--- a/src/Builder/Stage/ProjectStage.php
+++ b/src/Builder/Stage/ProjectStage.php
@@ -26,6 +26,7 @@ use function is_string;
 class ProjectStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['specification' => 'specification'];
 
     /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $specification */
     public readonly stdClass $specification;

--- a/src/Builder/Stage/RedactStage.php
+++ b/src/Builder/Stage/RedactStage.php
@@ -23,6 +23,7 @@ use stdClass;
 class RedactStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Stage/ReplaceRootStage.php
+++ b/src/Builder/Stage/ReplaceRootStage.php
@@ -24,6 +24,7 @@ use stdClass;
 class ReplaceRootStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['newRoot' => 'newRoot'];
 
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $newRoot */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array $newRoot;

--- a/src/Builder/Stage/ReplaceWithStage.php
+++ b/src/Builder/Stage/ReplaceWithStage.php
@@ -25,6 +25,7 @@ use stdClass;
 class ReplaceWithStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $expression */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array $expression;

--- a/src/Builder/Stage/SampleStage.php
+++ b/src/Builder/Stage/SampleStage.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\StageInterface;
 class SampleStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['size' => 'size'];
 
     /** @var int $size The number of documents to randomly select. */
     public readonly int $size;

--- a/src/Builder/Stage/SearchMetaStage.php
+++ b/src/Builder/Stage/SearchMetaStage.php
@@ -24,6 +24,7 @@ use stdClass;
 class SearchMetaStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['meta' => 'meta'];
 
     /** @var Document|Serializable|array|stdClass $meta */
     public readonly Document|Serializable|stdClass|array $meta;

--- a/src/Builder/Stage/SearchStage.php
+++ b/src/Builder/Stage/SearchStage.php
@@ -24,6 +24,7 @@ use stdClass;
 class SearchStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['search' => 'search'];
 
     /** @var Document|Serializable|array|stdClass $search */
     public readonly Document|Serializable|stdClass|array $search;

--- a/src/Builder/Stage/SetStage.php
+++ b/src/Builder/Stage/SetStage.php
@@ -27,6 +27,7 @@ use function is_string;
 class SetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['field' => 'field'];
 
     /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;

--- a/src/Builder/Stage/SetWindowFieldsStage.php
+++ b/src/Builder/Stage/SetWindowFieldsStage.php
@@ -27,6 +27,7 @@ use stdClass;
 class SetWindowFieldsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['sortBy' => 'sortBy', 'output' => 'output', 'partitionBy' => 'partitionBy'];
 
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting. */
     public readonly Document|Serializable|stdClass|array $sortBy;

--- a/src/Builder/Stage/SkipStage.php
+++ b/src/Builder/Stage/SkipStage.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\StageInterface;
 class SkipStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['skip' => 'skip'];
 
     /** @var int $skip */
     public readonly int $skip;

--- a/src/Builder/Stage/SortByCountStage.php
+++ b/src/Builder/Stage/SortByCountStage.php
@@ -23,6 +23,7 @@ use stdClass;
 class SortByCountStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;

--- a/src/Builder/Stage/SortStage.php
+++ b/src/Builder/Stage/SortStage.php
@@ -27,6 +27,7 @@ use function is_string;
 class SortStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['sort' => 'sort'];
 
     /** @var stdClass<ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string> $sort */
     public readonly stdClass $sort;

--- a/src/Builder/Stage/UnionWithStage.php
+++ b/src/Builder/Stage/UnionWithStage.php
@@ -29,6 +29,7 @@ use function is_array;
 class UnionWithStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const PROPERTIES = ['coll' => 'coll', 'pipeline' => 'pipeline'];
 
     /** @var string $coll The collection or view whose pipeline results you wish to include in the result set. */
     public readonly string $coll;

--- a/src/Builder/Stage/UnsetStage.php
+++ b/src/Builder/Stage/UnsetStage.php
@@ -25,6 +25,7 @@ use function array_is_list;
 class UnsetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const PROPERTIES = ['field' => 'field'];
 
     /** @var list<FieldPath|string> $field */
     public readonly array $field;

--- a/src/Builder/Stage/UnwindStage.php
+++ b/src/Builder/Stage/UnwindStage.php
@@ -23,6 +23,12 @@ class UnwindStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 
+    public const PROPERTIES = [
+        'path' => 'path',
+        'includeArrayIndex' => 'includeArrayIndex',
+        'preserveNullAndEmptyArrays' => 'preserveNullAndEmptyArrays',
+    ];
+
     /** @var ArrayFieldPath|string $path Field path to an array field. */
     public readonly ArrayFieldPath|string $path;
 

--- a/src/Builder/Type/Encode.php
+++ b/src/Builder/Type/Encode.php
@@ -29,19 +29,9 @@ enum Encode
     case FlatObject;
 
     /**
-     * Parameters are encoded as an object with keys matching the parameter names prefixed with a dollar sign ($)
-     */
-    case DollarObject;
-
-    /**
      * Get the single parameter value
      */
     case Single;
-
-    /**
-     * Specific for $group stage
-     */
-    case Group;
 
     /**
      * Default case used in the interface; implementing classes are expected to override this value

--- a/src/Builder/Type/OperatorInterface.php
+++ b/src/Builder/Type/OperatorInterface.php
@@ -9,8 +9,11 @@ namespace MongoDB\Builder\Type;
  */
 interface OperatorInterface
 {
-    /** To be overridden by implementing classes */
+    /** @var Encode */
     public const ENCODE = Encode::Undefined;
+
+    /** @var array<string, string|null> */
+    public const PROPERTIES = [];
 
     public function getOperator(): string;
 }


### PR DESCRIPTION
For every Operator class, we add a `PROPERTIES` constant that contains a map of PHP property name to the operator name.
This allows to remove 2 specific encoders:
- `$group` stage is now `[ '_id' => '_id', 'field' => null ]`. This means every property for the `field` object are encoded as properties of the operator object.
- `$near` operator is now `['geometry' => null, 'maxDistance' => '$maxDistance', 'minDistance' => '$minDistance']`. The property `$geometry` of the `geometry` object is set to the operator object properties. And the name of the other properties get the `$` prefix.
