### PR TITLE
Fix interface for builderEncoder option in phpdoc

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -92,7 +92,7 @@ class Client
      *
      * Supported driver-specific options:
      *
-     *  * builderEncoder (MongoDB\Builder\Encoder): Encoder for query and
+     *  * builderEncoder (MongoDB\Codec\Encoder): Encoder for query and
      *    aggregation builders. If not given, the default encoder will be used.
      *
      *  * typeMap (array): Default type map for cursors and BSON documents.

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -114,7 +114,7 @@ class Collection
      *
      * Supported options:
      *
-     *  * builderEncoder (MongoDB\Builder\Encoder): Encoder for query and
+     *  * builderEncoder (MongoDB\Codec\Encoder): Encoder for query and
      *    aggregation builders. If not given, the default encoder will be used.
      *
      *  * codec (MongoDB\Codec\DocumentCodec): Codec used to decode documents

--- a/src/Database.php
+++ b/src/Database.php
@@ -90,7 +90,7 @@ class Database
      *
      * Supported options:
      *
-     *  * builderEncoder (MongoDB\Builder\Encoder): Encoder for query and
+     *  * builderEncoder (MongoDB\Codec\Encoder): Encoder for query and
      *    aggregation builders. If not given, the default encoder will be used.
      *
      *  * readConcern (MongoDB\Driver\ReadConcern): The default read concern to

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -98,7 +98,7 @@ class BulkWrite implements Executable
      *
      * Supported options for the bulk write operation:
      *
-     *  * builderEncoder (MongoDB\Builder\Encoder): Encoder for query and
+     *  * builderEncoder (MongoDB\Codec\Encoder): Encoder for query and
      *    aggregation builders. If not given, the default encoder will be used.
      *
      *  * bypassDocumentValidation (boolean): If true, allows the write to


### PR DESCRIPTION
Spotted in https://github.com/mongodb/docs-php-library/pull/200