### PR TITLE
PHPLIB-1598 Use named types for enums

### DIFF
--- a/generator/config/accumulator/bottom.yaml
+++ b/generator/config/accumulator/bottom.yaml
@@ -12,7 +12,7 @@ arguments:
     -
         name: sortBy
         type:
-            - object # SortSpec
+            - sortBy
         description: |
             Specifies the order of results, with syntax similar to $sort.
     -

--- a/generator/config/accumulator/bottomN.yaml
+++ b/generator/config/accumulator/bottomN.yaml
@@ -19,7 +19,7 @@ arguments:
     -
         name: sortBy
         type:
-            - object # SortSpec
+            - sortBy
         description: |
             Specifies the order of results, with syntax similar to $sort.
     -

--- a/generator/config/accumulator/median.yaml
+++ b/generator/config/accumulator/median.yaml
@@ -22,7 +22,7 @@ arguments:
     -
         name: method
         type:
-            - string # AccumulatorPercentile
+            - accumulatorPercentile
         description: |
             The method that mongod uses to calculate the 50th percentile value. The method must be 'approximate'.
 tests:

--- a/generator/config/accumulator/percentile.yaml
+++ b/generator/config/accumulator/percentile.yaml
@@ -32,7 +32,7 @@ arguments:
     -
         name: method
         type:
-            - string # AccumulatorPercentile
+            - accumulatorPercentile
         description: |
             The method that mongod uses to calculate the percentile value. The method must be 'approximate'.
 tests:

--- a/generator/config/accumulator/top.yaml
+++ b/generator/config/accumulator/top.yaml
@@ -13,7 +13,7 @@ arguments:
     -
         name: sortBy
         type:
-            - object # SortSpec
+            - sortBy
         description: |
             Specifies the order of results, with syntax similar to $sort.
     -

--- a/generator/config/accumulator/topN.yaml
+++ b/generator/config/accumulator/topN.yaml
@@ -19,7 +19,7 @@ arguments:
     -
         name: sortBy
         type:
-            - object # SortSpec
+            - sortBy
         description: |
             Specifies the order of results, with syntax similar to $sort.
     -

--- a/generator/config/expression/median.yaml
+++ b/generator/config/expression/median.yaml
@@ -22,7 +22,7 @@ arguments:
     -
         name: method
         type:
-            - string # AccumulatorPercentile
+            - accumulatorPercentile
         description: |
             The method that mongod uses to calculate the 50th percentile value. The method must be 'approximate'.
 tests:

--- a/generator/config/expression/percentile.yaml
+++ b/generator/config/expression/percentile.yaml
@@ -32,7 +32,7 @@ arguments:
     -
         name: method
         type:
-            - string # AccumulatorPercentile
+            - accumulatorPercentile
         description: |
             The method that mongod uses to calculate the percentile value. The method must be 'approximate'.
 tests:

--- a/generator/config/expression/sortArray.yaml
+++ b/generator/config/expression/sortArray.yaml
@@ -18,9 +18,9 @@ arguments:
     -
         name: sortBy
         type:
-            - object # SortSpec
             - int
             - sortSpec
+            - sortBy
         description: |
             The document specifies a sort ordering.
 tests:

--- a/generator/config/expressions.php
+++ b/generator/config/expressions.php
@@ -131,45 +131,36 @@ return $expressions + [
     ],
 
     // @todo add enum values
