### PR TITLE
Fix typo in Yaml config

### DIFF
--- a/generator/config/accumulator/accumulator.yaml
+++ b/generator/config/accumulator/accumulator.yaml
@@ -73,7 +73,7 @@ tests:
                                     function(state, numCopies) {
                                         return { count: state.count + 1, sum: state.sum + numCopies }
                                     }
-                            accumulateArgs: [ "$copies" ],
+                            accumulateArgs: [ "$copies" ]
                             merge:
                                 $code: |-
                                     function(state1, state2) {


### PR DESCRIPTION
New error when updating `symfony/yaml` in the generator to v7.2.3:
> Unexpected token "," at line 76 (near "accumulateArgs: [ "$copies" ],"). 

The change was made somewhere around this PR:
- https://github.com/symfony/symfony/pull/59381
- https://github.com/symfony/symfony/pull/59349
