### PR TITLE
Replace `OperatorInterface::getOperator()` with `OperatorInterface::NAME` constant

### DIFF
--- a/generator/config/expression/case.yaml
+++ b/generator/config/expression/case.yaml
@@ -3,7 +3,8 @@ name: $case
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/'
 type:
     - switchBranch
-encode: flat_object
+encode: object
+wrapObject: false
 description: |
     Represents a single case in a $switch expression
 arguments:

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -60,13 +60,17 @@
                     "enum": [
                         "array",
                         "object",
-                        "flat_object",
                         "single"
                     ]
                 },
                 "description": {
                     "$comment": "The description of the argument from MongoDB's documentation.",
                     "type": "string"
+                },
+                "wrapObject": {
+                    "$comment": "Wrap the properties in an object with the operator name",
+                    "type": "boolean",
+                    "default": true
                 },
                 "arguments": {
                     "$comment": "An optional list of arguments for the operator.",

--- a/generator/src/Definition/OperatorDefinition.php
+++ b/generator/src/Definition/OperatorDefinition.php
@@ -32,6 +32,7 @@ final class OperatorDefinition
         /** @var list<string> */
         public array $type,
         public string|null $description = null,
+        public bool $wrapObject = true,
         array $arguments = [],
         array $tests = [],
     ) {
@@ -39,7 +40,6 @@ final class OperatorDefinition
             'single' => Encode::Single,
             'array' => Encode::Array,
             'object' => Encode::Object,
-            'flat_object' => Encode::FlatObject,
             default => throw new UnexpectedValueException(sprintf('Unexpected "encode" value for operator "%s". Got "%s"', $name, $encode)),
         };
 

--- a/generator/src/Definition/OperatorDefinition.php
+++ b/generator/src/Definition/OperatorDefinition.php
@@ -43,6 +43,10 @@ final class OperatorDefinition
             default => throw new UnexpectedValueException(sprintf('Unexpected "encode" value for operator "%s". Got "%s"', $name, $encode)),
         };
 
+        if (! $wrapObject && $this->encode !== Encode::Object) {
+            throw new UnexpectedValueException(sprintf('Operator "%s" cannot have wrapObject set to false when encode is not "object"', $name));
+        }
+
         // Convert arguments to ArgumentDefinition objects
         // Optional arguments must be after required arguments
         $requiredArgs = $optionalArgs = [];

--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -22,7 +22,6 @@ use function assert;
 use function interface_exists;
 use function rtrim;
 use function sprintf;
-use function var_export;
 
 /**
  * Generates a value object class for stages and operators.
@@ -62,6 +61,7 @@ class OperatorClassGenerator extends OperatorGenerator
         $class->addComment('@internal');
         $namespace->addUse(Encode::class);
         $class->addConstant('ENCODE', new Literal('Encode::' . $operator->encode->name));
+        $class->addConstant('NAME', $operator->wrapObject ? $operator->name : null);
 
         $encodeNames = [];
         $constructor = $class->addMethod('__construct');
@@ -178,10 +178,6 @@ class OperatorClassGenerator extends OperatorGenerator
         if ($encodeNames !== []) {
             $class->addConstant('PROPERTIES', $encodeNames);
         }
-
-        $class->addMethod('getOperator')
-            ->setReturnType('string')
-            ->setBody('return ' . var_export($operator->name, true) . ';');
 
         return $namespace;
     }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -75,6 +75,12 @@
       <code><![CDATA[$val]]></code>
       <code><![CDATA[$val]]></code>
     </MixedAssignment>
+    <MixedInferredReturnType>
+      <code><![CDATA[stdClass]]></code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[$result]]></code>
+    </MixedReturnStatement>
     <PossibleRawObjectIteration>
       <code><![CDATA[$val]]></code>
     </PossibleRawObjectIteration>
@@ -172,7 +178,26 @@
       <code><![CDATA[stdClass]]></code>
     </TooManyTemplateParams>
   </file>
+  <file src="src/Builder/Type/CombinedFieldQuery.php">
+    <MixedArgument>
+      <code><![CDATA[$operator]]></code>
+      <code><![CDATA[$operator]]></code>
+    </MixedArgument>
+    <MixedArrayOffset>
+      <code><![CDATA[$seenOperators[$operator]]]></code>
+    </MixedArrayOffset>
+    <MixedAssignment>
+      <code><![CDATA[$operator]]></code>
+    </MixedAssignment>
+  </file>
   <file src="src/Builder/Type/QueryObject.php">
+    <MixedArgument>
+      <code><![CDATA[$query::NAME]]></code>
+    </MixedArgument>
+    <MixedArrayOffset>
+      <code><![CDATA[$seenQueryOperators[$query::NAME]]]></code>
+      <code><![CDATA[$seenQueryOperators[$query::NAME]]]></code>
+    </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$queries[$fieldPath]]]></code>
       <code><![CDATA[$query]]></code>
@@ -183,6 +208,11 @@
             is_array($queriesOrArrayOfQueries[0]) &&
             count($queriesOrArrayOfQueries[0]) > 0]]></code>
     </RedundantConditionGivenDocblockType>
+    <UndefinedConstant>
+      <code><![CDATA[$query::NAME]]></code>
+      <code><![CDATA[$query::NAME]]></code>
+      <code><![CDATA[$query::NAME]]></code>
+    </UndefinedConstant>
   </file>
   <file src="src/ChangeStream.php">
     <DeprecatedConstant>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -75,12 +75,6 @@
       <code><![CDATA[$val]]></code>
       <code><![CDATA[$val]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[stdClass]]></code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$result]]></code>
-    </MixedReturnStatement>
     <PossibleRawObjectIteration>
       <code><![CDATA[$val]]></code>
     </PossibleRawObjectIteration>

--- a/src/Builder/Accumulator/AccumulatorAccumulator.php
+++ b/src/Builder/Accumulator/AccumulatorAccumulator.php
@@ -32,6 +32,7 @@ use function is_string;
 final class AccumulatorAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$accumulator';
 
     public const PROPERTIES = [
         'init' => 'init',
@@ -113,10 +114,5 @@ final class AccumulatorAccumulator implements AccumulatorInterface, OperatorInte
         }
 
         $this->finalize = $finalize;
-    }
-
-    public function getOperator(): string
-    {
-        return '$accumulator';
     }
 }

--- a/src/Builder/Accumulator/AddToSetAccumulator.php
+++ b/src/Builder/Accumulator/AddToSetAccumulator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class AddToSetAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$addToSet';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -37,10 +38,5 @@ final class AddToSetAccumulator implements AccumulatorInterface, WindowInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$addToSet';
     }
 }

--- a/src/Builder/Accumulator/AvgAccumulator.php
+++ b/src/Builder/Accumulator/AvgAccumulator.php
@@ -26,6 +26,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class AvgAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$avg';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
@@ -37,10 +38,5 @@ final class AvgAccumulator implements AccumulatorInterface, WindowInterface, Ope
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$avg';
     }
 }

--- a/src/Builder/Accumulator/BottomAccumulator.php
+++ b/src/Builder/Accumulator/BottomAccumulator.php
@@ -28,6 +28,7 @@ use stdClass;
 final class BottomAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$bottom';
     public const PROPERTIES = ['sortBy' => 'sortBy', 'output' => 'output'];
 
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
@@ -46,10 +47,5 @@ final class BottomAccumulator implements AccumulatorInterface, WindowInterface, 
     ) {
         $this->sortBy = $sortBy;
         $this->output = $output;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bottom';
     }
 }

--- a/src/Builder/Accumulator/BottomNAccumulator.php
+++ b/src/Builder/Accumulator/BottomNAccumulator.php
@@ -30,6 +30,7 @@ use stdClass;
 final class BottomNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$bottomN';
     public const PROPERTIES = ['n' => 'n', 'sortBy' => 'sortBy', 'output' => 'output'];
 
     /** @var ResolvesToInt|int $n Limits the number of results per group and has to be a positive integral expression that is either a constant or depends on the _id value for $group. */
@@ -54,10 +55,5 @@ final class BottomNAccumulator implements AccumulatorInterface, WindowInterface,
         $this->n = $n;
         $this->sortBy = $sortBy;
         $this->output = $output;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bottomN';
     }
 }

--- a/src/Builder/Accumulator/CountAccumulator.php
+++ b/src/Builder/Accumulator/CountAccumulator.php
@@ -24,13 +24,9 @@ use MongoDB\Builder\Type\WindowInterface;
 final class CountAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$count';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$count';
     }
 }

--- a/src/Builder/Accumulator/CovariancePopAccumulator.php
+++ b/src/Builder/Accumulator/CovariancePopAccumulator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class CovariancePopAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$covariancePop';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression1 */
@@ -43,10 +44,5 @@ final class CovariancePopAccumulator implements WindowInterface, OperatorInterfa
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$covariancePop';
     }
 }

--- a/src/Builder/Accumulator/CovarianceSampAccumulator.php
+++ b/src/Builder/Accumulator/CovarianceSampAccumulator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class CovarianceSampAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$covarianceSamp';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression1 */
@@ -43,10 +44,5 @@ final class CovarianceSampAccumulator implements WindowInterface, OperatorInterf
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$covarianceSamp';
     }
 }

--- a/src/Builder/Accumulator/DenseRankAccumulator.php
+++ b/src/Builder/Accumulator/DenseRankAccumulator.php
@@ -22,13 +22,9 @@ use MongoDB\Builder\Type\WindowInterface;
 final class DenseRankAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$denseRank';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$denseRank';
     }
 }

--- a/src/Builder/Accumulator/DerivativeAccumulator.php
+++ b/src/Builder/Accumulator/DerivativeAccumulator.php
@@ -30,6 +30,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class DerivativeAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$derivative';
     public const PROPERTIES = ['input' => 'input', 'unit' => 'unit'];
 
     /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $input */
@@ -52,10 +53,5 @@ final class DerivativeAccumulator implements WindowInterface, OperatorInterface
     ) {
         $this->input = $input;
         $this->unit = $unit;
-    }
-
-    public function getOperator(): string
-    {
-        return '$derivative';
     }
 }

--- a/src/Builder/Accumulator/DocumentNumberAccumulator.php
+++ b/src/Builder/Accumulator/DocumentNumberAccumulator.php
@@ -22,13 +22,9 @@ use MongoDB\Builder\Type\WindowInterface;
 final class DocumentNumberAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$documentNumber';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$documentNumber';
     }
 }

--- a/src/Builder/Accumulator/ExpMovingAvgAccumulator.php
+++ b/src/Builder/Accumulator/ExpMovingAvgAccumulator.php
@@ -26,6 +26,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class ExpMovingAvgAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$expMovingAvg';
     public const PROPERTIES = ['input' => 'input', 'N' => 'N', 'alpha' => 'alpha'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $input */
@@ -60,10 +61,5 @@ final class ExpMovingAvgAccumulator implements WindowInterface, OperatorInterfac
         $this->input = $input;
         $this->N = $N;
         $this->alpha = $alpha;
-    }
-
-    public function getOperator(): string
-    {
-        return '$expMovingAvg';
     }
 }

--- a/src/Builder/Accumulator/FirstAccumulator.php
+++ b/src/Builder/Accumulator/FirstAccumulator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class FirstAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$first';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -37,10 +38,5 @@ final class FirstAccumulator implements AccumulatorInterface, WindowInterface, O
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$first';
     }
 }

--- a/src/Builder/Accumulator/FirstNAccumulator.php
+++ b/src/Builder/Accumulator/FirstNAccumulator.php
@@ -28,6 +28,7 @@ use stdClass;
 final class FirstNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$firstN';
     public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input An expression that resolves to the array from which to return n elements. */
@@ -46,10 +47,5 @@ final class FirstNAccumulator implements AccumulatorInterface, WindowInterface, 
     ) {
         $this->input = $input;
         $this->n = $n;
-    }
-
-    public function getOperator(): string
-    {
-        return '$firstN';
     }
 }

--- a/src/Builder/Accumulator/IntegralAccumulator.php
+++ b/src/Builder/Accumulator/IntegralAccumulator.php
@@ -30,6 +30,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class IntegralAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$integral';
     public const PROPERTIES = ['input' => 'input', 'unit' => 'unit'];
 
     /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $input */
@@ -52,10 +53,5 @@ final class IntegralAccumulator implements WindowInterface, OperatorInterface
     ) {
         $this->input = $input;
         $this->unit = $unit;
-    }
-
-    public function getOperator(): string
-    {
-        return '$integral';
     }
 }

--- a/src/Builder/Accumulator/LastAccumulator.php
+++ b/src/Builder/Accumulator/LastAccumulator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class LastAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$last';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -37,10 +38,5 @@ final class LastAccumulator implements AccumulatorInterface, WindowInterface, Op
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$last';
     }
 }

--- a/src/Builder/Accumulator/LastNAccumulator.php
+++ b/src/Builder/Accumulator/LastNAccumulator.php
@@ -32,6 +32,7 @@ use function is_array;
 final class LastNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$lastN';
     public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return n elements. */
@@ -52,10 +53,5 @@ final class LastNAccumulator implements AccumulatorInterface, WindowInterface, O
 
         $this->input = $input;
         $this->n = $n;
-    }
-
-    public function getOperator(): string
-    {
-        return '$lastN';
     }
 }

--- a/src/Builder/Accumulator/LinearFillAccumulator.php
+++ b/src/Builder/Accumulator/LinearFillAccumulator.php
@@ -26,6 +26,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class LinearFillAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$linearFill';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
@@ -37,10 +38,5 @@ final class LinearFillAccumulator implements WindowInterface, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$linearFill';
     }
 }

--- a/src/Builder/Accumulator/LocfAccumulator.php
+++ b/src/Builder/Accumulator/LocfAccumulator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class LocfAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$locf';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -37,10 +38,5 @@ final class LocfAccumulator implements WindowInterface, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$locf';
     }
 }

--- a/src/Builder/Accumulator/MaxAccumulator.php
+++ b/src/Builder/Accumulator/MaxAccumulator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class MaxAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$max';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -37,10 +38,5 @@ final class MaxAccumulator implements AccumulatorInterface, WindowInterface, Ope
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$max';
     }
 }

--- a/src/Builder/Accumulator/MaxNAccumulator.php
+++ b/src/Builder/Accumulator/MaxNAccumulator.php
@@ -30,6 +30,7 @@ use function is_array;
 final class MaxNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$maxN';
     public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return the maximal n elements. */
@@ -50,10 +51,5 @@ final class MaxNAccumulator implements AccumulatorInterface, WindowInterface, Op
 
         $this->input = $input;
         $this->n = $n;
-    }
-
-    public function getOperator(): string
-    {
-        return '$maxN';
     }
 }

--- a/src/Builder/Accumulator/MedianAccumulator.php
+++ b/src/Builder/Accumulator/MedianAccumulator.php
@@ -30,6 +30,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class MedianAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$median';
     public const PROPERTIES = ['input' => 'input', 'method' => 'method'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it. */
@@ -46,10 +47,5 @@ final class MedianAccumulator implements AccumulatorInterface, WindowInterface, 
     {
         $this->input = $input;
         $this->method = $method;
-    }
-
-    public function getOperator(): string
-    {
-        return '$median';
     }
 }

--- a/src/Builder/Accumulator/MergeObjectsAccumulator.php
+++ b/src/Builder/Accumulator/MergeObjectsAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 final class MergeObjectsAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$mergeObjects';
     public const PROPERTIES = ['document' => 'document'];
 
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $document Any valid expression that resolves to a document. */
@@ -36,10 +37,5 @@ final class MergeObjectsAccumulator implements AccumulatorInterface, OperatorInt
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array $document)
     {
         $this->document = $document;
-    }
-
-    public function getOperator(): string
-    {
-        return '$mergeObjects';
     }
 }

--- a/src/Builder/Accumulator/MinAccumulator.php
+++ b/src/Builder/Accumulator/MinAccumulator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class MinAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$min';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -37,10 +38,5 @@ final class MinAccumulator implements AccumulatorInterface, WindowInterface, Ope
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$min';
     }
 }

--- a/src/Builder/Accumulator/MinNAccumulator.php
+++ b/src/Builder/Accumulator/MinNAccumulator.php
@@ -30,6 +30,7 @@ use function is_array;
 final class MinNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$minN';
     public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return the maximal n elements. */