-    'Granularity' => [
+    'granularity' => [
         'acceptedTypes' => [...$bsonTypes['string']],
     ],
-    'FullDocument' => [
+    'fullDocument' => [
         'acceptedTypes' => [...$bsonTypes['string']],
     ],
-    'FullDocumentBeforeChange' => [
+    'fullDocumentBeforeChange' => [
         'acceptedTypes' => [...$bsonTypes['string']],
     ],
-    'AccumulatorPercentile' => [
+    'accumulatorPercentile' => [
         'acceptedTypes' => [...$bsonTypes['string']],
     ],
-    'WhenMatched' => [
+    'whenMatched' => [
         'acceptedTypes' => [...$bsonTypes['string']],
     ],
-    'WhenNotMatched' => [
+    'whenNotMatched' => [
         'acceptedTypes' => [...$bsonTypes['string']],
     ],
 
     // @todo create specific model classes factories
-    'OutCollection' => [
+    'outCollection' => [
         'acceptedTypes' => [...$bsonTypes['object']],
     ],
-    'CollStats' => [
+    'range' => [
         'acceptedTypes' => [...$bsonTypes['object']],
     ],
-    'Range' => [
+    'sortBy' => [
         'acceptedTypes' => [...$bsonTypes['object']],
     ],
-    'FillOut' => [
-        'acceptedTypes' => [...$bsonTypes['object']],
-    ],
-    'SortSpec' => [
-        'acceptedTypes' => [...$bsonTypes['object']],
-    ],
-    'Window' => [
-        'acceptedTypes' => [...$bsonTypes['object']],
-    ],
-    'GeoPoint' => [
+    'geoPoint' => [
         'acceptedTypes' => [...$bsonTypes['object']],
     ],
 

--- a/generator/config/schema.json
+++ b/generator/config/schema.json
@@ -9,7 +9,7 @@
                 "name": {
                     "$comment": "The name of the operator. Must start with a $",
                     "type": "string",
-                    "pattern": "^\\$[a-z0-9][a-zA-Z0-9]*$"
+                    "pattern": "^\\$?[a-z][a-zA-Z0-9]*$"
                 },
                 "link": {
                     "$comment": "The link to the operator's documentation on MongoDB's website.",
@@ -122,6 +122,16 @@
                             "timeUnit",
                             "sortSpec",
                             "any",
+                            "granularity",
+                            "fullDocument",
+                            "fullDocumentBeforeChange",
+                            "accumulatorPercentile",
+                            "whenMatched",
+                            "whenNotMatched",
+                            "outCollection",
+                            "range",
+                            "sortBy",
+                            "geoPoint",
                             "resolvesToNumber", "numberFieldPath", "number",
                             "resolvesToDouble", "doubleFieldPath", "double",
                             "resolvesToString", "stringFieldPath", "string",

--- a/generator/config/stage/bucketAuto.yaml
+++ b/generator/config/stage/bucketAuto.yaml
@@ -30,7 +30,7 @@ arguments:
     -
         name: granularity
         type:
-            - object # Granularity
+            - granularity
         optional: true
         description: |
             A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.

--- a/generator/config/stage/changeStream.yaml
+++ b/generator/config/stage/changeStream.yaml
@@ -17,14 +17,14 @@ arguments:
     -
         name: fullDocument
         type:
-            - string # FullDocument
+            - fullDocument
         optional: true
         description: |
             Specifies whether change notifications include a copy of the full document when modified by update operations.
     -
         name: fullDocumentBeforeChange
         type:
-            - string # FullDocumentBeforeChange
+            - fullDocumentBeforeChange
         optional: true
         description: |
             Valid values are "off", "whenAvailable", or "required". If set to "off", the "fullDocumentBeforeChange" field of the output document is always omitted. If set to "whenAvailable", the "fullDocumentBeforeChange" field will be populated with the pre-image of the document modified by the current change event if such a pre-image is available, and will be omitted otherwise. If set to "required", then the "fullDocumentBeforeChange" field is always populated and an exception is thrown if the pre-image is not              available.

--- a/generator/config/stage/densify.yaml
+++ b/generator/config/stage/densify.yaml
@@ -25,7 +25,7 @@ arguments:
     -
         name: range
         type:
-            - object # Range
+            - range
         description: |
             Specification for range based densification.
 tests:

--- a/generator/config/stage/fill.yaml
+++ b/generator/config/stage/fill.yaml
@@ -29,7 +29,7 @@ arguments:
     -
         name: sortBy
         type:
-            - object # SortSpec
+            - sortBy
         optional: true
         description: |
             Specifies the field or fields to sort the documents within each partition. Uses the same syntax as the $sort stage.

--- a/generator/config/stage/geoNear.yaml
+++ b/generator/config/stage/geoNear.yaml
@@ -53,7 +53,7 @@ arguments:
     -
         name: near
         type:
-            - object # GeoPoint
+            - geoPoint
             - resolvesToObject
         description: |
             The point for which to find the closest documents.

--- a/generator/config/stage/merge.yaml
+++ b/generator/config/stage/merge.yaml
@@ -12,7 +12,7 @@ arguments:
         name: into
         type:
             - string
-            - object # OutCollection
+            - outCollection
         description: |
             The output collection.
     -
@@ -33,7 +33,7 @@ arguments:
     -
         name: whenMatched
         type:
-            - string # WhenMatched
+            - whenMatched
             - pipeline
         optional: true
         description: |
@@ -41,7 +41,7 @@ arguments:
     -
         name: whenNotMatched
         type:
-            - string # WhenNotMatched
+            - whenNotMatched
         optional: true
         description: |
             The behavior of $merge if a result document does not match an existing document in the out collection.

--- a/generator/config/stage/out.yaml
+++ b/generator/config/stage/out.yaml
@@ -10,7 +10,7 @@ arguments:
     -   name: coll
         type:
             - string
-            - object # OutCollection
+            - outCollection
         description: |
             Target database name to write documents from $out to.
 tests:

--- a/generator/config/stage/setWindowFields.yaml
+++ b/generator/config/stage/setWindowFields.yaml
@@ -11,7 +11,7 @@ arguments:
     -
         name: sortBy
         type:
-            - object # SortSpec
+            - sortBy
         description: |
             Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting.
     -

--- a/src/Builder/Stage/BucketAutoStage.php
+++ b/src/Builder/Stage/BucketAutoStage.php
@@ -49,24 +49,24 @@ final class BucketAutoStage implements StageInterface, OperatorInterface
     public readonly Optional|Document|Serializable|stdClass|array $output;
 
     /**
-     * @var Optional|Document|Serializable|array|stdClass $granularity A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
+     * @var Optional|string $granularity A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
      * Available only if the all groupBy values are numeric and none of them are NaN.
      */
-    public readonly Optional|Document|Serializable|stdClass|array $granularity;
+    public readonly Optional|string $granularity;
 
     /**
      * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * @param int $buckets A positive 32-bit integer that specifies the number of buckets into which input documents are grouped.
      * @param Optional|Document|Serializable|array|stdClass $output A document that specifies the fields to include in the output documents in addition to the _id field. To specify the field to include, you must use accumulator expressions.
      * The default count field is not included in the output document when output is specified. Explicitly specify the count expression as part of the output document to include it.
-     * @param Optional|Document|Serializable|array|stdClass $granularity A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
+     * @param Optional|string $granularity A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
      * Available only if the all groupBy values are numeric and none of them are NaN.
      */
     public function __construct(
         Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
         int $buckets,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
-        Optional|Document|Serializable|stdClass|array $granularity = Optional::Undefined,
+        Optional|string $granularity = Optional::Undefined,
     ) {
         $this->groupBy = $groupBy;
         $this->buckets = $buckets;

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -79,14 +79,14 @@ trait FactoryTrait
      * @param int $buckets A positive 32-bit integer that specifies the number of buckets into which input documents are grouped.
      * @param Optional|Document|Serializable|array|stdClass $output A document that specifies the fields to include in the output documents in addition to the _id field. To specify the field to include, you must use accumulator expressions.
      * The default count field is not included in the output document when output is specified. Explicitly specify the count expression as part of the output document to include it.
-     * @param Optional|Document|Serializable|array|stdClass $granularity A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
+     * @param Optional|string $granularity A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
      * Available only if the all groupBy values are numeric and none of them are NaN.
      */
     public static function bucketAuto(
         Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
         int $buckets,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
-        Optional|Document|Serializable|stdClass|array $granularity = Optional::Undefined,
+        Optional|string $granularity = Optional::Undefined,
     ): BucketAutoStage {
         return new BucketAutoStage($groupBy, $buckets, $output, $granularity);
     }

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -106,14 +106,14 @@ trait FluentFactoryTrait
      * @param int $buckets A positive 32-bit integer that specifies the number of buckets into which input documents are grouped.
      * @param Optional|Document|Serializable|array|stdClass $output A document that specifies the fields to include in the output documents in addition to the _id field. To specify the field to include, you must use accumulator expressions.
      * The default count field is not included in the output document when output is specified. Explicitly specify the count expression as part of the output document to include it.
-     * @param Optional|Document|Serializable|array|stdClass $granularity A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
+     * @param Optional|string $granularity A string that specifies the preferred number series to use to ensure that the calculated boundary edges end on preferred round numbers or their powers of 10.
      * Available only if the all groupBy values are numeric and none of them are NaN.
      */
     public function bucketAuto(
         Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $groupBy,
         int $buckets,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
-        Optional|Document|Serializable|stdClass|array $granularity = Optional::Undefined,
+        Optional|string $granularity = Optional::Undefined,
     ): static {
         $this->pipeline[] = Stage::bucketAuto($groupBy, $buckets, $output, $granularity);
 


### PR DESCRIPTION
Fix PHPLIB-1598

When a field accepts a specific list of values, I use a named type. It will be possible to improve the parameter types later by specifying the list of accepted values.