### PR TITLE
PHPLIB-1619: Pass ReadPreference via options array for executeCommand()

### DIFF
--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -334,7 +334,7 @@ abstract class FunctionalTestCase extends TestCase
         $cursor = $this->manager->executeCommand(
             'admin',
             new Command(['getParameter' => 1, 'featureCompatibilityVersion' => 1]),
-            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY),
+            ['readPreference' => $readPreference ?: new ReadPreference(ReadPreference::PRIMARY)],
         );
 
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);
@@ -357,7 +357,7 @@ abstract class FunctionalTestCase extends TestCase
         $buildInfo = $this->manager->executeCommand(
             $this->getDatabaseName(),
             new Command(['buildInfo' => 1]),
-            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY),
+            ['readPreference' => $readPreference ?: new ReadPreference(ReadPreference::PRIMARY)],
         )->toArray()[0];
 
         if (isset($buildInfo->version) && is_string($buildInfo->version)) {
@@ -372,7 +372,7 @@ abstract class FunctionalTestCase extends TestCase
         $cursor = $this->manager->executeCommand(
             $this->getDatabaseName(),
             new Command(['serverStatus' => 1]),
-            $readPreference ?: new ReadPreference(ReadPreference::PRIMARY),
+            ['readPreference' => $readPreference ?: new ReadPreference(ReadPreference::PRIMARY)],
         );
 
         $result = current($cursor->toArray());

--- a/tests/SpecTests/PrimaryStepDownSpecTest.php
+++ b/tests/SpecTests/PrimaryStepDownSpecTest.php
@@ -270,7 +270,7 @@ class PrimaryStepDownSpecTest extends FunctionalTestCase
         $cursor = $server->executeCommand(
             $this->getDatabaseName(),
             new Command(['serverStatus' => 1]),
-            new ReadPreference(ReadPreference::PRIMARY),
+            ['readPreference' => new ReadPreference(ReadPreference::PRIMARY)],
         );
 
         $cursor->setTypeMap(['root' => 'array', 'document' => 'array']);


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1619

Passing a ReadPreference directly was deprecated in PHPC 1.21 (PHPC-2489) and removed in 2.0 (PHPC-2485).