@@ -50,10 +51,5 @@ final class MinNAccumulator implements AccumulatorInterface, WindowInterface, Op
 
         $this->input = $input;
         $this->n = $n;
-    }
-
-    public function getOperator(): string
-    {
-        return '$minN';
     }
 }

--- a/src/Builder/Accumulator/PercentileAccumulator.php
+++ b/src/Builder/Accumulator/PercentileAccumulator.php
@@ -40,6 +40,7 @@ use function is_array;
 final class PercentileAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$percentile';
     public const PROPERTIES = ['input' => 'input', 'p' => 'p', 'method' => 'method'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it. */
@@ -72,10 +73,5 @@ final class PercentileAccumulator implements AccumulatorInterface, WindowInterfa
 
         $this->p = $p;
         $this->method = $method;
-    }
-
-    public function getOperator(): string
-    {
-        return '$percentile';
     }
 }

--- a/src/Builder/Accumulator/PushAccumulator.php
+++ b/src/Builder/Accumulator/PushAccumulator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class PushAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$push';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -37,10 +38,5 @@ final class PushAccumulator implements AccumulatorInterface, WindowInterface, Op
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$push';
     }
 }

--- a/src/Builder/Accumulator/RankAccumulator.php
+++ b/src/Builder/Accumulator/RankAccumulator.php
@@ -22,13 +22,9 @@ use MongoDB\Builder\Type\WindowInterface;
 final class RankAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$rank';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$rank';
     }
 }

--- a/src/Builder/Accumulator/ShiftAccumulator.php
+++ b/src/Builder/Accumulator/ShiftAccumulator.php
@@ -25,6 +25,7 @@ use stdClass;
 final class ShiftAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$shift';
     public const PROPERTIES = ['output' => 'output', 'by' => 'by', 'default' => 'default'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Specifies an expression to evaluate and return in the output. */
@@ -65,10 +66,5 @@ final class ShiftAccumulator implements WindowInterface, OperatorInterface
         $this->output = $output;
         $this->by = $by;
         $this->default = $default;
-    }
-
-    public function getOperator(): string
-    {
-        return '$shift';
     }
 }

--- a/src/Builder/Accumulator/StdDevPopAccumulator.php
+++ b/src/Builder/Accumulator/StdDevPopAccumulator.php
@@ -27,6 +27,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class StdDevPopAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$stdDevPop';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
@@ -38,10 +39,5 @@ final class StdDevPopAccumulator implements AccumulatorInterface, WindowInterfac
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$stdDevPop';
     }
 }

--- a/src/Builder/Accumulator/StdDevSampAccumulator.php
+++ b/src/Builder/Accumulator/StdDevSampAccumulator.php
@@ -27,6 +27,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class StdDevSampAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$stdDevSamp';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
@@ -38,10 +39,5 @@ final class StdDevSampAccumulator implements AccumulatorInterface, WindowInterfa
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$stdDevSamp';
     }
 }

--- a/src/Builder/Accumulator/SumAccumulator.php
+++ b/src/Builder/Accumulator/SumAccumulator.php
@@ -26,6 +26,7 @@ use MongoDB\Builder\Type\WindowInterface;
 final class SumAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$sum';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
@@ -37,10 +38,5 @@ final class SumAccumulator implements AccumulatorInterface, WindowInterface, Ope
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sum';
     }
 }

--- a/src/Builder/Accumulator/TopAccumulator.php
+++ b/src/Builder/Accumulator/TopAccumulator.php
@@ -29,6 +29,7 @@ use stdClass;
 final class TopAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$top';
     public const PROPERTIES = ['sortBy' => 'sortBy', 'output' => 'output'];
 
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
@@ -47,10 +48,5 @@ final class TopAccumulator implements AccumulatorInterface, OperatorInterface
     ) {
         $this->sortBy = $sortBy;
         $this->output = $output;
-    }
-
-    public function getOperator(): string
-    {
-        return '$top';
     }
 }

--- a/src/Builder/Accumulator/TopNAccumulator.php
+++ b/src/Builder/Accumulator/TopNAccumulator.php
@@ -30,6 +30,7 @@ use stdClass;
 final class TopNAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$topN';
     public const PROPERTIES = ['n' => 'n', 'sortBy' => 'sortBy', 'output' => 'output'];
 
     /** @var ResolvesToInt|int $n limits the number of results per group and has to be a positive integral expression that is either a constant or depends on the _id value for $group. */
@@ -54,10 +55,5 @@ final class TopNAccumulator implements AccumulatorInterface, OperatorInterface
         $this->n = $n;
         $this->sortBy = $sortBy;
         $this->output = $output;
-    }
-
-    public function getOperator(): string
-    {
-        return '$topN';
     }
 }

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -37,7 +37,7 @@ final class OperatorEncoder extends AbstractExpressionEncoder
         return match ($value::ENCODE) {
             Encode::Single => $this->encodeAsSingle($value),
             Encode::Array => $this->encodeAsArray($value),
-            Encode::Object, Encode::FlatObject => $this->encodeAsObject($value),
+            Encode::Object => $this->encodeAsObject($value),
             default => throw new LogicException(sprintf('Class "%s" does not have a valid ENCODE constant.', $value::class)),
         };
     }
@@ -89,9 +89,7 @@ final class OperatorEncoder extends AbstractExpressionEncoder
             }
         }
 
-        return $value::ENCODE === Encode::FlatObject
-            ? $result
-            : $this->wrap($value, $result);
+        return $this->wrap($value, $result);
     }
 
     /**
@@ -108,10 +106,19 @@ final class OperatorEncoder extends AbstractExpressionEncoder
         throw new LogicException(sprintf('Class "%s" does not have a single property.', $value::class));
     }
 
+    /**
+     * Wrap the result in an object if the operator has a name.
+     * The operator name is NULL, and the result is returned as is
+     * when wrapObject is false in the YAML configuration of the operator.
+     */
     private function wrap(OperatorInterface $value, mixed $result): stdClass
     {
+        if ($value::NAME === null) {
+            return $result;
+        }
+
         $object = new stdClass();
-        $object->{$value->getOperator()} = $result;
+        $object->{$value::NAME} = $result;
 
         return $object;
     }

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -12,6 +12,8 @@ use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 use stdClass;
 
+use function assert;
+use function is_string;
 use function sprintf;
 
 /**
@@ -89,6 +91,10 @@ final class OperatorEncoder extends AbstractExpressionEncoder
             }
         }
 
+        if ($value::NAME === null) {
+            return $result;
+        }
+
         return $this->wrap($value, $result);
     }
 
@@ -106,16 +112,9 @@ final class OperatorEncoder extends AbstractExpressionEncoder
         throw new LogicException(sprintf('Class "%s" does not have a single property.', $value::class));
     }
 
-    /**
-     * Wrap the result in an object if the operator has a name.
-     * The operator name is NULL, and the result is returned as is
-     * when wrapObject is false in the YAML configuration of the operator.
-     */
     private function wrap(OperatorInterface $value, mixed $result): stdClass
     {
-        if ($value::NAME === null) {
-            return $result;
-        }
+        assert(is_string($value::NAME));
 
         $object = new stdClass();
         $object->{$value::NAME} = $result;

--- a/src/Builder/Expression/AbsOperator.php
+++ b/src/Builder/Expression/AbsOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class AbsOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$abs';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $value */
@@ -33,10 +34,5 @@ final class AbsOperator implements ResolvesToNumber, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$abs';
     }
 }

--- a/src/Builder/Expression/AcosOperator.php
+++ b/src/Builder/Expression/AcosOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class AcosOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$acos';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -39,10 +40,5 @@ final class AcosOperator implements ResolvesToDouble, ResolvesToDecimal, Operato
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$acos';
     }
 }

--- a/src/Builder/Expression/AcoshOperator.php
+++ b/src/Builder/Expression/AcoshOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class AcoshOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$acosh';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -39,10 +40,5 @@ final class AcoshOperator implements ResolvesToDouble, ResolvesToDecimal, Operat
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$acosh';
     }
 }

--- a/src/Builder/Expression/AddOperator.php
+++ b/src/Builder/Expression/AddOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 final class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$add';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int> $expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date. */
@@ -46,10 +47,5 @@ final class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDoub
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$add';
     }
 }

--- a/src/Builder/Expression/AllElementsTrueOperator.php
+++ b/src/Builder/Expression/AllElementsTrueOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class AllElementsTrueOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$allElementsTrue';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
@@ -41,10 +42,5 @@ final class AllElementsTrueOperator implements ResolvesToBool, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$allElementsTrue';
     }
 }

--- a/src/Builder/Expression/AndOperator.php
+++ b/src/Builder/Expression/AndOperator.php
@@ -28,6 +28,7 @@ use function array_is_list;
 final class AndOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$and';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|null|stdClass|string> $expression */
@@ -49,10 +50,5 @@ final class AndOperator implements ResolvesToBool, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$and';
     }
 }

--- a/src/Builder/Expression/AnyElementTrueOperator.php
+++ b/src/Builder/Expression/AnyElementTrueOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class AnyElementTrueOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$anyElementTrue';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
@@ -41,10 +42,5 @@ final class AnyElementTrueOperator implements ResolvesToBool, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$anyElementTrue';
     }
 }

--- a/src/Builder/Expression/ArrayElemAtOperator.php
+++ b/src/Builder/Expression/ArrayElemAtOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class ArrayElemAtOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$arrayElemAt';
     public const PROPERTIES = ['array' => 'array', 'idx' => 'idx'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $array */
@@ -46,10 +47,5 @@ final class ArrayElemAtOperator implements ResolvesToAny, OperatorInterface
 
         $this->array = $array;
         $this->idx = $idx;
-    }
-
-    public function getOperator(): string
-    {
-        return '$arrayElemAt';
     }
 }

--- a/src/Builder/Expression/ArrayToObjectOperator.php
+++ b/src/Builder/Expression/ArrayToObjectOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class ArrayToObjectOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$arrayToObject';
     public const PROPERTIES = ['array' => 'array'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $array */
@@ -41,10 +42,5 @@ final class ArrayToObjectOperator implements ResolvesToObject, OperatorInterface
         }
 
         $this->array = $array;
-    }
-
-    public function getOperator(): string
-    {
-        return '$arrayToObject';
     }
 }

--- a/src/Builder/Expression/AsinOperator.php
+++ b/src/Builder/Expression/AsinOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class AsinOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$asin';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -39,10 +40,5 @@ final class AsinOperator implements ResolvesToDouble, ResolvesToDecimal, Operato
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$asin';
     }
 }

--- a/src/Builder/Expression/AsinhOperator.php
+++ b/src/Builder/Expression/AsinhOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class AsinhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$asinh';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -39,10 +40,5 @@ final class AsinhOperator implements ResolvesToDouble, ResolvesToDecimal, Operat
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$asinh';
     }
 }

--- a/src/Builder/Expression/Atan2Operator.php
+++ b/src/Builder/Expression/Atan2Operator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class Atan2Operator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$atan2';
     public const PROPERTIES = ['y' => 'y', 'x' => 'x'];
 
     /**
@@ -46,10 +47,5 @@ final class Atan2Operator implements ResolvesToDouble, ResolvesToDecimal, Operat
     ) {
         $this->y = $y;
         $this->x = $x;
-    }
-
-    public function getOperator(): string
-    {
-        return '$atan2';
     }
 }

--- a/src/Builder/Expression/AtanOperator.php
+++ b/src/Builder/Expression/AtanOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class AtanOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$atan';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -39,10 +40,5 @@ final class AtanOperator implements ResolvesToDouble, ResolvesToDecimal, Operato
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$atan';
     }
 }

--- a/src/Builder/Expression/AtanhOperator.php
+++ b/src/Builder/Expression/AtanhOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class AtanhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$atanh';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -39,10 +40,5 @@ final class AtanhOperator implements ResolvesToDouble, ResolvesToDecimal, Operat
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$atanh';
     }
 }

--- a/src/Builder/Expression/AvgOperator.php
+++ b/src/Builder/Expression/AvgOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 final class AvgOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$avg';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|Int64|ResolvesToNumber|float|int> $expression */
@@ -46,10 +47,5 @@ final class AvgOperator implements ResolvesToNumber, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$avg';
     }
 }

--- a/src/Builder/Expression/BinarySizeOperator.php
+++ b/src/Builder/Expression/BinarySizeOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class BinarySizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$binarySize';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression */
@@ -32,10 +33,5 @@ final class BinarySizeOperator implements ResolvesToInt, OperatorInterface
     public function __construct(Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$binarySize';
     }
 }

--- a/src/Builder/Expression/BitAndOperator.php
+++ b/src/Builder/Expression/BitAndOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 final class BitAndOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bitAnd';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Int64|ResolvesToInt|ResolvesToLong|int> $expression */
@@ -45,10 +46,5 @@ final class BitAndOperator implements ResolvesToInt, ResolvesToLong, OperatorInt
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bitAnd';
     }
 }

--- a/src/Builder/Expression/BitNotOperator.php
+++ b/src/Builder/Expression/BitNotOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class BitNotOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bitNot';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Int64|ResolvesToInt|ResolvesToLong|int $expression */
@@ -33,10 +34,5 @@ final class BitNotOperator implements ResolvesToInt, ResolvesToLong, OperatorInt
     public function __construct(Int64|ResolvesToInt|ResolvesToLong|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bitNot';
     }
 }

--- a/src/Builder/Expression/BitOrOperator.php
+++ b/src/Builder/Expression/BitOrOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 final class BitOrOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bitOr';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Int64|ResolvesToInt|ResolvesToLong|int> $expression */
@@ -45,10 +46,5 @@ final class BitOrOperator implements ResolvesToInt, ResolvesToLong, OperatorInte
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bitOr';
     }
 }

--- a/src/Builder/Expression/BitXorOperator.php
+++ b/src/Builder/Expression/BitXorOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 final class BitXorOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bitXor';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Int64|ResolvesToInt|ResolvesToLong|int> $expression */
@@ -45,10 +46,5 @@ final class BitXorOperator implements ResolvesToInt, ResolvesToLong, OperatorInt
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bitXor';
     }
 }

--- a/src/Builder/Expression/BsonSizeOperator.php
+++ b/src/Builder/Expression/BsonSizeOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class BsonSizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bsonSize';
     public const PROPERTIES = ['object' => 'object'];
 
     /** @var Document|ResolvesToNull|ResolvesToObject|Serializable|array|null|stdClass $object */
@@ -34,10 +35,5 @@ final class BsonSizeOperator implements ResolvesToInt, OperatorInterface
     public function __construct(Document|Serializable|ResolvesToNull|ResolvesToObject|stdClass|array|null $object)
     {
         $this->object = $object;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bsonSize';
     }
 }

--- a/src/Builder/Expression/CaseOperator.php
+++ b/src/Builder/Expression/CaseOperator.php
@@ -23,7 +23,8 @@ use stdClass;
  */
 final class CaseOperator implements SwitchBranchInterface, OperatorInterface
 {
-    public const ENCODE = Encode::FlatObject;
+    public const ENCODE = Encode::Object;
+    public const NAME = null;
     public const PROPERTIES = ['case' => 'case', 'then' => 'then'];
 
     /** @var ResolvesToBool|bool $case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here. */
@@ -42,10 +43,5 @@ final class CaseOperator implements SwitchBranchInterface, OperatorInterface
     ) {
         $this->case = $case;
         $this->then = $then;
-    }
-
-    public function getOperator(): string
-    {
-        return '$case';
     }
 }

--- a/src/Builder/Expression/CeilOperator.php
+++ b/src/Builder/Expression/CeilOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class CeilOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$ceil';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression If the argument resolves to a value of null or refers to a field that is missing, $ceil returns null. If the argument resolves to NaN, $ceil returns NaN. */
@@ -33,10 +34,5 @@ final class CeilOperator implements ResolvesToInt, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$ceil';
     }
 }

--- a/src/Builder/Expression/CmpOperator.php
+++ b/src/Builder/Expression/CmpOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class CmpOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$cmp';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
@@ -41,10 +42,5 @@ final class CmpOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$cmp';
     }
 }

