### PR TITLE
Mark builder classes as final and internal

### DIFF
--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -50,6 +50,7 @@ class OperatorClassGenerator extends OperatorGenerator
         }
 
         $class = $namespace->addClass($this->getOperatorClassName($definition, $operator));
+        $class->setFinal();
         $class->setImplements($interfaces);
         $namespace->addUse(OperatorInterface::class);
         $class->addImplement(OperatorInterface::class);
@@ -58,6 +59,7 @@ class OperatorClassGenerator extends OperatorGenerator
         // @todo move to encoder class
         $class->addComment($operator->description);
         $class->addComment('@see ' . $operator->link);
+        $class->addComment('@internal');
         $namespace->addUse(Encode::class);
         $class->addConstant('ENCODE', new Literal('Encode::' . $operator->encode->name));
 

--- a/src/Builder/Accumulator/AccumulatorAccumulator.php
+++ b/src/Builder/Accumulator/AccumulatorAccumulator.php
@@ -27,8 +27,9 @@ use function is_string;
  * New in MongoDB 4.4.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/accumulator/
+ * @internal
  */
-class AccumulatorAccumulator implements AccumulatorInterface, OperatorInterface
+final class AccumulatorAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/AddToSetAccumulator.php
+++ b/src/Builder/Accumulator/AddToSetAccumulator.php
@@ -21,8 +21,9 @@ use stdClass;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/addToSet/
+ * @internal
  */
-class AddToSetAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class AddToSetAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/AvgAccumulator.php
+++ b/src/Builder/Accumulator/AvgAccumulator.php
@@ -21,8 +21,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/
+ * @internal
  */
-class AvgAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class AvgAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/BottomAccumulator.php
+++ b/src/Builder/Accumulator/BottomAccumulator.php
@@ -23,8 +23,9 @@ use stdClass;
  * New in MongoDB 5.2: Available in the $group and $setWindowFields stages.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom/
+ * @internal
  */
-class BottomAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class BottomAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/BottomNAccumulator.php
+++ b/src/Builder/Accumulator/BottomNAccumulator.php
@@ -25,8 +25,9 @@ use stdClass;
  * Available in the $group and $setWindowFields stages.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/
+ * @internal
  */
-class BottomNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class BottomNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/CountAccumulator.php
+++ b/src/Builder/Accumulator/CountAccumulator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/count-accumulator/
+ * @internal
  */
-class CountAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class CountAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/CovariancePopAccumulator.php
+++ b/src/Builder/Accumulator/CovariancePopAccumulator.php
@@ -20,8 +20,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/covariancePop/
+ * @internal
  */
-class CovariancePopAccumulator implements WindowInterface, OperatorInterface
+final class CovariancePopAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Accumulator/CovarianceSampAccumulator.php
+++ b/src/Builder/Accumulator/CovarianceSampAccumulator.php
@@ -20,8 +20,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/covarianceSamp/
+ * @internal
  */
-class CovarianceSampAccumulator implements WindowInterface, OperatorInterface
+final class CovarianceSampAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Accumulator/DenseRankAccumulator.php
+++ b/src/Builder/Accumulator/DenseRankAccumulator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/denseRank/
+ * @internal
  */
-class DenseRankAccumulator implements WindowInterface, OperatorInterface
+final class DenseRankAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/DerivativeAccumulator.php
+++ b/src/Builder/Accumulator/DerivativeAccumulator.php
@@ -25,8 +25,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/derivative/
+ * @internal
  */
-class DerivativeAccumulator implements WindowInterface, OperatorInterface
+final class DerivativeAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/DocumentNumberAccumulator.php
+++ b/src/Builder/Accumulator/DocumentNumberAccumulator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/documentNumber/
+ * @internal
  */
-class DocumentNumberAccumulator implements WindowInterface, OperatorInterface
+final class DocumentNumberAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/ExpMovingAvgAccumulator.php
+++ b/src/Builder/Accumulator/ExpMovingAvgAccumulator.php
@@ -21,8 +21,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/expMovingAvg/
+ * @internal
  */
-class ExpMovingAvgAccumulator implements WindowInterface, OperatorInterface
+final class ExpMovingAvgAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/FirstAccumulator.php
+++ b/src/Builder/Accumulator/FirstAccumulator.php
@@ -21,8 +21,9 @@ use stdClass;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/
+ * @internal
  */
-class FirstAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class FirstAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/FirstNAccumulator.php
+++ b/src/Builder/Accumulator/FirstNAccumulator.php
@@ -23,8 +23,9 @@ use stdClass;
  * If the group contains fewer than n elements, $firstN returns all elements in the group.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/
+ * @internal
  */
-class FirstNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class FirstNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/IntegralAccumulator.php
+++ b/src/Builder/Accumulator/IntegralAccumulator.php
@@ -25,8 +25,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/integral/
+ * @internal
  */
-class IntegralAccumulator implements WindowInterface, OperatorInterface
+final class IntegralAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/LastAccumulator.php
+++ b/src/Builder/Accumulator/LastAccumulator.php
@@ -21,8 +21,9 @@ use stdClass;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/last/
+ * @internal
  */
-class LastAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class LastAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/LastNAccumulator.php
+++ b/src/Builder/Accumulator/LastNAccumulator.php
@@ -27,8 +27,9 @@ use function is_array;
  * If the group contains fewer than n elements, $lastN returns all elements in the group.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lastN/
+ * @internal
  */
-class LastNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class LastNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/LinearFillAccumulator.php
+++ b/src/Builder/Accumulator/LinearFillAccumulator.php
@@ -21,8 +21,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.3.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/linearFill/
+ * @internal
  */
-class LinearFillAccumulator implements WindowInterface, OperatorInterface
+final class LinearFillAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/LocfAccumulator.php
+++ b/src/Builder/Accumulator/LocfAccumulator.php
@@ -21,8 +21,9 @@ use stdClass;
  * New in MongoDB 5.2.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/locf/
+ * @internal
  */
-class LocfAccumulator implements WindowInterface, OperatorInterface
+final class LocfAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/MaxAccumulator.php
+++ b/src/Builder/Accumulator/MaxAccumulator.php
@@ -21,8 +21,9 @@ use stdClass;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/
+ * @internal
  */
-class MaxAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class MaxAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/MaxNAccumulator.php
+++ b/src/Builder/Accumulator/MaxNAccumulator.php
@@ -25,8 +25,9 @@ use function is_array;
  * Returns the n largest values in an array. Distinct from the $maxN accumulator.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN/
+ * @internal
  */
-class MaxNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class MaxNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/MedianAccumulator.php
+++ b/src/Builder/Accumulator/MedianAccumulator.php
@@ -25,8 +25,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * It is also available as an aggregation expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/
+ * @internal
  */
-class MedianAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class MedianAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/MergeObjectsAccumulator.php
+++ b/src/Builder/Accumulator/MergeObjectsAccumulator.php
@@ -20,8 +20,9 @@ use stdClass;
  * Combines multiple documents into a single document.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/
+ * @internal
  */
-class MergeObjectsAccumulator implements AccumulatorInterface, OperatorInterface
+final class MergeObjectsAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/MinAccumulator.php
+++ b/src/Builder/Accumulator/MinAccumulator.php
@@ -21,8 +21,9 @@ use stdClass;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/
+ * @internal
  */
-class MinAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class MinAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/MinNAccumulator.php
+++ b/src/Builder/Accumulator/MinNAccumulator.php
@@ -25,8 +25,9 @@ use function is_array;
  * Returns the n smallest values in an array. Distinct from the $minN accumulator.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minN/
+ * @internal
  */
-class MinNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class MinNAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/PercentileAccumulator.php
+++ b/src/Builder/Accumulator/PercentileAccumulator.php
@@ -35,8 +35,9 @@ use function is_array;
  * It is also available as an aggregation expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/
+ * @internal
  */
-class PercentileAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class PercentileAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/PushAccumulator.php
+++ b/src/Builder/Accumulator/PushAccumulator.php
@@ -21,8 +21,9 @@ use stdClass;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/push/
+ * @internal
  */
-class PushAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class PushAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/RankAccumulator.php
+++ b/src/Builder/Accumulator/RankAccumulator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rank/
+ * @internal
  */
-class RankAccumulator implements WindowInterface, OperatorInterface
+final class RankAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/ShiftAccumulator.php
+++ b/src/Builder/Accumulator/ShiftAccumulator.php
@@ -20,8 +20,9 @@ use stdClass;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/shift/
+ * @internal
  */
-class ShiftAccumulator implements WindowInterface, OperatorInterface
+final class ShiftAccumulator implements WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/StdDevPopAccumulator.php
+++ b/src/Builder/Accumulator/StdDevPopAccumulator.php
@@ -22,8 +22,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/
+ * @internal
  */
-class StdDevPopAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class StdDevPopAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/StdDevSampAccumulator.php
+++ b/src/Builder/Accumulator/StdDevSampAccumulator.php
@@ -22,8 +22,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/
+ * @internal
  */
-class StdDevSampAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class StdDevSampAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/SumAccumulator.php
+++ b/src/Builder/Accumulator/SumAccumulator.php
@@ -21,8 +21,9 @@ use MongoDB\Builder\Type\WindowInterface;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/
+ * @internal
  */
-class SumAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
+final class SumAccumulator implements AccumulatorInterface, WindowInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Accumulator/TopAccumulator.php
+++ b/src/Builder/Accumulator/TopAccumulator.php
@@ -24,8 +24,9 @@ use stdClass;
  * Available in the $group and $setWindowFields stages.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/top/
+ * @internal
  */
-class TopAccumulator implements AccumulatorInterface, OperatorInterface
+final class TopAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Accumulator/TopNAccumulator.php
+++ b/src/Builder/Accumulator/TopNAccumulator.php
@@ -25,8 +25,9 @@ use stdClass;
  * Available in the $group and $setWindowFields stages.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/
+ * @internal
  */
