### PR TITLE
PHPLIB-1609 Don't mandate the use of "distanceField" in `$geoNear`

### DIFF
--- a/generator/config/stage/geoNear.yaml
+++ b/generator/config/stage/geoNear.yaml
@@ -11,6 +11,7 @@ arguments:
         name: distanceField
         type:
             - string
+        optional: true
         description: |
             The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
     -

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -248,8 +248,8 @@ trait FactoryTrait
      * Returns an ordered stream of documents based on the proximity to a geospatial point. Incorporates the functionality of $match, $sort, and $limit for geospatial data. The output documents include an additional distance field and can include a location identifier field.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/
-     * @param string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
      * @param Document|ResolvesToObject|Serializable|array|stdClass $near The point for which to find the closest documents.
+     * @param Optional|string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
      * @param Optional|Decimal128|Int64|float|int $distanceMultiplier The factor to multiply all distances returned by the query. For example, use the distanceMultiplier to convert radians, as returned by a spherical query, to kilometers by multiplying by the radius of the Earth.
      * @param Optional|string $includeLocs This specifies the output field that identifies the location used to calculate the distance. This option is useful when a location field contains multiple locations. To specify a field within an embedded document, use dot notation.
      * @param Optional|string $key Specify the geospatial indexed field to use when calculating the distance.
@@ -265,8 +265,8 @@ trait FactoryTrait
      * Default: false.
      */
     public static function geoNear(
-        string $distanceField,
         Document|Serializable|ResolvesToObject|stdClass|array $near,
+        Optional|string $distanceField = Optional::Undefined,
         Optional|Decimal128|Int64|float|int $distanceMultiplier = Optional::Undefined,
         Optional|string $includeLocs = Optional::Undefined,
         Optional|string $key = Optional::Undefined,
@@ -275,7 +275,7 @@ trait FactoryTrait
         Optional|QueryInterface|array $query = Optional::Undefined,
         Optional|bool $spherical = Optional::Undefined,
     ): GeoNearStage {
-        return new GeoNearStage($distanceField, $near, $distanceMultiplier, $includeLocs, $key, $maxDistance, $minDistance, $query, $spherical);
+        return new GeoNearStage($near, $distanceField, $distanceMultiplier, $includeLocs, $key, $maxDistance, $minDistance, $query, $spherical);
     }
 
     /**

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -295,8 +295,8 @@ trait FluentFactoryTrait
      * Returns an ordered stream of documents based on the proximity to a geospatial point. Incorporates the functionality of $match, $sort, and $limit for geospatial data. The output documents include an additional distance field and can include a location identifier field.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/geoNear/
-     * @param string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
      * @param Document|ResolvesToObject|Serializable|array|stdClass $near The point for which to find the closest documents.
+     * @param Optional|string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
      * @param Optional|Decimal128|Int64|float|int $distanceMultiplier The factor to multiply all distances returned by the query. For example, use the distanceMultiplier to convert radians, as returned by a spherical query, to kilometers by multiplying by the radius of the Earth.
      * @param Optional|string $includeLocs This specifies the output field that identifies the location used to calculate the distance. This option is useful when a location field contains multiple locations. To specify a field within an embedded document, use dot notation.
      * @param Optional|string $key Specify the geospatial indexed field to use when calculating the distance.
@@ -312,8 +312,8 @@ trait FluentFactoryTrait
      * Default: false.
      */
     public function geoNear(
-        string $distanceField,
         Document|Serializable|ResolvesToObject|stdClass|array $near,
+        Optional|string $distanceField = Optional::Undefined,
         Optional|Decimal128|Int64|int|float $distanceMultiplier = Optional::Undefined,
         Optional|string $includeLocs = Optional::Undefined,
         Optional|string $key = Optional::Undefined,
@@ -322,7 +322,7 @@ trait FluentFactoryTrait
         Optional|QueryInterface|array $query = Optional::Undefined,
         Optional|bool $spherical = Optional::Undefined,
     ): static {
-        $this->pipeline[] = Stage::geoNear($distanceField, $near, $distanceMultiplier, $includeLocs, $key, $maxDistance, $minDistance, $query, $spherical);
+        $this->pipeline[] = Stage::geoNear($near, $distanceField, $distanceMultiplier, $includeLocs, $key, $maxDistance, $minDistance, $query, $spherical);
 
         return $this;
     }

--- a/src/Builder/Stage/GeoNearStage.php
+++ b/src/Builder/Stage/GeoNearStage.php
@@ -35,8 +35,8 @@ final class GeoNearStage implements StageInterface, OperatorInterface
     public const NAME = '$geoNear';
 
     public const PROPERTIES = [
-        'distanceField' => 'distanceField',
         'near' => 'near',
+        'distanceField' => 'distanceField',
         'distanceMultiplier' => 'distanceMultiplier',
         'includeLocs' => 'includeLocs',
         'key' => 'key',
@@ -46,11 +46,11 @@ final class GeoNearStage implements StageInterface, OperatorInterface
         'spherical' => 'spherical',
     ];
 
-    /** @var string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation. */
-    public readonly string $distanceField;
-
     /** @var Document|ResolvesToObject|Serializable|array|stdClass $near The point for which to find the closest documents. */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array $near;
+
+    /** @var Optional|string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation. */
+    public readonly Optional|string $distanceField;
 
     /** @var Optional|Decimal128|Int64|float|int $distanceMultiplier The factor to multiply all distances returned by the query. For example, use the distanceMultiplier to convert radians, as returned by a spherical query, to kilometers by multiplying by the radius of the Earth. */
     public readonly Optional|Decimal128|Int64|float|int $distanceMultiplier;
@@ -88,8 +88,8 @@ final class GeoNearStage implements StageInterface, OperatorInterface
     public readonly Optional|bool $spherical;
 
     /**
-     * @param string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
      * @param Document|ResolvesToObject|Serializable|array|stdClass $near The point for which to find the closest documents.
+     * @param Optional|string $distanceField The output field that contains the calculated distance. To specify a field within an embedded document, use dot notation.
      * @param Optional|Decimal128|Int64|float|int $distanceMultiplier The factor to multiply all distances returned by the query. For example, use the distanceMultiplier to convert radians, as returned by a spherical query, to kilometers by multiplying by the radius of the Earth.
      * @param Optional|string $includeLocs This specifies the output field that identifies the location used to calculate the distance. This option is useful when a location field contains multiple locations. To specify a field within an embedded document, use dot notation.
      * @param Optional|string $key Specify the geospatial indexed field to use when calculating the distance.
@@ -105,8 +105,8 @@ final class GeoNearStage implements StageInterface, OperatorInterface
      * Default: false.
      */
     public function __construct(
-        string $distanceField,
         Document|Serializable|ResolvesToObject|stdClass|array $near,
+        Optional|string $distanceField = Optional::Undefined,
         Optional|Decimal128|Int64|float|int $distanceMultiplier = Optional::Undefined,
         Optional|string $includeLocs = Optional::Undefined,
         Optional|string $key = Optional::Undefined,
@@ -115,8 +115,8 @@ final class GeoNearStage implements StageInterface, OperatorInterface
         Optional|QueryInterface|array $query = Optional::Undefined,
         Optional|bool $spherical = Optional::Undefined,
     ) {
-        $this->distanceField = $distanceField;
         $this->near = $near;
+        $this->distanceField = $distanceField;
         $this->distanceMultiplier = $distanceMultiplier;
         $this->includeLocs = $includeLocs;
         $this->key = $key;


### PR DESCRIPTION
Fix PHPLIB-1609 see DRIVERS-3071

The `$geoNear` distanceField argument is now optional for queries on non-timeseries collections.