--- a/src/Builder/Expression/ConcatArraysOperator.php
+++ b/src/Builder/Expression/ConcatArraysOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 final class ConcatArraysOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$concatArrays';
     public const PROPERTIES = ['array' => 'array'];
 
     /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $array */
@@ -45,10 +46,5 @@ final class ConcatArraysOperator implements ResolvesToArray, OperatorInterface
         }
 
         $this->array = $array;
-    }
-
-    public function getOperator(): string
-    {
-        return '$concatArrays';
     }
 }

--- a/src/Builder/Expression/ConcatOperator.php
+++ b/src/Builder/Expression/ConcatOperator.php
@@ -23,6 +23,7 @@ use function array_is_list;
 final class ConcatOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$concat';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ResolvesToString|string> $expression */
@@ -43,10 +44,5 @@ final class ConcatOperator implements ResolvesToString, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$concat';
     }
 }

--- a/src/Builder/Expression/CondOperator.php
+++ b/src/Builder/Expression/CondOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class CondOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$cond';
     public const PROPERTIES = ['if' => 'if', 'then' => 'then', 'else' => 'else'];
 
     /** @var ResolvesToBool|bool $if */
@@ -47,10 +48,5 @@ final class CondOperator implements ResolvesToAny, OperatorInterface
         $this->if = $if;
         $this->then = $then;
         $this->else = $else;
-    }
-
-    public function getOperator(): string
-    {
-        return '$cond';
     }
 }

--- a/src/Builder/Expression/ConvertOperator.php
+++ b/src/Builder/Expression/ConvertOperator.php
@@ -25,6 +25,7 @@ use stdClass;
 final class ConvertOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$convert';
     public const PROPERTIES = ['input' => 'input', 'to' => 'to', 'onError' => 'onError', 'onNull' => 'onNull'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
@@ -63,10 +64,5 @@ final class ConvertOperator implements ResolvesToAny, OperatorInterface
         $this->to = $to;
         $this->onError = $onError;
         $this->onNull = $onNull;
-    }
-
-    public function getOperator(): string
-    {
-        return '$convert';
     }
 }

--- a/src/Builder/Expression/CosOperator.php
+++ b/src/Builder/Expression/CosOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class CosOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$cos';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -37,10 +38,5 @@ final class CosOperator implements ResolvesToDouble, ResolvesToDecimal, Operator
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$cos';
     }
 }

--- a/src/Builder/Expression/CoshOperator.php
+++ b/src/Builder/Expression/CoshOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class CoshOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$cosh';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -37,10 +38,5 @@ final class CoshOperator implements ResolvesToDouble, ResolvesToDecimal, Operato
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$cosh';
     }
 }

--- a/src/Builder/Expression/DateAddOperator.php
+++ b/src/Builder/Expression/DateAddOperator.php
@@ -26,6 +26,7 @@ use MongoDB\Builder\Type\TimeUnit;
 final class DateAddOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dateAdd';
     public const PROPERTIES = ['startDate' => 'startDate', 'unit' => 'unit', 'amount' => 'amount', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -56,10 +57,5 @@ final class DateAddOperator implements ResolvesToDate, OperatorInterface
         $this->unit = $unit;
         $this->amount = $amount;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dateAdd';
     }
 }

--- a/src/Builder/Expression/DateDiffOperator.php
+++ b/src/Builder/Expression/DateDiffOperator.php
@@ -25,6 +25,7 @@ use MongoDB\Builder\Type\TimeUnit;
 final class DateDiffOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dateDiff';
 
     public const PROPERTIES = [
         'startDate' => 'startDate',
@@ -68,10 +69,5 @@ final class DateDiffOperator implements ResolvesToInt, OperatorInterface
         $this->unit = $unit;
         $this->timezone = $timezone;
         $this->startOfWeek = $startOfWeek;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dateDiff';
     }
 }

--- a/src/Builder/Expression/DateFromPartsOperator.php
+++ b/src/Builder/Expression/DateFromPartsOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 final class DateFromPartsOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dateFromParts';
 
     public const PROPERTIES = [
         'year' => 'year',
@@ -108,10 +109,5 @@ final class DateFromPartsOperator implements ResolvesToDate, OperatorInterface
         $this->second = $second;
         $this->millisecond = $millisecond;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dateFromParts';
     }
 }

--- a/src/Builder/Expression/DateFromStringOperator.php
+++ b/src/Builder/Expression/DateFromStringOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class DateFromStringOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dateFromString';
 
     public const PROPERTIES = [
         'dateString' => 'dateString',
@@ -79,10 +80,5 @@ final class DateFromStringOperator implements ResolvesToDate, OperatorInterface
         $this->timezone = $timezone;
         $this->onError = $onError;
         $this->onNull = $onNull;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dateFromString';
     }
 }

--- a/src/Builder/Expression/DateSubtractOperator.php
+++ b/src/Builder/Expression/DateSubtractOperator.php
@@ -26,6 +26,7 @@ use MongoDB\Builder\Type\TimeUnit;
 final class DateSubtractOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dateSubtract';
     public const PROPERTIES = ['startDate' => 'startDate', 'unit' => 'unit', 'amount' => 'amount', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -56,10 +57,5 @@ final class DateSubtractOperator implements ResolvesToDate, OperatorInterface
         $this->unit = $unit;
         $this->amount = $amount;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dateSubtract';
     }
 }

--- a/src/Builder/Expression/DateToPartsOperator.php
+++ b/src/Builder/Expression/DateToPartsOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class DateToPartsOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dateToParts';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone', 'iso8601' => 'iso8601'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The input date for which to return parts. date can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -48,10 +49,5 @@ final class DateToPartsOperator implements ResolvesToObject, OperatorInterface
         $this->date = $date;
         $this->timezone = $timezone;
         $this->iso8601 = $iso8601;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dateToParts';
     }
 }

--- a/src/Builder/Expression/DateToStringOperator.php
+++ b/src/Builder/Expression/DateToStringOperator.php
@@ -27,6 +27,7 @@ use stdClass;
 final class DateToStringOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dateToString';
     public const PROPERTIES = ['date' => 'date', 'format' => 'format', 'timezone' => 'timezone', 'onNull' => 'onNull'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to convert to string. Must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -65,10 +66,5 @@ final class DateToStringOperator implements ResolvesToString, OperatorInterface
         $this->format = $format;
         $this->timezone = $timezone;
         $this->onNull = $onNull;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dateToString';
     }
 }

--- a/src/Builder/Expression/DateTruncOperator.php
+++ b/src/Builder/Expression/DateTruncOperator.php
@@ -27,6 +27,7 @@ use MongoDB\Builder\Type\TimeUnit;
 final class DateTruncOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dateTrunc';
 
     public const PROPERTIES = [
         'date' => 'date',
@@ -82,10 +83,5 @@ final class DateTruncOperator implements ResolvesToDate, OperatorInterface
         $this->binSize = $binSize;
         $this->timezone = $timezone;
         $this->startOfWeek = $startOfWeek;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dateTrunc';
     }
 }

--- a/src/Builder/Expression/DayOfMonthOperator.php
+++ b/src/Builder/Expression/DayOfMonthOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class DayOfMonthOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dayOfMonth';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class DayOfMonthOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dayOfMonth';
     }
 }

--- a/src/Builder/Expression/DayOfWeekOperator.php
+++ b/src/Builder/Expression/DayOfWeekOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class DayOfWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dayOfWeek';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class DayOfWeekOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dayOfWeek';
     }
 }

--- a/src/Builder/Expression/DayOfYearOperator.php
+++ b/src/Builder/Expression/DayOfYearOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class DayOfYearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$dayOfYear';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class DayOfYearOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$dayOfYear';
     }
 }

--- a/src/Builder/Expression/DegreesToRadiansOperator.php
+++ b/src/Builder/Expression/DegreesToRadiansOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class DegreesToRadiansOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$degreesToRadians';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -37,10 +38,5 @@ final class DegreesToRadiansOperator implements ResolvesToDouble, ResolvesToDeci
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$degreesToRadians';
     }
 }

--- a/src/Builder/Expression/DivideOperator.php
+++ b/src/Builder/Expression/DivideOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class DivideOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$divide';
     public const PROPERTIES = ['dividend' => 'dividend', 'divisor' => 'divisor'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $dividend The first argument is the dividend, and the second argument is the divisor; i.e. the first argument is divided by the second argument. */
@@ -40,10 +41,5 @@ final class DivideOperator implements ResolvesToDouble, OperatorInterface
     ) {
         $this->dividend = $dividend;
         $this->divisor = $divisor;
-    }
-
-    public function getOperator(): string
-    {
-        return '$divide';
     }
 }

--- a/src/Builder/Expression/EqOperator.php
+++ b/src/Builder/Expression/EqOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class EqOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$eq';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
@@ -41,10 +42,5 @@ final class EqOperator implements ResolvesToBool, OperatorInterface
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$eq';
     }
 }

--- a/src/Builder/Expression/ExpOperator.php
+++ b/src/Builder/Expression/ExpOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class ExpOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$exp';
     public const PROPERTIES = ['exponent' => 'exponent'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $exponent */
@@ -33,10 +34,5 @@ final class ExpOperator implements ResolvesToDouble, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $exponent)
     {
         $this->exponent = $exponent;
-    }
-
-    public function getOperator(): string
-    {
-        return '$exp';
     }
 }

--- a/src/Builder/Expression/FilterOperator.php
+++ b/src/Builder/Expression/FilterOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class FilterOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$filter';
     public const PROPERTIES = ['input' => 'input', 'cond' => 'cond', 'as' => 'as', 'limit' => 'limit'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input */
@@ -65,10 +66,5 @@ final class FilterOperator implements ResolvesToArray, OperatorInterface
         $this->cond = $cond;
         $this->as = $as;
         $this->limit = $limit;
-    }
-
-    public function getOperator(): string
-    {
-        return '$filter';
     }
 }

--- a/src/Builder/Expression/FirstNOperator.php
+++ b/src/Builder/Expression/FirstNOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class FirstNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$firstN';
     public const PROPERTIES = ['n' => 'n', 'input' => 'input'];
 
     /** @var ResolvesToInt|int $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $firstN returns. */
@@ -46,10 +47,5 @@ final class FirstNOperator implements ResolvesToArray, OperatorInterface
         }
 
         $this->input = $input;
-    }
-
-    public function getOperator(): string
-    {
-        return '$firstN';
     }
 }

--- a/src/Builder/Expression/FirstOperator.php
+++ b/src/Builder/Expression/FirstOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class FirstOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$first';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
@@ -41,10 +42,5 @@ final class FirstOperator implements ResolvesToAny, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$first';
     }
 }

--- a/src/Builder/Expression/FloorOperator.php
+++ b/src/Builder/Expression/FloorOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class FloorOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$floor';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
@@ -33,10 +34,5 @@ final class FloorOperator implements ResolvesToInt, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$floor';
     }
 }

--- a/src/Builder/Expression/FunctionOperator.php
+++ b/src/Builder/Expression/FunctionOperator.php
@@ -29,6 +29,7 @@ use function is_string;
 final class FunctionOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$function';
     public const PROPERTIES = ['body' => 'body', 'args' => 'args', 'lang' => 'lang'];
 
     /**
@@ -62,10 +63,5 @@ final class FunctionOperator implements ResolvesToAny, OperatorInterface
 
         $this->args = $args;
         $this->lang = $lang;
-    }
-
-    public function getOperator(): string
-    {
-        return '$function';
     }
 }

--- a/src/Builder/Expression/GetFieldOperator.php
+++ b/src/Builder/Expression/GetFieldOperator.php
@@ -25,6 +25,7 @@ use stdClass;
 final class GetFieldOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$getField';
     public const PROPERTIES = ['field' => 'field', 'input' => 'input'];
 
     /**
@@ -51,10 +52,5 @@ final class GetFieldOperator implements ResolvesToAny, OperatorInterface
     ) {
         $this->field = $field;
         $this->input = $input;
-    }
-
-    public function getOperator(): string
-    {
-        return '$getField';
     }
 }

--- a/src/Builder/Expression/GtOperator.php
+++ b/src/Builder/Expression/GtOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class GtOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$gt';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
@@ -41,10 +42,5 @@ final class GtOperator implements ResolvesToBool, OperatorInterface
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$gt';
     }
 }

--- a/src/Builder/Expression/GteOperator.php
+++ b/src/Builder/Expression/GteOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class GteOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$gte';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
@@ -41,10 +42,5 @@ final class GteOperator implements ResolvesToBool, OperatorInterface
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$gte';
     }
 }

--- a/src/Builder/Expression/HourOperator.php
+++ b/src/Builder/Expression/HourOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class HourOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$hour';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class HourOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$hour';
     }
 }

--- a/src/Builder/Expression/IfNullOperator.php
+++ b/src/Builder/Expression/IfNullOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 final class IfNullOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$ifNull';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
@@ -46,10 +47,5 @@ final class IfNullOperator implements ResolvesToAny, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$ifNull';
     }
 }

--- a/src/Builder/Expression/InOperator.php
+++ b/src/Builder/Expression/InOperator.php
@@ -29,6 +29,7 @@ use function is_array;
 final class InOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$in';
     public const PROPERTIES = ['expression' => 'expression', 'array' => 'array'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression Any valid expression expression. */
@@ -51,10 +52,5 @@ final class InOperator implements ResolvesToBool, OperatorInterface
         }
 
         $this->array = $array;
-    }
-
-    public function getOperator(): string
-    {
-        return '$in';
     }
 }

--- a/src/Builder/Expression/IndexOfArrayOperator.php
+++ b/src/Builder/Expression/IndexOfArrayOperator.php
@@ -30,6 +30,7 @@ use function is_array;
 final class IndexOfArrayOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$indexOfArray';
     public const PROPERTIES = ['array' => 'array', 'search' => 'search', 'start' => 'start', 'end' => 'end'];
 
     /**
@@ -78,10 +79,5 @@ final class IndexOfArrayOperator implements ResolvesToInt, OperatorInterface
         $this->search = $search;
         $this->start = $start;
         $this->end = $end;
-    }
-
-    public function getOperator(): string
-    {
-        return '$indexOfArray';
     }
 }

--- a/src/Builder/Expression/IndexOfBytesOperator.php
+++ b/src/Builder/Expression/IndexOfBytesOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\Optional;
 final class IndexOfBytesOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$indexOfBytes';
     public const PROPERTIES = ['string' => 'string', 'substring' => 'substring', 'start' => 'start', 'end' => 'end'];
 
     /**
@@ -65,10 +66,5 @@ final class IndexOfBytesOperator implements ResolvesToInt, OperatorInterface
         $this->substring = $substring;
         $this->start = $start;
         $this->end = $end;
-    }
-
-    public function getOperator(): string
-    {
-        return '$indexOfBytes';
     }
 }

--- a/src/Builder/Expression/IndexOfCPOperator.php
+++ b/src/Builder/Expression/IndexOfCPOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\Optional;
 final class IndexOfCPOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$indexOfCP';
     public const PROPERTIES = ['string' => 'string', 'substring' => 'substring', 'start' => 'start', 'end' => 'end'];
 
     /**
@@ -65,10 +66,5 @@ final class IndexOfCPOperator implements ResolvesToInt, OperatorInterface
         $this->substring = $substring;
         $this->start = $start;
         $this->end = $end;
-    }
-
-    public function getOperator(): string
-    {
-        return '$indexOfCP';
     }
 }

--- a/src/Builder/Expression/IsArrayOperator.php
+++ b/src/Builder/Expression/IsArrayOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class IsArrayOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$isArray';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -34,10 +35,5 @@ final class IsArrayOperator implements ResolvesToBool, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$isArray';
     }
 }

--- a/src/Builder/Expression/IsNumberOperator.php
+++ b/src/Builder/Expression/IsNumberOperator.php
@@ -25,6 +25,7 @@ use stdClass;
 final class IsNumberOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$isNumber';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -36,10 +37,5 @@ final class IsNumberOperator implements ResolvesToBool, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$isNumber';
     }
 }

--- a/src/Builder/Expression/IsoDayOfWeekOperator.php
+++ b/src/Builder/Expression/IsoDayOfWeekOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class IsoDayOfWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$isoDayOfWeek';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class IsoDayOfWeekOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$isoDayOfWeek';
     }
 }

--- a/src/Builder/Expression/IsoWeekOperator.php
+++ b/src/Builder/Expression/IsoWeekOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class IsoWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$isoWeek';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class IsoWeekOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$isoWeek';
     }
 }

--- a/src/Builder/Expression/IsoWeekYearOperator.php
+++ b/src/Builder/Expression/IsoWeekYearOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class IsoWeekYearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$isoWeekYear';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class IsoWeekYearOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$isoWeekYear';
     }
 }

--- a/src/Builder/Expression/LastNOperator.php
+++ b/src/Builder/Expression/LastNOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class LastNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$lastN';
     public const PROPERTIES = ['n' => 'n', 'input' => 'input'];
 
     /** @var ResolvesToInt|int $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $firstN returns. */
