### PR TITLE
PHPLIB-1600 Accept `stdClass` objects in `BSONDocument` constructor

### DIFF
--- a/src/Model/BSONDocument.php
+++ b/src/Model/BSONDocument.php
@@ -52,10 +52,10 @@ class BSONDocument extends ArrayObject implements JsonSerializable, Serializable
      * by default.
      *
      * @see https://php.net/arrayobject.construct
-     * @param object|array<string, mixed> $input
+     * @param array<string, mixed>|stdClass $input
      * @psalm-param class-string<ArrayIterator<string,mixed>>|class-string<ArrayObject<string,mixed>> $iteratorClass
      */
-    public function __construct(array|object $input = [], int $flags = ArrayObject::ARRAY_AS_PROPS, string $iteratorClass = ArrayIterator::class)
+    public function __construct(array|stdClass $input = [], int $flags = ArrayObject::ARRAY_AS_PROPS, string $iteratorClass = ArrayIterator::class)
     {
         parent::__construct($input, $flags, $iteratorClass);
     }

--- a/src/Model/BSONDocument.php
+++ b/src/Model/BSONDocument.php
@@ -52,10 +52,10 @@ class BSONDocument extends ArrayObject implements JsonSerializable, Serializable
      * by default.
      *
      * @see https://php.net/arrayobject.construct
-     * @param array<string, mixed> $input
+     * @param object|array<string, mixed> $input
      * @psalm-param class-string<ArrayIterator<string,mixed>>|class-string<ArrayObject<string,mixed>> $iteratorClass
      */
-    public function __construct(array $input = [], int $flags = ArrayObject::ARRAY_AS_PROPS, string $iteratorClass = ArrayIterator::class)
+    public function __construct(array|object $input = [], int $flags = ArrayObject::ARRAY_AS_PROPS, string $iteratorClass = ArrayIterator::class)
     {
         parent::__construct($input, $flags, $iteratorClass);
     }

--- a/tests/Model/BSONDocumentTest.php
+++ b/tests/Model/BSONDocumentTest.php
@@ -25,18 +25,9 @@ class BSONDocumentTest extends TestCase
 
     public function testConstructorWithStandardObject(): void
     {
-        $document = new BSONDocument((object) ['foo' => 'bar']);
-        $this->assertSame('bar', $document->foo);
-    }
-
-    public function testConstructorWithClassObject(): void
-    {
-        $document = new BSONDocument(new class () {
-            public string $foo = 'bar';
-            protected string $baz = 'qux';
-        });
-        $this->assertSame('bar', $document->foo);
-        $this->assertObjectNotHasProperty('baz', $document);
+        $object = (object) ['foo' => 'bar'];
+        $document = new BSONDocument($object);
+        $this->assertEquals($object, $document->bsonSerialize());
     }
 
     public function testBsonSerializeCastsToObject(): void

--- a/tests/Model/BSONDocumentTest.php
+++ b/tests/Model/BSONDocumentTest.php
@@ -23,6 +23,22 @@ class BSONDocumentTest extends TestCase
         $this->assertSame('bar', $document->foo);
     }
 
+    public function testConstructorWithStandardObject(): void
+    {
+        $document = new BSONDocument((object) ['foo' => 'bar']);
+        $this->assertSame('bar', $document->foo);
+    }
+
+    public function testConstructorWithClassObject(): void
+    {
+        $document = new BSONDocument(new class () {
+            public string $foo = 'bar';
+            protected string $baz = 'qux';
+        });
+        $this->assertSame('bar', $document->foo);
+        $this->assertObjectNotHasProperty('baz', $document);
+    }
+
     public function testBsonSerializeCastsToObject(): void
     {
         $data = [0 => 'foo', 2 => 'bar'];


### PR DESCRIPTION
Fixes PHPLIB-1600
Fixes https://github.com/mongodb/mongo-php-library/issues/1549

Only `stdClass` objects are allowed, because other types of objects can have private/protected properties and we don't what to define the rule for this properties (keep or skip).