### PR TITLE
Lock drivers-evergreen-tools to a working version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
           submodules: true
 
       - id: setup-mongodb
-        uses: mongodb-labs/drivers-evergreen-tools@master
+        uses: mongodb-labs/drivers-evergreen-tools@81c6b49dd61e833229d750084f9f3c71b31acd8d
         with:
           version: ${{ matrix.mongodb-version }}
           topology: ${{ matrix.topology }}


### PR DESCRIPTION
The job doesn't work starting https://github.com/mongodb-labs/drivers-evergreen-tools/commit/50f50f9c039b4f13932e4d26c3cea1e1a732f881