@@ -46,10 +47,5 @@ final class LastNOperator implements ResolvesToArray, OperatorInterface
         }
 
         $this->input = $input;
-    }
-
-    public function getOperator(): string
-    {
-        return '$lastN';
     }
 }

--- a/src/Builder/Expression/LastOperator.php
+++ b/src/Builder/Expression/LastOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class LastOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$last';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression */
@@ -41,10 +42,5 @@ final class LastOperator implements ResolvesToAny, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$last';
     }
 }

--- a/src/Builder/Expression/LetOperator.php
+++ b/src/Builder/Expression/LetOperator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class LetOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$let';
     public const PROPERTIES = ['vars' => 'vars', 'in' => 'in'];
 
     /**
@@ -48,10 +49,5 @@ final class LetOperator implements ResolvesToAny, OperatorInterface
     ) {
         $this->vars = $vars;
         $this->in = $in;
-    }
-
-    public function getOperator(): string
-    {
-        return '$let';
     }
 }

--- a/src/Builder/Expression/LiteralOperator.php
+++ b/src/Builder/Expression/LiteralOperator.php
@@ -22,6 +22,7 @@ use stdClass;
 final class LiteralOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$literal';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression. */
@@ -33,10 +34,5 @@ final class LiteralOperator implements ResolvesToAny, OperatorInterface
     public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$literal';
     }
 }

--- a/src/Builder/Expression/LnOperator.php
+++ b/src/Builder/Expression/LnOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class LnOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$ln';
     public const PROPERTIES = ['number' => 'number'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number Any valid expression as long as it resolves to a non-negative number. For more information on expressions, see Expressions. */
@@ -34,10 +35,5 @@ final class LnOperator implements ResolvesToDouble, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $number)
     {
         $this->number = $number;
-    }
-
-    public function getOperator(): string
-    {
-        return '$ln';
     }
 }

--- a/src/Builder/Expression/Log10Operator.php
+++ b/src/Builder/Expression/Log10Operator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class Log10Operator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$log10';
     public const PROPERTIES = ['number' => 'number'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number Any valid expression as long as it resolves to a non-negative number. */
@@ -33,10 +34,5 @@ final class Log10Operator implements ResolvesToDouble, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $number)
     {
         $this->number = $number;
-    }
-
-    public function getOperator(): string
-    {
-        return '$log10';
     }
 }

--- a/src/Builder/Expression/LogOperator.php
+++ b/src/Builder/Expression/LogOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class LogOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$log';
     public const PROPERTIES = ['number' => 'number', 'base' => 'base'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number Any valid expression as long as it resolves to a non-negative number. */
@@ -40,10 +41,5 @@ final class LogOperator implements ResolvesToDouble, OperatorInterface
     ) {
         $this->number = $number;
         $this->base = $base;
-    }
-
-    public function getOperator(): string
-    {
-        return '$log';
     }
 }

--- a/src/Builder/Expression/LtOperator.php
+++ b/src/Builder/Expression/LtOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class LtOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$lt';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
@@ -41,10 +42,5 @@ final class LtOperator implements ResolvesToBool, OperatorInterface
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$lt';
     }
 }

--- a/src/Builder/Expression/LteOperator.php
+++ b/src/Builder/Expression/LteOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class LteOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$lte';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
@@ -41,10 +42,5 @@ final class LteOperator implements ResolvesToBool, OperatorInterface
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$lte';
     }
 }

--- a/src/Builder/Expression/LtrimOperator.php
+++ b/src/Builder/Expression/LtrimOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\Optional;
 final class LtrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$ltrim';
     public const PROPERTIES = ['input' => 'input', 'chars' => 'chars'];
 
     /** @var ResolvesToString|string $input The string to trim. The argument can be any valid expression that resolves to a string. */
@@ -46,10 +47,5 @@ final class LtrimOperator implements ResolvesToString, OperatorInterface
     ) {
         $this->input = $input;
         $this->chars = $chars;
-    }
-
-    public function getOperator(): string
-    {
-        return '$ltrim';
     }
 }

--- a/src/Builder/Expression/MapOperator.php
+++ b/src/Builder/Expression/MapOperator.php
@@ -30,6 +30,7 @@ use function is_array;
 final class MapOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$map';
     public const PROPERTIES = ['input' => 'input', 'in' => 'in', 'as' => 'as'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to an array. */
@@ -58,10 +59,5 @@ final class MapOperator implements ResolvesToArray, OperatorInterface
         $this->input = $input;
         $this->in = $in;
         $this->as = $as;
-    }
-
-    public function getOperator(): string
-    {
-        return '$map';
     }
 }

--- a/src/Builder/Expression/MaxNOperator.php
+++ b/src/Builder/Expression/MaxNOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class MaxNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$maxN';
     public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return the maximal n elements. */
@@ -46,10 +47,5 @@ final class MaxNOperator implements ResolvesToArray, OperatorInterface
 
         $this->input = $input;
         $this->n = $n;
-    }
-
-    public function getOperator(): string
-    {
-        return '$maxN';
     }
 }

--- a/src/Builder/Expression/MaxOperator.php
+++ b/src/Builder/Expression/MaxOperator.php
@@ -27,6 +27,7 @@ use function array_is_list;
 final class MaxOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$max';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
@@ -47,10 +48,5 @@ final class MaxOperator implements ResolvesToAny, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$max';
     }
 }

--- a/src/Builder/Expression/MedianOperator.php
+++ b/src/Builder/Expression/MedianOperator.php
@@ -33,6 +33,7 @@ use function is_array;
 final class MedianOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$median';
     public const PROPERTIES = ['input' => 'input', 'method' => 'method'];
 
     /** @var BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $median calculates the 50th percentile value of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $median calculation ignores it. */
@@ -55,10 +56,5 @@ final class MedianOperator implements ResolvesToDouble, OperatorInterface
 
         $this->input = $input;
         $this->method = $method;
-    }
-
-    public function getOperator(): string
-    {
-        return '$median';
     }
 }

--- a/src/Builder/Expression/MergeObjectsOperator.php
+++ b/src/Builder/Expression/MergeObjectsOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 final class MergeObjectsOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$mergeObjects';
     public const PROPERTIES = ['document' => 'document'];
 
     /** @var list<Document|ResolvesToObject|Serializable|array|stdClass> $document Any valid expression that resolves to a document. */
@@ -46,10 +47,5 @@ final class MergeObjectsOperator implements ResolvesToObject, OperatorInterface
         }
 
         $this->document = $document;
-    }
-
-    public function getOperator(): string
-    {
-        return '$mergeObjects';
     }
 }

--- a/src/Builder/Expression/MetaOperator.php
+++ b/src/Builder/Expression/MetaOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class MetaOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$meta';
     public const PROPERTIES = ['keyword' => 'keyword'];
 
     /** @var string $keyword */
@@ -31,10 +32,5 @@ final class MetaOperator implements ResolvesToAny, OperatorInterface
     public function __construct(string $keyword)
     {
         $this->keyword = $keyword;
-    }
-
-    public function getOperator(): string
-    {
-        return '$meta';
     }
 }

--- a/src/Builder/Expression/MillisecondOperator.php
+++ b/src/Builder/Expression/MillisecondOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class MillisecondOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$millisecond';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class MillisecondOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$millisecond';
     }
 }

--- a/src/Builder/Expression/MinNOperator.php
+++ b/src/Builder/Expression/MinNOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class MinNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$minN';
     public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $input An expression that resolves to the array from which to return the maximal n elements. */
@@ -46,10 +47,5 @@ final class MinNOperator implements ResolvesToArray, OperatorInterface
 
         $this->input = $input;
         $this->n = $n;
-    }
-
-    public function getOperator(): string
-    {
-        return '$minN';
     }
 }

--- a/src/Builder/Expression/MinOperator.php
+++ b/src/Builder/Expression/MinOperator.php
@@ -27,6 +27,7 @@ use function array_is_list;
 final class MinOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$min';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
@@ -47,10 +48,5 @@ final class MinOperator implements ResolvesToAny, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$min';
     }
 }

--- a/src/Builder/Expression/MinuteOperator.php
+++ b/src/Builder/Expression/MinuteOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class MinuteOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$minute';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class MinuteOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$minute';
     }
 }

--- a/src/Builder/Expression/ModOperator.php
+++ b/src/Builder/Expression/ModOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class ModOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$mod';
     public const PROPERTIES = ['dividend' => 'dividend', 'divisor' => 'divisor'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $dividend The first argument is the dividend, and the second argument is the divisor; i.e. first argument is divided by the second argument. */
@@ -40,10 +41,5 @@ final class ModOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->dividend = $dividend;
         $this->divisor = $divisor;
-    }
-
-    public function getOperator(): string
-    {
-        return '$mod';
     }
 }

--- a/src/Builder/Expression/MonthOperator.php
+++ b/src/Builder/Expression/MonthOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class MonthOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$month';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class MonthOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$month';
     }
 }

--- a/src/Builder/Expression/MultiplyOperator.php
+++ b/src/Builder/Expression/MultiplyOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 final class MultiplyOperator implements ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$multiply';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -49,10 +50,5 @@ final class MultiplyOperator implements ResolvesToDecimal, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$multiply';
     }
 }

--- a/src/Builder/Expression/NeOperator.php
+++ b/src/Builder/Expression/NeOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class NeOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$ne';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
@@ -41,10 +42,5 @@ final class NeOperator implements ResolvesToBool, OperatorInterface
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$ne';
     }
 }

--- a/src/Builder/Expression/NotOperator.php
+++ b/src/Builder/Expression/NotOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class NotOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$not';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class NotOperator implements ResolvesToBool, OperatorInterface
         Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$not';
     }
 }

--- a/src/Builder/Expression/ObjectToArrayOperator.php
+++ b/src/Builder/Expression/ObjectToArrayOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class ObjectToArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$objectToArray';
     public const PROPERTIES = ['object' => 'object'];
 
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $object Any valid expression as long as it resolves to a document object. $objectToArray applies to the top-level fields of its argument. If the argument is a document that itself contains embedded document fields, the $objectToArray does not recursively apply to the embedded document fields. */
@@ -34,10 +35,5 @@ final class ObjectToArrayOperator implements ResolvesToArray, OperatorInterface
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array $object)
     {
         $this->object = $object;
-    }
-
-    public function getOperator(): string
-    {
-        return '$objectToArray';
     }
 }

--- a/src/Builder/Expression/OrOperator.php
+++ b/src/Builder/Expression/OrOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 final class OrOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$or';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string> $expression */
@@ -47,10 +48,5 @@ final class OrOperator implements ResolvesToBool, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$or';
     }
 }

--- a/src/Builder/Expression/PercentileOperator.php
+++ b/src/Builder/Expression/PercentileOperator.php
@@ -36,6 +36,7 @@ use function is_array;
 final class PercentileOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$percentile';
     public const PROPERTIES = ['input' => 'input', 'p' => 'p', 'method' => 'method'];
 
     /** @var BSONArray|Decimal128|Int64|PackedArray|ResolvesToNumber|array|float|int $input $percentile calculates the percentile values of this data. input must be a field name or an expression that evaluates to a numeric type. If the expression cannot be converted to a numeric type, the $percentile calculation ignores it. */
@@ -72,10 +73,5 @@ final class PercentileOperator implements ResolvesToArray, OperatorInterface
 
         $this->p = $p;
         $this->method = $method;
-    }
-
-    public function getOperator(): string
-    {
-        return '$percentile';
     }
 }

--- a/src/Builder/Expression/PowOperator.php
+++ b/src/Builder/Expression/PowOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class PowOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$pow';
     public const PROPERTIES = ['number' => 'number', 'exponent' => 'exponent'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number */
@@ -40,10 +41,5 @@ final class PowOperator implements ResolvesToNumber, OperatorInterface
     ) {
         $this->number = $number;
         $this->exponent = $exponent;
-    }
-
-    public function getOperator(): string
-    {
-        return '$pow';
     }
 }

--- a/src/Builder/Expression/RadiansToDegreesOperator.php
+++ b/src/Builder/Expression/RadiansToDegreesOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class RadiansToDegreesOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$radiansToDegrees';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $expression */
@@ -33,10 +34,5 @@ final class RadiansToDegreesOperator implements ResolvesToDouble, ResolvesToDeci
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$radiansToDegrees';
     }
 }

--- a/src/Builder/Expression/RandOperator.php
+++ b/src/Builder/Expression/RandOperator.php
@@ -20,13 +20,9 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class RandOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$rand';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$rand';
     }
 }

--- a/src/Builder/Expression/RangeOperator.php
+++ b/src/Builder/Expression/RangeOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\Optional;
 final class RangeOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$range';
     public const PROPERTIES = ['start' => 'start', 'end' => 'end', 'step' => 'step'];
 
     /** @var ResolvesToInt|int $start An integer that specifies the start of the sequence. Can be any valid expression that resolves to an integer. */
@@ -45,10 +46,5 @@ final class RangeOperator implements ResolvesToArray, OperatorInterface
         $this->start = $start;
         $this->end = $end;
         $this->step = $step;
-    }
-
-    public function getOperator(): string
-    {
-        return '$range';
     }
 }

--- a/src/Builder/Expression/ReduceOperator.php
+++ b/src/Builder/Expression/ReduceOperator.php
@@ -29,6 +29,7 @@ use function is_array;
 final class ReduceOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$reduce';
     public const PROPERTIES = ['input' => 'input', 'initialValue' => 'initialValue', 'in' => 'in'];
 
     /**
@@ -71,10 +72,5 @@ final class ReduceOperator implements ResolvesToAny, OperatorInterface
         $this->input = $input;
         $this->initialValue = $initialValue;
         $this->in = $in;
-    }
-
-    public function getOperator(): string
-    {
-        return '$reduce';
     }
 }

--- a/src/Builder/Expression/RegexFindAllOperator.php
+++ b/src/Builder/Expression/RegexFindAllOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 final class RegexFindAllOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$regexFindAll';
     public const PROPERTIES = ['input' => 'input', 'regex' => 'regex', 'options' => 'options'];
 
     /** @var ResolvesToString|string $input The string on which you wish to apply the regex pattern. Can be a string or any valid expression that resolves to a string. */
@@ -47,10 +48,5 @@ final class RegexFindAllOperator implements ResolvesToArray, OperatorInterface
         $this->input = $input;
         $this->regex = $regex;
         $this->options = $options;
-    }
-
-    public function getOperator(): string
-    {
-        return '$regexFindAll';
     }
 }

--- a/src/Builder/Expression/RegexFindOperator.php
+++ b/src/Builder/Expression/RegexFindOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 final class RegexFindOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$regexFind';
     public const PROPERTIES = ['input' => 'input', 'regex' => 'regex', 'options' => 'options'];
 
     /** @var ResolvesToString|string $input The string on which you wish to apply the regex pattern. Can be a string or any valid expression that resolves to a string. */
@@ -47,10 +48,5 @@ final class RegexFindOperator implements ResolvesToObject, OperatorInterface
         $this->input = $input;
         $this->regex = $regex;
         $this->options = $options;
-    }
-
-    public function getOperator(): string
-    {
-        return '$regexFind';
     }
 }

--- a/src/Builder/Expression/RegexMatchOperator.php
+++ b/src/Builder/Expression/RegexMatchOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 final class RegexMatchOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$regexMatch';
     public const PROPERTIES = ['input' => 'input', 'regex' => 'regex', 'options' => 'options'];
 
     /** @var ResolvesToString|string $input The string on which you wish to apply the regex pattern. Can be a string or any valid expression that resolves to a string. */