-class TopNAccumulator implements AccumulatorInterface, OperatorInterface
+final class TopNAccumulator implements AccumulatorInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -32,7 +32,7 @@ use function array_key_exists;
 use function is_object;
 
 /** @template-implements Encoder<stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
-class BuilderEncoder implements Encoder
+final class BuilderEncoder implements Encoder
 {
     /** @template-use EncodeIfSupported<stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
     use EncodeIfSupported;

--- a/src/Builder/Encoder/AbstractExpressionEncoder.php
+++ b/src/Builder/Encoder/AbstractExpressionEncoder.php
@@ -14,6 +14,7 @@ use function is_array;
  * @template BSONType of stdClass|array|string|int
  * @template NativeType
  * @template-implements ExpressionEncoder<BSONType, NativeType>
+ * @internal
  */
 abstract class AbstractExpressionEncoder implements ExpressionEncoder
 {

--- a/src/Builder/Encoder/CombinedFieldQueryEncoder.php
+++ b/src/Builder/Encoder/CombinedFieldQueryEncoder.php
@@ -16,8 +16,11 @@ use function is_array;
 use function is_object;
 use function sprintf;
 
-/** @template-extends AbstractExpressionEncoder<stdClass, CombinedFieldQuery> */
-class CombinedFieldQueryEncoder extends AbstractExpressionEncoder
+/**
+ * @template-extends AbstractExpressionEncoder<stdClass, CombinedFieldQuery>
+ * @internal
+ */
+final class CombinedFieldQueryEncoder extends AbstractExpressionEncoder
 {
     /** @template-use EncodeIfSupported<stdClass, CombinedFieldQuery> */
     use EncodeIfSupported;

--- a/src/Builder/Encoder/DictionaryEncoder.php
+++ b/src/Builder/Encoder/DictionaryEncoder.php
@@ -9,8 +9,11 @@ use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 use stdClass;
 
-/** @template-extends AbstractExpressionEncoder<string|int|array|stdClass, DictionaryInterface> */
-class DictionaryEncoder extends AbstractExpressionEncoder
+/**
+ * @template-extends AbstractExpressionEncoder<string|int|array|stdClass, DictionaryInterface>
+ * @internal
+ */
+final class DictionaryEncoder extends AbstractExpressionEncoder
 {
     /** @template-use EncodeIfSupported<string|int|array|stdClass, DictionaryInterface> */
     use EncodeIfSupported;

--- a/src/Builder/Encoder/ExpressionEncoder.php
+++ b/src/Builder/Encoder/ExpressionEncoder.php
@@ -12,6 +12,7 @@ use stdClass;
  * @template BSONType of stdClass|array|string|int
  * @template NativeType
  * @template-extends Encoder<BSONType, NativeType>
+ * @internal
  */
 interface ExpressionEncoder extends Encoder
 {

--- a/src/Builder/Encoder/FieldPathEncoder.php
+++ b/src/Builder/Encoder/FieldPathEncoder.php
@@ -8,8 +8,11 @@ use MongoDB\Builder\Type\FieldPathInterface;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 
-/** @template-extends AbstractExpressionEncoder<string, FieldPathInterface> */
-class FieldPathEncoder extends AbstractExpressionEncoder
+/**
+ * @template-extends AbstractExpressionEncoder<string, FieldPathInterface>
+ * @internal
+ */
+final class FieldPathEncoder extends AbstractExpressionEncoder
 {
     /** @template-use EncodeIfSupported<string, FieldPathInterface> */
     use EncodeIfSupported;
@@ -25,7 +28,6 @@ class FieldPathEncoder extends AbstractExpressionEncoder
             throw UnsupportedValueException::invalidEncodableValue($value);
         }
 
-        // TODO: needs method because interfaces can't have properties
         return '$' . $value->name;
     }
 }

--- a/src/Builder/Encoder/OperatorEncoder.php
+++ b/src/Builder/Encoder/OperatorEncoder.php
@@ -21,8 +21,11 @@ use function is_object;
 use function property_exists;
 use function sprintf;
 
-/** @template-extends AbstractExpressionEncoder<stdClass, OperatorInterface> */
-class OperatorEncoder extends AbstractExpressionEncoder
+/**
+ * @template-extends AbstractExpressionEncoder<stdClass, OperatorInterface>
+ * @internal
+ */
+final class OperatorEncoder extends AbstractExpressionEncoder
 {
     /** @template-use EncodeIfSupported<stdClass, OperatorInterface> */
     use EncodeIfSupported;

--- a/src/Builder/Encoder/OutputWindowEncoder.php
+++ b/src/Builder/Encoder/OutputWindowEncoder.php
@@ -17,8 +17,11 @@ use function get_debug_type;
 use function MongoDB\is_first_key_operator;
 use function sprintf;
 
-/** @template-extends AbstractExpressionEncoder<stdClass, OutputWindow> */
-class OutputWindowEncoder extends AbstractExpressionEncoder
+/**
+ * @template-extends AbstractExpressionEncoder<stdClass, OutputWindow>
+ * @internal
+ */
+final class OutputWindowEncoder extends AbstractExpressionEncoder
 {
     /** @template-use EncodeIfSupported<stdClass, OutputWindow> */
     use EncodeIfSupported;

--- a/src/Builder/Encoder/PipelineEncoder.php
+++ b/src/Builder/Encoder/PipelineEncoder.php
@@ -8,8 +8,11 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 
-/** @template-extends AbstractExpressionEncoder<list<mixed>, Pipeline> */
-class PipelineEncoder extends AbstractExpressionEncoder
+/**
+ * @template-extends AbstractExpressionEncoder<list<mixed>, Pipeline>
+ * @internal
+ */
+final class PipelineEncoder extends AbstractExpressionEncoder
 {
     /** @template-use EncodeIfSupported<list<mixed>, Pipeline> */
     use EncodeIfSupported;

--- a/src/Builder/Encoder/QueryEncoder.php
+++ b/src/Builder/Encoder/QueryEncoder.php
@@ -15,8 +15,11 @@ use function get_object_vars;
 use function property_exists;
 use function sprintf;
 
-/** @template-extends AbstractExpressionEncoder<stdClass, QueryObject> */
-class QueryEncoder extends AbstractExpressionEncoder
+/**
+ * @template-extends AbstractExpressionEncoder<stdClass, QueryObject>
+ * @internal
+ */
+final class QueryEncoder extends AbstractExpressionEncoder
 {
     /** @template-use EncodeIfSupported<stdClass, QueryObject> */
     use EncodeIfSupported;

--- a/src/Builder/Encoder/VariableEncoder.php
+++ b/src/Builder/Encoder/VariableEncoder.php
@@ -8,8 +8,11 @@ use MongoDB\Builder\Expression\Variable;
 use MongoDB\Codec\EncodeIfSupported;
 use MongoDB\Exception\UnsupportedValueException;
 
-/** @template-extends AbstractExpressionEncoder<string, Variable> */
-class VariableEncoder extends AbstractExpressionEncoder
+/**
+ * @template-extends AbstractExpressionEncoder<string, Variable>
+ * @internal
+ */
+final class VariableEncoder extends AbstractExpressionEncoder
 {
     /** @template-use EncodeIfSupported<string, Variable> */
     use EncodeIfSupported;

--- a/src/Builder/Expression/AbsOperator.php
+++ b/src/Builder/Expression/AbsOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the absolute value of a number.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/abs/
+ * @internal
  */
-class AbsOperator implements ResolvesToNumber, OperatorInterface
+final class AbsOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/AcosOperator.php
+++ b/src/Builder/Expression/AcosOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the inverse cosine (arc cosine) of a value in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/acos/
+ * @internal
  */
-class AcosOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class AcosOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/AcoshOperator.php
+++ b/src/Builder/Expression/AcoshOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the inverse hyperbolic cosine (hyperbolic arc cosine) of a value in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/acosh/
+ * @internal
  */
-class AcoshOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class AcoshOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/AddOperator.php
+++ b/src/Builder/Expression/AddOperator.php
@@ -21,8 +21,9 @@ use function array_is_list;
  * Adds numbers to return the sum, or adds numbers and a date to return a new date. If adding numbers and a date, treats the numbers as milliseconds. Accepts any number of argument expressions, but at most, one expression can resolve to a date.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/
+ * @internal
  */
-class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
+final class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/AllElementsTrueOperator.php
+++ b/src/Builder/Expression/AllElementsTrueOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns true if no element of a set evaluates to false, otherwise, returns false. Accepts a single argument expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/allElementsTrue/
+ * @internal
  */
-class AllElementsTrueOperator implements ResolvesToBool, OperatorInterface
+final class AllElementsTrueOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/AndOperator.php
+++ b/src/Builder/Expression/AndOperator.php
@@ -23,8 +23,9 @@ use function array_is_list;
  * Returns true only when all its expressions evaluate to true. Accepts any number of argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/and/
+ * @internal
  */
-class AndOperator implements ResolvesToBool, OperatorInterface
+final class AndOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/AnyElementTrueOperator.php
+++ b/src/Builder/Expression/AnyElementTrueOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns true if any elements of a set evaluate to true; otherwise, returns false. Accepts a single argument expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/anyElementTrue/
+ * @internal
  */
-class AnyElementTrueOperator implements ResolvesToBool, OperatorInterface
+final class AnyElementTrueOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/ArrayElemAtOperator.php
+++ b/src/Builder/Expression/ArrayElemAtOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns the element at the specified array index.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayElemAt/
+ * @internal
  */
-class ArrayElemAtOperator implements ResolvesToAny, OperatorInterface
+final class ArrayElemAtOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/ArrayToObjectOperator.php
+++ b/src/Builder/Expression/ArrayToObjectOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Converts an array of key value pairs to a document.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/arrayToObject/
+ * @internal
  */
-class ArrayToObjectOperator implements ResolvesToObject, OperatorInterface
+final class ArrayToObjectOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/AsinOperator.php
+++ b/src/Builder/Expression/AsinOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the inverse sin (arc sine) of a value in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/asin/
+ * @internal
  */
-class AsinOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class AsinOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/AsinhOperator.php
+++ b/src/Builder/Expression/AsinhOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the inverse hyperbolic sine (hyperbolic arc sine) of a value in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/asinh/
+ * @internal
  */
-class AsinhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class AsinhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/Atan2Operator.php
+++ b/src/Builder/Expression/Atan2Operator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the inverse tangent (arc tangent) of y / x in radians, where y and x are the first and second values passed to the expression respectively.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/atan2/
+ * @internal
  */
-class Atan2Operator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class Atan2Operator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/AtanOperator.php
+++ b/src/Builder/Expression/AtanOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the inverse tangent (arc tangent) of a value in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/atan/
+ * @internal
  */
-class AtanOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class AtanOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/AtanhOperator.php
+++ b/src/Builder/Expression/AtanhOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the inverse hyperbolic tangent (hyperbolic arc tangent) of a value in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/atanh/
+ * @internal
  */
-class AtanhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class AtanhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/AvgOperator.php
+++ b/src/Builder/Expression/AvgOperator.php
@@ -21,8 +21,9 @@ use function array_is_list;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/
+ * @internal
  */
-class AvgOperator implements ResolvesToNumber, OperatorInterface
+final class AvgOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/BinarySizeOperator.php
+++ b/src/Builder/Expression/BinarySizeOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the size of a given string or binary data value's content in bytes.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/binarySize/
+ * @internal
  */
-class BinarySizeOperator implements ResolvesToInt, OperatorInterface
+final class BinarySizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/BitAndOperator.php
+++ b/src/Builder/Expression/BitAndOperator.php
@@ -20,8 +20,9 @@ use function array_is_list;
  * New in MongoDB 6.3.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bitAnd/
+ * @internal
  */
-class BitAndOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
+final class BitAndOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/BitNotOperator.php
+++ b/src/Builder/Expression/BitNotOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * New in MongoDB 6.3.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bitNot/
+ * @internal
  */
-class BitNotOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
+final class BitNotOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/BitOrOperator.php
+++ b/src/Builder/Expression/BitOrOperator.php
@@ -20,8 +20,9 @@ use function array_is_list;
  * New in MongoDB 6.3.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bitOr/
+ * @internal
  */
-class BitOrOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
+final class BitOrOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/BitXorOperator.php
+++ b/src/Builder/Expression/BitXorOperator.php
@@ -20,8 +20,9 @@ use function array_is_list;
  * New in MongoDB 6.3.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bitXor/
+ * @internal
  */
-class BitXorOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
+final class BitXorOperator implements ResolvesToInt, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/BsonSizeOperator.php
+++ b/src/Builder/Expression/BsonSizeOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns the size in bytes of a given document (i.e. BSON type Object) when encoded as BSON.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bsonSize/
+ * @internal
  */
-class BsonSizeOperator implements ResolvesToInt, OperatorInterface
+final class BsonSizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/CaseOperator.php
+++ b/src/Builder/Expression/CaseOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * Represents a single case in a $switch expression
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/
+ * @internal
  */
-class CaseOperator implements SwitchBranchInterface, OperatorInterface
+final class CaseOperator implements SwitchBranchInterface, OperatorInterface
 {
     public const ENCODE = Encode::FlatObject;
 

--- a/src/Builder/Expression/CeilOperator.php
+++ b/src/Builder/Expression/CeilOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the smallest integer greater than or equal to the specified number.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ceil/
+ * @internal
  */
-class CeilOperator implements ResolvesToInt, OperatorInterface
+final class CeilOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/CmpOperator.php
+++ b/src/Builder/Expression/CmpOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns 0 if the two values are equivalent, 1 if the first value is greater than the second, and -1 if the first value is less than the second.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cmp/
+ * @internal
  */
-class CmpOperator implements ResolvesToInt, OperatorInterface
+final class CmpOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/ConcatArraysOperator.php
+++ b/src/Builder/Expression/ConcatArraysOperator.php
@@ -20,8 +20,9 @@ use function array_is_list;
  * Concatenates arrays to return the concatenated array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/concatArrays/
+ * @internal
  */
-class ConcatArraysOperator implements ResolvesToArray, OperatorInterface
+final class ConcatArraysOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ConcatOperator.php
+++ b/src/Builder/Expression/ConcatOperator.php
@@ -18,8 +18,9 @@ use function array_is_list;
  * Concatenates any number of strings.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/concat/
+ * @internal
  */
-class ConcatOperator implements ResolvesToString, OperatorInterface
+final class ConcatOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/CondOperator.php
+++ b/src/Builder/Expression/CondOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * A ternary operator that evaluates one expression, and depending on the result, returns the value of one of the other two expressions. Accepts either three expressions in an ordered list or three named parameters.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cond/
+ * @internal
  */
-class CondOperator implements ResolvesToAny, OperatorInterface
+final class CondOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/ConvertOperator.php
+++ b/src/Builder/Expression/ConvertOperator.php
@@ -20,8 +20,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/
+ * @internal
  */
-class ConvertOperator implements ResolvesToAny, OperatorInterface
+final class ConvertOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/CosOperator.php
+++ b/src/Builder/Expression/CosOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the cosine of a value that is measured in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cos/
+ * @internal
  */
-class CosOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class CosOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/CoshOperator.php
+++ b/src/Builder/Expression/CoshOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the hyperbolic cosine of a value that is measured in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cosh/
+ * @internal
  */
-class CoshOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class CoshOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/DateAddOperator.php
+++ b/src/Builder/Expression/DateAddOperator.php
@@ -21,8 +21,9 @@ use MongoDB\Builder\Type\TimeUnit;
  * Adds a number of time units to a date object.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/
+ * @internal
  */
-class DateAddOperator implements ResolvesToDate, OperatorInterface
+final class DateAddOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DateDiffOperator.php
+++ b/src/Builder/Expression/DateDiffOperator.php
@@ -20,8 +20,9 @@ use MongoDB\Builder\Type\TimeUnit;
  * Returns the difference between two dates.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/
+ * @internal
  */
-class DateDiffOperator implements ResolvesToInt, OperatorInterface
+final class DateDiffOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DateFromPartsOperator.php
+++ b/src/Builder/Expression/DateFromPartsOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\Optional;
  * Constructs a BSON Date object given the date's constituent parts.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromParts/
+ * @internal
  */
-class DateFromPartsOperator implements ResolvesToDate, OperatorInterface
+final class DateFromPartsOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DateFromStringOperator.php
+++ b/src/Builder/Expression/DateFromStringOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * Converts a date/time string to a date object.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateFromString/
+ * @internal
  */
-class DateFromStringOperator implements ResolvesToDate, OperatorInterface
+final class DateFromStringOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DateSubtractOperator.php
+++ b/src/Builder/Expression/DateSubtractOperator.php
@@ -21,8 +21,9 @@ use MongoDB\Builder\Type\TimeUnit;
  * Subtracts a number of time units from a date object.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/
+ * @internal
  */
-class DateSubtractOperator implements ResolvesToDate, OperatorInterface
+final class DateSubtractOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DateToPartsOperator.php
+++ b/src/Builder/Expression/DateToPartsOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns a document containing the constituent parts of a date.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToParts/
+ * @internal
  */
-class DateToPartsOperator implements ResolvesToObject, OperatorInterface
+final class DateToPartsOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DateToStringOperator.php
+++ b/src/Builder/Expression/DateToStringOperator.php
@@ -22,8 +22,9 @@ use stdClass;
  * Returns the date as a formatted string.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToString/
+ * @internal
  */
-class DateToStringOperator implements ResolvesToString, OperatorInterface
+final class DateToStringOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DateTruncOperator.php
+++ b/src/Builder/Expression/DateTruncOperator.php
@@ -22,8 +22,9 @@ use MongoDB\Builder\Type\TimeUnit;
  * Truncates a date.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateTrunc/
+ * @internal
  */
-class DateTruncOperator implements ResolvesToDate, OperatorInterface
+final class DateTruncOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DayOfMonthOperator.php
+++ b/src/Builder/Expression/DayOfMonthOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the day of the month for a date as a number between 1 and 31.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfMonth/
+ * @internal
  */
-class DayOfMonthOperator implements ResolvesToInt, OperatorInterface
+final class DayOfMonthOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DayOfWeekOperator.php
+++ b/src/Builder/Expression/DayOfWeekOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the day of the week for a date as a number between 1 (Sunday) and 7 (Saturday).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfWeek/
+ * @internal
  */
-class DayOfWeekOperator implements ResolvesToInt, OperatorInterface
+final class DayOfWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DayOfYearOperator.php
+++ b/src/Builder/Expression/DayOfYearOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the day of the year for a date as a number between 1 and 366 (leap year).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfYear/
+ * @internal
  */
-class DayOfYearOperator implements ResolvesToInt, OperatorInterface
+final class DayOfYearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/DegreesToRadiansOperator.php
+++ b/src/Builder/Expression/DegreesToRadiansOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Converts a value from degrees to radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/degreesToRadians/
+ * @internal
  */
-class DegreesToRadiansOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class DegreesToRadiansOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/DivideOperator.php
+++ b/src/Builder/Expression/DivideOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the result of dividing the first number by the second. Accepts two argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/divide/
+ * @internal
  */
-class DivideOperator implements ResolvesToDouble, OperatorInterface
+final class DivideOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/EqOperator.php
+++ b/src/Builder/Expression/EqOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns true if the values are equivalent.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/eq/
+ * @internal
  */
-class EqOperator implements ResolvesToBool, OperatorInterface
+final class EqOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/ExpOperator.php
+++ b/src/Builder/Expression/ExpOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Raises e to the specified exponent.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/exp/
+ * @internal
  */
-class ExpOperator implements ResolvesToDouble, OperatorInterface
+final class ExpOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/FilterOperator.php
+++ b/src/Builder/Expression/FilterOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Selects a subset of the array to return an array with only the elements that match the filter condition.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/
+ * @internal
  */
-class FilterOperator implements ResolvesToArray, OperatorInterface
+final class FilterOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/FirstNOperator.php
+++ b/src/Builder/Expression/FirstNOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns a specified number of elements from the beginning of an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN-array-element/
+ * @internal
  */
-class FirstNOperator implements ResolvesToArray, OperatorInterface
+final class FirstNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/FirstOperator.php
+++ b/src/Builder/Expression/FirstOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns the result of an expression for the first document in an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/
+ * @internal
  */
-class FirstOperator implements ResolvesToAny, OperatorInterface
+final class FirstOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/FloorOperator.php
+++ b/src/Builder/Expression/FloorOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the largest integer less than or equal to the specified number.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/floor/
+ * @internal
  */
-class FloorOperator implements ResolvesToInt, OperatorInterface
+final class FloorOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/FunctionOperator.php
+++ b/src/Builder/Expression/FunctionOperator.php
@@ -24,8 +24,9 @@ use function is_string;
  * New in MongoDB 4.4.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/function/
+ * @internal
  */
-class FunctionOperator implements ResolvesToAny, OperatorInterface
+final class FunctionOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/GetFieldOperator.php
+++ b/src/Builder/Expression/GetFieldOperator.php
@@ -20,8 +20,9 @@ use stdClass;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/
+ * @internal
  */
-class GetFieldOperator implements ResolvesToAny, OperatorInterface
+final class GetFieldOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/GtOperator.php
+++ b/src/Builder/Expression/GtOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns true if the first value is greater than the second.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gt/
+ * @internal
  */
-class GtOperator implements ResolvesToBool, OperatorInterface
+final class GtOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/GteOperator.php
+++ b/src/Builder/Expression/GteOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns true if the first value is greater than or equal to the second.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gte/
+ * @internal
  */
-class GteOperator implements ResolvesToBool, OperatorInterface
+final class GteOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/HourOperator.php
+++ b/src/Builder/Expression/HourOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the hour for a date as a number between 0 and 23.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hour/
+ * @internal
  */
-class HourOperator implements ResolvesToInt, OperatorInterface
+final class HourOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/IfNullOperator.php
+++ b/src/Builder/Expression/IfNullOperator.php
@@ -21,8 +21,9 @@ use function array_is_list;
  * Returns either the non-null result of the first expression or the result of the second expression if the first expression results in a null result. Null result encompasses instances of undefined values or missing fields. Accepts two expressions as arguments. The result of the second expression can be null.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/
+ * @internal
  */
-class IfNullOperator implements ResolvesToAny, OperatorInterface
+final class IfNullOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/InOperator.php
+++ b/src/Builder/Expression/InOperator.php
@@ -24,8 +24,9 @@ use function is_array;
  * Returns a boolean indicating whether a specified value is in an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/in/
+ * @internal
  */
-class InOperator implements ResolvesToBool, OperatorInterface
+final class InOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/IndexOfArrayOperator.php
+++ b/src/Builder/Expression/IndexOfArrayOperator.php
@@ -25,8 +25,9 @@ use function is_array;
  * Searches an array for an occurrence of a specified value and returns the array index of the first occurrence. Array indexes start at zero.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfArray/
+ * @internal
  */
-class IndexOfArrayOperator implements ResolvesToInt, OperatorInterface
+final class IndexOfArrayOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/IndexOfBytesOperator.php
+++ b/src/Builder/Expression/IndexOfBytesOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\Optional;
  * Searches a string for an occurrence of a substring and returns the UTF-8 byte index of the first occurrence. If the substring is not found, returns -1.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfBytes/
+ * @internal
  */
-class IndexOfBytesOperator implements ResolvesToInt, OperatorInterface
+final class IndexOfBytesOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/IndexOfCPOperator.php
+++ b/src/Builder/Expression/IndexOfCPOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\Optional;
  * Searches a string for an occurrence of a substring and returns the UTF-8 code point index of the first occurrence. If the substring is not found, returns -1
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexOfCP/
+ * @internal
  */
-class IndexOfCPOperator implements ResolvesToInt, OperatorInterface
+final class IndexOfCPOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/IsArrayOperator.php
+++ b/src/Builder/Expression/IsArrayOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Determines if the operand is an array. Returns a boolean.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/
+ * @internal
  */
-class IsArrayOperator implements ResolvesToBool, OperatorInterface
+final class IsArrayOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/IsNumberOperator.php
+++ b/src/Builder/Expression/IsNumberOperator.php
@@ -20,8 +20,9 @@ use stdClass;
  * New in MongoDB 4.4.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/
+ * @internal
  */
-class IsNumberOperator implements ResolvesToBool, OperatorInterface
+final class IsNumberOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/IsoDayOfWeekOperator.php
+++ b/src/Builder/Expression/IsoDayOfWeekOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the weekday number in ISO 8601 format, ranging from 1 (for Monday) to 7 (for Sunday).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoDayOfWeek/
+ * @internal
  */
-class IsoDayOfWeekOperator implements ResolvesToInt, OperatorInterface
+final class IsoDayOfWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/IsoWeekOperator.php
+++ b/src/Builder/Expression/IsoWeekOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the week number in ISO 8601 format, ranging from 1 to 53. Week numbers start at 1 with the week (Monday through Sunday) that contains the year's first Thursday.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoWeek/
+ * @internal
  */
-class IsoWeekOperator implements ResolvesToInt, OperatorInterface
+final class IsoWeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/IsoWeekYearOperator.php
+++ b/src/Builder/Expression/IsoWeekYearOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the year number in ISO 8601 format. The year starts with the Monday of week 1 (ISO 8601) and ends with the Sunday of the last week (ISO 8601).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoWeekYear/
+ * @internal
  */
-class IsoWeekYearOperator implements ResolvesToInt, OperatorInterface
+final class IsoWeekYearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/LastNOperator.php
+++ b/src/Builder/Expression/LastNOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns a specified number of elements from the end of an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lastN-array-element/
+ * @internal
  */
-class LastNOperator implements ResolvesToArray, OperatorInterface
+final class LastNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/LastOperator.php
+++ b/src/Builder/Expression/LastOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns the result of an expression for the last document in an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/last/
+ * @internal
  */
-class LastOperator implements ResolvesToAny, OperatorInterface
+final class LastOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/LetOperator.php
+++ b/src/Builder/Expression/LetOperator.php
@@ -21,8 +21,9 @@ use stdClass;
  * Accepts any number of argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/let/
+ * @internal
  */
-class LetOperator implements ResolvesToAny, OperatorInterface
+final class LetOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/LiteralOperator.php
+++ b/src/Builder/Expression/LiteralOperator.php
@@ -17,8 +17,9 @@ use stdClass;
  * Return a value without parsing. Use for values that the aggregation pipeline may interpret as an expression. For example, use a $literal expression to a string that starts with a dollar sign ($) to avoid parsing as a field path.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/literal/
+ * @internal
  */
-class LiteralOperator implements ResolvesToAny, OperatorInterface
+final class LiteralOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/LnOperator.php
+++ b/src/Builder/Expression/LnOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * $ln is equivalent to $log: [ <number>, Math.E ] expression, where Math.E is a JavaScript representation for Euler's number e.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ln/
+ * @internal
  */
-class LnOperator implements ResolvesToDouble, OperatorInterface
+final class LnOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/Log10Operator.php
+++ b/src/Builder/Expression/Log10Operator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Calculates the log base 10 of a number.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/log10/
+ * @internal
  */
-class Log10Operator implements ResolvesToDouble, OperatorInterface
+final class Log10Operator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/LogOperator.php
+++ b/src/Builder/Expression/LogOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Calculates the log of a number in the specified base.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/log/
+ * @internal
  */
-class LogOperator implements ResolvesToDouble, OperatorInterface
+final class LogOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/LtOperator.php
+++ b/src/Builder/Expression/LtOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns true if the first value is less than the second.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lt/
+ * @internal
  */
-class LtOperator implements ResolvesToBool, OperatorInterface
+final class LtOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/LteOperator.php
+++ b/src/Builder/Expression/LteOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns true if the first value is less than or equal to the second.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lte/
+ * @internal
  */
-class LteOperator implements ResolvesToBool, OperatorInterface
+final class LteOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/LtrimOperator.php
+++ b/src/Builder/Expression/LtrimOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\Optional;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ltrim/
+ * @internal
  */
-class LtrimOperator implements ResolvesToString, OperatorInterface
+final class LtrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/MapOperator.php
+++ b/src/Builder/Expression/MapOperator.php
@@ -25,8 +25,9 @@ use function is_array;
  * Applies a subexpression to each element of an array and returns the array of resulting values in order. Accepts named parameters.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/
+ * @internal
  */
-class MapOperator implements ResolvesToArray, OperatorInterface
+final class MapOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/MaxNOperator.php
+++ b/src/Builder/Expression/MaxNOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns the n largest values in an array. Distinct from the $maxN accumulator.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/maxN-array-element/
+ * @internal
  */
-class MaxNOperator implements ResolvesToArray, OperatorInterface
+final class MaxNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/MaxOperator.php
+++ b/src/Builder/Expression/MaxOperator.php
@@ -22,8 +22,9 @@ use function array_is_list;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/
+ * @internal
  */
-class MaxOperator implements ResolvesToAny, OperatorInterface
+final class MaxOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/MedianOperator.php
+++ b/src/Builder/Expression/MedianOperator.php
@@ -28,8 +28,9 @@ use function is_array;
  * It is also available as an aggregation expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/median/
+ * @internal
  */
-class MedianOperator implements ResolvesToDouble, OperatorInterface
+final class MedianOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/MergeObjectsOperator.php
+++ b/src/Builder/Expression/MergeObjectsOperator.php
@@ -21,8 +21,9 @@ use function array_is_list;
  * Combines multiple documents into a single document.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mergeObjects/
+ * @internal
  */
-class MergeObjectsOperator implements ResolvesToObject, OperatorInterface
+final class MergeObjectsOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/MetaOperator.php
+++ b/src/Builder/Expression/MetaOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Access available per-document metadata related to the aggregation operation.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/meta/
+ * @internal
  */
-class MetaOperator implements ResolvesToAny, OperatorInterface
+final class MetaOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/MillisecondOperator.php
+++ b/src/Builder/Expression/MillisecondOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the milliseconds of a date as a number between 0 and 999.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/millisecond/
+ * @internal
  */
-class MillisecondOperator implements ResolvesToInt, OperatorInterface
+final class MillisecondOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/MinNOperator.php
+++ b/src/Builder/Expression/MinNOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns the n smallest values in an array. Distinct from the $minN accumulator.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minN-array-element/
+ * @internal
  */
-class MinNOperator implements ResolvesToArray, OperatorInterface
+final class MinNOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/MinOperator.php
+++ b/src/Builder/Expression/MinOperator.php
@@ -22,8 +22,9 @@ use function array_is_list;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/
+ * @internal
  */
-class MinOperator implements ResolvesToAny, OperatorInterface
+final class MinOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/MinuteOperator.php
+++ b/src/Builder/Expression/MinuteOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the minute for a date as a number between 0 and 59.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minute/
+ * @internal
  */
-class MinuteOperator implements ResolvesToInt, OperatorInterface
+final class MinuteOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/ModOperator.php
+++ b/src/Builder/Expression/ModOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the remainder of the first number divided by the second. Accepts two argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/mod/
+ * @internal
  */
-class ModOperator implements ResolvesToInt, OperatorInterface
+final class ModOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/MonthOperator.php
+++ b/src/Builder/Expression/MonthOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the month for a date as a number between 1 (January) and 12 (December).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/month/
+ * @internal
  */
-class MonthOperator implements ResolvesToInt, OperatorInterface
+final class MonthOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/MultiplyOperator.php
+++ b/src/Builder/Expression/MultiplyOperator.php
@@ -20,8 +20,9 @@ use function array_is_list;
  * Multiplies numbers to return the product. Accepts any number of argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/multiply/
+ * @internal
  */
-class MultiplyOperator implements ResolvesToDecimal, OperatorInterface
+final class MultiplyOperator implements ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/NeOperator.php
+++ b/src/Builder/Expression/NeOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns true if the values are not equivalent.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ne/
+ * @internal
  */
-class NeOperator implements ResolvesToBool, OperatorInterface
+final class NeOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/NotOperator.php
+++ b/src/Builder/Expression/NotOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Returns the boolean value that is the opposite of its argument expression. Accepts a single argument expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/not/
+ * @internal
  */
-class NotOperator implements ResolvesToBool, OperatorInterface
+final class NotOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/ObjectToArrayOperator.php
+++ b/src/Builder/Expression/ObjectToArrayOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Converts a document to an array of documents representing key-value pairs.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/objectToArray/
+ * @internal
  */
-class ObjectToArrayOperator implements ResolvesToArray, OperatorInterface
+final class ObjectToArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/OrOperator.php
+++ b/src/Builder/Expression/OrOperator.php
@@ -21,8 +21,9 @@ use function array_is_list;
  * Returns true when any of its expressions evaluates to true. Accepts any number of argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/or/
+ * @internal
  */
-class OrOperator implements ResolvesToBool, OperatorInterface
+final class OrOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/PercentileOperator.php
+++ b/src/Builder/Expression/PercentileOperator.php
@@ -31,8 +31,9 @@ use function is_array;
  * It is also available as an aggregation expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/percentile/
+ * @internal
  */
-class PercentileOperator implements ResolvesToArray, OperatorInterface
+final class PercentileOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/PowOperator.php
+++ b/src/Builder/Expression/PowOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Raises a number to the specified exponent.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/pow/
+ * @internal
  */
-class PowOperator implements ResolvesToNumber, OperatorInterface
+final class PowOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/RadiansToDegreesOperator.php
+++ b/src/Builder/Expression/RadiansToDegreesOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Converts a value from radians to degrees.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/radiansToDegrees/
+ * @internal
  */
-class RadiansToDegreesOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class RadiansToDegreesOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/RandOperator.php
+++ b/src/Builder/Expression/RandOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns a random float between 0 and 1
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rand/
+ * @internal
  */
-class RandOperator implements ResolvesToDouble, OperatorInterface
+final class RandOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/RangeOperator.php
+++ b/src/Builder/Expression/RangeOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\Optional;
  * Outputs an array containing a sequence of integers according to user-defined inputs.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/range/
+ * @internal
  */
-class RangeOperator implements ResolvesToArray, OperatorInterface
+final class RangeOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/ReduceOperator.php
+++ b/src/Builder/Expression/ReduceOperator.php
@@ -24,8 +24,9 @@ use function is_array;
  * Applies an expression to each element in an array and combines them into a single value.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/
+ * @internal
  */
-class ReduceOperator implements ResolvesToAny, OperatorInterface
+final class ReduceOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/RegexFindAllOperator.php
+++ b/src/Builder/Expression/RegexFindAllOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\Optional;
  * New in MongoDB 4.2.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFindAll/
+ * @internal
  */
-class RegexFindAllOperator implements ResolvesToArray, OperatorInterface
+final class RegexFindAllOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/RegexFindOperator.php
+++ b/src/Builder/Expression/RegexFindOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\Optional;
  * New in MongoDB 4.2.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexFind/
+ * @internal
  */
-class RegexFindOperator implements ResolvesToObject, OperatorInterface
+final class RegexFindOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/RegexMatchOperator.php
+++ b/src/Builder/Expression/RegexMatchOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\Optional;
  * New in MongoDB 4.2.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/regexMatch/
+ * @internal
  */
-class RegexMatchOperator implements ResolvesToBool, OperatorInterface
+final class RegexMatchOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/ReplaceAllOperator.php
+++ b/src/Builder/Expression/ReplaceAllOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * New in MongoDB 4.4.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceAll/
+ * @internal
  */
-class ReplaceAllOperator implements ResolvesToString, OperatorInterface
+final class ReplaceAllOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/ReplaceOneOperator.php
+++ b/src/Builder/Expression/ReplaceOneOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * New in MongoDB 4.4.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceOne/
+ * @internal
  */
-class ReplaceOneOperator implements ResolvesToString, OperatorInterface
+final class ReplaceOneOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/ReverseArrayOperator.php
+++ b/src/Builder/Expression/ReverseArrayOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns an array with the elements in reverse order.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reverseArray/
+ * @internal
  */
-class ReverseArrayOperator implements ResolvesToArray, OperatorInterface
+final class ReverseArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/RoundOperator.php
+++ b/src/Builder/Expression/RoundOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\Optional;
  * Rounds a number to a whole integer or to a specified decimal place.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/round/
+ * @internal
  */
-class RoundOperator implements ResolvesToInt, ResolvesToDouble, ResolvesToDecimal, ResolvesToLong, OperatorInterface
+final class RoundOperator implements ResolvesToInt, ResolvesToDouble, ResolvesToDecimal, ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/RtrimOperator.php
+++ b/src/Builder/Expression/RtrimOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\Optional;
  * Removes whitespace characters, including null, or the specified characters from the end of a string.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rtrim/
+ * @internal
  */
-class RtrimOperator implements ResolvesToString, OperatorInterface
+final class RtrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/SecondOperator.php
+++ b/src/Builder/Expression/SecondOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the seconds for a date as a number between 0 and 60 (leap seconds).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/second/
+ * @internal
  */
-class SecondOperator implements ResolvesToInt, OperatorInterface
+final class SecondOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/SetDifferenceOperator.php
+++ b/src/Builder/Expression/SetDifferenceOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns a set with elements that appear in the first set but not in the second set; i.e. performs a relative complement of the second set relative to the first. Accepts exactly two argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setDifference/
+ * @internal
  */
-class SetDifferenceOperator implements ResolvesToArray, OperatorInterface
+final class SetDifferenceOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SetEqualsOperator.php
+++ b/src/Builder/Expression/SetEqualsOperator.php
@@ -20,8 +20,9 @@ use function array_is_list;
  * Returns true if the input sets have the same distinct elements. Accepts two or more argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setEquals/
+ * @internal
  */
-class SetEqualsOperator implements ResolvesToBool, OperatorInterface
+final class SetEqualsOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/SetFieldOperator.php
+++ b/src/Builder/Expression/SetFieldOperator.php
@@ -21,8 +21,9 @@ use stdClass;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/
+ * @internal
  */
-class SetFieldOperator implements ResolvesToObject, OperatorInterface
+final class SetFieldOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/SetIntersectionOperator.php
+++ b/src/Builder/Expression/SetIntersectionOperator.php
@@ -20,8 +20,9 @@ use function array_is_list;
  * Returns a set with elements that appear in all of the input sets. Accepts any number of argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIntersection/
+ * @internal
  */
-class SetIntersectionOperator implements ResolvesToArray, OperatorInterface
+final class SetIntersectionOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/SetIsSubsetOperator.php
+++ b/src/Builder/Expression/SetIsSubsetOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns true if all elements of the first set appear in the second set, including when the first set equals the second set; i.e. not a strict subset. Accepts exactly two argument expressions.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setIsSubset/
+ * @internal
  */
-class SetIsSubsetOperator implements ResolvesToBool, OperatorInterface
+final class SetIsSubsetOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SetUnionOperator.php
+++ b/src/Builder/Expression/SetUnionOperator.php
@@ -20,8 +20,9 @@ use function array_is_list;
  * Returns a set with elements that appear in any of the input sets.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setUnion/
+ * @internal
  */
-class SetUnionOperator implements ResolvesToArray, OperatorInterface
+final class SetUnionOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/SinOperator.php
+++ b/src/Builder/Expression/SinOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the sine of a value that is measured in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sin/
+ * @internal
  */
-class SinOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class SinOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/SinhOperator.php
+++ b/src/Builder/Expression/SinhOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the hyperbolic sine of a value that is measured in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sinh/
+ * @internal
  */
-class SinhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class SinhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/SizeOperator.php
+++ b/src/Builder/Expression/SizeOperator.php
@@ -21,8 +21,9 @@ use function is_array;
  * Returns the number of elements in the array. Accepts a single expression as argument.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/size/
+ * @internal
  */
-class SizeOperator implements ResolvesToInt, OperatorInterface
+final class SizeOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/SliceOperator.php
+++ b/src/Builder/Expression/SliceOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Returns a subset of an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/slice/
+ * @internal
  */
-class SliceOperator implements ResolvesToArray, OperatorInterface
+final class SliceOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SortArrayOperator.php
+++ b/src/Builder/Expression/SortArrayOperator.php
@@ -25,8 +25,9 @@ use function is_array;
  * Sorts the elements of an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortArray/
+ * @internal
  */
-class SortArrayOperator implements ResolvesToArray, OperatorInterface
+final class SortArrayOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/SplitOperator.php
+++ b/src/Builder/Expression/SplitOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Splits a string into substrings based on a delimiter. Returns an array of substrings. If the delimiter is not found within the string, returns an array containing the original string.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/split/
+ * @internal
  */
-class SplitOperator implements ResolvesToArray, OperatorInterface
+final class SplitOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SqrtOperator.php
+++ b/src/Builder/Expression/SqrtOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Calculates the square root.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sqrt/
+ * @internal
  */
-class SqrtOperator implements ResolvesToDouble, OperatorInterface
+final class SqrtOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/StdDevPopOperator.php
+++ b/src/Builder/Expression/StdDevPopOperator.php
@@ -22,8 +22,9 @@ use function array_is_list;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevPop/
+ * @internal
  */
-class StdDevPopOperator implements ResolvesToDouble, OperatorInterface
+final class StdDevPopOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/StdDevSampOperator.php
+++ b/src/Builder/Expression/StdDevSampOperator.php
@@ -21,8 +21,9 @@ use function array_is_list;
  * If the values represent the entire population of data or you do not wish to generalize about a larger population, use $stdDevPop instead.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/stdDevSamp/
+ * @internal
  */
-class StdDevSampOperator implements ResolvesToDouble, OperatorInterface
+final class StdDevSampOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/StrLenBytesOperator.php
+++ b/src/Builder/Expression/StrLenBytesOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the number of UTF-8 encoded bytes in a string.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/strLenBytes/
+ * @internal
  */
-class StrLenBytesOperator implements ResolvesToInt, OperatorInterface
+final class StrLenBytesOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/StrLenCPOperator.php
+++ b/src/Builder/Expression/StrLenCPOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the number of UTF-8 code points in a string.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/strLenCP/
+ * @internal
  */
-class StrLenCPOperator implements ResolvesToInt, OperatorInterface
+final class StrLenCPOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/StrcasecmpOperator.php
+++ b/src/Builder/Expression/StrcasecmpOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Performs case-insensitive string comparison and returns: 0 if two strings are equivalent, 1 if the first string is greater than the second, and -1 if the first string is less than the second.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/strcasecmp/
+ * @internal
  */
-class StrcasecmpOperator implements ResolvesToInt, OperatorInterface
+final class StrcasecmpOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SubstrBytesOperator.php
+++ b/src/Builder/Expression/SubstrBytesOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the substring of a string. Starts with the character at the specified UTF-8 byte index (zero-based) in the string and continues for the specified number of bytes.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrBytes/
+ * @internal
  */
-class SubstrBytesOperator implements ResolvesToString, OperatorInterface
+final class SubstrBytesOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SubstrCPOperator.php
+++ b/src/Builder/Expression/SubstrCPOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the substring of a string. Starts with the character at the specified UTF-8 code point (CP) index (zero-based) in the string and continues for the number of code points specified.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/substrCP/
+ * @internal
  */
-class SubstrCPOperator implements ResolvesToString, OperatorInterface
+final class SubstrCPOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SubstrOperator.php
+++ b/src/Builder/Expression/SubstrOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Deprecated. Use $substrBytes or $substrCP.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/substr/
+ * @internal
  */
-class SubstrOperator implements ResolvesToString, OperatorInterface
+final class SubstrOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SubtractOperator.php
+++ b/src/Builder/Expression/SubtractOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the result of subtracting the second value from the first. If the two values are numbers, return the difference. If the two values are dates, return the difference in milliseconds. If the two values are a date and a number in milliseconds, return the resulting date. Accepts two argument expressions. If the two values are a date and a number, specify the date argument first as it is not meaningful to subtract a date from a number.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/
+ * @internal
  */
-class SubtractOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
+final class SubtractOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDouble, ResolvesToDecimal, ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/SumOperator.php
+++ b/src/Builder/Expression/SumOperator.php
@@ -23,8 +23,9 @@ use function array_is_list;
  * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/
+ * @internal
  */
-class SumOperator implements ResolvesToNumber, OperatorInterface
+final class SumOperator implements ResolvesToNumber, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/SwitchOperator.php
+++ b/src/Builder/Expression/SwitchOperator.php
@@ -25,8 +25,9 @@ use function is_array;
  * Evaluates a series of case expressions. When it finds an expression which evaluates to true, $switch executes a specified expression and breaks out of the control flow.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/
+ * @internal
  */
-class SwitchOperator implements ResolvesToAny, OperatorInterface
+final class SwitchOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/TanOperator.php
+++ b/src/Builder/Expression/TanOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the tangent of a value that is measured in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tan/
+ * @internal
  */
-class TanOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class TanOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/TanhOperator.php
+++ b/src/Builder/Expression/TanhOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Returns the hyperbolic tangent of a value that is measured in radians.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tanh/
+ * @internal
  */
-class TanhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
+final class TanhOperator implements ResolvesToDouble, ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToBoolOperator.php
+++ b/src/Builder/Expression/ToBoolOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toBool/
+ * @internal
  */
-class ToBoolOperator implements ResolvesToBool, OperatorInterface
+final class ToBoolOperator implements ResolvesToBool, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToDateOperator.php
+++ b/src/Builder/Expression/ToDateOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDate/
+ * @internal
  */
-class ToDateOperator implements ResolvesToDate, OperatorInterface
+final class ToDateOperator implements ResolvesToDate, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToDecimalOperator.php
+++ b/src/Builder/Expression/ToDecimalOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDecimal/
+ * @internal
  */
-class ToDecimalOperator implements ResolvesToDecimal, OperatorInterface
+final class ToDecimalOperator implements ResolvesToDecimal, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToDoubleOperator.php
+++ b/src/Builder/Expression/ToDoubleOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDouble/
+ * @internal
  */
-class ToDoubleOperator implements ResolvesToDouble, OperatorInterface
+final class ToDoubleOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToHashedIndexKeyOperator.php
+++ b/src/Builder/Expression/ToHashedIndexKeyOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Computes and returns the hash value of the input expression using the same hash function that MongoDB uses to create a hashed index. A hash function maps a key or string to a fixed-size numeric value.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/
+ * @internal
  */
-class ToHashedIndexKeyOperator implements ResolvesToLong, OperatorInterface
+final class ToHashedIndexKeyOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToIntOperator.php
+++ b/src/Builder/Expression/ToIntOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toInt/
+ * @internal
  */
-class ToIntOperator implements ResolvesToInt, OperatorInterface
+final class ToIntOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToLongOperator.php
+++ b/src/Builder/Expression/ToLongOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLong/
+ * @internal
  */
-class ToLongOperator implements ResolvesToLong, OperatorInterface
+final class ToLongOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToLowerOperator.php
+++ b/src/Builder/Expression/ToLowerOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Converts a string to lowercase. Accepts a single argument expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLower/
+ * @internal
  */
-class ToLowerOperator implements ResolvesToString, OperatorInterface
+final class ToLowerOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToObjectIdOperator.php
+++ b/src/Builder/Expression/ToObjectIdOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toObjectId/
+ * @internal
  */
-class ToObjectIdOperator implements ResolvesToObjectId, OperatorInterface
+final class ToObjectIdOperator implements ResolvesToObjectId, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToStringOperator.php
+++ b/src/Builder/Expression/ToStringOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toString/
+ * @internal
  */
-class ToStringOperator implements ResolvesToString, OperatorInterface
+final class ToStringOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/ToUpperOperator.php
+++ b/src/Builder/Expression/ToUpperOperator.php
@@ -15,8 +15,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Converts a string to uppercase. Accepts a single argument expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toUpper/
+ * @internal
  */
-class ToUpperOperator implements ResolvesToString, OperatorInterface
+final class ToUpperOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/TrimOperator.php
+++ b/src/Builder/Expression/TrimOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\Optional;
  * New in MongoDB 4.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/trim/
+ * @internal
  */
-class TrimOperator implements ResolvesToString, OperatorInterface
+final class TrimOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/TruncOperator.php
+++ b/src/Builder/Expression/TruncOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\Optional;
  * Truncates a number to a whole integer or to a specified decimal place.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/trunc/
+ * @internal
  */
-class TruncOperator implements ResolvesToString, OperatorInterface
+final class TruncOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Expression/TsIncrementOperator.php
+++ b/src/Builder/Expression/TsIncrementOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * New in MongoDB 5.1.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsIncrement/
+ * @internal
  */
-class TsIncrementOperator implements ResolvesToLong, OperatorInterface
+final class TsIncrementOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/TsSecondOperator.php
+++ b/src/Builder/Expression/TsSecondOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * New in MongoDB 5.1.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/tsSecond/
+ * @internal
  */
-class TsSecondOperator implements ResolvesToLong, OperatorInterface
+final class TsSecondOperator implements ResolvesToLong, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/TypeOperator.php
+++ b/src/Builder/Expression/TypeOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Return the BSON data type of the field.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/type/
+ * @internal
  */
-class TypeOperator implements ResolvesToString, OperatorInterface
+final class TypeOperator implements ResolvesToString, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Expression/UnsetFieldOperator.php
+++ b/src/Builder/Expression/UnsetFieldOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * $unsetField is an alias for $setField using $$REMOVE to remove fields.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unsetField/
+ * @internal
  */
-class UnsetFieldOperator implements ResolvesToObject, OperatorInterface
+final class UnsetFieldOperator implements ResolvesToObject, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/WeekOperator.php
+++ b/src/Builder/Expression/WeekOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the week number for a date as a number between 0 (the partial week that precedes the first Sunday of the year) and 53 (leap year).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/week/
+ * @internal
  */
-class WeekOperator implements ResolvesToInt, OperatorInterface
+final class WeekOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/YearOperator.php
+++ b/src/Builder/Expression/YearOperator.php
@@ -19,8 +19,9 @@ use MongoDB\Builder\Type\Optional;
  * Returns the year for a date as a number (e.g. 2014).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/year/
+ * @internal
  */
-class YearOperator implements ResolvesToInt, OperatorInterface
+final class YearOperator implements ResolvesToInt, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Expression/ZipOperator.php
+++ b/src/Builder/Expression/ZipOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Merge two arrays together.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/zip/
+ * @internal
  */
-class ZipOperator implements ResolvesToArray, OperatorInterface
+final class ZipOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Query/AllOperator.php
+++ b/src/Builder/Query/AllOperator.php
@@ -21,8 +21,9 @@ use function array_is_list;
  * Matches arrays that contain all elements specified in the query.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/all/
+ * @internal
  */
-class AllOperator implements FieldQueryInterface, OperatorInterface
+final class AllOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/AndOperator.php
+++ b/src/Builder/Query/AndOperator.php
@@ -19,8 +19,9 @@ use function array_is_list;
  * Joins query clauses with a logical AND returns all documents that match the conditions of both clauses.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/and/
+ * @internal
  */
-class AndOperator implements QueryInterface, OperatorInterface
+final class AndOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/BitsAllClearOperator.php
+++ b/src/Builder/Query/BitsAllClearOperator.php
@@ -23,8 +23,9 @@ use function is_array;
  * Matches numeric or binary values in which a set of bit positions all have a value of 0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/bitsAllClear/
+ * @internal
  */
-class BitsAllClearOperator implements FieldQueryInterface, OperatorInterface
+final class BitsAllClearOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/BitsAllSetOperator.php
+++ b/src/Builder/Query/BitsAllSetOperator.php
@@ -23,8 +23,9 @@ use function is_array;
  * Matches numeric or binary values in which a set of bit positions all have a value of 1.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/bitsAllSet/
+ * @internal
  */
-class BitsAllSetOperator implements FieldQueryInterface, OperatorInterface
+final class BitsAllSetOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/BitsAnyClearOperator.php
+++ b/src/Builder/Query/BitsAnyClearOperator.php
@@ -23,8 +23,9 @@ use function is_array;
  * Matches numeric or binary values in which any bit from a set of bit positions has a value of 0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/bitsAnyClear/
+ * @internal
  */
-class BitsAnyClearOperator implements FieldQueryInterface, OperatorInterface
+final class BitsAnyClearOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/BitsAnySetOperator.php
+++ b/src/Builder/Query/BitsAnySetOperator.php
@@ -23,8 +23,9 @@ use function is_array;
  * Matches numeric or binary values in which any bit from a set of bit positions has a value of 1.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/bitsAnySet/
+ * @internal
  */
-class BitsAnySetOperator implements FieldQueryInterface, OperatorInterface
+final class BitsAnySetOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/BoxOperator.php
+++ b/src/Builder/Query/BoxOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Specifies a rectangular box using legacy coordinate pairs for $geoWithin queries. The 2d index supports $box.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/box/
+ * @internal
  */
-class BoxOperator implements GeometryInterface, OperatorInterface
+final class BoxOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/CenterOperator.php
+++ b/src/Builder/Query/CenterOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Specifies a circle using legacy coordinate pairs to $geoWithin queries when using planar geometry. The 2d index supports $center.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/center/
+ * @internal
  */
-class CenterOperator implements GeometryInterface, OperatorInterface
+final class CenterOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/CenterSphereOperator.php
+++ b/src/Builder/Query/CenterSphereOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Specifies a circle using either legacy coordinate pairs or GeoJSON format for $geoWithin queries when using spherical geometry. The 2dsphere and 2d indexes support $centerSphere.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/centerSphere/
+ * @internal
  */
-class CenterSphereOperator implements GeometryInterface, OperatorInterface
+final class CenterSphereOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/CommentOperator.php
+++ b/src/Builder/Query/CommentOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\QueryInterface;
  * Adds a comment to a query predicate.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/comment/
+ * @internal
  */
-class CommentOperator implements QueryInterface, OperatorInterface
+final class CommentOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/ElemMatchOperator.php
+++ b/src/Builder/Query/ElemMatchOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * The $elemMatch operator matches documents that contain an array field with at least one element that matches all the specified query criteria.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/elemMatch/
+ * @internal
  */
-class ElemMatchOperator implements FieldQueryInterface, OperatorInterface
+final class ElemMatchOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/EqOperator.php
+++ b/src/Builder/Query/EqOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Matches values that are equal to a specified value.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/eq/
+ * @internal
  */
-class EqOperator implements FieldQueryInterface, OperatorInterface
+final class EqOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/ExistsOperator.php
+++ b/src/Builder/Query/ExistsOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Matches documents that have the specified field.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/exists/
+ * @internal
  */
-class ExistsOperator implements FieldQueryInterface, OperatorInterface
+final class ExistsOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/ExprOperator.php
+++ b/src/Builder/Query/ExprOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * Allows use of aggregation expressions within the query language.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/expr/
+ * @internal
  */
-class ExprOperator implements QueryInterface, OperatorInterface
+final class ExprOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/GeoIntersectsOperator.php
+++ b/src/Builder/Query/GeoIntersectsOperator.php
@@ -20,8 +20,9 @@ use stdClass;
  * Selects geometries that intersect with a GeoJSON geometry. The 2dsphere index supports $geoIntersects.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/geoIntersects/
+ * @internal
  */
-class GeoIntersectsOperator implements FieldQueryInterface, OperatorInterface
+final class GeoIntersectsOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/GeoWithinOperator.php
+++ b/src/Builder/Query/GeoWithinOperator.php
@@ -20,8 +20,9 @@ use stdClass;
  * Selects geometries within a bounding GeoJSON geometry. The 2dsphere and 2d indexes support $geoWithin.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/geoWithin/
+ * @internal
  */
-class GeoWithinOperator implements FieldQueryInterface, OperatorInterface
+final class GeoWithinOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/GeometryOperator.php
+++ b/src/Builder/Query/GeometryOperator.php
@@ -26,8 +26,9 @@ use function is_array;
  * Specifies a geometry in GeoJSON format to geospatial query operators.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/geometry/
+ * @internal
  */
-class GeometryOperator implements GeometryInterface, OperatorInterface
+final class GeometryOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Query/GtOperator.php
+++ b/src/Builder/Query/GtOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Matches values that are greater than a specified value.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/gt/
+ * @internal
  */
-class GtOperator implements FieldQueryInterface, OperatorInterface
+final class GtOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/GteOperator.php
+++ b/src/Builder/Query/GteOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Matches values that are greater than or equal to a specified value.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/gte/
+ * @internal
  */
-class GteOperator implements FieldQueryInterface, OperatorInterface
+final class GteOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/InOperator.php
+++ b/src/Builder/Query/InOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Matches any of the values specified in an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/in/
+ * @internal
  */
-class InOperator implements FieldQueryInterface, OperatorInterface
+final class InOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/JsonSchemaOperator.php
+++ b/src/Builder/Query/JsonSchemaOperator.php
@@ -19,8 +19,9 @@ use stdClass;
  * Validate documents against the given JSON Schema.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/jsonSchema/
+ * @internal
  */
-class JsonSchemaOperator implements QueryInterface, OperatorInterface
+final class JsonSchemaOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/LtOperator.php
+++ b/src/Builder/Query/LtOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Matches values that are less than a specified value.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/lt/
+ * @internal
  */
-class LtOperator implements FieldQueryInterface, OperatorInterface
+final class LtOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/LteOperator.php
+++ b/src/Builder/Query/LteOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Matches values that are less than or equal to a specified value.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/lte/
+ * @internal
  */
-class LteOperator implements FieldQueryInterface, OperatorInterface
+final class LteOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/MaxDistanceOperator.php
+++ b/src/Builder/Query/MaxDistanceOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Specifies a maximum distance to limit the results of $near and $nearSphere queries. The 2dsphere and 2d indexes support $maxDistance.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/maxDistance/
+ * @internal
  */
-class MaxDistanceOperator implements FieldQueryInterface, OperatorInterface
+final class MaxDistanceOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/MinDistanceOperator.php
+++ b/src/Builder/Query/MinDistanceOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Specifies a minimum distance to limit the results of $near and $nearSphere queries. For use with 2dsphere index only.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/minDistance/
+ * @internal
  */
-class MinDistanceOperator implements FieldQueryInterface, OperatorInterface
+final class MinDistanceOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/ModOperator.php
+++ b/src/Builder/Query/ModOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Performs a modulo operation on the value of a field and selects documents with a specified result.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/mod/
+ * @internal
  */
-class ModOperator implements FieldQueryInterface, OperatorInterface
+final class ModOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Array;
 

--- a/src/Builder/Query/NeOperator.php
+++ b/src/Builder/Query/NeOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Matches all values that are not equal to a specified value.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/ne/
+ * @internal
  */
-class NeOperator implements FieldQueryInterface, OperatorInterface
+final class NeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/NearOperator.php
+++ b/src/Builder/Query/NearOperator.php
@@ -23,8 +23,9 @@ use stdClass;
  * Returns geospatial objects in proximity to a point. Requires a geospatial index. The 2dsphere and 2d indexes support $near.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/near/
+ * @internal
  */
-class NearOperator implements FieldQueryInterface, OperatorInterface
+final class NearOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::DollarObject;
 

--- a/src/Builder/Query/NearSphereOperator.php
+++ b/src/Builder/Query/NearSphereOperator.php
@@ -23,8 +23,9 @@ use stdClass;
  * Returns geospatial objects in proximity to a point on a sphere. Requires a geospatial index. The 2dsphere and 2d indexes support $nearSphere.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/nearSphere/
+ * @internal
  */
-class NearSphereOperator implements FieldQueryInterface, OperatorInterface
+final class NearSphereOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::DollarObject;
 

--- a/src/Builder/Query/NinOperator.php
+++ b/src/Builder/Query/NinOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Matches none of the values specified in an array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/nin/
+ * @internal
  */
-class NinOperator implements FieldQueryInterface, OperatorInterface
+final class NinOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/NorOperator.php
+++ b/src/Builder/Query/NorOperator.php
@@ -19,8 +19,9 @@ use function array_is_list;
  * Joins query clauses with a logical NOR returns all documents that fail to match both clauses.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/nor/
+ * @internal
  */
-class NorOperator implements QueryInterface, OperatorInterface
+final class NorOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/NotOperator.php
+++ b/src/Builder/Query/NotOperator.php
@@ -18,8 +18,9 @@ use stdClass;
  * Inverts the effect of a query expression and returns documents that do not match the query expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/not/
+ * @internal
  */
-class NotOperator implements FieldQueryInterface, OperatorInterface
+final class NotOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/OrOperator.php
+++ b/src/Builder/Query/OrOperator.php
@@ -19,8 +19,9 @@ use function array_is_list;
  * Joins query clauses with a logical OR returns all documents that match the conditions of either clause.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/or/
+ * @internal
  */
-class OrOperator implements QueryInterface, OperatorInterface
+final class OrOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/PolygonOperator.php
+++ b/src/Builder/Query/PolygonOperator.php
@@ -22,8 +22,9 @@ use function is_array;
  * Specifies a polygon to using legacy coordinate pairs for $geoWithin queries. The 2d index supports $center.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/polygon/
+ * @internal
  */
-class PolygonOperator implements GeometryInterface, OperatorInterface
+final class PolygonOperator implements GeometryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/RandOperator.php
+++ b/src/Builder/Query/RandOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Generates a random float between 0 and 1.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/rand/
+ * @internal
  */
-class RandOperator implements ResolvesToDouble, OperatorInterface
+final class RandOperator implements ResolvesToDouble, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Query/RegexOperator.php
+++ b/src/Builder/Query/RegexOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Selects documents where values match a specified regular expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/regex/
+ * @internal
  */
-class RegexOperator implements FieldQueryInterface, OperatorInterface
+final class RegexOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/SampleRateOperator.php
+++ b/src/Builder/Query/SampleRateOperator.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\QueryInterface;
  * Randomly select documents at a given rate. Although the exact number of documents selected varies on each run, the quantity chosen approximates the sample rate expressed as a percentage of the total number of documents.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sampleRate/
+ * @internal
  */
-class SampleRateOperator implements QueryInterface, OperatorInterface
+final class SampleRateOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/SizeOperator.php
+++ b/src/Builder/Query/SizeOperator.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\OperatorInterface;
  * Selects documents if the array field is a specified size.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/size/
+ * @internal
  */
-class SizeOperator implements FieldQueryInterface, OperatorInterface
+final class SizeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/TextOperator.php
+++ b/src/Builder/Query/TextOperator.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\QueryInterface;
  * Performs text search.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/text/
+ * @internal
  */
-class TextOperator implements QueryInterface, OperatorInterface
+final class TextOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::DollarObject;
 

--- a/src/Builder/Query/TypeOperator.php
+++ b/src/Builder/Query/TypeOperator.php
@@ -19,8 +19,9 @@ use function array_is_list;
  * Selects documents if a field is of the specified type.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/type/
+ * @internal
  */
-class TypeOperator implements FieldQueryInterface, OperatorInterface
+final class TypeOperator implements FieldQueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Query/WhereOperator.php
+++ b/src/Builder/Query/WhereOperator.php
@@ -19,8 +19,9 @@ use function is_string;
  * Matches documents that satisfy a JavaScript expression.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/query/where/
+ * @internal
  */
-class WhereOperator implements QueryInterface, OperatorInterface
+final class WhereOperator implements QueryInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/AddFieldsStage.php
+++ b/src/Builder/Stage/AddFieldsStage.php
@@ -22,8 +22,9 @@ use function is_string;
  * Adds new fields to documents. Outputs documents that contain all existing fields from the input documents and newly added fields.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/
+ * @internal
  */
-class AddFieldsStage implements StageInterface, OperatorInterface
+final class AddFieldsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/BucketAutoStage.php
+++ b/src/Builder/Stage/BucketAutoStage.php
@@ -22,8 +22,9 @@ use stdClass;
  * Categorizes incoming documents into a specific number of groups, called buckets, based on a specified expression. Bucket boundaries are automatically determined in an attempt to evenly distribute the documents into the specified number of buckets.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/
+ * @internal
  */
-class BucketAutoStage implements StageInterface, OperatorInterface
+final class BucketAutoStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/BucketStage.php
+++ b/src/Builder/Stage/BucketStage.php
@@ -28,8 +28,9 @@ use function is_array;
  * Categorizes incoming documents into groups, called buckets, based on a specified expression and bucket boundaries.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/
+ * @internal
  */
-class BucketStage implements StageInterface, OperatorInterface
+final class BucketStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/ChangeStreamSplitLargeEventStage.php
+++ b/src/Builder/Stage/ChangeStreamSplitLargeEventStage.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\StageInterface;
  * You can only use $changeStreamSplitLargeEvent in a $changeStream pipeline and it must be the final stage in the pipeline.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/changeStreamSplitLargeEvent/
+ * @internal
  */
-class ChangeStreamSplitLargeEventStage implements StageInterface, OperatorInterface
+final class ChangeStreamSplitLargeEventStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/ChangeStreamStage.php
+++ b/src/Builder/Stage/ChangeStreamStage.php
@@ -21,8 +21,9 @@ use stdClass;
  * Returns a Change Stream cursor for the collection or database. This stage can only occur once in an aggregation pipeline and it must occur as the first stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/changeStream/
+ * @internal
  */
-class ChangeStreamStage implements StageInterface, OperatorInterface
+final class ChangeStreamStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/CollStatsStage.php
+++ b/src/Builder/Stage/CollStatsStage.php
@@ -20,8 +20,9 @@ use stdClass;
  * Returns statistics regarding a collection or view.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/
+ * @internal
  */
-class CollStatsStage implements StageInterface, OperatorInterface
+final class CollStatsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/CountStage.php
+++ b/src/Builder/Stage/CountStage.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Distinct from the $count aggregation accumulator.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/count/
+ * @internal
  */
-class CountStage implements StageInterface, OperatorInterface
+final class CountStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/CurrentOpStage.php
+++ b/src/Builder/Stage/CurrentOpStage.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Returns information on active and/or dormant operations for the MongoDB deployment. To run, use the db.aggregate() method.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/
+ * @internal
  */
-class CurrentOpStage implements StageInterface, OperatorInterface
+final class CurrentOpStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/DensifyStage.php
+++ b/src/Builder/Stage/DensifyStage.php
@@ -26,8 +26,9 @@ use function is_array;
  * Creates new documents in a sequence of documents where certain values in a field are missing.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/densify/
+ * @internal
  */
-class DensifyStage implements StageInterface, OperatorInterface
+final class DensifyStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/DocumentsStage.php
+++ b/src/Builder/Stage/DocumentsStage.php
@@ -23,8 +23,9 @@ use function is_array;
  * Returns literal documents from input values.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/documents/
+ * @internal
  */
-class DocumentsStage implements StageInterface, OperatorInterface
+final class DocumentsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/FacetStage.php
+++ b/src/Builder/Stage/FacetStage.php
@@ -23,8 +23,9 @@ use function is_string;
  * Processes multiple aggregation pipelines within a single stage on the same set of input documents. Enables the creation of multi-faceted aggregations capable of characterizing data across multiple dimensions, or facets, in a single stage.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/facet/
+ * @internal
  */
-class FacetStage implements StageInterface, OperatorInterface
+final class FacetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/FillStage.php
+++ b/src/Builder/Stage/FillStage.php
@@ -26,8 +26,9 @@ use function is_array;
  * Populates null and missing field values within documents.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/fill/
+ * @internal
  */
-class FillStage implements StageInterface, OperatorInterface
+final class FillStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/GeoNearStage.php
+++ b/src/Builder/Stage/GeoNearStage.php
@@ -27,8 +27,9 @@ use function is_array;
  * Returns an ordered stream of documents based on the proximity to a geospatial point. Incorporates the functionality of $match, $sort, and $limit for geospatial data. The output documents include an additional distance field and can include a location identifier field.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/
+ * @internal
  */
-class GeoNearStage implements StageInterface, OperatorInterface
+final class GeoNearStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/GraphLookupStage.php
+++ b/src/Builder/Stage/GraphLookupStage.php
@@ -28,8 +28,9 @@ use function is_array;
  * Performs a recursive search on a collection. To each output document, adds a new array field that contains the traversal results of the recursive search for that document.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/
+ * @internal
  */
-class GraphLookupStage implements StageInterface, OperatorInterface
+final class GraphLookupStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/GroupStage.php
+++ b/src/Builder/Stage/GroupStage.php
@@ -25,8 +25,9 @@ use function is_string;
  * Groups input documents by a specified identifier expression and applies the accumulator expression(s), if specified, to each group. Consumes all input documents and outputs one document per each distinct group. The output documents only contain the identifier field and, if specified, accumulated fields.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/
+ * @internal
  */
-class GroupStage implements StageInterface, OperatorInterface
+final class GroupStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Group;
 

--- a/src/Builder/Stage/IndexStatsStage.php
+++ b/src/Builder/Stage/IndexStatsStage.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Returns statistics regarding the use of each index for the collection.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/indexStats/
+ * @internal
  */
-class IndexStatsStage implements StageInterface, OperatorInterface
+final class IndexStatsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/LimitStage.php
+++ b/src/Builder/Stage/LimitStage.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Passes the first n documents unmodified to the pipeline where n is the specified limit. For each input document, outputs either one document (for the first n documents) or zero documents (after the first n documents).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/limit/
+ * @internal
  */
-class LimitStage implements StageInterface, OperatorInterface
+final class LimitStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/ListLocalSessionsStage.php
+++ b/src/Builder/Stage/ListLocalSessionsStage.php
@@ -23,8 +23,9 @@ use function is_array;
  * Lists all active sessions recently in use on the currently connected mongos or mongod instance. These sessions may have not yet propagated to the system.sessions collection.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listLocalSessions/
+ * @internal
  */
-class ListLocalSessionsStage implements StageInterface, OperatorInterface
+final class ListLocalSessionsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/ListSampledQueriesStage.php
+++ b/src/Builder/Stage/ListSampledQueriesStage.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Lists sampled queries for all collections or a specific collection.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSampledQueries/
+ * @internal
  */
-class ListSampledQueriesStage implements StageInterface, OperatorInterface
+final class ListSampledQueriesStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/ListSearchIndexesStage.php
+++ b/src/Builder/Stage/ListSearchIndexesStage.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Returns information about existing Atlas Search indexes on a specified collection.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSearchIndexes/
+ * @internal
  */
-class ListSearchIndexesStage implements StageInterface, OperatorInterface
+final class ListSearchIndexesStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/ListSessionsStage.php
+++ b/src/Builder/Stage/ListSessionsStage.php
@@ -23,8 +23,9 @@ use function is_array;
  * Lists all sessions that have been active long enough to propagate to the system.sessions collection.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/listSessions/
+ * @internal
  */
-class ListSessionsStage implements StageInterface, OperatorInterface
+final class ListSessionsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/LookupStage.php
+++ b/src/Builder/Stage/LookupStage.php
@@ -27,8 +27,9 @@ use function is_array;
  * Performs a left outer join to another collection in the same database to filter in documents from the "joined" collection for processing.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/
+ * @internal
  */
-class LookupStage implements StageInterface, OperatorInterface
+final class LookupStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/MatchStage.php
+++ b/src/Builder/Stage/MatchStage.php
@@ -20,8 +20,9 @@ use function is_array;
  * Filters the document stream to allow only matching documents to pass unmodified into the next pipeline stage. $match uses standard MongoDB queries. For each input document, outputs either one document (a match) or zero documents (no match).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
+ * @internal
  */
-class MatchStage implements StageInterface, OperatorInterface
+final class MatchStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/MergeStage.php
+++ b/src/Builder/Stage/MergeStage.php
@@ -28,8 +28,9 @@ use function is_array;
  * New in MongoDB 4.2.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/merge/
+ * @internal
  */
-class MergeStage implements StageInterface, OperatorInterface
+final class MergeStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/OutStage.php
+++ b/src/Builder/Stage/OutStage.php
@@ -19,8 +19,9 @@ use stdClass;
  * Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
+ * @internal
  */
-class OutStage implements StageInterface, OperatorInterface
+final class OutStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/PlanCacheStatsStage.php
+++ b/src/Builder/Stage/PlanCacheStatsStage.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Returns plan cache information for a collection.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/planCacheStats/
+ * @internal
  */
-class PlanCacheStatsStage implements StageInterface, OperatorInterface
+final class PlanCacheStatsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/ProjectStage.php
+++ b/src/Builder/Stage/ProjectStage.php
@@ -22,8 +22,9 @@ use function is_string;
  * Reshapes each document in the stream, such as by adding new fields or removing existing fields. For each input document, outputs one document.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/
+ * @internal
  */
-class ProjectStage implements StageInterface, OperatorInterface
+final class ProjectStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/RedactStage.php
+++ b/src/Builder/Stage/RedactStage.php
@@ -19,8 +19,9 @@ use stdClass;
  * Reshapes each document in the stream by restricting the content for each document based on information stored in the documents themselves. Incorporates the functionality of $project and $match. Can be used to implement field level redaction. For each input document, outputs either one or zero documents.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/
+ * @internal
  */
-class RedactStage implements StageInterface, OperatorInterface
+final class RedactStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/ReplaceRootStage.php
+++ b/src/Builder/Stage/ReplaceRootStage.php
@@ -20,8 +20,9 @@ use stdClass;
  * Replaces a document with the specified embedded document. The operation replaces all existing fields in the input document, including the _id field. Specify a document embedded in the input document to promote the embedded document to the top level.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/
+ * @internal
  */
-class ReplaceRootStage implements StageInterface, OperatorInterface
+final class ReplaceRootStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/ReplaceWithStage.php
+++ b/src/Builder/Stage/ReplaceWithStage.php
@@ -21,8 +21,9 @@ use stdClass;
  * Alias for $replaceRoot.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/
+ * @internal
  */
-class ReplaceWithStage implements StageInterface, OperatorInterface
+final class ReplaceWithStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/SampleStage.php
+++ b/src/Builder/Stage/SampleStage.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Randomly selects the specified number of documents from its input.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/
+ * @internal
  */
-class SampleStage implements StageInterface, OperatorInterface
+final class SampleStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/SearchMetaStage.php
+++ b/src/Builder/Stage/SearchMetaStage.php
@@ -20,8 +20,9 @@ use stdClass;
  * NOTE: $searchMeta is only available for MongoDB Atlas clusters running MongoDB v4.4.9 or higher, and is not available for self-managed deployments.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/searchMeta/
+ * @internal
  */
-class SearchMetaStage implements StageInterface, OperatorInterface
+final class SearchMetaStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/SearchStage.php
+++ b/src/Builder/Stage/SearchStage.php
@@ -20,8 +20,9 @@ use stdClass;
  * NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/search/
+ * @internal
  */
-class SearchStage implements StageInterface, OperatorInterface
+final class SearchStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/SetStage.php
+++ b/src/Builder/Stage/SetStage.php
@@ -23,8 +23,9 @@ use function is_string;
  * Alias for $addFields.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/
+ * @internal
  */
-class SetStage implements StageInterface, OperatorInterface
+final class SetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/SetWindowFieldsStage.php
+++ b/src/Builder/Stage/SetWindowFieldsStage.php
@@ -23,8 +23,9 @@ use stdClass;
  * New in MongoDB 5.0.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/
+ * @internal
  */
-class SetWindowFieldsStage implements StageInterface, OperatorInterface
+final class SetWindowFieldsStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/ShardedDataDistributionStage.php
+++ b/src/Builder/Stage/ShardedDataDistributionStage.php
@@ -17,8 +17,9 @@ use MongoDB\Builder\Type\StageInterface;
  * New in MongoDB 6.0.3.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/shardedDataDistribution/
+ * @internal
  */
-class ShardedDataDistributionStage implements StageInterface, OperatorInterface
+final class ShardedDataDistributionStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/SkipStage.php
+++ b/src/Builder/Stage/SkipStage.php
@@ -16,8 +16,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Skips the first n documents where n is the specified skip number and passes the remaining documents unmodified to the pipeline. For each input document, outputs either zero documents (for the first n documents) or one document (if after the first n documents).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/skip/
+ * @internal
  */
-class SkipStage implements StageInterface, OperatorInterface
+final class SkipStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/SortByCountStage.php
+++ b/src/Builder/Stage/SortByCountStage.php
@@ -19,8 +19,9 @@ use stdClass;
  * Groups incoming documents based on the value of a specified expression, then computes the count of documents in each distinct group.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/
+ * @internal
  */
-class SortByCountStage implements StageInterface, OperatorInterface
+final class SortByCountStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/SortStage.php
+++ b/src/Builder/Stage/SortStage.php
@@ -23,8 +23,9 @@ use function is_string;
  * Reorders the document stream by a specified sort key. Only the order changes; the documents remain unmodified. For each input document, outputs one document.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/
+ * @internal
  */
-class SortStage implements StageInterface, OperatorInterface
+final class SortStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/UnionWithStage.php
+++ b/src/Builder/Stage/UnionWithStage.php
@@ -25,8 +25,9 @@ use function is_array;
  * New in MongoDB 4.4.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unionWith/
+ * @internal
  */
-class UnionWithStage implements StageInterface, OperatorInterface
+final class UnionWithStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Stage/UnsetStage.php
+++ b/src/Builder/Stage/UnsetStage.php
@@ -21,8 +21,9 @@ use function array_is_list;
  * Alias for $project stage that removes or excludes fields.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unset/
+ * @internal
  */
-class UnsetStage implements StageInterface, OperatorInterface
+final class UnsetStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Single;
 

--- a/src/Builder/Stage/UnwindStage.php
+++ b/src/Builder/Stage/UnwindStage.php
@@ -18,8 +18,9 @@ use MongoDB\Builder\Type\StageInterface;
  * Deconstructs an array field from the input documents to output a document for each element. Each output document replaces the array with an element value. For each input document, outputs n documents where n is the number of array elements and can be zero for an empty array.
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/
+ * @internal
  */
-class UnwindStage implements StageInterface, OperatorInterface
+final class UnwindStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
 

--- a/src/Builder/Type/CombinedFieldQuery.php
+++ b/src/Builder/Type/CombinedFieldQuery.php
@@ -23,8 +23,10 @@ use function str_starts_with;
 
 /**
  * List of field queries that apply to the same field path.
+ *
+ * @internal
  */
-class CombinedFieldQuery implements FieldQueryInterface
+final class CombinedFieldQuery implements FieldQueryInterface
 {
     /** @var list<QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null> $fieldQueries */
     public readonly array $fieldQueries;

--- a/src/Builder/Type/Encode.php
+++ b/src/Builder/Type/Encode.php
@@ -10,6 +10,7 @@ use MongoDB\Builder\BuilderEncoder;
  * Defines how to encode a stage or an operator into BSON.
  *
  * @see BuilderEncoder
+ * @internal
  */
 enum Encode
 {

--- a/src/Builder/Type/OutputWindow.php
+++ b/src/Builder/Type/OutputWindow.php
@@ -23,7 +23,7 @@ use function sprintf;
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setWindowFields/
  */
-class OutputWindow implements WindowInterface
+final class OutputWindow implements WindowInterface
 {
     /**
      * Function used to initialize the state. The init function receives its arguments from the initArgs array expression.


### PR DESCRIPTION
Most of the classes don't need to be used outside of the factory methods. Mark them as internal and final. This can be changed later if necessary.
This allows us to make changes as needed to this classes.