### PR TITLE
Lock drivers-evergreen-tools version

### DIFF
--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -119,6 +119,10 @@ functions:
             cp -R ${PROJECT_DIRECTORY}/ $DRIVERS_TOOLS
           else
             git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git --depth 1 $DRIVERS_TOOLS
+
+            # Last working version working
+            git -C $DRIVERS_TOOLS fetch --depth=1 origin 6a0686e0194d30b0a259404839c3e8bf9be12a5b
+            git -C $DRIVERS_TOOLS checkout 6a0686e0194d30b0a259404839c3e8bf9be12a5b
           fi
           echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
           python-version: '3.13'
 
       - id: setup-mongodb
-        uses: mongodb-labs/drivers-evergreen-tools@master
+        uses: mongodb-labs/drivers-evergreen-tools@6a0686e0194d30b0a259404839c3e8bf9be12a5b
         with:
           version: ${{ matrix.mongodb-version }}
           topology: ${{ matrix.topology }}


### PR DESCRIPTION
Lock evergreen tools version, as the commit https://github.com/mongodb-labs/drivers-evergreen-tools/commit/50d13abef3759ad76bd594cb67fc8cc01e6648bb broke the build.

This can be reverted once fixed by https://github.com/mongodb/mongo-php-library/pull/1577