@@ -47,10 +48,5 @@ final class RegexMatchOperator implements ResolvesToBool, OperatorInterface
         $this->input = $input;
         $this->regex = $regex;
         $this->options = $options;
-    }
-
-    public function getOperator(): string
-    {
-        return '$regexMatch';
     }
 }

--- a/src/Builder/Expression/ReplaceAllOperator.php
+++ b/src/Builder/Expression/ReplaceAllOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class ReplaceAllOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$replaceAll';
     public const PROPERTIES = ['input' => 'input', 'find' => 'find', 'replacement' => 'replacement'];
 
     /** @var ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceAll returns null. */
@@ -46,10 +47,5 @@ final class ReplaceAllOperator implements ResolvesToString, OperatorInterface
         $this->input = $input;
         $this->find = $find;
         $this->replacement = $replacement;
-    }
-
-    public function getOperator(): string
-    {
-        return '$replaceAll';
     }
 }

--- a/src/Builder/Expression/ReplaceOneOperator.php
+++ b/src/Builder/Expression/ReplaceOneOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class ReplaceOneOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$replaceOne';
     public const PROPERTIES = ['input' => 'input', 'find' => 'find', 'replacement' => 'replacement'];
 
     /** @var ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceAll returns null. */
@@ -45,10 +46,5 @@ final class ReplaceOneOperator implements ResolvesToString, OperatorInterface
         $this->input = $input;
         $this->find = $find;
         $this->replacement = $replacement;
-    }
-
-    public function getOperator(): string
-    {
-        return '$replaceOne';
     }
 }

--- a/src/Builder/Expression/ReverseArrayOperator.php
+++ b/src/Builder/Expression/ReverseArrayOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class ReverseArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$reverseArray';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression The argument can be any valid expression as long as it resolves to an array. */
@@ -41,10 +42,5 @@ final class ReverseArrayOperator implements ResolvesToArray, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$reverseArray';
     }
 }

--- a/src/Builder/Expression/RoundOperator.php
+++ b/src/Builder/Expression/RoundOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 final class RoundOperator implements ResolvesToInt, ResolvesToDouble, ResolvesToDecimal, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$round';
     public const PROPERTIES = ['number' => 'number', 'place' => 'place'];
 
     /**
@@ -45,10 +46,5 @@ final class RoundOperator implements ResolvesToInt, ResolvesToDouble, ResolvesTo
     ) {
         $this->number = $number;
         $this->place = $place;
-    }
-
-    public function getOperator(): string
-    {
-        return '$round';
     }
 }

--- a/src/Builder/Expression/RtrimOperator.php
+++ b/src/Builder/Expression/RtrimOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\Optional;
 final class RtrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$rtrim';
     public const PROPERTIES = ['input' => 'input', 'chars' => 'chars'];
 
     /** @var ResolvesToString|string $input The string to trim. The argument can be any valid expression that resolves to a string. */
@@ -45,10 +46,5 @@ final class RtrimOperator implements ResolvesToString, OperatorInterface
     ) {
         $this->input = $input;
         $this->chars = $chars;
-    }
-
-    public function getOperator(): string
-    {
-        return '$rtrim';
     }
 }

--- a/src/Builder/Expression/SecondOperator.php
+++ b/src/Builder/Expression/SecondOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class SecondOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$second';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class SecondOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$second';
     }
 }

--- a/src/Builder/Expression/SetDifferenceOperator.php
+++ b/src/Builder/Expression/SetDifferenceOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class SetDifferenceOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$setDifference';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression1 The arguments can be any valid expression as long as they each resolve to an array. */
@@ -52,10 +53,5 @@ final class SetDifferenceOperator implements ResolvesToArray, OperatorInterface
         }
 
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$setDifference';
     }
 }

--- a/src/Builder/Expression/SetEqualsOperator.php
+++ b/src/Builder/Expression/SetEqualsOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 final class SetEqualsOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$setEquals';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $expression */
@@ -45,10 +46,5 @@ final class SetEqualsOperator implements ResolvesToBool, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$setEquals';
     }
 }

--- a/src/Builder/Expression/SetFieldOperator.php
+++ b/src/Builder/Expression/SetFieldOperator.php
@@ -26,6 +26,7 @@ use stdClass;
 final class SetFieldOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$setField';
     public const PROPERTIES = ['field' => 'field', 'input' => 'input', 'value' => 'value'];
 
     /** @var ResolvesToString|string $field Field in the input object that you want to add, update, or remove. field can be any valid expression that resolves to a string constant. */
@@ -54,10 +55,5 @@ final class SetFieldOperator implements ResolvesToObject, OperatorInterface
         $this->field = $field;
         $this->input = $input;
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$setField';
     }
 }

--- a/src/Builder/Expression/SetIntersectionOperator.php
+++ b/src/Builder/Expression/SetIntersectionOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 final class SetIntersectionOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$setIntersection';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $expression */
@@ -45,10 +46,5 @@ final class SetIntersectionOperator implements ResolvesToArray, OperatorInterfac
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$setIntersection';
     }
 }

--- a/src/Builder/Expression/SetIsSubsetOperator.php
+++ b/src/Builder/Expression/SetIsSubsetOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class SetIsSubsetOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$setIsSubset';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression1 */
@@ -52,10 +53,5 @@ final class SetIsSubsetOperator implements ResolvesToBool, OperatorInterface
         }
 
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$setIsSubset';
     }
 }

--- a/src/Builder/Expression/SetUnionOperator.php
+++ b/src/Builder/Expression/SetUnionOperator.php
@@ -25,6 +25,7 @@ use function array_is_list;
 final class SetUnionOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$setUnion';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<BSONArray|PackedArray|ResolvesToArray|array> $expression */
@@ -45,10 +46,5 @@ final class SetUnionOperator implements ResolvesToArray, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$setUnion';
     }
 }

--- a/src/Builder/Expression/SinOperator.php
+++ b/src/Builder/Expression/SinOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SinOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$sin';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -37,10 +38,5 @@ final class SinOperator implements ResolvesToDouble, ResolvesToDecimal, Operator
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sin';
     }
 }

--- a/src/Builder/Expression/SinhOperator.php
+++ b/src/Builder/Expression/SinhOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SinhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$sinh';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -37,10 +38,5 @@ final class SinhOperator implements ResolvesToDouble, ResolvesToDecimal, Operato
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sinh';
     }
 }

--- a/src/Builder/Expression/SizeOperator.php
+++ b/src/Builder/Expression/SizeOperator.php
@@ -26,6 +26,7 @@ use function is_array;
 final class SizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$size';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression The argument for $size can be any expression as long as it resolves to an array. */
@@ -41,10 +42,5 @@ final class SizeOperator implements ResolvesToInt, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$size';
     }
 }

--- a/src/Builder/Expression/SliceOperator.php
+++ b/src/Builder/Expression/SliceOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class SliceOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$slice';
     public const PROPERTIES = ['expression' => 'expression', 'n' => 'n', 'position' => 'position'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array $expression Any valid expression as long as it resolves to an array. */
@@ -67,10 +68,5 @@ final class SliceOperator implements ResolvesToArray, OperatorInterface
         $this->expression = $expression;
         $this->n = $n;
         $this->position = $position;
-    }
-
-    public function getOperator(): string
-    {
-        return '$slice';
     }
 }

--- a/src/Builder/Expression/SortArrayOperator.php
+++ b/src/Builder/Expression/SortArrayOperator.php
@@ -30,6 +30,7 @@ use function is_array;
 final class SortArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$sortArray';
     public const PROPERTIES = ['input' => 'input', 'sortBy' => 'sortBy'];
 
     /**
@@ -58,10 +59,5 @@ final class SortArrayOperator implements ResolvesToArray, OperatorInterface
 
         $this->input = $input;
         $this->sortBy = $sortBy;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sortArray';
     }
 }

--- a/src/Builder/Expression/SplitOperator.php
+++ b/src/Builder/Expression/SplitOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SplitOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$split';
     public const PROPERTIES = ['string' => 'string', 'delimiter' => 'delimiter'];
 
     /** @var ResolvesToString|string $string The string to be split. string expression can be any valid expression as long as it resolves to a string. */
@@ -36,10 +37,5 @@ final class SplitOperator implements ResolvesToArray, OperatorInterface
     {
         $this->string = $string;
         $this->delimiter = $delimiter;
-    }
-
-    public function getOperator(): string
-    {
-        return '$split';
     }
 }

--- a/src/Builder/Expression/SqrtOperator.php
+++ b/src/Builder/Expression/SqrtOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SqrtOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$sqrt';
     public const PROPERTIES = ['number' => 'number'];
 
     /** @var Decimal128|Int64|ResolvesToNumber|float|int $number The argument can be any valid expression as long as it resolves to a non-negative number. */
@@ -33,10 +34,5 @@ final class SqrtOperator implements ResolvesToDouble, OperatorInterface
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $number)
     {
         $this->number = $number;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sqrt';
     }
 }

--- a/src/Builder/Expression/StdDevPopOperator.php
+++ b/src/Builder/Expression/StdDevPopOperator.php
@@ -27,6 +27,7 @@ use function array_is_list;
 final class StdDevPopOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$stdDevPop';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|Int64|ResolvesToNumber|float|int> $expression */
@@ -47,10 +48,5 @@ final class StdDevPopOperator implements ResolvesToDouble, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$stdDevPop';
     }
 }

--- a/src/Builder/Expression/StdDevSampOperator.php
+++ b/src/Builder/Expression/StdDevSampOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 final class StdDevSampOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$stdDevSamp';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<Decimal128|Int64|ResolvesToNumber|float|int> $expression */
@@ -46,10 +47,5 @@ final class StdDevSampOperator implements ResolvesToDouble, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$stdDevSamp';
     }
 }

--- a/src/Builder/Expression/StrLenBytesOperator.php
+++ b/src/Builder/Expression/StrLenBytesOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class StrLenBytesOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$strLenBytes';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToString|string $expression */
@@ -31,10 +32,5 @@ final class StrLenBytesOperator implements ResolvesToInt, OperatorInterface
     public function __construct(ResolvesToString|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$strLenBytes';
     }
 }

--- a/src/Builder/Expression/StrLenCPOperator.php
+++ b/src/Builder/Expression/StrLenCPOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class StrLenCPOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$strLenCP';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToString|string $expression */
@@ -31,10 +32,5 @@ final class StrLenCPOperator implements ResolvesToInt, OperatorInterface
     public function __construct(ResolvesToString|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$strLenCP';
     }
 }

--- a/src/Builder/Expression/StrcasecmpOperator.php
+++ b/src/Builder/Expression/StrcasecmpOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class StrcasecmpOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$strcasecmp';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var ResolvesToString|string $expression1 */
@@ -36,10 +37,5 @@ final class StrcasecmpOperator implements ResolvesToInt, OperatorInterface
     {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$strcasecmp';
     }
 }

--- a/src/Builder/Expression/SubstrBytesOperator.php
+++ b/src/Builder/Expression/SubstrBytesOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SubstrBytesOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$substrBytes';
     public const PROPERTIES = ['string' => 'string', 'start' => 'start', 'length' => 'length'];
 
     /** @var ResolvesToString|string $string */
@@ -41,10 +42,5 @@ final class SubstrBytesOperator implements ResolvesToString, OperatorInterface
         $this->string = $string;
         $this->start = $start;
         $this->length = $length;
-    }
-
-    public function getOperator(): string
-    {
-        return '$substrBytes';
     }
 }

--- a/src/Builder/Expression/SubstrCPOperator.php
+++ b/src/Builder/Expression/SubstrCPOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SubstrCPOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$substrCP';
     public const PROPERTIES = ['string' => 'string', 'start' => 'start', 'length' => 'length'];
 
     /** @var ResolvesToString|string $string */
@@ -41,10 +42,5 @@ final class SubstrCPOperator implements ResolvesToString, OperatorInterface
         $this->string = $string;
         $this->start = $start;
         $this->length = $length;
-    }
-
-    public function getOperator(): string
-    {
-        return '$substrCP';
     }
 }

--- a/src/Builder/Expression/SubstrOperator.php
+++ b/src/Builder/Expression/SubstrOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SubstrOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$substr';
     public const PROPERTIES = ['string' => 'string', 'start' => 'start', 'length' => 'length'];
 
     /** @var ResolvesToString|string $string */
@@ -41,10 +42,5 @@ final class SubstrOperator implements ResolvesToString, OperatorInterface
         $this->string = $string;
         $this->start = $start;
         $this->length = $length;
-    }
-
-    public function getOperator(): string
-    {
-        return '$substr';
     }
 }

--- a/src/Builder/Expression/SubtractOperator.php
+++ b/src/Builder/Expression/SubtractOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SubtractOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$subtract';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
     /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int $expression1 */
@@ -41,10 +42,5 @@ final class SubtractOperator implements ResolvesToInt, ResolvesToLong, ResolvesT
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;
-    }
-
-    public function getOperator(): string
-    {
-        return '$subtract';
     }
 }

--- a/src/Builder/Expression/SumOperator.php
+++ b/src/Builder/Expression/SumOperator.php
@@ -28,6 +28,7 @@ use function array_is_list;
 final class SumOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$sum';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var list<BSONArray|Decimal128|Int64|PackedArray|ResolvesToArray|ResolvesToNumber|array|float|int> $expression */
@@ -49,10 +50,5 @@ final class SumOperator implements ResolvesToNumber, OperatorInterface
         }
 
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sum';
     }
 }

--- a/src/Builder/Expression/SwitchOperator.php
+++ b/src/Builder/Expression/SwitchOperator.php
@@ -30,6 +30,7 @@ use function is_array;
 final class SwitchOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$switch';
     public const PROPERTIES = ['branches' => 'branches', 'default' => 'default'];
 
     /**
@@ -64,10 +65,5 @@ final class SwitchOperator implements ResolvesToAny, OperatorInterface
 
         $this->branches = $branches;
         $this->default = $default;
-    }
-
-    public function getOperator(): string
-    {
-        return '$switch';
     }
 }

--- a/src/Builder/Expression/TanOperator.php
+++ b/src/Builder/Expression/TanOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class TanOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$tan';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -37,10 +38,5 @@ final class TanOperator implements ResolvesToDouble, ResolvesToDecimal, Operator
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$tan';
     }
 }

--- a/src/Builder/Expression/TanhOperator.php
+++ b/src/Builder/Expression/TanhOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class TanhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$tanh';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /**
@@ -37,10 +38,5 @@ final class TanhOperator implements ResolvesToDouble, ResolvesToDecimal, Operato
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$tanh';
     }
 }

--- a/src/Builder/Expression/ToBoolOperator.php
+++ b/src/Builder/Expression/ToBoolOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ToBoolOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toBool';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ToBoolOperator implements ResolvesToBool, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toBool';
     }
 }

--- a/src/Builder/Expression/ToDateOperator.php
+++ b/src/Builder/Expression/ToDateOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ToDateOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toDate';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ToDateOperator implements ResolvesToDate, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toDate';
     }
 }

--- a/src/Builder/Expression/ToDecimalOperator.php
+++ b/src/Builder/Expression/ToDecimalOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ToDecimalOperator implements ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toDecimal';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ToDecimalOperator implements ResolvesToDecimal, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toDecimal';
     }
 }

--- a/src/Builder/Expression/ToDoubleOperator.php
+++ b/src/Builder/Expression/ToDoubleOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ToDoubleOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toDouble';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ToDoubleOperator implements ResolvesToDouble, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toDouble';
     }
 }

--- a/src/Builder/Expression/ToHashedIndexKeyOperator.php
+++ b/src/Builder/Expression/ToHashedIndexKeyOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class ToHashedIndexKeyOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toHashedIndexKey';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash */
@@ -34,10 +35,5 @@ final class ToHashedIndexKeyOperator implements ResolvesToLong, OperatorInterfac
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toHashedIndexKey';
     }
 }

--- a/src/Builder/Expression/ToIntOperator.php
+++ b/src/Builder/Expression/ToIntOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ToIntOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toInt';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ToIntOperator implements ResolvesToInt, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toInt';
     }
 }

--- a/src/Builder/Expression/ToLongOperator.php
+++ b/src/Builder/Expression/ToLongOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ToLongOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toLong';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ToLongOperator implements ResolvesToLong, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toLong';
     }
 }

--- a/src/Builder/Expression/ToLowerOperator.php
+++ b/src/Builder/Expression/ToLowerOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class ToLowerOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toLower';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToString|string $expression */
@@ -31,10 +32,5 @@ final class ToLowerOperator implements ResolvesToString, OperatorInterface
     public function __construct(ResolvesToString|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toLower';
     }
 }

--- a/src/Builder/Expression/ToObjectIdOperator.php
+++ b/src/Builder/Expression/ToObjectIdOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ToObjectIdOperator implements ResolvesToObjectId, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toObjectId';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ToObjectIdOperator implements ResolvesToObjectId, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toObjectId';
     }
 }

--- a/src/Builder/Expression/ToStringOperator.php
+++ b/src/Builder/Expression/ToStringOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ToStringOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toString';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ToStringOperator implements ResolvesToString, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toString';
     }
 }

--- a/src/Builder/Expression/ToUpperOperator.php
+++ b/src/Builder/Expression/ToUpperOperator.php
@@ -20,6 +20,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class ToUpperOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$toUpper';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToString|string $expression */
@@ -31,10 +32,5 @@ final class ToUpperOperator implements ResolvesToString, OperatorInterface
     public function __construct(ResolvesToString|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$toUpper';
     }
 }

--- a/src/Builder/Expression/TrimOperator.php
+++ b/src/Builder/Expression/TrimOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\Optional;
 final class TrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$trim';
     public const PROPERTIES = ['input' => 'input', 'chars' => 'chars'];
 
     /** @var ResolvesToString|string $input The string to trim. The argument can be any valid expression that resolves to a string. */
@@ -46,10 +47,5 @@ final class TrimOperator implements ResolvesToString, OperatorInterface
     ) {
         $this->input = $input;
         $this->chars = $chars;
-    }
-
-    public function getOperator(): string
-    {
-        return '$trim';
     }
 }

--- a/src/Builder/Expression/TruncOperator.php
+++ b/src/Builder/Expression/TruncOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\Optional;
 final class TruncOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$trunc';
     public const PROPERTIES = ['number' => 'number', 'place' => 'place'];
 
     /**
@@ -45,10 +46,5 @@ final class TruncOperator implements ResolvesToString, OperatorInterface
     ) {
         $this->number = $number;
         $this->place = $place;
-    }
-
-    public function getOperator(): string
-    {
-        return '$trunc';
     }
 }

--- a/src/Builder/Expression/TsIncrementOperator.php
+++ b/src/Builder/Expression/TsIncrementOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class TsIncrementOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$tsIncrement';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToTimestamp|Timestamp|int $expression */
@@ -33,10 +34,5 @@ final class TsIncrementOperator implements ResolvesToLong, OperatorInterface
     public function __construct(Timestamp|ResolvesToTimestamp|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$tsIncrement';
     }
 }

--- a/src/Builder/Expression/TsSecondOperator.php
+++ b/src/Builder/Expression/TsSecondOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class TsSecondOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$tsSecond';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ResolvesToTimestamp|Timestamp|int $expression */
@@ -33,10 +34,5 @@ final class TsSecondOperator implements ResolvesToLong, OperatorInterface
     public function __construct(Timestamp|ResolvesToTimestamp|int $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$tsSecond';
     }
 }

--- a/src/Builder/Expression/TypeOperator.php
+++ b/src/Builder/Expression/TypeOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class TypeOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$type';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -34,10 +35,5 @@ final class TypeOperator implements ResolvesToString, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$type';
     }
 }

--- a/src/Builder/Expression/UnsetFieldOperator.php
+++ b/src/Builder/Expression/UnsetFieldOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class UnsetFieldOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$unsetField';
     public const PROPERTIES = ['field' => 'field', 'input' => 'input'];
 
     /** @var ResolvesToString|string $field Field in the input object that you want to add, update, or remove. field can be any valid expression that resolves to a string constant. */
@@ -42,10 +43,5 @@ final class UnsetFieldOperator implements ResolvesToObject, OperatorInterface
     ) {
         $this->field = $field;
         $this->input = $input;
-    }
-
-    public function getOperator(): string
-    {
-        return '$unsetField';
     }
 }

--- a/src/Builder/Expression/WeekOperator.php
+++ b/src/Builder/Expression/WeekOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class WeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$week';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class WeekOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$week';
     }
 }

--- a/src/Builder/Expression/YearOperator.php
+++ b/src/Builder/Expression/YearOperator.php
@@ -24,6 +24,7 @@ use MongoDB\Builder\Type\Optional;
 final class YearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$year';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
     /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
@@ -42,10 +43,5 @@ final class YearOperator implements ResolvesToInt, OperatorInterface
     ) {
         $this->date = $date;
         $this->timezone = $timezone;
-    }
-
-    public function getOperator(): string
-    {
-        return '$year';
     }
 }

--- a/src/Builder/Expression/ZipOperator.php
+++ b/src/Builder/Expression/ZipOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class ZipOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$zip';
     public const PROPERTIES = ['inputs' => 'inputs', 'useLongestLength' => 'useLongestLength', 'defaults' => 'defaults'];
 
     /**
@@ -75,10 +76,5 @@ final class ZipOperator implements ResolvesToArray, OperatorInterface
         }
 
         $this->defaults = $defaults;
-    }
-
-    public function getOperator(): string
-    {
-        return '$zip';
     }
 }

--- a/src/Builder/Query/AllOperator.php
+++ b/src/Builder/Query/AllOperator.php
@@ -26,6 +26,7 @@ use function array_is_list;
 final class AllOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$all';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var list<FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string> $value */
@@ -46,10 +47,5 @@ final class AllOperator implements FieldQueryInterface, OperatorInterface
         }
 
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$all';
     }
 }

--- a/src/Builder/Query/AndOperator.php
+++ b/src/Builder/Query/AndOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 final class AndOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$and';
     public const PROPERTIES = ['queries' => 'queries'];
 
     /** @var list<QueryInterface|array> $queries */
@@ -44,10 +45,5 @@ final class AndOperator implements QueryInterface, OperatorInterface
         }
 
         $this->queries = $queries;
-    }
-
-    public function getOperator(): string
-    {
-        return '$and';
     }
 }

--- a/src/Builder/Query/BitsAllClearOperator.php
+++ b/src/Builder/Query/BitsAllClearOperator.php
@@ -28,6 +28,7 @@ use function is_array;
 final class BitsAllClearOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bitsAllClear';
     public const PROPERTIES = ['bitmask' => 'bitmask'];
 
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
@@ -43,10 +44,5 @@ final class BitsAllClearOperator implements FieldQueryInterface, OperatorInterfa
         }
 
         $this->bitmask = $bitmask;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bitsAllClear';
     }
 }

--- a/src/Builder/Query/BitsAllSetOperator.php
+++ b/src/Builder/Query/BitsAllSetOperator.php
@@ -28,6 +28,7 @@ use function is_array;
 final class BitsAllSetOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bitsAllSet';
     public const PROPERTIES = ['bitmask' => 'bitmask'];
 
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
@@ -43,10 +44,5 @@ final class BitsAllSetOperator implements FieldQueryInterface, OperatorInterface
         }
 
         $this->bitmask = $bitmask;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bitsAllSet';
     }
 }

--- a/src/Builder/Query/BitsAnyClearOperator.php
+++ b/src/Builder/Query/BitsAnyClearOperator.php
@@ -28,6 +28,7 @@ use function is_array;
 final class BitsAnyClearOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bitsAnyClear';
     public const PROPERTIES = ['bitmask' => 'bitmask'];
 
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
@@ -43,10 +44,5 @@ final class BitsAnyClearOperator implements FieldQueryInterface, OperatorInterfa
         }
 
         $this->bitmask = $bitmask;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bitsAnyClear';
     }
 }

--- a/src/Builder/Query/BitsAnySetOperator.php
+++ b/src/Builder/Query/BitsAnySetOperator.php
@@ -28,6 +28,7 @@ use function is_array;
 final class BitsAnySetOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$bitsAnySet';
     public const PROPERTIES = ['bitmask' => 'bitmask'];
 
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
@@ -43,10 +44,5 @@ final class BitsAnySetOperator implements FieldQueryInterface, OperatorInterface
         }
 
         $this->bitmask = $bitmask;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bitsAnySet';
     }
 }

--- a/src/Builder/Query/BoxOperator.php
+++ b/src/Builder/Query/BoxOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class BoxOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$box';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
@@ -42,10 +43,5 @@ final class BoxOperator implements GeometryInterface, OperatorInterface
         }
 
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$box';
     }
 }

--- a/src/Builder/Query/CenterOperator.php
+++ b/src/Builder/Query/CenterOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class CenterOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$center';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
@@ -42,10 +43,5 @@ final class CenterOperator implements GeometryInterface, OperatorInterface
         }
 
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$center';
     }
 }

--- a/src/Builder/Query/CenterSphereOperator.php
+++ b/src/Builder/Query/CenterSphereOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class CenterSphereOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$centerSphere';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
@@ -42,10 +43,5 @@ final class CenterSphereOperator implements GeometryInterface, OperatorInterface
         }
 
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$centerSphere';
     }
 }

--- a/src/Builder/Query/CommentOperator.php
+++ b/src/Builder/Query/CommentOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\QueryInterface;
 final class CommentOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$comment';
     public const PROPERTIES = ['comment' => 'comment'];
 
     /** @var string $comment */
@@ -32,10 +33,5 @@ final class CommentOperator implements QueryInterface, OperatorInterface
     public function __construct(string $comment)
     {
         $this->comment = $comment;
-    }
-
-    public function getOperator(): string
-    {
-        return '$comment';
     }
 }

--- a/src/Builder/Query/ElemMatchOperator.php
+++ b/src/Builder/Query/ElemMatchOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class ElemMatchOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$elemMatch';
     public const PROPERTIES = ['query' => 'query'];
 
     /** @var FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query */
@@ -43,10 +44,5 @@ final class ElemMatchOperator implements FieldQueryInterface, OperatorInterface
         }
 
         $this->query = $query;
-    }
-
-    public function getOperator(): string
-    {
-        return '$elemMatch';
     }
 }

--- a/src/Builder/Query/EqOperator.php
+++ b/src/Builder/Query/EqOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class EqOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$eq';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
@@ -34,10 +35,5 @@ final class EqOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$eq';
     }
 }

--- a/src/Builder/Query/ExistsOperator.php
+++ b/src/Builder/Query/ExistsOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class ExistsOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$exists';
     public const PROPERTIES = ['exists' => 'exists'];
 
     /** @var bool $exists */
@@ -32,10 +33,5 @@ final class ExistsOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(bool $exists = true)
     {
         $this->exists = $exists;
-    }
-
-    public function getOperator(): string
-    {
-        return '$exists';
     }
 }

--- a/src/Builder/Query/ExprOperator.php
+++ b/src/Builder/Query/ExprOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class ExprOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$expr';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class ExprOperator implements QueryInterface, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$expr';
     }
 }

--- a/src/Builder/Query/GeoIntersectsOperator.php
+++ b/src/Builder/Query/GeoIntersectsOperator.php
@@ -25,6 +25,7 @@ use stdClass;
 final class GeoIntersectsOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$geoIntersects';
     public const PROPERTIES = ['geometry' => null];
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
@@ -36,10 +37,5 @@ final class GeoIntersectsOperator implements FieldQueryInterface, OperatorInterf
     public function __construct(Document|Serializable|GeometryInterface|stdClass|array $geometry)
     {
         $this->geometry = $geometry;
-    }
-
-    public function getOperator(): string
-    {
-        return '$geoIntersects';
     }
 }

--- a/src/Builder/Query/GeoWithinOperator.php
+++ b/src/Builder/Query/GeoWithinOperator.php
@@ -25,6 +25,7 @@ use stdClass;
 final class GeoWithinOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$geoWithin';
     public const PROPERTIES = ['geometry' => null];
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
@@ -36,10 +37,5 @@ final class GeoWithinOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Document|Serializable|GeometryInterface|stdClass|array $geometry)
     {
         $this->geometry = $geometry;
-    }
-
-    public function getOperator(): string
-    {
-        return '$geoWithin';
     }
 }

--- a/src/Builder/Query/GeometryOperator.php
+++ b/src/Builder/Query/GeometryOperator.php
@@ -31,6 +31,7 @@ use function is_array;
 final class GeometryOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$geometry';
     public const PROPERTIES = ['type' => 'type', 'coordinates' => 'coordinates', 'crs' => 'crs'];
 
     /** @var string $type */
@@ -59,10 +60,5 @@ final class GeometryOperator implements GeometryInterface, OperatorInterface
 
         $this->coordinates = $coordinates;
         $this->crs = $crs;
-    }
-
-    public function getOperator(): string
-    {
-        return '$geometry';
     }
 }

--- a/src/Builder/Query/GtOperator.php
+++ b/src/Builder/Query/GtOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class GtOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$gt';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
@@ -34,10 +35,5 @@ final class GtOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$gt';
     }
 }

--- a/src/Builder/Query/GteOperator.php
+++ b/src/Builder/Query/GteOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class GteOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$gte';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
@@ -34,10 +35,5 @@ final class GteOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$gte';
     }
 }

--- a/src/Builder/Query/InOperator.php
+++ b/src/Builder/Query/InOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class InOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$in';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
@@ -42,10 +43,5 @@ final class InOperator implements FieldQueryInterface, OperatorInterface
         }
 
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$in';
     }
 }

--- a/src/Builder/Query/JsonSchemaOperator.php
+++ b/src/Builder/Query/JsonSchemaOperator.php
@@ -24,6 +24,7 @@ use stdClass;
 final class JsonSchemaOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$jsonSchema';
     public const PROPERTIES = ['schema' => 'schema'];
 
     /** @var Document|Serializable|array|stdClass $schema */
@@ -35,10 +36,5 @@ final class JsonSchemaOperator implements QueryInterface, OperatorInterface
     public function __construct(Document|Serializable|stdClass|array $schema)
     {
         $this->schema = $schema;
-    }
-
-    public function getOperator(): string
-    {
-        return '$jsonSchema';
     }
 }

--- a/src/Builder/Query/LtOperator.php
+++ b/src/Builder/Query/LtOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class LtOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$lt';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
@@ -34,10 +35,5 @@ final class LtOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$lt';
     }
 }

--- a/src/Builder/Query/LteOperator.php
+++ b/src/Builder/Query/LteOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class LteOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$lte';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
@@ -34,10 +35,5 @@ final class LteOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$lte';
     }
 }

--- a/src/Builder/Query/MaxDistanceOperator.php
+++ b/src/Builder/Query/MaxDistanceOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class MaxDistanceOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$maxDistance';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Decimal128|Int64|float|int $value */
@@ -34,10 +35,5 @@ final class MaxDistanceOperator implements FieldQueryInterface, OperatorInterfac
     public function __construct(Decimal128|Int64|float|int $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$maxDistance';
     }
 }

--- a/src/Builder/Query/MinDistanceOperator.php
+++ b/src/Builder/Query/MinDistanceOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class MinDistanceOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$minDistance';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Int64|float|int $value */
@@ -33,10 +34,5 @@ final class MinDistanceOperator implements FieldQueryInterface, OperatorInterfac
     public function __construct(Int64|float|int $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$minDistance';
     }
 }

--- a/src/Builder/Query/ModOperator.php
+++ b/src/Builder/Query/ModOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class ModOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
+    public const NAME = '$mod';
     public const PROPERTIES = ['divisor' => 'divisor', 'remainder' => 'remainder'];
 
     /** @var Decimal128|Int64|float|int $divisor */
@@ -39,10 +40,5 @@ final class ModOperator implements FieldQueryInterface, OperatorInterface
     {
         $this->divisor = $divisor;
         $this->remainder = $remainder;
-    }
-
-    public function getOperator(): string
-    {
-        return '$mod';
     }
 }

--- a/src/Builder/Query/NeOperator.php
+++ b/src/Builder/Query/NeOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class NeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$ne';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var Type|array|bool|float|int|null|stdClass|string $value */
@@ -34,10 +35,5 @@ final class NeOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$ne';
     }
 }

--- a/src/Builder/Query/NearOperator.php
+++ b/src/Builder/Query/NearOperator.php
@@ -28,6 +28,7 @@ use stdClass;
 final class NearOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$near';
     public const PROPERTIES = ['geometry' => null, 'maxDistance' => '$maxDistance', 'minDistance' => '$minDistance'];
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
@@ -52,10 +53,5 @@ final class NearOperator implements FieldQueryInterface, OperatorInterface
         $this->geometry = $geometry;
         $this->maxDistance = $maxDistance;
         $this->minDistance = $minDistance;
-    }
-
-    public function getOperator(): string
-    {
-        return '$near';
     }
 }

--- a/src/Builder/Query/NearSphereOperator.php
+++ b/src/Builder/Query/NearSphereOperator.php
@@ -28,6 +28,7 @@ use stdClass;
 final class NearSphereOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$nearSphere';
     public const PROPERTIES = ['geometry' => null, 'maxDistance' => '$maxDistance', 'minDistance' => '$minDistance'];
 
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
@@ -52,10 +53,5 @@ final class NearSphereOperator implements FieldQueryInterface, OperatorInterface
         $this->geometry = $geometry;
         $this->maxDistance = $maxDistance;
         $this->minDistance = $minDistance;
-    }
-
-    public function getOperator(): string
-    {
-        return '$nearSphere';
     }
 }

--- a/src/Builder/Query/NinOperator.php
+++ b/src/Builder/Query/NinOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class NinOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$nin';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var BSONArray|PackedArray|array $value */
@@ -42,10 +43,5 @@ final class NinOperator implements FieldQueryInterface, OperatorInterface
         }
 
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$nin';
     }
 }

--- a/src/Builder/Query/NorOperator.php
+++ b/src/Builder/Query/NorOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 final class NorOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$nor';
     public const PROPERTIES = ['queries' => 'queries'];
 
     /** @var list<QueryInterface|array> $queries */
@@ -44,10 +45,5 @@ final class NorOperator implements QueryInterface, OperatorInterface
         }
 
         $this->queries = $queries;
-    }
-
-    public function getOperator(): string
-    {
-        return '$nor';
     }
 }

--- a/src/Builder/Query/NotOperator.php
+++ b/src/Builder/Query/NotOperator.php
@@ -23,6 +23,7 @@ use stdClass;
 final class NotOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$not';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -34,10 +35,5 @@ final class NotOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$not';
     }
 }

--- a/src/Builder/Query/OrOperator.php
+++ b/src/Builder/Query/OrOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 final class OrOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$or';
     public const PROPERTIES = ['queries' => 'queries'];
 
     /** @var list<QueryInterface|array> $queries */
@@ -44,10 +45,5 @@ final class OrOperator implements QueryInterface, OperatorInterface
         }
 
         $this->queries = $queries;
-    }
-
-    public function getOperator(): string
-    {
-        return '$or';
     }
 }

--- a/src/Builder/Query/PolygonOperator.php
+++ b/src/Builder/Query/PolygonOperator.php
@@ -27,6 +27,7 @@ use function is_array;
 final class PolygonOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$polygon';
     public const PROPERTIES = ['points' => 'points'];
 
     /** @var BSONArray|PackedArray|array $points */
@@ -42,10 +43,5 @@ final class PolygonOperator implements GeometryInterface, OperatorInterface
         }
 
         $this->points = $points;
-    }
-
-    public function getOperator(): string
-    {
-        return '$polygon';
     }
 }

--- a/src/Builder/Query/RandOperator.php
+++ b/src/Builder/Query/RandOperator.php
@@ -21,13 +21,9 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class RandOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$rand';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$rand';
     }
 }

--- a/src/Builder/Query/RegexOperator.php
+++ b/src/Builder/Query/RegexOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class RegexOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$regex';
     public const PROPERTIES = ['regex' => 'regex'];
 
     /** @var Regex $regex */
@@ -33,10 +34,5 @@ final class RegexOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(Regex $regex)
     {
         $this->regex = $regex;
-    }
-
-    public function getOperator(): string
-    {
-        return '$regex';
     }
 }

--- a/src/Builder/Query/SampleRateOperator.php
+++ b/src/Builder/Query/SampleRateOperator.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\QueryInterface;
 final class SampleRateOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$sampleRate';
     public const PROPERTIES = ['rate' => 'rate'];
 
     /**
@@ -38,10 +39,5 @@ final class SampleRateOperator implements QueryInterface, OperatorInterface
     public function __construct(Int64|ResolvesToDouble|float|int $rate)
     {
         $this->rate = $rate;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sampleRate';
     }
 }

--- a/src/Builder/Query/SizeOperator.php
+++ b/src/Builder/Query/SizeOperator.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\OperatorInterface;
 final class SizeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$size';
     public const PROPERTIES = ['value' => 'value'];
 
     /** @var int $value */
@@ -32,10 +33,5 @@ final class SizeOperator implements FieldQueryInterface, OperatorInterface
     public function __construct(int $value)
     {
         $this->value = $value;
-    }
-
-    public function getOperator(): string
-    {
-        return '$size';
     }
 }

--- a/src/Builder/Query/TextOperator.php
+++ b/src/Builder/Query/TextOperator.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\QueryInterface;
 final class TextOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$text';
 
     public const PROPERTIES = [
         'search' => '$search',
@@ -66,10 +67,5 @@ final class TextOperator implements QueryInterface, OperatorInterface
         $this->language = $language;
         $this->caseSensitive = $caseSensitive;
         $this->diacriticSensitive = $diacriticSensitive;
-    }
-
-    public function getOperator(): string
-    {
-        return '$text';
     }
 }

--- a/src/Builder/Query/TypeOperator.php
+++ b/src/Builder/Query/TypeOperator.php
@@ -24,6 +24,7 @@ use function array_is_list;
 final class TypeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$type';
     public const PROPERTIES = ['type' => 'type'];
 
     /** @var list<int|string> $type */
@@ -44,10 +45,5 @@ final class TypeOperator implements FieldQueryInterface, OperatorInterface
         }
 
         $this->type = $type;
-    }
-
-    public function getOperator(): string
-    {
-        return '$type';
     }
 }

--- a/src/Builder/Query/WhereOperator.php
+++ b/src/Builder/Query/WhereOperator.php
@@ -24,6 +24,7 @@ use function is_string;
 final class WhereOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$where';
     public const PROPERTIES = ['function' => 'function'];
 
     /** @var Javascript|string $function */
@@ -39,10 +40,5 @@ final class WhereOperator implements QueryInterface, OperatorInterface
         }
 
         $this->function = $function;
-    }
-
-    public function getOperator(): string
-    {
-        return '$where';
     }
 }

--- a/src/Builder/Stage/AddFieldsStage.php
+++ b/src/Builder/Stage/AddFieldsStage.php
@@ -27,6 +27,7 @@ use function is_string;
 final class AddFieldsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$addFields';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression Specify the name of each field to add and set its value to an aggregation expression or an empty object. */
@@ -49,10 +50,5 @@ final class AddFieldsStage implements StageInterface, OperatorInterface
 
         $expression = (object) $expression;
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$addFields';
     }
 }

--- a/src/Builder/Stage/BucketAutoStage.php
+++ b/src/Builder/Stage/BucketAutoStage.php
@@ -27,6 +27,7 @@ use stdClass;
 final class BucketAutoStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$bucketAuto';
 
     public const PROPERTIES = [
         'groupBy' => 'groupBy',
@@ -71,10 +72,5 @@ final class BucketAutoStage implements StageInterface, OperatorInterface
         $this->buckets = $buckets;
         $this->output = $output;
         $this->granularity = $granularity;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bucketAuto';
     }
 }

--- a/src/Builder/Stage/BucketStage.php
+++ b/src/Builder/Stage/BucketStage.php
@@ -33,6 +33,7 @@ use function is_array;
 final class BucketStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$bucket';
 
     public const PROPERTIES = [
         'groupBy' => 'groupBy',
@@ -95,10 +96,5 @@ final class BucketStage implements StageInterface, OperatorInterface
         $this->boundaries = $boundaries;
         $this->default = $default;
         $this->output = $output;
-    }
-
-    public function getOperator(): string
-    {
-        return '$bucket';
     }
 }

--- a/src/Builder/Stage/ChangeStreamSplitLargeEventStage.php
+++ b/src/Builder/Stage/ChangeStreamSplitLargeEventStage.php
@@ -22,13 +22,9 @@ use MongoDB\Builder\Type\StageInterface;
 final class ChangeStreamSplitLargeEventStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$changeStreamSplitLargeEvent';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$changeStreamSplitLargeEvent';
     }
 }

--- a/src/Builder/Stage/ChangeStreamStage.php
+++ b/src/Builder/Stage/ChangeStreamStage.php
@@ -26,6 +26,7 @@ use stdClass;
 final class ChangeStreamStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$changeStream';
 
     public const PROPERTIES = [
         'allChangesForCluster' => 'allChangesForCluster',
@@ -87,10 +88,5 @@ final class ChangeStreamStage implements StageInterface, OperatorInterface
         $this->showExpandedEvents = $showExpandedEvents;
         $this->startAfter = $startAfter;
         $this->startAtOperationTime = $startAtOperationTime;
-    }
-
-    public function getOperator(): string
-    {
-        return '$changeStream';
     }
 }

--- a/src/Builder/Stage/CollStatsStage.php
+++ b/src/Builder/Stage/CollStatsStage.php
@@ -25,6 +25,7 @@ use stdClass;
 final class CollStatsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$collStats';
 
     public const PROPERTIES = [
         'latencyStats' => 'latencyStats',
@@ -61,10 +62,5 @@ final class CollStatsStage implements StageInterface, OperatorInterface
         $this->storageStats = $storageStats;
         $this->count = $count;
         $this->queryExecStats = $queryExecStats;
-    }
-
-    public function getOperator(): string
-    {
-        return '$collStats';
     }
 }

--- a/src/Builder/Stage/CountStage.php
+++ b/src/Builder/Stage/CountStage.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\StageInterface;
 final class CountStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$count';
     public const PROPERTIES = ['field' => 'field'];
 
     /** @var string $field Name of the output field which has the count as its value. It must be a non-empty string, must not start with $ and must not contain the . character. */
@@ -33,10 +34,5 @@ final class CountStage implements StageInterface, OperatorInterface
     public function __construct(string $field)
     {
         $this->field = $field;
-    }
-
-    public function getOperator(): string
-    {
-        return '$count';
     }
 }

--- a/src/Builder/Stage/CurrentOpStage.php
+++ b/src/Builder/Stage/CurrentOpStage.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\StageInterface;
 final class CurrentOpStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$currentOp';
 
     public const PROPERTIES = [
         'allUsers' => 'allUsers',
@@ -65,10 +66,5 @@ final class CurrentOpStage implements StageInterface, OperatorInterface
         $this->idleCursors = $idleCursors;
         $this->idleSessions = $idleSessions;
         $this->localOps = $localOps;
-    }
-
-    public function getOperator(): string
-    {
-        return '$currentOp';
     }
 }

--- a/src/Builder/Stage/DensifyStage.php
+++ b/src/Builder/Stage/DensifyStage.php
@@ -31,6 +31,7 @@ use function is_array;
 final class DensifyStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$densify';
     public const PROPERTIES = ['field' => 'field', 'range' => 'range', 'partitionByFields' => 'partitionByFields'];
 
     /**
@@ -65,10 +66,5 @@ final class DensifyStage implements StageInterface, OperatorInterface
         }
 
         $this->partitionByFields = $partitionByFields;
-    }
-
-    public function getOperator(): string
-    {
-        return '$densify';
     }
 }

--- a/src/Builder/Stage/DocumentsStage.php
+++ b/src/Builder/Stage/DocumentsStage.php
@@ -28,6 +28,7 @@ use function is_array;
 final class DocumentsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$documents';
     public const PROPERTIES = ['documents' => 'documents'];
 
     /**
@@ -53,10 +54,5 @@ final class DocumentsStage implements StageInterface, OperatorInterface
         }
 
         $this->documents = $documents;
-    }
-
-    public function getOperator(): string
-    {
-        return '$documents';
     }
 }

--- a/src/Builder/Stage/FacetStage.php
+++ b/src/Builder/Stage/FacetStage.php
@@ -28,6 +28,7 @@ use function is_string;
 final class FacetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$facet';
     public const PROPERTIES = ['facet' => 'facet'];
 
     /** @var stdClass<BSONArray|PackedArray|Pipeline|array> $facet */
@@ -50,10 +51,5 @@ final class FacetStage implements StageInterface, OperatorInterface
 
         $facet = (object) $facet;
         $this->facet = $facet;
-    }
-
-    public function getOperator(): string
-    {
-        return '$facet';
     }
 }

--- a/src/Builder/Stage/FillStage.php
+++ b/src/Builder/Stage/FillStage.php
@@ -31,6 +31,7 @@ use function is_array;
 final class FillStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$fill';
 
     public const PROPERTIES = [
         'output' => 'output',
@@ -87,10 +88,5 @@ final class FillStage implements StageInterface, OperatorInterface
 
         $this->partitionByFields = $partitionByFields;
         $this->sortBy = $sortBy;
-    }
-
-    public function getOperator(): string
-    {
-        return '$fill';
     }
 }

--- a/src/Builder/Stage/GeoNearStage.php
+++ b/src/Builder/Stage/GeoNearStage.php
@@ -32,6 +32,7 @@ use function is_array;
 final class GeoNearStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$geoNear';
 
     public const PROPERTIES = [
         'distanceField' => 'distanceField',
@@ -127,10 +128,5 @@ final class GeoNearStage implements StageInterface, OperatorInterface
 
         $this->query = $query;
         $this->spherical = $spherical;
-    }
-
-    public function getOperator(): string
-    {
-        return '$geoNear';
     }
 }

--- a/src/Builder/Stage/GraphLookupStage.php
+++ b/src/Builder/Stage/GraphLookupStage.php
@@ -33,6 +33,7 @@ use function is_array;
 final class GraphLookupStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$graphLookup';
 
     public const PROPERTIES = [
         'from' => 'from',
@@ -109,10 +110,5 @@ final class GraphLookupStage implements StageInterface, OperatorInterface
         }
 
         $this->restrictSearchWithMatch = $restrictSearchWithMatch;
-    }
-
-    public function getOperator(): string
-    {
-        return '$graphLookup';
     }
 }

--- a/src/Builder/Stage/GroupStage.php
+++ b/src/Builder/Stage/GroupStage.php
@@ -30,6 +30,7 @@ use function is_string;
 final class GroupStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$group';
     public const PROPERTIES = ['_id' => '_id', 'field' => null];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents. */
@@ -55,10 +56,5 @@ final class GroupStage implements StageInterface, OperatorInterface
 
         $field = (object) $field;
         $this->field = $field;
-    }
-
-    public function getOperator(): string
-    {
-        return '$group';
     }
 }

--- a/src/Builder/Stage/IndexStatsStage.php
+++ b/src/Builder/Stage/IndexStatsStage.php
@@ -21,13 +21,9 @@ use MongoDB\Builder\Type\StageInterface;
 final class IndexStatsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$indexStats';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$indexStats';
     }
 }

--- a/src/Builder/Stage/LimitStage.php
+++ b/src/Builder/Stage/LimitStage.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\StageInterface;
 final class LimitStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$limit';
     public const PROPERTIES = ['limit' => 'limit'];
 
     /** @var int $limit */
@@ -32,10 +33,5 @@ final class LimitStage implements StageInterface, OperatorInterface
     public function __construct(int $limit)
     {
         $this->limit = $limit;
-    }
-
-    public function getOperator(): string
-    {
-        return '$limit';
     }
 }

--- a/src/Builder/Stage/ListLocalSessionsStage.php
+++ b/src/Builder/Stage/ListLocalSessionsStage.php
@@ -28,6 +28,7 @@ use function is_array;
 final class ListLocalSessionsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$listLocalSessions';
     public const PROPERTIES = ['users' => 'users', 'allUsers' => 'allUsers'];
 
     /** @var Optional|BSONArray|PackedArray|array $users Returns all sessions for the specified users. If running with access control, the authenticated user must have privileges with listSessions action on the cluster to list sessions for other users. */
@@ -50,10 +51,5 @@ final class ListLocalSessionsStage implements StageInterface, OperatorInterface
 
         $this->users = $users;
         $this->allUsers = $allUsers;
-    }
-
-    public function getOperator(): string
-    {
-        return '$listLocalSessions';
     }
 }

--- a/src/Builder/Stage/ListSampledQueriesStage.php
+++ b/src/Builder/Stage/ListSampledQueriesStage.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\StageInterface;
 final class ListSampledQueriesStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$listSampledQueries';
     public const PROPERTIES = ['namespace' => 'namespace'];
 
     /** @var Optional|string $namespace */
@@ -33,10 +34,5 @@ final class ListSampledQueriesStage implements StageInterface, OperatorInterface
     public function __construct(Optional|string $namespace = Optional::Undefined)
     {
         $this->namespace = $namespace;
-    }
-
-    public function getOperator(): string
-    {
-        return '$listSampledQueries';
     }
 }

--- a/src/Builder/Stage/ListSearchIndexesStage.php
+++ b/src/Builder/Stage/ListSearchIndexesStage.php
@@ -22,6 +22,7 @@ use MongoDB\Builder\Type\StageInterface;
 final class ListSearchIndexesStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$listSearchIndexes';
     public const PROPERTIES = ['id' => 'id', 'name' => 'name'];
 
     /** @var Optional|string $id The id of the index to return information about. */
@@ -40,10 +41,5 @@ final class ListSearchIndexesStage implements StageInterface, OperatorInterface
     ) {
         $this->id = $id;
         $this->name = $name;
-    }
-
-    public function getOperator(): string
-    {
-        return '$listSearchIndexes';
     }
 }

--- a/src/Builder/Stage/ListSessionsStage.php
+++ b/src/Builder/Stage/ListSessionsStage.php
@@ -28,6 +28,7 @@ use function is_array;
 final class ListSessionsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$listSessions';
     public const PROPERTIES = ['users' => 'users', 'allUsers' => 'allUsers'];
 
     /** @var Optional|BSONArray|PackedArray|array $users Returns all sessions for the specified users. If running with access control, the authenticated user must have privileges with listSessions action on the cluster to list sessions for other users. */
@@ -50,10 +51,5 @@ final class ListSessionsStage implements StageInterface, OperatorInterface
 
         $this->users = $users;
         $this->allUsers = $allUsers;
-    }
-
-    public function getOperator(): string
-    {
-        return '$listSessions';
     }
 }

--- a/src/Builder/Stage/LookupStage.php
+++ b/src/Builder/Stage/LookupStage.php
@@ -32,6 +32,7 @@ use function is_array;
 final class LookupStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$lookup';
 
     public const PROPERTIES = [
         'as' => 'as',
@@ -98,10 +99,5 @@ final class LookupStage implements StageInterface, OperatorInterface
         }
 
         $this->pipeline = $pipeline;
-    }
-
-    public function getOperator(): string
-    {
-        return '$lookup';
     }
 }

--- a/src/Builder/Stage/MatchStage.php
+++ b/src/Builder/Stage/MatchStage.php
@@ -25,6 +25,7 @@ use function is_array;
 final class MatchStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$match';
     public const PROPERTIES = ['query' => 'query'];
 
     /** @var QueryInterface|array $query */
@@ -40,10 +41,5 @@ final class MatchStage implements StageInterface, OperatorInterface
         }
 
         $this->query = $query;
-    }
-
-    public function getOperator(): string
-    {
-        return '$match';
     }
 }

--- a/src/Builder/Stage/MergeStage.php
+++ b/src/Builder/Stage/MergeStage.php
@@ -33,6 +33,7 @@ use function is_array;
 final class MergeStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$merge';
 
     public const PROPERTIES = [
         'into' => 'into',
@@ -84,10 +85,5 @@ final class MergeStage implements StageInterface, OperatorInterface
 
         $this->whenMatched = $whenMatched;
         $this->whenNotMatched = $whenNotMatched;
-    }
-
-    public function getOperator(): string
-    {
-        return '$merge';
     }
 }

--- a/src/Builder/Stage/OutStage.php
+++ b/src/Builder/Stage/OutStage.php
@@ -24,6 +24,7 @@ use stdClass;
 final class OutStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$out';
     public const PROPERTIES = ['coll' => 'coll'];
 
     /** @var Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to. */
@@ -35,10 +36,5 @@ final class OutStage implements StageInterface, OperatorInterface
     public function __construct(Document|Serializable|stdClass|array|string $coll)
     {
         $this->coll = $coll;
-    }
-
-    public function getOperator(): string
-    {
-        return '$out';
     }
 }

--- a/src/Builder/Stage/PlanCacheStatsStage.php
+++ b/src/Builder/Stage/PlanCacheStatsStage.php
@@ -21,13 +21,9 @@ use MongoDB\Builder\Type\StageInterface;
 final class PlanCacheStatsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$planCacheStats';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$planCacheStats';
     }
 }

--- a/src/Builder/Stage/ProjectStage.php
+++ b/src/Builder/Stage/ProjectStage.php
@@ -27,6 +27,7 @@ use function is_string;
 final class ProjectStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$project';
     public const PROPERTIES = ['specification' => 'specification'];
 
     /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $specification */
@@ -49,10 +50,5 @@ final class ProjectStage implements StageInterface, OperatorInterface
 
         $specification = (object) $specification;
         $this->specification = $specification;
-    }
-
-    public function getOperator(): string
-    {
-        return '$project';
     }
 }

--- a/src/Builder/Stage/RedactStage.php
+++ b/src/Builder/Stage/RedactStage.php
@@ -24,6 +24,7 @@ use stdClass;
 final class RedactStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$redact';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class RedactStage implements StageInterface, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$redact';
     }
 }

--- a/src/Builder/Stage/ReplaceRootStage.php
+++ b/src/Builder/Stage/ReplaceRootStage.php
@@ -25,6 +25,7 @@ use stdClass;
 final class ReplaceRootStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$replaceRoot';
     public const PROPERTIES = ['newRoot' => 'newRoot'];
 
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $newRoot */
@@ -36,10 +37,5 @@ final class ReplaceRootStage implements StageInterface, OperatorInterface
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array $newRoot)
     {
         $this->newRoot = $newRoot;
-    }
-
-    public function getOperator(): string
-    {
-        return '$replaceRoot';
     }
 }

--- a/src/Builder/Stage/ReplaceWithStage.php
+++ b/src/Builder/Stage/ReplaceWithStage.php
@@ -26,6 +26,7 @@ use stdClass;
 final class ReplaceWithStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$replaceWith';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $expression */
@@ -37,10 +38,5 @@ final class ReplaceWithStage implements StageInterface, OperatorInterface
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$replaceWith';
     }
 }

--- a/src/Builder/Stage/SampleStage.php
+++ b/src/Builder/Stage/SampleStage.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\StageInterface;
 final class SampleStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$sample';
     public const PROPERTIES = ['size' => 'size'];
 
     /** @var int $size The number of documents to randomly select. */
@@ -32,10 +33,5 @@ final class SampleStage implements StageInterface, OperatorInterface
     public function __construct(int $size)
     {
         $this->size = $size;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sample';
     }
 }

--- a/src/Builder/Stage/SearchMetaStage.php
+++ b/src/Builder/Stage/SearchMetaStage.php
@@ -25,6 +25,7 @@ use stdClass;
 final class SearchMetaStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$searchMeta';
     public const PROPERTIES = ['meta' => 'meta'];
 
     /** @var Document|Serializable|array|stdClass $meta */
@@ -36,10 +37,5 @@ final class SearchMetaStage implements StageInterface, OperatorInterface
     public function __construct(Document|Serializable|stdClass|array $meta)
     {
         $this->meta = $meta;
-    }
-
-    public function getOperator(): string
-    {
-        return '$searchMeta';
     }
 }

--- a/src/Builder/Stage/SearchStage.php
+++ b/src/Builder/Stage/SearchStage.php
@@ -25,6 +25,7 @@ use stdClass;
 final class SearchStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$search';
     public const PROPERTIES = ['search' => 'search'];
 
     /** @var Document|Serializable|array|stdClass $search */
@@ -36,10 +37,5 @@ final class SearchStage implements StageInterface, OperatorInterface
     public function __construct(Document|Serializable|stdClass|array $search)
     {
         $this->search = $search;
-    }
-
-    public function getOperator(): string
-    {
-        return '$search';
     }
 }

--- a/src/Builder/Stage/SetStage.php
+++ b/src/Builder/Stage/SetStage.php
@@ -28,6 +28,7 @@ use function is_string;
 final class SetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$set';
     public const PROPERTIES = ['field' => 'field'];
 
     /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $field */
@@ -50,10 +51,5 @@ final class SetStage implements StageInterface, OperatorInterface
 
         $field = (object) $field;
         $this->field = $field;
-    }
-
-    public function getOperator(): string
-    {
-        return '$set';
     }
 }

--- a/src/Builder/Stage/SetWindowFieldsStage.php
+++ b/src/Builder/Stage/SetWindowFieldsStage.php
@@ -28,6 +28,7 @@ use stdClass;
 final class SetWindowFieldsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$setWindowFields';
     public const PROPERTIES = ['sortBy' => 'sortBy', 'output' => 'output', 'partitionBy' => 'partitionBy'];
 
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting. */
@@ -56,10 +57,5 @@ final class SetWindowFieldsStage implements StageInterface, OperatorInterface
         $this->sortBy = $sortBy;
         $this->output = $output;
         $this->partitionBy = $partitionBy;
-    }
-
-    public function getOperator(): string
-    {
-        return '$setWindowFields';
     }
 }

--- a/src/Builder/Stage/ShardedDataDistributionStage.php
+++ b/src/Builder/Stage/ShardedDataDistributionStage.php
@@ -22,13 +22,9 @@ use MongoDB\Builder\Type\StageInterface;
 final class ShardedDataDistributionStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$shardedDataDistribution';
 
     public function __construct()
     {
-    }
-
-    public function getOperator(): string
-    {
-        return '$shardedDataDistribution';
     }
 }

--- a/src/Builder/Stage/SkipStage.php
+++ b/src/Builder/Stage/SkipStage.php
@@ -21,6 +21,7 @@ use MongoDB\Builder\Type\StageInterface;
 final class SkipStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$skip';
     public const PROPERTIES = ['skip' => 'skip'];
 
     /** @var int $skip */
@@ -32,10 +33,5 @@ final class SkipStage implements StageInterface, OperatorInterface
     public function __construct(int $skip)
     {
         $this->skip = $skip;
-    }
-
-    public function getOperator(): string
-    {
-        return '$skip';
     }
 }

--- a/src/Builder/Stage/SortByCountStage.php
+++ b/src/Builder/Stage/SortByCountStage.php
@@ -24,6 +24,7 @@ use stdClass;
 final class SortByCountStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$sortByCount';
     public const PROPERTIES = ['expression' => 'expression'];
 
     /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
@@ -35,10 +36,5 @@ final class SortByCountStage implements StageInterface, OperatorInterface
     public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
     {
         $this->expression = $expression;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sortByCount';
     }
 }

--- a/src/Builder/Stage/SortStage.php
+++ b/src/Builder/Stage/SortStage.php
@@ -28,6 +28,7 @@ use function is_string;
 final class SortStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$sort';
     public const PROPERTIES = ['sort' => 'sort'];
 
     /** @var stdClass<ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string> $sort */
@@ -50,10 +51,5 @@ final class SortStage implements StageInterface, OperatorInterface
 
         $sort = (object) $sort;
         $this->sort = $sort;
-    }
-
-    public function getOperator(): string
-    {
-        return '$sort';
     }
 }

--- a/src/Builder/Stage/UnionWithStage.php
+++ b/src/Builder/Stage/UnionWithStage.php
@@ -30,6 +30,7 @@ use function is_array;
 final class UnionWithStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$unionWith';
     public const PROPERTIES = ['coll' => 'coll', 'pipeline' => 'pipeline'];
 
     /** @var string $coll The collection or view whose pipeline results you wish to include in the result set. */
@@ -56,10 +57,5 @@ final class UnionWithStage implements StageInterface, OperatorInterface
         }
 
         $this->pipeline = $pipeline;
-    }
-
-    public function getOperator(): string
-    {
-        return '$unionWith';
     }
 }

--- a/src/Builder/Stage/UnsetStage.php
+++ b/src/Builder/Stage/UnsetStage.php
@@ -26,6 +26,7 @@ use function array_is_list;
 final class UnsetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
+    public const NAME = '$unset';
     public const PROPERTIES = ['field' => 'field'];
 
     /** @var list<FieldPath|string> $field */
@@ -46,10 +47,5 @@ final class UnsetStage implements StageInterface, OperatorInterface
         }
 
         $this->field = $field;
-    }
-
-    public function getOperator(): string
-    {
-        return '$unset';
     }
 }

--- a/src/Builder/Stage/UnwindStage.php
+++ b/src/Builder/Stage/UnwindStage.php
@@ -23,6 +23,7 @@ use MongoDB\Builder\Type\StageInterface;
 final class UnwindStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
+    public const NAME = '$unwind';
 
     public const PROPERTIES = [
         'path' => 'path',
@@ -58,10 +59,5 @@ final class UnwindStage implements StageInterface, OperatorInterface
         $this->path = $path;
         $this->includeArrayIndex = $includeArrayIndex;
         $this->preserveNullAndEmptyArrays = $preserveNullAndEmptyArrays;
-    }
-
-    public function getOperator(): string
-    {
-        return '$unwind';
     }
 }

--- a/src/Builder/Type/CombinedFieldQuery.php
+++ b/src/Builder/Type/CombinedFieldQuery.php
@@ -59,6 +59,7 @@ final class CombinedFieldQuery implements FieldQueryInterface
         );
 
         // Validate FieldQuery types and non-duplicate operators
+        /** @var array<string, true> $seenOperators */
         $seenOperators = [];
         foreach ($this->fieldQueries as $fieldQuery) {
             if ($fieldQuery instanceof stdClass) {
@@ -66,7 +67,7 @@ final class CombinedFieldQuery implements FieldQueryInterface
             }
 
             if ($fieldQuery instanceof FieldQueryInterface && $fieldQuery instanceof OperatorInterface) {
-                $operator = $fieldQuery->getOperator();
+                $operator = $fieldQuery::NAME;
             } elseif (is_array($fieldQuery)) {
                 if (count($fieldQuery) !== 1) {
                     throw new InvalidArgumentException(sprintf('Operator must contain exactly one key, %d given', count($fieldQuery)));

--- a/src/Builder/Type/Encode.php
+++ b/src/Builder/Type/Encode.php
@@ -25,11 +25,6 @@ enum Encode
     case Object;
 
     /**
-     * Same as Object, but only parameters are returned. The operator name will not be used.
-     */
-    case FlatObject;
-
-    /**
      * Get the single parameter value
      */
     case Single;

--- a/src/Builder/Type/OperatorInterface.php
+++ b/src/Builder/Type/OperatorInterface.php
@@ -15,5 +15,6 @@ interface OperatorInterface
     /** @var array<string, string|null> */
     public const PROPERTIES = [];
 
-    public function getOperator(): string;
+    /** @var string|null */
+    public const NAME = null;
 }

--- a/src/Builder/Type/QueryObject.php
+++ b/src/Builder/Type/QueryObject.php
@@ -56,11 +56,11 @@ final class QueryObject implements QueryInterface
         foreach ($queriesOrArrayOfQueries as $fieldPath => $query) {
             if ($query instanceof QueryInterface) {
                 if ($query instanceof OperatorInterface) {
-                    if (isset($seenQueryOperators[$query->getOperator()])) {
-                        throw new InvalidArgumentException(sprintf('Query operator "%s" cannot be used multiple times in the same query.', $query->getOperator()));
+                    if (isset($seenQueryOperators[$query::NAME])) {
+                        throw new InvalidArgumentException(sprintf('Query operator "%s" cannot be used multiple times in the same query.', $query::NAME));
                     }
 
-                    $seenQueryOperators[$query->getOperator()] = true;
+                    $seenQueryOperators[$query::NAME] = true;
                 }
 
                 $queries[] = $query;


### PR DESCRIPTION
- Remove the `Encode::FlatObject` specific encoding by setting `null` for the operator name.
- Replace `OperatorInterface::getOperator()` with `OperatorInterface::NAME` constant. This doesn't need to be dynamic.
