### PR TITLE
PHPLIB-1634: Support encoding DateTimeInterface instances in aggregation builder

### DIFF
--- a/generator/config/expressions.php
+++ b/generator/config/expressions.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Type;
@@ -26,7 +27,7 @@ $bsonTypes = [
     'binData' => ['string', BSON\Binary::class],
     'objectId' => [BSON\ObjectId::class],
     'bool' => ['bool'],
-    'date' => [BSON\UTCDateTime::class],
+    'date' => [BSON\UTCDateTime::class, DateTimeInterface::class],
     'null' => ['null'],
     'regex' => [BSON\Regex::class],
     'javascript' => ['string', BSON\Javascript::class],
@@ -37,7 +38,7 @@ $bsonTypes = [
 ];
 
 // "any" accepts all the BSON types. No generic "object" or "mixed"
-$bsonTypes['any'] = ['bool', 'int', 'float', 'string', 'array', 'null', stdClass::class, BSON\Type::class];
+$bsonTypes['any'] = ['bool', 'int', 'float', 'string', 'array', 'null', stdClass::class, BSON\Type::class, DateTimeInterface::class];
 
 // "number" accepts all the numeric types
 $bsonTypes['number'] = ['int', 'float', BSON\Int64::class, BSON\Decimal128::class];

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -248,6 +248,8 @@
       <code><![CDATA[($value is NativeType ? BSONType : $value)]]></code>
       <code><![CDATA[($value is NativeType ? BSONType : $value)]]></code>
       <code><![CDATA[($value is NativeType ? BSONType : $value)]]></code>
+      <code><![CDATA[($value is NativeType ? BSONType : $value)]]></code>
+      <code><![CDATA[($value is NativeType ? BSONType : $value)]]></code>
     </InvalidReturnType>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$value]]></code>

--- a/src/Builder/Accumulator/AddToSetAccumulator.php
+++ b/src/Builder/Accumulator/AddToSetAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
@@ -29,14 +30,15 @@ final class AddToSetAccumulator implements AccumulatorInterface, WindowInterface
     public const NAME = '$addToSet';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Accumulator/BottomAccumulator.php
+++ b/src/Builder/Accumulator/BottomAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -34,16 +35,16 @@ final class BottomAccumulator implements AccumulatorInterface, WindowInterface, 
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
     public readonly Document|Serializable|stdClass|array $sortBy;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
 
     /**
      * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
      */
     public function __construct(
         Document|Serializable|stdClass|array $sortBy,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
     ) {
         $this->sortBy = $sortBy;
         $this->output = $output;

--- a/src/Builder/Accumulator/BottomNAccumulator.php
+++ b/src/Builder/Accumulator/BottomNAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -43,18 +44,18 @@ final class BottomNAccumulator implements AccumulatorInterface, WindowInterface,
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
     public readonly Document|Serializable|stdClass|array $sortBy;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
 
     /**
      * @param ResolvesToInt|int|string $n Limits the number of results per group and has to be a positive integral expression that is either a constant or depends on the _id value for $group.
      * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
      */
     public function __construct(
         ResolvesToInt|int|string $n,
         Document|Serializable|stdClass|array $sortBy,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
     ) {
         if (is_string($n) && ! str_starts_with($n, '$')) {
             throw new InvalidArgumentException('Argument $n can be an expression, field paths and variable names must be prefixed by "$" or "$$".');

--- a/src/Builder/Accumulator/DerivativeAccumulator.php
+++ b/src/Builder/Accumulator/DerivativeAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
@@ -37,8 +38,8 @@ final class DerivativeAccumulator implements WindowInterface, OperatorInterface
     public const NAME = '$derivative';
     public const PROPERTIES = ['input' => 'input', 'unit' => 'unit'];
 
-    /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input */
-    public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input;
+    /** @var DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input */
+    public readonly DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input;
 
     /**
      * @var Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
@@ -47,12 +48,12 @@ final class DerivativeAccumulator implements WindowInterface, OperatorInterface
     public readonly Optional|ResolvesToString|TimeUnit|string $unit;
 
     /**
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input
      * @param Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
     public function __construct(
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input,
         Optional|ResolvesToString|TimeUnit|string $unit = Optional::Undefined,
     ) {
         if (is_string($input) && ! str_starts_with($input, '$')) {

--- a/src/Builder/Accumulator/FactoryTrait.php
+++ b/src/Builder/Accumulator/FactoryTrait.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
@@ -63,10 +64,10 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/addToSet/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function addToSet(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): AddToSetAccumulator {
         return new AddToSetAccumulator($expression);
     }
@@ -89,11 +90,11 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom/
      * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
      */
     public static function bottom(
         Document|Serializable|stdClass|array $sortBy,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
     ): BottomAccumulator {
         return new BottomAccumulator($sortBy, $output);
     }
@@ -106,12 +107,12 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN/
      * @param ResolvesToInt|int|string $n Limits the number of results per group and has to be a positive integral expression that is either a constant or depends on the _id value for $group.
      * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
      */
     public static function bottomN(
         ResolvesToInt|int|string $n,
         Document|Serializable|stdClass|array $sortBy,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
     ): BottomNAccumulator {
         return new BottomNAccumulator($n, $sortBy, $output);
     }
@@ -174,12 +175,12 @@ trait FactoryTrait
      * New in MongoDB 5.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/derivative/
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input
      * @param Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
     public static function derivative(
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input,
         Optional|ResolvesToString|TimeUnit|string $unit = Optional::Undefined,
     ): DerivativeAccumulator {
         return new DerivativeAccumulator($input, $unit);
@@ -221,10 +222,10 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/first/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function first(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): FirstAccumulator {
         return new FirstAccumulator($expression);
     }
@@ -235,11 +236,11 @@ trait FactoryTrait
      * If the group contains fewer than n elements, $firstN returns all elements in the group.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/firstN/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input An expression that resolves to the array from which to return n elements.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input An expression that resolves to the array from which to return n elements.
      * @param ResolvesToInt|int|string $n A positive integral expression that is either a constant or depends on the _id value for $group.
      */
     public static function firstN(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
         ResolvesToInt|int|string $n,
     ): FirstNAccumulator {
         return new FirstNAccumulator($input, $n);
@@ -250,12 +251,12 @@ trait FactoryTrait
      * New in MongoDB 5.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/integral/
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input
      * @param Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
     public static function integral(
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input,
         Optional|ResolvesToString|TimeUnit|string $unit = Optional::Undefined,
     ): IntegralAccumulator {
         return new IntegralAccumulator($input, $unit);
@@ -266,10 +267,10 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/last/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function last(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): LastAccumulator {
         return new LastAccumulator($expression);
     }
@@ -310,10 +311,10 @@ trait FactoryTrait
      * New in MongoDB 5.2.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/locf/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function locf(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): LocfAccumulator {
         return new LocfAccumulator($expression);
     }
@@ -323,10 +324,10 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function max(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): MaxAccumulator {
         return new MaxAccumulator($expression);
     }
@@ -381,10 +382,10 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function min(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): MinAccumulator {
         return new MinAccumulator($expression);
     }
@@ -433,10 +434,10 @@ trait FactoryTrait
      * Changed in MongoDB 5.0: Available in the $setWindowFields stage.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/push/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function push(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): PushAccumulator {
         return new PushAccumulator($expression);
     }
@@ -457,20 +458,20 @@ trait FactoryTrait
      * New in MongoDB 5.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/shift/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Specifies an expression to evaluate and return in the output.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Specifies an expression to evaluate and return in the output.
      * @param int $by Specifies an integer with a numeric document position relative to the current document in the output.
      * For example:
      * 1 specifies the document position after the current document.
      * -1 specifies the document position before the current document.
      * -2 specifies the document position that is two positions before the current document.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default Specifies an optional default expression to evaluate if the document position is outside of the implicit $setWindowFields stage window. The implicit window contains all the documents in the partition.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default Specifies an optional default expression to evaluate if the document position is outside of the implicit $setWindowFields stage window. The implicit window contains all the documents in the partition.
      * The default expression must evaluate to a constant value.
      * If you do not specify a default expression, $shift returns null for documents whose positions are outside of the implicit $setWindowFields stage window.
      */
     public static function shift(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
         int $by,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default,
     ): ShiftAccumulator {
         return new ShiftAccumulator($output, $by, $default);
     }
@@ -523,11 +524,11 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/top/
      * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
      */
     public static function top(
         Document|Serializable|stdClass|array $sortBy,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
     ): TopAccumulator {
         return new TopAccumulator($sortBy, $output);
     }
@@ -541,12 +542,12 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN/
      * @param ResolvesToInt|int|string $n limits the number of results per group and has to be a positive integral expression that is either a constant or depends on the _id value for $group.
      * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
      */
     public static function topN(
         ResolvesToInt|int|string $n,
         Document|Serializable|stdClass|array $sortBy,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
     ): TopNAccumulator {
         return new TopNAccumulator($n, $sortBy, $output);
     }

--- a/src/Builder/Accumulator/FirstAccumulator.php
+++ b/src/Builder/Accumulator/FirstAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
@@ -29,14 +30,15 @@ final class FirstAccumulator implements AccumulatorInterface, WindowInterface, O
     public const NAME = '$first';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Accumulator/FirstNAccumulator.php
+++ b/src/Builder/Accumulator/FirstNAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Expression\ResolvesToInt;
 use MongoDB\Builder\Type\AccumulatorInterface;
@@ -35,18 +36,18 @@ final class FirstNAccumulator implements AccumulatorInterface, WindowInterface, 
     public const NAME = '$firstN';
     public const PROPERTIES = ['input' => 'input', 'n' => 'n'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input An expression that resolves to the array from which to return n elements. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input An expression that resolves to the array from which to return n elements. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
 
     /** @var ResolvesToInt|int|string $n A positive integral expression that is either a constant or depends on the _id value for $group. */
     public readonly ResolvesToInt|int|string $n;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input An expression that resolves to the array from which to return n elements.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input An expression that resolves to the array from which to return n elements.
      * @param ResolvesToInt|int|string $n A positive integral expression that is either a constant or depends on the _id value for $group.
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
         ResolvesToInt|int|string $n,
     ) {
         $this->input = $input;

--- a/src/Builder/Accumulator/IntegralAccumulator.php
+++ b/src/Builder/Accumulator/IntegralAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
@@ -37,8 +38,8 @@ final class IntegralAccumulator implements WindowInterface, OperatorInterface
     public const NAME = '$integral';
     public const PROPERTIES = ['input' => 'input', 'unit' => 'unit'];
 
-    /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input */
-    public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input;
+    /** @var DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input */
+    public readonly DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input;
 
     /**
      * @var Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
@@ -47,12 +48,12 @@ final class IntegralAccumulator implements WindowInterface, OperatorInterface
     public readonly Optional|ResolvesToString|TimeUnit|string $unit;
 
     /**
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $input
      * @param Optional|ResolvesToString|TimeUnit|string $unit A string that specifies the time unit. Use one of these strings: "week", "day","hour", "minute", "second", "millisecond".
      * If the sortBy field is not a date, you must omit a unit. If you specify a unit, you must specify a date in the sortBy field.
      */
     public function __construct(
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $input,
         Optional|ResolvesToString|TimeUnit|string $unit = Optional::Undefined,
     ) {
         if (is_string($input) && ! str_starts_with($input, '$')) {

--- a/src/Builder/Accumulator/LastAccumulator.php
+++ b/src/Builder/Accumulator/LastAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
@@ -29,14 +30,15 @@ final class LastAccumulator implements AccumulatorInterface, WindowInterface, Op
     public const NAME = '$last';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Accumulator/LocfAccumulator.php
+++ b/src/Builder/Accumulator/LocfAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -29,14 +30,15 @@ final class LocfAccumulator implements WindowInterface, OperatorInterface
     public const NAME = '$locf';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Accumulator/MaxAccumulator.php
+++ b/src/Builder/Accumulator/MaxAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
@@ -29,14 +30,15 @@ final class MaxAccumulator implements AccumulatorInterface, WindowInterface, Ope
     public const NAME = '$max';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Accumulator/MinAccumulator.php
+++ b/src/Builder/Accumulator/MinAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
@@ -29,14 +30,15 @@ final class MinAccumulator implements AccumulatorInterface, WindowInterface, Ope
     public const NAME = '$min';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Accumulator/PushAccumulator.php
+++ b/src/Builder/Accumulator/PushAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\AccumulatorInterface;
 use MongoDB\Builder\Type\Encode;
@@ -29,14 +30,15 @@ final class PushAccumulator implements AccumulatorInterface, WindowInterface, Op
     public const NAME = '$push';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Accumulator/ShiftAccumulator.php
+++ b/src/Builder/Accumulator/ShiftAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -28,8 +29,8 @@ final class ShiftAccumulator implements WindowInterface, OperatorInterface
     public const NAME = '$shift';
     public const PROPERTIES = ['output' => 'output', 'by' => 'by', 'default' => 'default'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Specifies an expression to evaluate and return in the output. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Specifies an expression to evaluate and return in the output. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
 
     /**
      * @var int $by Specifies an integer with a numeric document position relative to the current document in the output.
@@ -41,27 +42,27 @@ final class ShiftAccumulator implements WindowInterface, OperatorInterface
     public readonly int $by;
 
     /**
-     * @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default Specifies an optional default expression to evaluate if the document position is outside of the implicit $setWindowFields stage window. The implicit window contains all the documents in the partition.
+     * @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default Specifies an optional default expression to evaluate if the document position is outside of the implicit $setWindowFields stage window. The implicit window contains all the documents in the partition.
      * The default expression must evaluate to a constant value.
      * If you do not specify a default expression, $shift returns null for documents whose positions are outside of the implicit $setWindowFields stage window.
      */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default;
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Specifies an expression to evaluate and return in the output.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Specifies an expression to evaluate and return in the output.
      * @param int $by Specifies an integer with a numeric document position relative to the current document in the output.
      * For example:
      * 1 specifies the document position after the current document.
      * -1 specifies the document position before the current document.
      * -2 specifies the document position that is two positions before the current document.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default Specifies an optional default expression to evaluate if the document position is outside of the implicit $setWindowFields stage window. The implicit window contains all the documents in the partition.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default Specifies an optional default expression to evaluate if the document position is outside of the implicit $setWindowFields stage window. The implicit window contains all the documents in the partition.
      * The default expression must evaluate to a constant value.
      * If you do not specify a default expression, $shift returns null for documents whose positions are outside of the implicit $setWindowFields stage window.
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
         int $by,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default,
     ) {
         $this->output = $output;
         $this->by = $by;

--- a/src/Builder/Accumulator/TopAccumulator.php
+++ b/src/Builder/Accumulator/TopAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -35,16 +36,16 @@ final class TopAccumulator implements AccumulatorInterface, OperatorInterface
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
     public readonly Document|Serializable|stdClass|array $sortBy;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
 
     /**
      * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
      */
     public function __construct(
         Document|Serializable|stdClass|array $sortBy,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
     ) {
         $this->sortBy = $sortBy;
         $this->output = $output;

--- a/src/Builder/Accumulator/TopNAccumulator.php
+++ b/src/Builder/Accumulator/TopNAccumulator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Accumulator;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -43,18 +44,18 @@ final class TopNAccumulator implements AccumulatorInterface, OperatorInterface
     /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
     public readonly Document|Serializable|stdClass|array $sortBy;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
 
     /**
      * @param ResolvesToInt|int|string $n limits the number of results per group and has to be a positive integral expression that is either a constant or depends on the _id value for $group.
      * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the group and can be any expression.
      */
     public function __construct(
         ResolvesToInt|int|string $n,
         Document|Serializable|stdClass|array $sortBy,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
     ) {
         if (is_string($n) && ! str_starts_with($n, '$')) {
             throw new InvalidArgumentException('Argument $n can be an expression, field paths and variable names must be prefixed by "$" or "$$".');

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder;
 
 use DateTimeInterface;
-use MongoDB\BSON\UTCDateTime;
+use MongoDB\BSON\Type;
 use MongoDB\Builder\Encoder\CombinedFieldQueryEncoder;
 use MongoDB\Builder\Encoder\DateTimeEncoder;
 use MongoDB\Builder\Encoder\DictionaryEncoder;
@@ -34,10 +34,10 @@ use stdClass;
 use function array_key_exists;
 use function is_object;
 
-/** @template-implements Encoder<stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
+/** @template-implements Encoder<Type|stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
 final class BuilderEncoder implements Encoder
 {
-    /** @template-use EncodeIfSupported<stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
+    /** @template-use EncodeIfSupported<Type|stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
     use EncodeIfSupported;
 
     /** @var array<class-string, class-string<ExpressionEncoder>> */
@@ -71,7 +71,7 @@ final class BuilderEncoder implements Encoder
         return (bool) $this->getEncoderFor($value)?->canEncode($value);
     }
 
-    public function encode(mixed $value): stdClass|array|string|int|UTCDateTime
+    public function encode(mixed $value): Type|stdClass|array|string|int
     {
         $encoder = $this->getEncoderFor($value);
 

--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder;
 
+use DateTimeInterface;
+use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\Encoder\CombinedFieldQueryEncoder;
+use MongoDB\Builder\Encoder\DateTimeEncoder;
 use MongoDB\Builder\Encoder\DictionaryEncoder;
 use MongoDB\Builder\Encoder\ExpressionEncoder;
 use MongoDB\Builder\Encoder\FieldPathEncoder;
@@ -47,6 +50,7 @@ final class BuilderEncoder implements Encoder
         QueryObject::class => QueryEncoder::class,
         OutputWindow::class => OutputWindowEncoder::class,
         OperatorInterface::class => OperatorEncoder::class,
+        DateTimeInterface::class => DateTimeEncoder::class,
     ];
 
     /** @var array<class-string, ExpressionEncoder|null> */
@@ -67,7 +71,7 @@ final class BuilderEncoder implements Encoder
         return (bool) $this->getEncoderFor($value)?->canEncode($value);
     }
 
-    public function encode(mixed $value): stdClass|array|string|int
+    public function encode(mixed $value): stdClass|array|string|int|UTCDateTime
     {
         $encoder = $this->getEncoderFor($value);
 

--- a/src/Builder/Encoder/AbstractExpressionEncoder.php
+++ b/src/Builder/Encoder/AbstractExpressionEncoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
+use MongoDB\BSON\UTCDateTime;
 use MongoDB\Builder\BuilderEncoder;
 use stdClass;
 
@@ -11,7 +12,7 @@ use function get_object_vars;
 use function is_array;
 
 /**
- * @template BSONType of stdClass|array|string|int
+ * @template BSONType of stdClass|array|string|int|UTCDateTime
  * @template NativeType
  * @template-implements ExpressionEncoder<BSONType, NativeType>
  * @internal

--- a/src/Builder/Encoder/AbstractExpressionEncoder.php
+++ b/src/Builder/Encoder/AbstractExpressionEncoder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
-use MongoDB\BSON\UTCDateTime;
+use MongoDB\BSON\Type;
 use MongoDB\Builder\BuilderEncoder;
 use stdClass;
 
@@ -12,7 +12,7 @@ use function get_object_vars;
 use function is_array;
 
 /**
- * @template BSONType of stdClass|array|string|int|UTCDateTime
+ * @template BSONType of Type|stdClass|array|string|int
  * @template NativeType
  * @template-implements ExpressionEncoder<BSONType, NativeType>
  * @internal
@@ -26,6 +26,7 @@ abstract class AbstractExpressionEncoder implements ExpressionEncoder
     /**
      * Nested arrays and objects must be encoded recursively.
      *
+     * @psalm-template T
      * @psalm-param T $value
      *
      * @psalm-return (T is stdClass ? stdClass : (T is array ? array : mixed))

--- a/src/Builder/Encoder/DateTimeEncoder.php
+++ b/src/Builder/Encoder/DateTimeEncoder.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Encoder;
+
+use DateTimeInterface;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Codec\EncodeIfSupported;
+use MongoDB\Exception\UnsupportedValueException;
+
+/**
+ * @template-extends AbstractExpressionEncoder<UTCDateTime, DateTimeInterface>
+ * @internal
+ */
+final class DateTimeEncoder extends AbstractExpressionEncoder
+{
+    /** @template-use EncodeIfSupported<UTCDateTime, DateTimeInterface> */
+    use EncodeIfSupported;
+
+    public function canEncode(mixed $value): bool
+    {
+        return $value instanceof DateTimeInterface;
+    }
+
+    public function encode(mixed $value): UTCDateTime
+    {
+        if (! $this->canEncode($value)) {
+            throw UnsupportedValueException::invalidEncodableValue($value);
+        }
+
+        return new UTCDateTime($value);
+    }
+}

--- a/src/Builder/Encoder/DateTimeEncoder.php
+++ b/src/Builder/Encoder/DateTimeEncoder.php
@@ -18,6 +18,7 @@ final class DateTimeEncoder extends AbstractExpressionEncoder
     /** @template-use EncodeIfSupported<UTCDateTime, DateTimeInterface> */
     use EncodeIfSupported;
 
+    /** @psalm-assert-if-true DateTimeInterface $value */
     public function canEncode(mixed $value): bool
     {
         return $value instanceof DateTimeInterface;

--- a/src/Builder/Encoder/ExpressionEncoder.php
+++ b/src/Builder/Encoder/ExpressionEncoder.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
+use MongoDB\BSON\Type;
 use MongoDB\Builder\BuilderEncoder;
 use MongoDB\Codec\Encoder;
 use stdClass;
 
 /**
- * @template BSONType of stdClass|array|string|int
+ * @template BSONType of Type|stdClass|array|string|int
  * @template NativeType
  * @template-extends Encoder<BSONType, NativeType>
  * @internal

--- a/src/Builder/Expression/AddOperator.php
+++ b/src/Builder/Expression/AddOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
@@ -29,15 +30,15 @@ final class AddOperator implements ResolvesToInt, ResolvesToLong, ResolvesToDoub
     public const NAME = '$add';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var list<Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string> $expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date. */
+    /** @var list<DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string> $expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date. */
     public readonly array $expression;
 
     /**
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string ...$expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date.
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string ...$expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date.
      * @no-named-arguments
      */
     public function __construct(
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string ...$expression,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string ...$expression,
     ) {
         if (\count($expression) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));

--- a/src/Builder/Expression/AndOperator.php
+++ b/src/Builder/Expression/AndOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\Type;
@@ -31,15 +32,15 @@ final class AndOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$and';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var list<Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|null|stdClass|string> $expression */
+    /** @var list<DateTimeInterface|Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;
 
     /**
-     * @param Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|null|stdClass|string ...$expression
      * @no-named-arguments
      */
     public function __construct(
-        Decimal128|Int64|Type|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        DateTimeInterface|Decimal128|Int64|Type|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ) {
         if (\count($expression) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));

--- a/src/Builder/Expression/CaseOperator.php
+++ b/src/Builder/Expression/CaseOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -34,16 +35,16 @@ final class CaseOperator implements SwitchBranchInterface, OperatorInterface
     /** @var ResolvesToBool|bool|string $case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here. */
     public readonly ResolvesToBool|bool|string $case;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then;
 
     /**
      * @param ResolvesToBool|bool|string $case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression.
      */
     public function __construct(
         ResolvesToBool|bool|string $case,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
     ) {
         if (is_string($case) && ! str_starts_with($case, '$')) {
             throw new InvalidArgumentException('Argument $case can be an expression, field paths and variable names must be prefixed by "$" or "$$".');

--- a/src/Builder/Expression/CmpOperator.php
+++ b/src/Builder/Expression/CmpOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,19 +27,19 @@ final class CmpOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$cmp';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;

--- a/src/Builder/Expression/CondOperator.php
+++ b/src/Builder/Expression/CondOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -33,21 +34,21 @@ final class CondOperator implements ResolvesToAny, OperatorInterface
     /** @var ResolvesToBool|bool|string $if */
     public readonly ResolvesToBool|bool|string $if;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $else */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $else;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $else */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $else;
 
     /**
      * @param ResolvesToBool|bool|string $if
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $else
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $else
      */
     public function __construct(
         ResolvesToBool|bool|string $if,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $else,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $else,
     ) {
         if (is_string($if) && ! str_starts_with($if, '$')) {
             throw new InvalidArgumentException('Argument $if can be an expression, field paths and variable names must be prefixed by "$" or "$$".');

--- a/src/Builder/Expression/ConvertOperator.php
+++ b/src/Builder/Expression/ConvertOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -28,37 +29,37 @@ final class ConvertOperator implements ResolvesToAny, OperatorInterface
     public const NAME = '$convert';
     public const PROPERTIES = ['input' => 'input', 'to' => 'to', 'onError' => 'onError', 'onNull' => 'onNull'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
 
     /** @var ResolvesToInt|ResolvesToString|int|string $to */
     public readonly ResolvesToInt|ResolvesToString|int|string $to;
 
     /**
-     * @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError The value to return on encountering an error during conversion, including unsupported type conversions. The arguments can be any valid expression.
+     * @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError The value to return on encountering an error during conversion, including unsupported type conversions. The arguments can be any valid expression.
      * If unspecified, the operation throws an error upon encountering an error and stops.
      */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError;
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError;
 
     /**
-     * @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the input is null or missing. The arguments can be any valid expression.
+     * @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the input is null or missing. The arguments can be any valid expression.
      * If unspecified, $convert returns null if the input is null or missing.
      */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull;
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
      * @param ResolvesToInt|ResolvesToString|int|string $to
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError The value to return on encountering an error during conversion, including unsupported type conversions. The arguments can be any valid expression.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError The value to return on encountering an error during conversion, including unsupported type conversions. The arguments can be any valid expression.
      * If unspecified, the operation throws an error upon encountering an error and stops.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the input is null or missing. The arguments can be any valid expression.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the input is null or missing. The arguments can be any valid expression.
      * If unspecified, $convert returns null if the input is null or missing.
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
         ResolvesToInt|ResolvesToString|int|string $to,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
     ) {
         $this->input = $input;
         $this->to = $to;

--- a/src/Builder/Expression/DateAddOperator.php
+++ b/src/Builder/Expression/DateAddOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
@@ -33,8 +34,8 @@ final class DateAddOperator implements ResolvesToDate, OperatorInterface
     public const NAME = '$dateAdd';
     public const PROPERTIES = ['startDate' => 'startDate', 'unit' => 'unit', 'amount' => 'amount', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate;
 
     /** @var ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate. */
     public readonly ResolvesToString|TimeUnit|string $unit;
@@ -46,13 +47,13 @@ final class DateAddOperator implements ResolvesToDate, OperatorInterface
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate.
      * @param Int64|ResolvesToInt|ResolvesToLong|int|string $amount
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
         ResolvesToString|TimeUnit|string $unit,
         Int64|ResolvesToInt|ResolvesToLong|int|string $amount,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,

--- a/src/Builder/Expression/DateDiffOperator.php
+++ b/src/Builder/Expression/DateDiffOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -39,11 +40,11 @@ final class DateDiffOperator implements ResolvesToInt, OperatorInterface
         'startOfWeek' => 'startOfWeek',
     ];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate;
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $endDate;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $endDate;
 
     /** @var ResolvesToString|TimeUnit|string $unit The time measurement unit between the startDate and endDate */
     public readonly ResolvesToString|TimeUnit|string $unit;
@@ -55,15 +56,15 @@ final class DateDiffOperator implements ResolvesToInt, OperatorInterface
     public readonly Optional|ResolvesToString|string $startOfWeek;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ResolvesToString|TimeUnit|string $unit The time measurement unit between the startDate and endDate
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      * @param Optional|ResolvesToString|string $startOfWeek Used when the unit is equal to week. Defaults to Sunday. The startOfWeek parameter is an expression that resolves to a case insensitive string
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $endDate,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $endDate,
         ResolvesToString|TimeUnit|string $unit,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
         Optional|ResolvesToString|string $startOfWeek = Optional::Undefined,

--- a/src/Builder/Expression/DateFromStringOperator.php
+++ b/src/Builder/Expression/DateFromStringOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -47,33 +48,33 @@ final class DateFromStringOperator implements ResolvesToDate, OperatorInterface
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError If $dateFromString encounters an error while parsing the given dateString, it outputs the result value of the provided onError expression. This result value can be of any type.
+     * @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError If $dateFromString encounters an error while parsing the given dateString, it outputs the result value of the provided onError expression. This result value can be of any type.
      * If you do not specify onError, $dateFromString throws an error if it cannot parse dateString.
      */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError;
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError;
 
     /**
-     * @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull If the dateString provided to $dateFromString is null or missing, it outputs the result value of the provided onNull expression. This result value can be of any type.
+     * @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull If the dateString provided to $dateFromString is null or missing, it outputs the result value of the provided onNull expression. This result value can be of any type.
      * If you do not specify onNull and dateString is null or missing, then $dateFromString outputs null.
      */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull;
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull;
 
     /**
      * @param ResolvesToString|string $dateString The date/time string to convert to a date object.
      * @param Optional|ResolvesToString|string $format The date format specification of the dateString. The format can be any expression that evaluates to a string literal, containing 0 or more format specifiers.
      * If unspecified, $dateFromString uses "%Y-%m-%dT%H:%M:%S.%LZ" as the default format but accepts a variety of formats and attempts to parse the dateString if possible.
      * @param Optional|ResolvesToString|string $timezone The time zone to use to format the date.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError If $dateFromString encounters an error while parsing the given dateString, it outputs the result value of the provided onError expression. This result value can be of any type.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError If $dateFromString encounters an error while parsing the given dateString, it outputs the result value of the provided onError expression. This result value can be of any type.
      * If you do not specify onError, $dateFromString throws an error if it cannot parse dateString.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull If the dateString provided to $dateFromString is null or missing, it outputs the result value of the provided onNull expression. This result value can be of any type.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull If the dateString provided to $dateFromString is null or missing, it outputs the result value of the provided onNull expression. This result value can be of any type.
      * If you do not specify onNull and dateString is null or missing, then $dateFromString outputs null.
      */
     public function __construct(
         ResolvesToString|string $dateString,
         Optional|ResolvesToString|string $format = Optional::Undefined,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
     ) {
         $this->dateString = $dateString;
         $this->format = $format;

--- a/src/Builder/Expression/DateSubtractOperator.php
+++ b/src/Builder/Expression/DateSubtractOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
@@ -33,8 +34,8 @@ final class DateSubtractOperator implements ResolvesToDate, OperatorInterface
     public const NAME = '$dateSubtract';
     public const PROPERTIES = ['startDate' => 'startDate', 'unit' => 'unit', 'amount' => 'amount', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate;
 
     /** @var ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate. */
     public readonly ResolvesToString|TimeUnit|string $unit;
@@ -46,13 +47,13 @@ final class DateSubtractOperator implements ResolvesToDate, OperatorInterface
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate.
      * @param Int64|ResolvesToInt|ResolvesToLong|int|string $amount
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
         ResolvesToString|TimeUnit|string $unit,
         Int64|ResolvesToInt|ResolvesToLong|int|string $amount,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,

--- a/src/Builder/Expression/DateToPartsOperator.php
+++ b/src/Builder/Expression/DateToPartsOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,8 +32,8 @@ final class DateToPartsOperator implements ResolvesToObject, OperatorInterface
     public const NAME = '$dateToParts';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone', 'iso8601' => 'iso8601'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The input date for which to return parts. date can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The input date for which to return parts. date can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
@@ -41,12 +42,12 @@ final class DateToPartsOperator implements ResolvesToObject, OperatorInterface
     public readonly Optional|bool $iso8601;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The input date for which to return parts. date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The input date for which to return parts. date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      * @param Optional|bool $iso8601 If set to true, modifies the output document to use ISO week date fields. Defaults to false.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
         Optional|bool $iso8601 = Optional::Undefined,
     ) {

--- a/src/Builder/Expression/DateToStringOperator.php
+++ b/src/Builder/Expression/DateToStringOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\Type;
@@ -34,8 +35,8 @@ final class DateToStringOperator implements ResolvesToString, OperatorInterface
     public const NAME = '$dateToString';
     public const PROPERTIES = ['date' => 'date', 'format' => 'format', 'timezone' => 'timezone', 'onNull' => 'onNull'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to convert to string. Must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to convert to string. Must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /**
      * @var Optional|ResolvesToString|string $format The date format specification of the dateString. The format can be any expression that evaluates to a string literal, containing 0 or more format specifiers.
@@ -47,24 +48,24 @@ final class DateToStringOperator implements ResolvesToString, OperatorInterface
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the date is null or missing.
+     * @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the date is null or missing.
      * If unspecified, $dateToString returns null if the date is null or missing.
      */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull;
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to convert to string. Must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to convert to string. Must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $format The date format specification of the dateString. The format can be any expression that evaluates to a string literal, containing 0 or more format specifiers.
      * If unspecified, $dateFromString uses "%Y-%m-%dT%H:%M:%S.%LZ" as the default format but accepts a variety of formats and attempts to parse the dateString if possible.
      * @param Optional|ResolvesToString|string $timezone The time zone to use to format the date.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the date is null or missing.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the date is null or missing.
      * If unspecified, $dateToString returns null if the date is null or missing.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $format = Optional::Undefined,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {
             throw new InvalidArgumentException('Argument $date can be an expression, field paths and variable names must be prefixed by "$" or "$$".');

--- a/src/Builder/Expression/DateTruncOperator.php
+++ b/src/Builder/Expression/DateTruncOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\ObjectId;
@@ -41,8 +42,8 @@ final class DateTruncOperator implements ResolvesToDate, OperatorInterface
         'startOfWeek' => 'startOfWeek',
     ];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /**
      * @var ResolvesToString|TimeUnit|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
@@ -66,7 +67,7 @@ final class DateTruncOperator implements ResolvesToDate, OperatorInterface
     public readonly Optional|string $startOfWeek;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ResolvesToString|TimeUnit|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
      * Together, binSize and unit specify the time period used in the $dateTrunc calculation.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int|string $binSize The numeric time value, specified as an expression that must resolve to a positive non-zero number. Defaults to 1.
@@ -76,7 +77,7 @@ final class DateTruncOperator implements ResolvesToDate, OperatorInterface
      * unit is week. Defaults to Sunday.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         ResolvesToString|TimeUnit|string $unit,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int|string $binSize = Optional::Undefined,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,

--- a/src/Builder/Expression/DayOfMonthOperator.php
+++ b/src/Builder/Expression/DayOfMonthOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class DayOfMonthOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$dayOfMonth';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/DayOfWeekOperator.php
+++ b/src/Builder/Expression/DayOfWeekOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class DayOfWeekOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$dayOfWeek';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/DayOfYearOperator.php
+++ b/src/Builder/Expression/DayOfYearOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class DayOfYearOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$dayOfYear';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/EqOperator.php
+++ b/src/Builder/Expression/EqOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,19 +27,19 @@ final class EqOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$eq';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
@@ -74,10 +75,10 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/add/
      * @no-named-arguments
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string ...$expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date.
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string ...$expression The arguments can be any valid expression as long as they resolve to either all numbers or to numbers and a date.
      */
     public static function add(
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string ...$expression,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string ...$expression,
     ): AddOperator {
         return new AddOperator(...$expression);
     }
@@ -99,10 +100,10 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/and/
      * @no-named-arguments
-     * @param Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|Decimal128|ExpressionInterface|Int64|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|Type|array|bool|float|int|null|stdClass|string ...$expression
      */
     public static function and(
-        Decimal128|Int64|Type|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        DateTimeInterface|Decimal128|Int64|Type|ResolvesToBool|ResolvesToNull|ResolvesToNumber|ResolvesToString|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ): AndOperator {
         return new AndOperator(...$expression);
     }
@@ -306,11 +307,11 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/switch/
      * @param ResolvesToBool|bool|string $case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then Can be any valid expression.
      */
     public static function case(
         ResolvesToBool|bool|string $case,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
     ): CaseOperator {
         return new CaseOperator($case, $then);
     }
@@ -330,12 +331,12 @@ trait FactoryTrait
      * Returns 0 if the two values are equivalent, 1 if the first value is greater than the second, and -1 if the first value is less than the second.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cmp/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public static function cmp(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ): CmpOperator {
         return new CmpOperator($expression1, $expression2);
     }
@@ -370,13 +371,13 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cond/
      * @param ResolvesToBool|bool|string $if
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $else
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $then
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $else
      */
     public static function cond(
         ResolvesToBool|bool|string $if,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $else,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $then,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $else,
     ): CondOperator {
         return new CondOperator($if, $then, $else);
     }
@@ -386,18 +387,18 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
      * @param ResolvesToInt|ResolvesToString|int|string $to
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError The value to return on encountering an error during conversion, including unsupported type conversions. The arguments can be any valid expression.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError The value to return on encountering an error during conversion, including unsupported type conversions. The arguments can be any valid expression.
      * If unspecified, the operation throws an error upon encountering an error and stops.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the input is null or missing. The arguments can be any valid expression.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the input is null or missing. The arguments can be any valid expression.
      * If unspecified, $convert returns null if the input is null or missing.
      */
     public static function convert(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
         ResolvesToInt|ResolvesToString|int|string $to,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
     ): ConvertOperator {
         return new ConvertOperator($input, $to, $onError, $onNull);
     }
@@ -430,13 +431,13 @@ trait FactoryTrait
      * Adds a number of time units to a date object.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate.
      * @param Int64|ResolvesToInt|ResolvesToLong|int|string $amount
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function dateAdd(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
         ResolvesToString|TimeUnit|string $unit,
         Int64|ResolvesToInt|ResolvesToLong|int|string $amount,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
@@ -448,15 +449,15 @@ trait FactoryTrait
      * Returns the difference between two dates.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateDiff/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The start of the time period. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $endDate The end of the time period. The endDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ResolvesToString|TimeUnit|string $unit The time measurement unit between the startDate and endDate
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      * @param Optional|ResolvesToString|string $startOfWeek Used when the unit is equal to week. Defaults to Sunday. The startOfWeek parameter is an expression that resolves to a case insensitive string
      */
     public static function dateDiff(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $endDate,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $endDate,
         ResolvesToString|TimeUnit|string $unit,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
         Optional|ResolvesToString|string $startOfWeek = Optional::Undefined,
@@ -504,17 +505,17 @@ trait FactoryTrait
      * @param Optional|ResolvesToString|string $format The date format specification of the dateString. The format can be any expression that evaluates to a string literal, containing 0 or more format specifiers.
      * If unspecified, $dateFromString uses "%Y-%m-%dT%H:%M:%S.%LZ" as the default format but accepts a variety of formats and attempts to parse the dateString if possible.
      * @param Optional|ResolvesToString|string $timezone The time zone to use to format the date.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError If $dateFromString encounters an error while parsing the given dateString, it outputs the result value of the provided onError expression. This result value can be of any type.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError If $dateFromString encounters an error while parsing the given dateString, it outputs the result value of the provided onError expression. This result value can be of any type.
      * If you do not specify onError, $dateFromString throws an error if it cannot parse dateString.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull If the dateString provided to $dateFromString is null or missing, it outputs the result value of the provided onNull expression. This result value can be of any type.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull If the dateString provided to $dateFromString is null or missing, it outputs the result value of the provided onNull expression. This result value can be of any type.
      * If you do not specify onNull and dateString is null or missing, then $dateFromString outputs null.
      */
     public static function dateFromString(
         ResolvesToString|string $dateString,
         Optional|ResolvesToString|string $format = Optional::Undefined,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
     ): DateFromStringOperator {
         return new DateFromStringOperator($dateString, $format, $timezone, $onError, $onNull);
     }
@@ -523,13 +524,13 @@ trait FactoryTrait
      * Subtracts a number of time units from a date object.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateSubtract/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $startDate The beginning date, in UTC, for the addition operation. The startDate can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ResolvesToString|TimeUnit|string $unit The unit used to measure the amount of time added to the startDate.
      * @param Int64|ResolvesToInt|ResolvesToLong|int|string $amount
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function dateSubtract(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $startDate,
         ResolvesToString|TimeUnit|string $unit,
         Int64|ResolvesToInt|ResolvesToLong|int|string $amount,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
@@ -541,12 +542,12 @@ trait FactoryTrait
      * Returns a document containing the constituent parts of a date.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToParts/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The input date for which to return parts. date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The input date for which to return parts. date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone to carry out the operation. $timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      * @param Optional|bool $iso8601 If set to true, modifies the output document to use ISO week date fields. Defaults to false.
      */
     public static function dateToParts(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
         Optional|bool $iso8601 = Optional::Undefined,
     ): DateToPartsOperator {
@@ -557,18 +558,18 @@ trait FactoryTrait
      * Returns the date as a formatted string.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToString/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to convert to string. Must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to convert to string. Must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $format The date format specification of the dateString. The format can be any expression that evaluates to a string literal, containing 0 or more format specifiers.
      * If unspecified, $dateFromString uses "%Y-%m-%dT%H:%M:%S.%LZ" as the default format but accepts a variety of formats and attempts to parse the dateString if possible.
      * @param Optional|ResolvesToString|string $timezone The time zone to use to format the date.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the date is null or missing.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the date is null or missing.
      * If unspecified, $dateToString returns null if the date is null or missing.
      */
     public static function dateToString(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $format = Optional::Undefined,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
     ): DateToStringOperator {
         return new DateToStringOperator($date, $format, $timezone, $onNull);
     }
@@ -577,7 +578,7 @@ trait FactoryTrait
      * Truncates a date.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateTrunc/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to truncate, specified in UTC. The date can be any expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param ResolvesToString|TimeUnit|string $unit The unit of time, specified as an expression that must resolve to one of these strings: year, quarter, week, month, day, hour, minute, second.
      * Together, binSize and unit specify the time period used in the $dateTrunc calculation.
      * @param Optional|Decimal128|Int64|ResolvesToNumber|float|int|string $binSize The numeric time value, specified as an expression that must resolve to a positive non-zero number. Defaults to 1.
@@ -587,7 +588,7 @@ trait FactoryTrait
      * unit is week. Defaults to Sunday.
      */
     public static function dateTrunc(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         ResolvesToString|TimeUnit|string $unit,
         Optional|Decimal128|Int64|ResolvesToNumber|float|int|string $binSize = Optional::Undefined,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
@@ -600,11 +601,11 @@ trait FactoryTrait
      * Returns the day of the month for a date as a number between 1 and 31.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfMonth/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function dayOfMonth(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): DayOfMonthOperator {
         return new DayOfMonthOperator($date, $timezone);
@@ -614,11 +615,11 @@ trait FactoryTrait
      * Returns the day of the week for a date as a number between 1 (Sunday) and 7 (Saturday).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfWeek/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function dayOfWeek(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): DayOfWeekOperator {
         return new DayOfWeekOperator($date, $timezone);
@@ -628,11 +629,11 @@ trait FactoryTrait
      * Returns the day of the year for a date as a number between 1 and 366 (leap year).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dayOfYear/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function dayOfYear(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): DayOfYearOperator {
         return new DayOfYearOperator($date, $timezone);
@@ -669,12 +670,12 @@ trait FactoryTrait
      * Returns true if the values are equivalent.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/eq/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public static function eq(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ): EqOperator {
         return new EqOperator($expression1, $expression2);
     }
@@ -770,12 +771,12 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/getField/
      * @param ResolvesToString|string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
      * If field begins with a dollar sign ($), place the field name inside of a $literal expression to return its value.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input Default: $$CURRENT
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input Default: $$CURRENT
      * A valid expression that contains the field for which you want to return a value. input must resolve to an object, missing, null, or undefined. If omitted, defaults to the document currently being processed in the pipeline ($$CURRENT).
      */
     public static function getField(
         ResolvesToString|string $field,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input = Optional::Undefined,
     ): GetFieldOperator {
         return new GetFieldOperator($field, $input);
     }
@@ -784,12 +785,12 @@ trait FactoryTrait
      * Returns true if the first value is greater than the second.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gt/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public static function gt(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ): GtOperator {
         return new GtOperator($expression1, $expression2);
     }
@@ -798,12 +799,12 @@ trait FactoryTrait
      * Returns true if the first value is greater than or equal to the second.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/gte/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public static function gte(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ): GteOperator {
         return new GteOperator($expression1, $expression2);
     }
@@ -812,11 +813,11 @@ trait FactoryTrait
      * Returns the hour for a date as a number between 0 and 23.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hour/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function hour(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): HourOperator {
         return new HourOperator($date, $timezone);
@@ -827,10 +828,10 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/
      * @no-named-arguments
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
      */
     public static function ifNull(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ): IfNullOperator {
         return new IfNullOperator(...$expression);
     }
@@ -839,11 +840,11 @@ trait FactoryTrait
      * Returns a boolean indicating whether a specified value is in an array.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/in/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression Any valid expression expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression Any valid expression expression.
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $array Any valid expression that resolves to an array.
      */
     public static function in(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
         PackedArray|ResolvesToArray|BSONArray|array|string $array,
     ): InOperator {
         return new InOperator($expression, $array);
@@ -856,7 +857,7 @@ trait FactoryTrait
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $array Can be any valid expression as long as it resolves to an array.
      * If the array expression resolves to a value of null or refers to a field that is missing, $indexOfArray returns null.
      * If the array expression does not resolve to an array or null nor refers to a missing field, $indexOfArray returns an error.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $search
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $search
      * @param Optional|ResolvesToInt|int|string $start An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * If unspecified, the starting index position for the search is the beginning of the string.
      * @param Optional|ResolvesToInt|int|string $end An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number. If you specify a <end> index value, you should also specify a <start> index value; otherwise, $indexOfArray uses the <end> value as the <start> index value instead of the <end> value.
@@ -864,7 +865,7 @@ trait FactoryTrait
      */
     public static function indexOfArray(
         PackedArray|ResolvesToArray|BSONArray|array|string $array,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $search,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $search,
         Optional|ResolvesToInt|int|string $start = Optional::Undefined,
         Optional|ResolvesToInt|int|string $end = Optional::Undefined,
     ): IndexOfArrayOperator {
@@ -919,10 +920,10 @@ trait FactoryTrait
      * Determines if the operand is an array. Returns a boolean.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isArray/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function isArray(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): IsArrayOperator {
         return new IsArrayOperator($expression);
     }
@@ -933,10 +934,10 @@ trait FactoryTrait
      * New in MongoDB 4.4.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isNumber/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function isNumber(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): IsNumberOperator {
         return new IsNumberOperator($expression);
     }
@@ -945,11 +946,11 @@ trait FactoryTrait
      * Returns the weekday number in ISO 8601 format, ranging from 1 (for Monday) to 7 (for Sunday).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoDayOfWeek/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function isoDayOfWeek(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): IsoDayOfWeekOperator {
         return new IsoDayOfWeekOperator($date, $timezone);
@@ -959,11 +960,11 @@ trait FactoryTrait
      * Returns the week number in ISO 8601 format, ranging from 1 to 53. Week numbers start at 1 with the week (Monday through Sunday) that contains the year's first Thursday.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoWeek/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function isoWeek(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): IsoWeekOperator {
         return new IsoWeekOperator($date, $timezone);
@@ -973,11 +974,11 @@ trait FactoryTrait
      * Returns the year number in ISO 8601 format. The year starts with the Monday of week 1 (ISO 8601) and ends with the Sunday of the last week (ISO 8601).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/isoWeekYear/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function isoWeekYear(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): IsoWeekYearOperator {
         return new IsoWeekYearOperator($date, $timezone);
@@ -1015,11 +1016,11 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/let/
      * @param Document|Serializable|array|stdClass $vars Assignment block for the variables accessible in the in expression. To assign a variable, specify a string for the variable name and assign a valid expression for the value.
      * The variable assignments have no meaning outside the in expression, not even within the vars block itself.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in The expression to evaluate.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in The expression to evaluate.
      */
     public static function let(
         Document|Serializable|stdClass|array $vars,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
     ): LetOperator {
         return new LetOperator($vars, $in);
     }
@@ -1028,10 +1029,11 @@ trait FactoryTrait
      * Return a value without parsing. Use for values that the aggregation pipeline may interpret as an expression. For example, use a $literal expression to a string that starts with a dollar sign ($) to avoid parsing as a field path.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/literal/
-     * @param Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression.
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression.
      */
-    public static function literal(Type|stdClass|array|bool|float|int|null|string $value): LiteralOperator
-    {
+    public static function literal(
+        DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value,
+    ): LiteralOperator {
         return new LiteralOperator($value);
     }
 
@@ -1076,12 +1078,12 @@ trait FactoryTrait
      * Returns true if the first value is less than the second.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lt/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public static function lt(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ): LtOperator {
         return new LtOperator($expression1, $expression2);
     }
@@ -1090,12 +1092,12 @@ trait FactoryTrait
      * Returns true if the first value is less than or equal to the second.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/lte/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public static function lte(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ): LteOperator {
         return new LteOperator($expression1, $expression2);
     }
@@ -1122,12 +1124,12 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to an array.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
      * @param Optional|ResolvesToString|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
      */
     public static function map(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
         Optional|ResolvesToString|string $as = Optional::Undefined,
     ): MapOperator {
         return new MapOperator($input, $in, $as);
@@ -1139,10 +1141,10 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/
      * @no-named-arguments
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
      */
     public static function max(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ): MaxOperator {
         return new MaxOperator(...$expression);
     }
@@ -1208,11 +1210,11 @@ trait FactoryTrait
      * Returns the milliseconds of a date as a number between 0 and 999.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/millisecond/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function millisecond(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): MillisecondOperator {
         return new MillisecondOperator($date, $timezone);
@@ -1224,10 +1226,10 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/
      * @no-named-arguments
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
      */
     public static function min(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ): MinOperator {
         return new MinOperator(...$expression);
     }
@@ -1250,11 +1252,11 @@ trait FactoryTrait
      * Returns the minute for a date as a number between 0 and 59.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minute/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function minute(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): MinuteOperator {
         return new MinuteOperator($date, $timezone);
@@ -1278,11 +1280,11 @@ trait FactoryTrait
      * Returns the month for a date as a number between 1 (January) and 12 (December).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/month/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function month(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): MonthOperator {
         return new MonthOperator($date, $timezone);
@@ -1306,12 +1308,12 @@ trait FactoryTrait
      * Returns true if the values are not equivalent.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/ne/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public static function ne(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ): NeOperator {
         return new NeOperator($expression1, $expression2);
     }
@@ -1320,10 +1322,10 @@ trait FactoryTrait
      * Returns the boolean value that is the opposite of its argument expression. Accepts a single argument expression.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/not/
-     * @param ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function not(
-        Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): NotOperator {
         return new NotOperator($expression);
     }
@@ -1345,10 +1347,10 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/or/
      * @no-named-arguments
-     * @param ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string ...$expression
      */
     public static function or(
-        Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        DateTimeInterface|Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ): OrOperator {
         return new OrOperator(...$expression);
     }
@@ -1437,16 +1439,16 @@ trait FactoryTrait
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input Can be any valid expression that resolves to an array.
      * If the argument resolves to a value of null or refers to a missing field, $reduce returns null.
      * If the argument does not resolve to an array or null nor refers to a missing field, $reduce returns an error.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $initialValue The initial cumulative value set before in is applied to the first element of the input array.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $initialValue The initial cumulative value set before in is applied to the first element of the input array.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      * During evaluation of the in expression, two variables will be available:
      * - value is the variable that represents the cumulative value of the expression.
      * - this is the variable that refers to the element being processed.
      */
     public static function reduce(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $initialValue,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $initialValue,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
     ): ReduceOperator {
         return new ReduceOperator($input, $initialValue, $in);
     }
@@ -1584,11 +1586,11 @@ trait FactoryTrait
      * Returns the seconds for a date as a number between 0 and 60 (leap seconds).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/second/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function second(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): SecondOperator {
         return new SecondOperator($date, $timezone);
@@ -1628,13 +1630,13 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/setField/
      * @param ResolvesToString|string $field Field in the input object that you want to add, update, or remove. field can be any valid expression that resolves to a string constant.
      * @param Document|ResolvesToObject|Serializable|array|stdClass|string $input Document that contains the field that you want to add or update. input must resolve to an object, missing, null, or undefined.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value The value that you want to assign to field. value can be any valid expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value The value that you want to assign to field. value can be any valid expression.
      * Set to $$REMOVE to remove field from the input document.
      */
     public static function setField(
         ResolvesToString|string $field,
         Document|Serializable|ResolvesToObject|stdClass|array|string $input,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
     ): SetFieldOperator {
         return new SetFieldOperator($field, $input, $value);
     }
@@ -1890,12 +1892,12 @@ trait FactoryTrait
      * Returns the result of subtracting the second value from the first. If the two values are numbers, return the difference. If the two values are dates, return the difference in milliseconds. If the two values are a date and a number in milliseconds, return the resulting date. Accepts two argument expressions. If the two values are a date and a number, specify the date argument first as it is not meaningful to subtract a date from a number.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtract/
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression1
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression2
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression1
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression2
      */
     public static function subtract(
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression1,
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression2,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression1,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression2,
     ): SubtractOperator {
         return new SubtractOperator($expression1, $expression2);
     }
@@ -1922,12 +1924,12 @@ trait FactoryTrait
      * - case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here.
      * - then Can be any valid expression.
      * The branches array must contain at least one branch document.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default The path to take if no branch case expression evaluates to true.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default The path to take if no branch case expression evaluates to true.
      * Although optional, if default is unspecified and no branch case evaluates to true, $switch returns an error.
      */
     public static function switch(
         PackedArray|BSONArray|array $branches,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default = Optional::Undefined,
     ): SwitchOperator {
         return new SwitchOperator($branches, $default);
     }
@@ -1961,10 +1963,10 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toBool/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function toBool(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToBoolOperator {
         return new ToBoolOperator($expression);
     }
@@ -1974,10 +1976,10 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDate/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function toDate(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToDateOperator {
         return new ToDateOperator($expression);
     }
@@ -1987,10 +1989,10 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDecimal/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function toDecimal(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToDecimalOperator {
         return new ToDecimalOperator($expression);
     }
@@ -2000,10 +2002,10 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDouble/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function toDouble(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToDoubleOperator {
         return new ToDoubleOperator($expression);
     }
@@ -2012,10 +2014,10 @@ trait FactoryTrait
      * Computes and returns the hash value of the input expression using the same hash function that MongoDB uses to create a hashed index. A hash function maps a key or string to a fixed-size numeric value.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toHashedIndexKey/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash
      */
     public static function toHashedIndexKey(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
     ): ToHashedIndexKeyOperator {
         return new ToHashedIndexKeyOperator($value);
     }
@@ -2025,10 +2027,10 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toInt/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function toInt(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToIntOperator {
         return new ToIntOperator($expression);
     }
@@ -2038,10 +2040,10 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLong/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function toLong(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToLongOperator {
         return new ToLongOperator($expression);
     }
@@ -2062,10 +2064,10 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toObjectId/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function toObjectId(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToObjectIdOperator {
         return new ToObjectIdOperator($expression);
     }
@@ -2075,10 +2077,10 @@ trait FactoryTrait
      * New in MongoDB 4.0.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/toString/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function toString(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToStringOperator {
         return new ToStringOperator($expression);
     }
@@ -2154,10 +2156,10 @@ trait FactoryTrait
      * Return the BSON data type of the field.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/type/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function type(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): TypeOperator {
         return new TypeOperator($expression);
     }
@@ -2181,11 +2183,11 @@ trait FactoryTrait
      * Returns the week number for a date as a number between 0 (the partial week that precedes the first Sunday of the year) and 53 (leap year).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/week/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function week(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): WeekOperator {
         return new WeekOperator($date, $timezone);
@@ -2195,11 +2197,11 @@ trait FactoryTrait
      * Returns the year for a date as a number (e.g. 2014).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/year/
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public static function year(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ): YearOperator {
         return new YearOperator($date, $timezone);

--- a/src/Builder/Expression/GetFieldOperator.php
+++ b/src/Builder/Expression/GetFieldOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -35,20 +36,20 @@ final class GetFieldOperator implements ResolvesToAny, OperatorInterface
     public readonly ResolvesToString|string $field;
 
     /**
-     * @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input Default: $$CURRENT
+     * @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input Default: $$CURRENT
      * A valid expression that contains the field for which you want to return a value. input must resolve to an object, missing, null, or undefined. If omitted, defaults to the document currently being processed in the pipeline ($$CURRENT).
      */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
 
     /**
      * @param ResolvesToString|string $field Field in the input object for which you want to return a value. field can be any valid expression that resolves to a string constant.
      * If field begins with a dollar sign ($), place the field name inside of a $literal expression to return its value.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input Default: $$CURRENT
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input Default: $$CURRENT
      * A valid expression that contains the field for which you want to return a value. input must resolve to an object, missing, null, or undefined. If omitted, defaults to the document currently being processed in the pipeline ($$CURRENT).
      */
     public function __construct(
         ResolvesToString|string $field,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input = Optional::Undefined,
     ) {
         $this->field = $field;
         $this->input = $input;

--- a/src/Builder/Expression/GtOperator.php
+++ b/src/Builder/Expression/GtOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,19 +27,19 @@ final class GtOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$gt';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;

--- a/src/Builder/Expression/GteOperator.php
+++ b/src/Builder/Expression/GteOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,19 +27,19 @@ final class GteOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$gte';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;

--- a/src/Builder/Expression/HourOperator.php
+++ b/src/Builder/Expression/HourOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class HourOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$hour';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/IfNullOperator.php
+++ b/src/Builder/Expression/IfNullOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -29,15 +30,16 @@ final class IfNullOperator implements ResolvesToAny, OperatorInterface
     public const NAME = '$ifNull';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
+    /** @var list<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
      * @no-named-arguments
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+    ) {
         if (\count($expression) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }

--- a/src/Builder/Expression/InOperator.php
+++ b/src/Builder/Expression/InOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
@@ -34,18 +35,18 @@ final class InOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$in';
     public const PROPERTIES = ['expression' => 'expression', 'array' => 'array'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression Any valid expression expression. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression Any valid expression expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $array Any valid expression that resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $array;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression Any valid expression expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression Any valid expression expression.
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $array Any valid expression that resolves to an array.
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
         PackedArray|ResolvesToArray|BSONArray|array|string $array,
     ) {
         $this->expression = $expression;

--- a/src/Builder/Expression/IndexOfArrayOperator.php
+++ b/src/Builder/Expression/IndexOfArrayOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
@@ -42,8 +43,8 @@ final class IndexOfArrayOperator implements ResolvesToInt, OperatorInterface
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $array;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $search */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $search;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $search */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $search;
 
     /**
      * @var Optional|ResolvesToInt|int|string $start An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
@@ -61,7 +62,7 @@ final class IndexOfArrayOperator implements ResolvesToInt, OperatorInterface
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $array Can be any valid expression as long as it resolves to an array.
      * If the array expression resolves to a value of null or refers to a field that is missing, $indexOfArray returns null.
      * If the array expression does not resolve to an array or null nor refers to a missing field, $indexOfArray returns an error.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $search
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $search
      * @param Optional|ResolvesToInt|int|string $start An integer, or a number that can be represented as integers (such as 2.0), that specifies the starting index position for the search. Can be any valid expression that resolves to a non-negative integral number.
      * If unspecified, the starting index position for the search is the beginning of the string.
      * @param Optional|ResolvesToInt|int|string $end An integer, or a number that can be represented as integers (such as 2.0), that specifies the ending index position for the search. Can be any valid expression that resolves to a non-negative integral number. If you specify a <end> index value, you should also specify a <start> index value; otherwise, $indexOfArray uses the <end> value as the <start> index value instead of the <end> value.
@@ -69,7 +70,7 @@ final class IndexOfArrayOperator implements ResolvesToInt, OperatorInterface
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $array,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $search,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $search,
         Optional|ResolvesToInt|int|string $start = Optional::Undefined,
         Optional|ResolvesToInt|int|string $end = Optional::Undefined,
     ) {

--- a/src/Builder/Expression/IsArrayOperator.php
+++ b/src/Builder/Expression/IsArrayOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,14 +27,15 @@ final class IsArrayOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$isArray';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/IsNumberOperator.php
+++ b/src/Builder/Expression/IsNumberOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -28,14 +29,15 @@ final class IsNumberOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$isNumber';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/IsoDayOfWeekOperator.php
+++ b/src/Builder/Expression/IsoDayOfWeekOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class IsoDayOfWeekOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$isoDayOfWeek';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/IsoWeekOperator.php
+++ b/src/Builder/Expression/IsoWeekOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class IsoWeekOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$isoWeek';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/IsoWeekYearOperator.php
+++ b/src/Builder/Expression/IsoWeekYearOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class IsoWeekYearOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$isoWeekYear';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/LetOperator.php
+++ b/src/Builder/Expression/LetOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -35,17 +36,17 @@ final class LetOperator implements ResolvesToAny, OperatorInterface
      */
     public readonly Document|Serializable|stdClass|array $vars;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in The expression to evaluate. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in The expression to evaluate. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in;
 
     /**
      * @param Document|Serializable|array|stdClass $vars Assignment block for the variables accessible in the in expression. To assign a variable, specify a string for the variable name and assign a valid expression for the value.
      * The variable assignments have no meaning outside the in expression, not even within the vars block itself.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in The expression to evaluate.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in The expression to evaluate.
      */
     public function __construct(
         Document|Serializable|stdClass|array $vars,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
     ) {
         $this->vars = $vars;
         $this->in = $in;

--- a/src/Builder/Expression/LiteralOperator.php
+++ b/src/Builder/Expression/LiteralOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -25,13 +26,13 @@ final class LiteralOperator implements ResolvesToAny, OperatorInterface
     public const NAME = '$literal';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression. */
-    public readonly Type|stdClass|array|bool|float|int|null|string $value;
+    /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression. */
+    public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
     /**
-     * @param Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression.
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression.
      */
-    public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
+    public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
     }

--- a/src/Builder/Expression/LtOperator.php
+++ b/src/Builder/Expression/LtOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,19 +27,19 @@ final class LtOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$lt';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;

--- a/src/Builder/Expression/LteOperator.php
+++ b/src/Builder/Expression/LteOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,19 +27,19 @@ final class LteOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$lte';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;

--- a/src/Builder/Expression/MapOperator.php
+++ b/src/Builder/Expression/MapOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
@@ -38,20 +39,20 @@ final class MapOperator implements ResolvesToArray, OperatorInterface
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $input;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in;
 
     /** @var Optional|ResolvesToString|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this. */
     public readonly Optional|ResolvesToString|string $as;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to an array.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
      * @param Optional|ResolvesToString|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
         Optional|ResolvesToString|string $as = Optional::Undefined,
     ) {
         if (is_string($input) && ! str_starts_with($input, '$')) {

--- a/src/Builder/Expression/MaxOperator.php
+++ b/src/Builder/Expression/MaxOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -30,15 +31,16 @@ final class MaxOperator implements ResolvesToAny, OperatorInterface
     public const NAME = '$max';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
+    /** @var list<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
      * @no-named-arguments
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+    ) {
         if (\count($expression) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }

--- a/src/Builder/Expression/MillisecondOperator.php
+++ b/src/Builder/Expression/MillisecondOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class MillisecondOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$millisecond';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/MinOperator.php
+++ b/src/Builder/Expression/MinOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -30,15 +31,16 @@ final class MinOperator implements ResolvesToAny, OperatorInterface
     public const NAME = '$min';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var list<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
+    /** @var list<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression
      * @no-named-arguments
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+    ) {
         if (\count($expression) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }

--- a/src/Builder/Expression/MinuteOperator.php
+++ b/src/Builder/Expression/MinuteOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class MinuteOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$minute';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/MonthOperator.php
+++ b/src/Builder/Expression/MonthOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class MonthOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$month';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/NeOperator.php
+++ b/src/Builder/Expression/NeOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,19 +27,19 @@ final class NeOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$ne';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2 */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression1
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression2
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression1,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression2,
     ) {
         $this->expression1 = $expression1;
         $this->expression2 = $expression2;

--- a/src/Builder/Expression/NotOperator.php
+++ b/src/Builder/Expression/NotOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,14 +27,14 @@ final class NotOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$not';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public function __construct(
-        Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {
         $this->expression = $expression;
     }

--- a/src/Builder/Expression/OrOperator.php
+++ b/src/Builder/Expression/OrOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -29,15 +30,15 @@ final class OrOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$or';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var list<ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string> $expression */
+    /** @var list<DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string> $expression */
     public readonly array $expression;
 
     /**
-     * @param ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string ...$expression
+     * @param DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string ...$expression
      * @no-named-arguments
      */
     public function __construct(
-        Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        DateTimeInterface|Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ) {
         if (\count($expression) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));

--- a/src/Builder/Expression/ReduceOperator.php
+++ b/src/Builder/Expression/ReduceOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
@@ -41,31 +42,31 @@ final class ReduceOperator implements ResolvesToAny, OperatorInterface
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $input;
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $initialValue The initial cumulative value set before in is applied to the first element of the input array. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $initialValue;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $initialValue The initial cumulative value set before in is applied to the first element of the input array. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $initialValue;
 
     /**
-     * @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
+     * @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      * During evaluation of the in expression, two variables will be available:
      * - value is the variable that represents the cumulative value of the expression.
      * - this is the variable that refers to the element being processed.
      */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in;
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input Can be any valid expression that resolves to an array.
      * If the argument resolves to a value of null or refers to a missing field, $reduce returns null.
      * If the argument does not resolve to an array or null nor refers to a missing field, $reduce returns an error.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $initialValue The initial cumulative value set before in is applied to the first element of the input array.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $initialValue The initial cumulative value set before in is applied to the first element of the input array.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      * During evaluation of the in expression, two variables will be available:
      * - value is the variable that represents the cumulative value of the expression.
      * - this is the variable that refers to the element being processed.
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $initialValue,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $initialValue,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
     ) {
         if (is_string($input) && ! str_starts_with($input, '$')) {
             throw new InvalidArgumentException('Argument $input can be an expression, field paths and variable names must be prefixed by "$" or "$$".');

--- a/src/Builder/Expression/SecondOperator.php
+++ b/src/Builder/Expression/SecondOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class SecondOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$second';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/SetFieldOperator.php
+++ b/src/Builder/Expression/SetFieldOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -40,21 +41,21 @@ final class SetFieldOperator implements ResolvesToObject, OperatorInterface
     public readonly Document|Serializable|ResolvesToObject|stdClass|array|string $input;
 
     /**
-     * @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value The value that you want to assign to field. value can be any valid expression.
+     * @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value The value that you want to assign to field. value can be any valid expression.
      * Set to $$REMOVE to remove field from the input document.
      */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value;
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value;
 
     /**
      * @param ResolvesToString|string $field Field in the input object that you want to add, update, or remove. field can be any valid expression that resolves to a string constant.
      * @param Document|ResolvesToObject|Serializable|array|stdClass|string $input Document that contains the field that you want to add or update. input must resolve to an object, missing, null, or undefined.
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value The value that you want to assign to field. value can be any valid expression.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value The value that you want to assign to field. value can be any valid expression.
      * Set to $$REMOVE to remove field from the input document.
      */
     public function __construct(
         ResolvesToString|string $field,
         Document|Serializable|ResolvesToObject|stdClass|array|string $input,
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
     ) {
         $this->field = $field;
         if (is_string($input) && ! str_starts_with($input, '$')) {

--- a/src/Builder/Expression/SubtractOperator.php
+++ b/src/Builder/Expression/SubtractOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Int64;
 use MongoDB\BSON\UTCDateTime;
@@ -30,19 +31,19 @@ final class SubtractOperator implements ResolvesToInt, ResolvesToLong, ResolvesT
     public const NAME = '$subtract';
     public const PROPERTIES = ['expression1' => 'expression1', 'expression2' => 'expression2'];
 
-    /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression1 */
-    public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression1;
+    /** @var DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression1 */
+    public readonly DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression1;
 
-    /** @var Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression2 */
-    public readonly Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression2;
+    /** @var DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression2 */
+    public readonly DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression2;
 
     /**
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression1
-     * @param Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression2
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression1
+     * @param DateTimeInterface|Decimal128|Int64|ResolvesToDate|ResolvesToNumber|UTCDateTime|float|int|string $expression2
      */
     public function __construct(
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression1,
-        Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression2,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression1,
+        DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression2,
     ) {
         if (is_string($expression1) && ! str_starts_with($expression1, '$')) {
             throw new InvalidArgumentException('Argument $expression1 can be an expression, field paths and variable names must be prefixed by "$" or "$$".');

--- a/src/Builder/Expression/SwitchOperator.php
+++ b/src/Builder/Expression/SwitchOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
@@ -42,22 +43,22 @@ final class SwitchOperator implements ResolvesToAny, OperatorInterface
     public readonly PackedArray|BSONArray|array $branches;
 
     /**
-     * @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default The path to take if no branch case expression evaluates to true.
+     * @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default The path to take if no branch case expression evaluates to true.
      * Although optional, if default is unspecified and no branch case evaluates to true, $switch returns an error.
      */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default;
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default;
 
     /**
      * @param BSONArray|PackedArray|array $branches An array of control branch documents. Each branch is a document with the following fields:
      * - case Can be any valid expression that resolves to a boolean. If the result is not a boolean, it is coerced to a boolean value. More information about how MongoDB evaluates expressions as either true or false can be found here.
      * - then Can be any valid expression.
      * The branches array must contain at least one branch document.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default The path to take if no branch case expression evaluates to true.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default The path to take if no branch case expression evaluates to true.
      * Although optional, if default is unspecified and no branch case evaluates to true, $switch returns an error.
      */
     public function __construct(
         PackedArray|BSONArray|array $branches,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default = Optional::Undefined,
     ) {
         if (is_array($branches) && ! array_is_list($branches)) {
             throw new InvalidArgumentException('Expected $branches argument to be a list, got an associative array.');

--- a/src/Builder/Expression/ToBoolOperator.php
+++ b/src/Builder/Expression/ToBoolOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ToBoolOperator implements ResolvesToBool, OperatorInterface
     public const NAME = '$toBool';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/ToDateOperator.php
+++ b/src/Builder/Expression/ToDateOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ToDateOperator implements ResolvesToDate, OperatorInterface
     public const NAME = '$toDate';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/ToDecimalOperator.php
+++ b/src/Builder/Expression/ToDecimalOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ToDecimalOperator implements ResolvesToDecimal, OperatorInterface
     public const NAME = '$toDecimal';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/ToDoubleOperator.php
+++ b/src/Builder/Expression/ToDoubleOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ToDoubleOperator implements ResolvesToDouble, OperatorInterface
     public const NAME = '$toDouble';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/ToHashedIndexKeyOperator.php
+++ b/src/Builder/Expression/ToHashedIndexKeyOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,14 +27,15 @@ final class ToHashedIndexKeyOperator implements ResolvesToLong, OperatorInterfac
     public const NAME = '$toHashedIndexKey';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
+    ) {
         $this->value = $value;
     }
 }

--- a/src/Builder/Expression/ToIntOperator.php
+++ b/src/Builder/Expression/ToIntOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ToIntOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$toInt';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/ToLongOperator.php
+++ b/src/Builder/Expression/ToLongOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ToLongOperator implements ResolvesToLong, OperatorInterface
     public const NAME = '$toLong';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/ToObjectIdOperator.php
+++ b/src/Builder/Expression/ToObjectIdOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ToObjectIdOperator implements ResolvesToObjectId, OperatorInterface
     public const NAME = '$toObjectId';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/ToStringOperator.php
+++ b/src/Builder/Expression/ToStringOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ToStringOperator implements ResolvesToString, OperatorInterface
     public const NAME = '$toString';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/TypeOperator.php
+++ b/src/Builder/Expression/TypeOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -26,14 +27,15 @@ final class TypeOperator implements ResolvesToString, OperatorInterface
     public const NAME = '$type';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Expression/WeekOperator.php
+++ b/src/Builder/Expression/WeekOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class WeekOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$week';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Expression/YearOperator.php
+++ b/src/Builder/Expression/YearOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use DateTimeInterface;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\UTCDateTime;
@@ -31,18 +32,18 @@ final class YearOperator implements ResolvesToInt, OperatorInterface
     public const NAME = '$year';
     public const PROPERTIES = ['date' => 'date', 'timezone' => 'timezone'];
 
-    /** @var ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
-    public readonly ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
+    /** @var DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID. */
+    public readonly DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date;
 
     /** @var Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC. */
     public readonly Optional|ResolvesToString|string $timezone;
 
     /**
-     * @param ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
+     * @param DateTimeInterface|ObjectId|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|Timestamp|UTCDateTime|int|string $date The date to which the operator is applied. date must be a valid expression that resolves to a Date, a Timestamp, or an ObjectID.
      * @param Optional|ResolvesToString|string $timezone The timezone of the operation result. timezone must be a valid expression that resolves to a string formatted as either an Olson Timezone Identifier or a UTC Offset. If no timezone is provided, the result is displayed in UTC.
      */
     public function __construct(
-        ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
+        DateTimeInterface|ObjectId|Timestamp|UTCDateTime|ResolvesToDate|ResolvesToObjectId|ResolvesToTimestamp|int|string $date,
         Optional|ResolvesToString|string $timezone = Optional::Undefined,
     ) {
         if (is_string($date) && ! str_starts_with($date, '$')) {

--- a/src/Builder/Query/AllOperator.php
+++ b/src/Builder/Query/AllOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -29,15 +30,16 @@ final class AllOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$all';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var list<FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string> $value */
+    /** @var list<DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string> $value */
     public readonly array $value;
 
     /**
-     * @param FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string ...$value
+     * @param DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string ...$value
      * @no-named-arguments
      */
-    public function __construct(Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string ...$value)
-    {
+    public function __construct(
+        DateTimeInterface|Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string ...$value,
+    ) {
         if (\count($value) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $value, got %d.', 1, \count($value)));
         }

--- a/src/Builder/Query/ElemMatchOperator.php
+++ b/src/Builder/Query/ElemMatchOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -30,14 +31,14 @@ final class ElemMatchOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$elemMatch';
     public const PROPERTIES = ['query' => 'query'];
 
-    /** @var FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query */
-    public readonly Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query;
+    /** @var DateTimeInterface|FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query */
+    public readonly DateTimeInterface|Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query;
 
     /**
-     * @param FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query
+     * @param DateTimeInterface|FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query
      */
     public function __construct(
-        Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query,
+        DateTimeInterface|Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query,
     ) {
         if (is_array($query)) {
             $query = QueryObject::create($query);

--- a/src/Builder/Query/EqOperator.php
+++ b/src/Builder/Query/EqOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -26,13 +27,13 @@ final class EqOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$eq';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var Type|array|bool|float|int|null|stdClass|string $value */
-    public readonly Type|stdClass|array|bool|float|int|null|string $value;
+    /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
+    public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
     /**
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
+    public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
     }

--- a/src/Builder/Query/ExprOperator.php
+++ b/src/Builder/Query/ExprOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class ExprOperator implements QueryInterface, OperatorInterface
     public const NAME = '$expr';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Query/FactoryTrait.php
+++ b/src/Builder/Query/FactoryTrait.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
@@ -36,10 +37,10 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/all/
      * @no-named-arguments
-     * @param FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string ...$value
+     * @param DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string ...$value
      */
     public static function all(
-        Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string ...$value,
+        DateTimeInterface|Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string ...$value,
     ): AllOperator {
         return new AllOperator(...$value);
     }
@@ -148,10 +149,10 @@ trait FactoryTrait
      * The $elemMatch operator matches documents that contain an array field with at least one element that matches all the specified query criteria.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/elemMatch/
-     * @param FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query
+     * @param DateTimeInterface|FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query
      */
     public static function elemMatch(
-        Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query,
+        DateTimeInterface|Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query,
     ): ElemMatchOperator {
         return new ElemMatchOperator($query);
     }
@@ -160,9 +161,9 @@ trait FactoryTrait
      * Matches values that are equal to a specified value.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/eq/
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public static function eq(Type|stdClass|array|bool|float|int|null|string $value): EqOperator
+    public static function eq(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value): EqOperator
     {
         return new EqOperator($value);
     }
@@ -182,10 +183,10 @@ trait FactoryTrait
      * Allows use of aggregation expressions within the query language.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/expr/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function expr(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ExprOperator {
         return new ExprOperator($expression);
     }
@@ -234,9 +235,9 @@ trait FactoryTrait
      * Matches values that are greater than a specified value.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/gt/
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public static function gt(Type|stdClass|array|bool|float|int|null|string $value): GtOperator
+    public static function gt(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value): GtOperator
     {
         return new GtOperator($value);
     }
@@ -245,9 +246,9 @@ trait FactoryTrait
      * Matches values that are greater than or equal to a specified value.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/gte/
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public static function gte(Type|stdClass|array|bool|float|int|null|string $value): GteOperator
+    public static function gte(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value): GteOperator
     {
         return new GteOperator($value);
     }
@@ -278,9 +279,9 @@ trait FactoryTrait
      * Matches values that are less than a specified value.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/lt/
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public static function lt(Type|stdClass|array|bool|float|int|null|string $value): LtOperator
+    public static function lt(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value): LtOperator
     {
         return new LtOperator($value);
     }
@@ -289,9 +290,9 @@ trait FactoryTrait
      * Matches values that are less than or equal to a specified value.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/lte/
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public static function lte(Type|stdClass|array|bool|float|int|null|string $value): LteOperator
+    public static function lte(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value): LteOperator
     {
         return new LteOperator($value);
     }
@@ -336,9 +337,9 @@ trait FactoryTrait
      * Matches all values that are not equal to a specified value.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/ne/
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public static function ne(Type|stdClass|array|bool|float|int|null|string $value): NeOperator
+    public static function ne(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value): NeOperator
     {
         return new NeOperator($value);
     }
@@ -402,10 +403,10 @@ trait FactoryTrait
      * Inverts the effect of a query expression and returns documents that do not match the query expression.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/query/not/
-     * @param FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function not(
-        Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression,
     ): NotOperator {
         return new NotOperator($expression);
     }

--- a/src/Builder/Query/GtOperator.php
+++ b/src/Builder/Query/GtOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -26,13 +27,13 @@ final class GtOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$gt';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var Type|array|bool|float|int|null|stdClass|string $value */
-    public readonly Type|stdClass|array|bool|float|int|null|string $value;
+    /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
+    public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
     /**
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
+    public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
     }

--- a/src/Builder/Query/GteOperator.php
+++ b/src/Builder/Query/GteOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -26,13 +27,13 @@ final class GteOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$gte';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var Type|array|bool|float|int|null|stdClass|string $value */
-    public readonly Type|stdClass|array|bool|float|int|null|string $value;
+    /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
+    public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
     /**
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
+    public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
     }

--- a/src/Builder/Query/LtOperator.php
+++ b/src/Builder/Query/LtOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -26,13 +27,13 @@ final class LtOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$lt';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var Type|array|bool|float|int|null|stdClass|string $value */
-    public readonly Type|stdClass|array|bool|float|int|null|string $value;
+    /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
+    public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
     /**
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
+    public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
     }

--- a/src/Builder/Query/LteOperator.php
+++ b/src/Builder/Query/LteOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -26,13 +27,13 @@ final class LteOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$lte';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var Type|array|bool|float|int|null|stdClass|string $value */
-    public readonly Type|stdClass|array|bool|float|int|null|string $value;
+    /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
+    public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
     /**
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
+    public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
     }

--- a/src/Builder/Query/NeOperator.php
+++ b/src/Builder/Query/NeOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -26,13 +27,13 @@ final class NeOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$ne';
     public const PROPERTIES = ['value' => 'value'];
 
-    /** @var Type|array|bool|float|int|null|stdClass|string $value */
-    public readonly Type|stdClass|array|bool|float|int|null|string $value;
+    /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
+    public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
     /**
-     * @param Type|array|bool|float|int|null|stdClass|string $value
+     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
      */
-    public function __construct(Type|stdClass|array|bool|float|int|null|string $value)
+    public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;
     }

--- a/src/Builder/Query/NotOperator.php
+++ b/src/Builder/Query/NotOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Query;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -26,14 +27,15 @@ final class NotOperator implements FieldQueryInterface, OperatorInterface
     public const NAME = '$not';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Search/EqualsOperator.php
+++ b/src/Builder/Search/EqualsOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Search;
 
+use DateTimeInterface;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
@@ -36,20 +37,20 @@ final class EqualsOperator implements SearchOperatorInterface, OperatorInterface
     /** @var array|string $path */
     public readonly array|string $path;
 
-    /** @var Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value */
-    public readonly Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value;
+    /** @var Binary|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value */
+    public readonly DateTimeInterface|Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value;
 
     /** @var Optional|Document|Serializable|array|stdClass $score */
     public readonly Optional|Document|Serializable|stdClass|array $score;
 
     /**
      * @param array|string $path
-     * @param Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value
+     * @param Binary|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value
      * @param Optional|Document|Serializable|array|stdClass $score
      */
     public function __construct(
         array|string $path,
-        Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value,
+        DateTimeInterface|Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value,
         Optional|Document|Serializable|stdClass|array $score = Optional::Undefined,
     ) {
         $this->path = $path;

--- a/src/Builder/Search/FactoryTrait.php
+++ b/src/Builder/Search/FactoryTrait.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Search;
 
+use DateTimeInterface;
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
@@ -99,12 +100,12 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/atlas/atlas-search/equals/
      * @param array|string $path
-     * @param Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value
+     * @param Binary|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value
      * @param Optional|Document|Serializable|array|stdClass $score
      */
     public static function equals(
         array|string $path,
-        Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value,
+        DateTimeInterface|Binary|Decimal128|Int64|ObjectId|UTCDateTime|bool|float|int|null|string $value,
         Optional|Document|Serializable|stdClass|array $score = Optional::Undefined,
     ): EqualsOperator {
         return new EqualsOperator($path, $value, $score);
@@ -185,12 +186,12 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/atlas/atlas-search/in/
      * @param array|string $path
-     * @param BSONArray|PackedArray|Type|array|bool|float|int|null|stdClass|string $value
+     * @param BSONArray|DateTimeInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $value
      * @param Optional|Document|Serializable|array|stdClass $score
      */
     public static function in(
         array|string $path,
-        PackedArray|Type|BSONArray|stdClass|array|bool|float|int|null|string $value,
+        DateTimeInterface|PackedArray|Type|BSONArray|stdClass|array|bool|float|int|null|string $value,
         Optional|Document|Serializable|stdClass|array $score = Optional::Undefined,
     ): InOperator {
         return new InOperator($path, $value, $score);
@@ -217,13 +218,13 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/atlas/atlas-search/near/
      * @param array|string $path
-     * @param Decimal128|Document|GeometryInterface|Int64|Serializable|UTCDateTime|array|float|int|stdClass $origin
+     * @param DateTimeInterface|Decimal128|Document|GeometryInterface|Int64|Serializable|UTCDateTime|array|float|int|stdClass $origin
      * @param Decimal128|Int64|float|int $pivot
      * @param Optional|Document|Serializable|array|stdClass $score
      */
     public static function near(
         array|string $path,
-        Decimal128|Document|Int64|Serializable|UTCDateTime|GeometryInterface|stdClass|array|float|int $origin,
+        DateTimeInterface|Decimal128|Document|Int64|Serializable|UTCDateTime|GeometryInterface|stdClass|array|float|int $origin,
         Decimal128|Int64|float|int $pivot,
         Optional|Document|Serializable|stdClass|array $score = Optional::Undefined,
     ): NearOperator {
@@ -266,18 +267,18 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/atlas/atlas-search/range/
      * @param array|string $path
-     * @param Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt
-     * @param Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte
-     * @param Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt
-     * @param Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte
+     * @param Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt
+     * @param Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte
+     * @param Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt
+     * @param Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte
      * @param Optional|Document|Serializable|array|stdClass $score
      */
     public static function range(
         array|string $path,
-        Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt = Optional::Undefined,
-        Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte = Optional::Undefined,
-        Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt = Optional::Undefined,
-        Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte = Optional::Undefined,
+        Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt = Optional::Undefined,
+        Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte = Optional::Undefined,
+        Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt = Optional::Undefined,
+        Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte = Optional::Undefined,
         Optional|Document|Serializable|stdClass|array $score = Optional::Undefined,
     ): RangeOperator {
         return new RangeOperator($path, $gt, $gte, $lt, $lte, $score);

--- a/src/Builder/Search/InOperator.php
+++ b/src/Builder/Search/InOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Search;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Serializable;
@@ -38,20 +39,20 @@ final class InOperator implements SearchOperatorInterface, OperatorInterface
     /** @var array|string $path */
     public readonly array|string $path;
 
-    /** @var BSONArray|PackedArray|Type|array|bool|float|int|null|stdClass|string $value */
-    public readonly PackedArray|Type|BSONArray|stdClass|array|bool|float|int|null|string $value;
+    /** @var BSONArray|DateTimeInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $value */
+    public readonly DateTimeInterface|PackedArray|Type|BSONArray|stdClass|array|bool|float|int|null|string $value;
 
     /** @var Optional|Document|Serializable|array|stdClass $score */
     public readonly Optional|Document|Serializable|stdClass|array $score;
 
     /**
      * @param array|string $path
-     * @param BSONArray|PackedArray|Type|array|bool|float|int|null|stdClass|string $value
+     * @param BSONArray|DateTimeInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $value
      * @param Optional|Document|Serializable|array|stdClass $score
      */
     public function __construct(
         array|string $path,
-        PackedArray|Type|BSONArray|stdClass|array|bool|float|int|null|string $value,
+        DateTimeInterface|PackedArray|Type|BSONArray|stdClass|array|bool|float|int|null|string $value,
         Optional|Document|Serializable|stdClass|array $score = Optional::Undefined,
     ) {
         $this->path = $path;

--- a/src/Builder/Search/NearOperator.php
+++ b/src/Builder/Search/NearOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Search;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
@@ -35,8 +36,8 @@ final class NearOperator implements SearchOperatorInterface, OperatorInterface
     /** @var array|string $path */
     public readonly array|string $path;
 
-    /** @var Decimal128|Document|GeometryInterface|Int64|Serializable|UTCDateTime|array|float|int|stdClass $origin */
-    public readonly Decimal128|Document|Int64|Serializable|UTCDateTime|GeometryInterface|stdClass|array|float|int $origin;
+    /** @var DateTimeInterface|Decimal128|Document|GeometryInterface|Int64|Serializable|UTCDateTime|array|float|int|stdClass $origin */
+    public readonly DateTimeInterface|Decimal128|Document|Int64|Serializable|UTCDateTime|GeometryInterface|stdClass|array|float|int $origin;
 
     /** @var Decimal128|Int64|float|int $pivot */
     public readonly Decimal128|Int64|float|int $pivot;
@@ -46,13 +47,13 @@ final class NearOperator implements SearchOperatorInterface, OperatorInterface
 
     /**
      * @param array|string $path
-     * @param Decimal128|Document|GeometryInterface|Int64|Serializable|UTCDateTime|array|float|int|stdClass $origin
+     * @param DateTimeInterface|Decimal128|Document|GeometryInterface|Int64|Serializable|UTCDateTime|array|float|int|stdClass $origin
      * @param Decimal128|Int64|float|int $pivot
      * @param Optional|Document|Serializable|array|stdClass $score
      */
     public function __construct(
         array|string $path,
-        Decimal128|Document|Int64|Serializable|UTCDateTime|GeometryInterface|stdClass|array|float|int $origin,
+        DateTimeInterface|Decimal128|Document|Int64|Serializable|UTCDateTime|GeometryInterface|stdClass|array|float|int $origin,
         Decimal128|Int64|float|int $pivot,
         Optional|Document|Serializable|stdClass|array $score = Optional::Undefined,
     ) {

--- a/src/Builder/Search/RangeOperator.php
+++ b/src/Builder/Search/RangeOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Search;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
@@ -44,35 +45,35 @@ final class RangeOperator implements SearchOperatorInterface, OperatorInterface
     /** @var array|string $path */
     public readonly array|string $path;
 
-    /** @var Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt */
-    public readonly Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt;
+    /** @var Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt */
+    public readonly Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt;
 
-    /** @var Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte */
-    public readonly Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte;
+    /** @var Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte */
+    public readonly Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte;
 
-    /** @var Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt */
-    public readonly Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt;
+    /** @var Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt */
+    public readonly Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt;
 
-    /** @var Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte */
-    public readonly Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte;
+    /** @var Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte */
+    public readonly Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte;
 
     /** @var Optional|Document|Serializable|array|stdClass $score */
     public readonly Optional|Document|Serializable|stdClass|array $score;
 
     /**
      * @param array|string $path
-     * @param Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt
-     * @param Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte
-     * @param Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt
-     * @param Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte
+     * @param Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt
+     * @param Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte
+     * @param Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt
+     * @param Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte
      * @param Optional|Document|Serializable|array|stdClass $score
      */
     public function __construct(
         array|string $path,
-        Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt = Optional::Undefined,
-        Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte = Optional::Undefined,
-        Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt = Optional::Undefined,
-        Optional|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte = Optional::Undefined,
+        Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gt = Optional::Undefined,
+        Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $gte = Optional::Undefined,
+        Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lt = Optional::Undefined,
+        Optional|DateTimeInterface|Decimal128|Int64|ObjectId|UTCDateTime|float|int|string $lte = Optional::Undefined,
         Optional|Document|Serializable|stdClass|array $score = Optional::Undefined,
     ) {
         $this->path = $path;

--- a/src/Builder/Stage.php
+++ b/src/Builder/Stage.php
@@ -22,9 +22,9 @@ final class Stage
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
      *
-     * @param QueryInterface|FieldQueryInterface|Type|stdClass|array<array-key, mixed>|bool|float|int|string|DateTimeInterface|null ...$queries The query predicates to match
+     * @param DateTimeInterface|QueryInterface|FieldQueryInterface|Type|stdClass|array<array-key, mixed>|bool|float|int|string|null ...$queries The query predicates to match
      */
-    public static function match(QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|DateTimeInterface|null ...$queries): MatchStage
+    public static function match(DateTimeInterface|QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null ...$queries): MatchStage
     {
         // Override the generated method to allow variadic arguments
         return self::generatedMatch($queries);

--- a/src/Builder/Stage.php
+++ b/src/Builder/Stage.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Stage\MatchStage;
 use MongoDB\Builder\Type\FieldQueryInterface;
@@ -21,9 +22,9 @@ final class Stage
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
      *
-     * @param QueryInterface|FieldQueryInterface|Type|stdClass|array<array-key,mixed>|bool|float|int|string|null ...$queries The query predicates to match
+     * @param QueryInterface|FieldQueryInterface|Type|stdClass|array<array-key, mixed>|bool|float|int|string|DateTimeInterface|null ...$queries The query predicates to match
      */
-    public static function match(QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null ...$queries): MatchStage
+    public static function match(QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|DateTimeInterface|null ...$queries): MatchStage
     {
         // Override the generated method to allow variadic arguments
         return self::generatedMatch($queries);

--- a/src/Builder/Stage/AddFieldsStage.php
+++ b/src/Builder/Stage/AddFieldsStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -30,14 +31,15 @@ final class AddFieldsStage implements StageInterface, OperatorInterface
     public const NAME = '$addFields';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression Specify the name of each field to add and set its value to an aggregation expression or an empty object. */
+    /** @var stdClass<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression Specify the name of each field to add and set its value to an aggregation expression or an empty object. */
     public readonly stdClass $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression Specify the name of each field to add and set its value to an aggregation expression or an empty object.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression Specify the name of each field to add and set its value to an aggregation expression or an empty object.
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+    ) {
         if (\count($expression) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $expression, got %d.', 1, \count($expression)));
         }

--- a/src/Builder/Stage/BucketAutoStage.php
+++ b/src/Builder/Stage/BucketAutoStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -36,8 +37,8 @@ final class BucketAutoStage implements StageInterface, OperatorInterface
         'granularity' => 'granularity',
     ];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy;
 
     /** @var int $buckets A positive 32-bit integer that specifies the number of buckets into which input documents are grouped. */
     public readonly int $buckets;
@@ -55,7 +56,7 @@ final class BucketAutoStage implements StageInterface, OperatorInterface
     public readonly Optional|string $granularity;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * @param int $buckets A positive 32-bit integer that specifies the number of buckets into which input documents are grouped.
      * @param Optional|Document|Serializable|array|stdClass $output A document that specifies the fields to include in the output documents in addition to the _id field. To specify the field to include, you must use accumulator expressions.
      * The default count field is not included in the output document when output is specified. Explicitly specify the count expression as part of the output document to include it.
@@ -63,7 +64,7 @@ final class BucketAutoStage implements StageInterface, OperatorInterface
      * Available only if the all groupBy values are numeric and none of them are NaN.
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
         int $buckets,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
         Optional|string $granularity = Optional::Undefined,

--- a/src/Builder/Stage/BucketStage.php
+++ b/src/Builder/Stage/BucketStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Serializable;
@@ -43,10 +44,10 @@ final class BucketStage implements StageInterface, OperatorInterface
     ];
 
     /**
-     * @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
+     * @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * Unless $bucket includes a default specification, each input document must resolve the groupBy field path or expression to a value that falls within one of the ranges specified by the boundaries.
      */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy;
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy;
 
     /**
      * @var BSONArray|PackedArray|array $boundaries An array of values based on the groupBy expression that specify the boundaries for each bucket. Each adjacent pair of values acts as the inclusive lower boundary and the exclusive upper boundary for the bucket. You must specify at least two boundaries.
@@ -55,12 +56,12 @@ final class BucketStage implements StageInterface, OperatorInterface
     public readonly PackedArray|BSONArray|array $boundaries;
 
     /**
-     * @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.
+     * @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.
      * If unspecified, each input document must resolve the groupBy expression to a value within one of the bucket ranges specified by boundaries or the operation throws an error.
      * The default value must be less than the lowest boundaries value, or greater than or equal to the highest boundaries value.
      * The default value can be of a different type than the entries in boundaries.
      */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default;
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default;
 
     /**
      * @var Optional|Document|Serializable|array|stdClass $output A document that specifies the fields to include in the output documents in addition to the _id field. To specify the field to include, you must use accumulator expressions.
@@ -70,11 +71,11 @@ final class BucketStage implements StageInterface, OperatorInterface
     public readonly Optional|Document|Serializable|stdClass|array $output;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * Unless $bucket includes a default specification, each input document must resolve the groupBy field path or expression to a value that falls within one of the ranges specified by the boundaries.
      * @param BSONArray|PackedArray|array $boundaries An array of values based on the groupBy expression that specify the boundaries for each bucket. Each adjacent pair of values acts as the inclusive lower boundary and the exclusive upper boundary for the bucket. You must specify at least two boundaries.
      * The specified values must be in ascending order and all of the same type. The exception is if the values are of mixed numeric types, such as:
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.
      * If unspecified, each input document must resolve the groupBy expression to a value within one of the bucket ranges specified by boundaries or the operation throws an error.
      * The default value must be less than the lowest boundaries value, or greater than or equal to the highest boundaries value.
      * The default value can be of a different type than the entries in boundaries.
@@ -83,9 +84,9 @@ final class BucketStage implements StageInterface, OperatorInterface
      * If you specify an output document, only the fields specified in the document are returned; i.e. the count field is not returned unless it is explicitly included in the output document.
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
         PackedArray|BSONArray|array $boundaries,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default = Optional::Undefined,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
     ) {
         $this->groupBy = $groupBy;

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
@@ -38,10 +39,10 @@ trait FactoryTrait
      * Adds new fields to documents. Outputs documents that contain all existing fields from the input documents and newly added fields.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression Specify the name of each field to add and set its value to an aggregation expression or an empty object.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression Specify the name of each field to add and set its value to an aggregation expression or an empty object.
      */
     public static function addFields(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ): AddFieldsStage {
         return new AddFieldsStage(...$expression);
     }
@@ -50,11 +51,11 @@ trait FactoryTrait
      * Categorizes incoming documents into groups, called buckets, based on a specified expression and bucket boundaries.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * Unless $bucket includes a default specification, each input document must resolve the groupBy field path or expression to a value that falls within one of the ranges specified by the boundaries.
      * @param BSONArray|PackedArray|array $boundaries An array of values based on the groupBy expression that specify the boundaries for each bucket. Each adjacent pair of values acts as the inclusive lower boundary and the exclusive upper boundary for the bucket. You must specify at least two boundaries.
      * The specified values must be in ascending order and all of the same type. The exception is if the values are of mixed numeric types, such as:
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.
      * If unspecified, each input document must resolve the groupBy expression to a value within one of the bucket ranges specified by boundaries or the operation throws an error.
      * The default value must be less than the lowest boundaries value, or greater than or equal to the highest boundaries value.
      * The default value can be of a different type than the entries in boundaries.
@@ -63,9 +64,9 @@ trait FactoryTrait
      * If you specify an output document, only the fields specified in the document are returned; i.e. the count field is not returned unless it is explicitly included in the output document.
      */
     public static function bucket(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
         PackedArray|BSONArray|array $boundaries,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $default = Optional::Undefined,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
     ): BucketStage {
         return new BucketStage($groupBy, $boundaries, $default, $output);
@@ -75,7 +76,7 @@ trait FactoryTrait
      * Categorizes incoming documents into a specific number of groups, called buckets, based on a specified expression. Bucket boundaries are automatically determined in an attempt to evenly distribute the documents into the specified number of buckets.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * @param int $buckets A positive 32-bit integer that specifies the number of buckets into which input documents are grouped.
      * @param Optional|Document|Serializable|array|stdClass $output A document that specifies the fields to include in the output documents in addition to the _id field. To specify the field to include, you must use accumulator expressions.
      * The default count field is not included in the output document when output is specified. Explicitly specify the count expression as part of the output document to include it.
@@ -83,7 +84,7 @@ trait FactoryTrait
      * Available only if the all groupBy values are numeric and none of them are NaN.
      */
     public static function bucketAuto(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $groupBy,
         int $buckets,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
         Optional|string $granularity = Optional::Undefined,
@@ -284,7 +285,7 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/
      * @param string $from Target collection for the $graphLookup operation to search, recursively matching the connectFromField to the connectToField. The from collection must be in the same database as any other collections used in the operation.
      * Starting in MongoDB 5.1, the collection specified in the from parameter can be sharded.
-     * @param BSONArray|ExpressionInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $startWith Expression that specifies the value of the connectFromField with which to start the recursive search. Optionally, startWith may be array of values, each of which is individually followed through the traversal process.
+     * @param BSONArray|DateTimeInterface|ExpressionInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $startWith Expression that specifies the value of the connectFromField with which to start the recursive search. Optionally, startWith may be array of values, each of which is individually followed through the traversal process.
      * @param string $connectFromField Field name whose value $graphLookup uses to recursively match against the connectToField of other documents in the collection. If the value is an array, each element is individually followed through the traversal process.
      * @param string $connectToField Field name in other documents against which to match the value of the field specified by the connectFromField parameter.
      * @param string $as Name of the array field added to each output document. Contains the documents traversed in the $graphLookup stage to reach the document.
@@ -294,7 +295,7 @@ trait FactoryTrait
      */
     public static function graphLookup(
         string $from,
-        PackedArray|Type|ExpressionInterface|BSONArray|stdClass|array|bool|float|int|null|string $startWith,
+        DateTimeInterface|PackedArray|Type|ExpressionInterface|BSONArray|stdClass|array|bool|float|int|null|string $startWith,
         string $connectFromField,
         string $connectToField,
         string $as,
@@ -309,11 +310,11 @@ trait FactoryTrait
      * Groups input documents by a specified identifier expression and applies the accumulator expression(s), if specified, to each group. Consumes all input documents and outputs one document per each distinct group. The output documents only contain the identifier field and, if specified, accumulated fields.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents.
      * @param AccumulatorInterface|Document|Serializable|array|stdClass ...$field Computed using the accumulator operators.
      */
     public static function group(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $_id,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $_id,
         Document|Serializable|AccumulatorInterface|stdClass|array ...$field,
     ): GroupStage {
         return new GroupStage($_id, ...$field);
@@ -477,10 +478,10 @@ trait FactoryTrait
      * Reshapes each document in the stream, such as by adding new fields or removing existing fields. For each input document, outputs one document.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$specification
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$specification
      */
     public static function project(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$specification,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$specification,
     ): ProjectStage {
         return new ProjectStage(...$specification);
     }
@@ -489,10 +490,10 @@ trait FactoryTrait
      * Reshapes each document in the stream by restricting the content for each document based on information stored in the documents themselves. Incorporates the functionality of $project and $match. Can be used to implement field level redaction. For each input document, outputs either one or zero documents.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function redact(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): RedactStage {
         return new RedactStage($expression);
     }
@@ -592,10 +593,11 @@ trait FactoryTrait
      * Alias for $addFields.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$field
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$field
      */
-    public static function set(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$field): SetStage
-    {
+    public static function set(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$field,
+    ): SetStage {
         return new SetStage(...$field);
     }
 
@@ -607,12 +609,12 @@ trait FactoryTrait
      * @param Document|Serializable|array|stdClass $sortBy Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting.
      * @param Document|Serializable|array|stdClass $output Specifies the field(s) to append to the documents in the output returned by the $setWindowFields stage. Each field is set to the result returned by the window operator.
      * A field can contain dots to specify embedded document fields and array fields. The semantics for the embedded document dotted notation in the $setWindowFields stage are the same as the $addFields and $set stages.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
      */
     public static function setWindowFields(
         Document|Serializable|stdClass|array $sortBy,
         Document|Serializable|stdClass|array $output,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy = Optional::Undefined,
     ): SetWindowFieldsStage {
         return new SetWindowFieldsStage($sortBy, $output, $partitionBy);
     }
@@ -643,10 +645,10 @@ trait FactoryTrait
      * Reorders the document stream by a specified sort key. Only the order changes; the documents remain unmodified. For each input document, outputs one document.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/
-     * @param ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
+     * @param DateTimeInterface|ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
      */
     public static function sort(
-        Type|ExpressionInterface|Sort|stdClass|array|bool|float|int|null|string ...$sort,
+        DateTimeInterface|Type|ExpressionInterface|Sort|stdClass|array|bool|float|int|null|string ...$sort,
     ): SortStage {
         return new SortStage(...$sort);
     }
@@ -655,10 +657,10 @@ trait FactoryTrait
      * Groups incoming documents based on the value of a specified expression, then computes the count of documents in each distinct group.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public static function sortByCount(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): SortByCountStage {
         return new SortByCountStage($expression);
     }

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
@@ -47,10 +48,10 @@ trait FluentFactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
      *
-     * @param QueryInterface|FieldQueryInterface|Type|stdClass|array<array-key,mixed>|bool|float|int|string|null ...$queries The query predicates to match
+     * @param QueryInterface|FieldQueryInterface|Type|stdClass|array<array-key, mixed>|bool|float|int|string|DateTimeInterface|null ...$queries The query predicates to match
      */
     public function match(
-        QueryInterface|FieldQueryInterface|Type|stdClass|array|string|int|float|bool|null ...$queries,
+        QueryInterface|FieldQueryInterface|Type|stdClass|DateTimeInterface|array|string|int|float|bool|null ...$queries,
     ): static {
         $this->pipeline[] = Stage::match(...$queries);
 
@@ -61,10 +62,10 @@ trait FluentFactoryTrait
      * Adds new fields to documents. Outputs documents that contain all existing fields from the input documents and newly added fields.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/addFields/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression Specify the name of each field to add and set its value to an aggregation expression or an empty object.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression Specify the name of each field to add and set its value to an aggregation expression or an empty object.
      */
     public function addFields(
-        Type|ExpressionInterface|stdClass|array|string|int|float|bool|null ...$expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null ...$expression,
     ): static {
         $this->pipeline[] = Stage::addFields(...$expression);
 
@@ -75,11 +76,11 @@ trait FluentFactoryTrait
      * Categorizes incoming documents into groups, called buckets, based on a specified expression and bucket boundaries.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucket/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * Unless $bucket includes a default specification, each input document must resolve the groupBy field path or expression to a value that falls within one of the ranges specified by the boundaries.
      * @param BSONArray|PackedArray|array $boundaries An array of values based on the groupBy expression that specify the boundaries for each bucket. Each adjacent pair of values acts as the inclusive lower boundary and the exclusive upper boundary for the bucket. You must specify at least two boundaries.
      * The specified values must be in ascending order and all of the same type. The exception is if the values are of mixed numeric types, such as:
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $default A literal that specifies the _id of an additional bucket that contains all documents whose groupBy expression result does not fall into a bucket specified by boundaries.
      * If unspecified, each input document must resolve the groupBy expression to a value within one of the bucket ranges specified by boundaries or the operation throws an error.
      * The default value must be less than the lowest boundaries value, or greater than or equal to the highest boundaries value.
      * The default value can be of a different type than the entries in boundaries.
@@ -88,9 +89,9 @@ trait FluentFactoryTrait
      * If you specify an output document, only the fields specified in the document are returned; i.e. the count field is not returned unless it is explicitly included in the output document.
      */
     public function bucket(
-        Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $groupBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $groupBy,
         PackedArray|BSONArray|array $boundaries,
-        Optional|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $default = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $default = Optional::Undefined,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
     ): static {
         $this->pipeline[] = Stage::bucket($groupBy, $boundaries, $default, $output);
@@ -102,7 +103,7 @@ trait FluentFactoryTrait
      * Categorizes incoming documents into a specific number of groups, called buckets, based on a specified expression. Bucket boundaries are automatically determined in an attempt to evenly distribute the documents into the specified number of buckets.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bucketAuto/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $groupBy An expression to group documents by. To specify a field path, prefix the field name with a dollar sign $ and enclose it in quotes.
      * @param int $buckets A positive 32-bit integer that specifies the number of buckets into which input documents are grouped.
      * @param Optional|Document|Serializable|array|stdClass $output A document that specifies the fields to include in the output documents in addition to the _id field. To specify the field to include, you must use accumulator expressions.
      * The default count field is not included in the output document when output is specified. Explicitly specify the count expression as part of the output document to include it.
@@ -110,7 +111,7 @@ trait FluentFactoryTrait
      * Available only if the all groupBy values are numeric and none of them are NaN.
      */
     public function bucketAuto(
-        Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $groupBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $groupBy,
         int $buckets,
         Optional|Document|Serializable|stdClass|array $output = Optional::Undefined,
         Optional|string $granularity = Optional::Undefined,
@@ -333,7 +334,7 @@ trait FluentFactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/graphLookup/
      * @param string $from Target collection for the $graphLookup operation to search, recursively matching the connectFromField to the connectToField. The from collection must be in the same database as any other collections used in the operation.
      * Starting in MongoDB 5.1, the collection specified in the from parameter can be sharded.
-     * @param BSONArray|ExpressionInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $startWith Expression that specifies the value of the connectFromField with which to start the recursive search. Optionally, startWith may be array of values, each of which is individually followed through the traversal process.
+     * @param BSONArray|DateTimeInterface|ExpressionInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $startWith Expression that specifies the value of the connectFromField with which to start the recursive search. Optionally, startWith may be array of values, each of which is individually followed through the traversal process.
      * @param string $connectFromField Field name whose value $graphLookup uses to recursively match against the connectToField of other documents in the collection. If the value is an array, each element is individually followed through the traversal process.
      * @param string $connectToField Field name in other documents against which to match the value of the field specified by the connectFromField parameter.
      * @param string $as Name of the array field added to each output document. Contains the documents traversed in the $graphLookup stage to reach the document.
@@ -343,7 +344,7 @@ trait FluentFactoryTrait
      */
     public function graphLookup(
         string $from,
-        PackedArray|Type|ExpressionInterface|BSONArray|stdClass|array|string|int|float|bool|null $startWith,
+        DateTimeInterface|PackedArray|Type|ExpressionInterface|BSONArray|stdClass|array|string|int|float|bool|null $startWith,
         string $connectFromField,
         string $connectToField,
         string $as,
@@ -360,11 +361,11 @@ trait FluentFactoryTrait
      * Groups input documents by a specified identifier expression and applies the accumulator expression(s), if specified, to each group. Consumes all input documents and outputs one document per each distinct group. The output documents only contain the identifier field and, if specified, accumulated fields.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents.
      * @param AccumulatorInterface|Document|Serializable|array|stdClass ...$field Computed using the accumulator operators.
      */
     public function group(
-        Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $_id,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $_id,
         Document|Serializable|AccumulatorInterface|stdClass|array ...$field,
     ): static {
         $this->pipeline[] = Stage::group($_id, ...$field);
@@ -538,10 +539,10 @@ trait FluentFactoryTrait
      * Reshapes each document in the stream, such as by adding new fields or removing existing fields. For each input document, outputs one document.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$specification
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$specification
      */
     public function project(
-        Type|ExpressionInterface|stdClass|array|string|int|float|bool|null ...$specification,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null ...$specification,
     ): static {
         $this->pipeline[] = Stage::project(...$specification);
 
@@ -552,10 +553,11 @@ trait FluentFactoryTrait
      * Reshapes each document in the stream by restricting the content for each document based on information stored in the documents themselves. Incorporates the functionality of $project and $match. Can be used to implement field level redaction. For each input document, outputs either one or zero documents.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/redact/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function redact(Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $expression): static
-    {
+    public function redact(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $expression,
+    ): static {
         $this->pipeline[] = Stage::redact($expression);
 
         return $this;
@@ -664,10 +666,11 @@ trait FluentFactoryTrait
      * Alias for $addFields.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/set/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$field
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$field
      */
-    public function set(Type|ExpressionInterface|stdClass|array|string|int|float|bool|null ...$field): static
-    {
+    public function set(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null ...$field,
+    ): static {
         $this->pipeline[] = Stage::set(...$field);
 
         return $this;
@@ -681,12 +684,12 @@ trait FluentFactoryTrait
      * @param Document|Serializable|array|stdClass $sortBy Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting.
      * @param Document|Serializable|array|stdClass $output Specifies the field(s) to append to the documents in the output returned by the $setWindowFields stage. Each field is set to the result returned by the window operator.
      * A field can contain dots to specify embedded document fields and array fields. The semantics for the embedded document dotted notation in the $setWindowFields stage are the same as the $addFields and $set stages.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
      */
     public function setWindowFields(
         Document|Serializable|stdClass|array $sortBy,
         Document|Serializable|stdClass|array $output,
-        Optional|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $partitionBy = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $partitionBy = Optional::Undefined,
     ): static {
         $this->pipeline[] = Stage::setWindowFields($sortBy, $output, $partitionBy);
 
@@ -723,10 +726,11 @@ trait FluentFactoryTrait
      * Reorders the document stream by a specified sort key. Only the order changes; the documents remain unmodified. For each input document, outputs one document.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/
-     * @param ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
+     * @param DateTimeInterface|ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
      */
-    public function sort(Type|ExpressionInterface|Sort|stdClass|array|string|int|float|bool|null ...$sort): static
-    {
+    public function sort(
+        DateTimeInterface|Type|ExpressionInterface|Sort|stdClass|array|string|int|float|bool|null ...$sort,
+    ): static {
         $this->pipeline[] = Stage::sort(...$sort);
 
         return $this;
@@ -736,10 +740,10 @@ trait FluentFactoryTrait
      * Groups incoming documents based on the value of a specified expression, then computes the count of documents in each distinct group.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sortByCount/
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
     public function sortByCount(
-        Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $expression,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $expression,
     ): static {
         $this->pipeline[] = Stage::sortByCount($expression);
 

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -48,10 +48,10 @@ trait FluentFactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
      *
-     * @param QueryInterface|FieldQueryInterface|Type|stdClass|array<array-key, mixed>|bool|float|int|string|DateTimeInterface|null ...$queries The query predicates to match
+     * @param DateTimeInterface|QueryInterface|FieldQueryInterface|Type|stdClass|array<array-key, mixed>|bool|float|int|string|null ...$queries The query predicates to match
      */
     public function match(
-        QueryInterface|FieldQueryInterface|Type|stdClass|DateTimeInterface|array|string|int|float|bool|null ...$queries,
+        DateTimeInterface|QueryInterface|FieldQueryInterface|Type|stdClass|array|string|int|float|bool|null ...$queries,
     ): static {
         $this->pipeline[] = Stage::match(...$queries);
 

--- a/src/Builder/Stage/GraphLookupStage.php
+++ b/src/Builder/Stage/GraphLookupStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\PackedArray;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
@@ -52,8 +53,8 @@ final class GraphLookupStage implements StageInterface, OperatorInterface
      */
     public readonly string $from;
 
-    /** @var BSONArray|ExpressionInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $startWith Expression that specifies the value of the connectFromField with which to start the recursive search. Optionally, startWith may be array of values, each of which is individually followed through the traversal process. */
-    public readonly PackedArray|Type|ExpressionInterface|BSONArray|stdClass|array|bool|float|int|null|string $startWith;
+    /** @var BSONArray|DateTimeInterface|ExpressionInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $startWith Expression that specifies the value of the connectFromField with which to start the recursive search. Optionally, startWith may be array of values, each of which is individually followed through the traversal process. */
+    public readonly DateTimeInterface|PackedArray|Type|ExpressionInterface|BSONArray|stdClass|array|bool|float|int|null|string $startWith;
 
     /** @var string $connectFromField Field name whose value $graphLookup uses to recursively match against the connectToField of other documents in the collection. If the value is an array, each element is individually followed through the traversal process. */
     public readonly string $connectFromField;
@@ -76,7 +77,7 @@ final class GraphLookupStage implements StageInterface, OperatorInterface
     /**
      * @param string $from Target collection for the $graphLookup operation to search, recursively matching the connectFromField to the connectToField. The from collection must be in the same database as any other collections used in the operation.
      * Starting in MongoDB 5.1, the collection specified in the from parameter can be sharded.
-     * @param BSONArray|ExpressionInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $startWith Expression that specifies the value of the connectFromField with which to start the recursive search. Optionally, startWith may be array of values, each of which is individually followed through the traversal process.
+     * @param BSONArray|DateTimeInterface|ExpressionInterface|PackedArray|Type|array|bool|float|int|null|stdClass|string $startWith Expression that specifies the value of the connectFromField with which to start the recursive search. Optionally, startWith may be array of values, each of which is individually followed through the traversal process.
      * @param string $connectFromField Field name whose value $graphLookup uses to recursively match against the connectToField of other documents in the collection. If the value is an array, each element is individually followed through the traversal process.
      * @param string $connectToField Field name in other documents against which to match the value of the field specified by the connectFromField parameter.
      * @param string $as Name of the array field added to each output document. Contains the documents traversed in the $graphLookup stage to reach the document.
@@ -86,7 +87,7 @@ final class GraphLookupStage implements StageInterface, OperatorInterface
      */
     public function __construct(
         string $from,
-        PackedArray|Type|ExpressionInterface|BSONArray|stdClass|array|bool|float|int|null|string $startWith,
+        DateTimeInterface|PackedArray|Type|ExpressionInterface|BSONArray|stdClass|array|bool|float|int|null|string $startWith,
         string $connectFromField,
         string $connectToField,
         string $as,

--- a/src/Builder/Stage/GroupStage.php
+++ b/src/Builder/Stage/GroupStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -33,18 +34,18 @@ final class GroupStage implements StageInterface, OperatorInterface
     public const NAME = '$group';
     public const PROPERTIES = ['_id' => '_id', 'field' => null];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents. */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $_id;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $_id;
 
     /** @var stdClass<AccumulatorInterface|Document|Serializable|array|stdClass> $field Computed using the accumulator operators. */
     public readonly stdClass $field;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $_id The _id expression specifies the group key. If you specify an _id value of null, or any other constant value, the $group stage returns a single document that aggregates values across all of the input documents.
      * @param AccumulatorInterface|Document|Serializable|array|stdClass ...$field Computed using the accumulator operators.
      */
     public function __construct(
-        Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $_id,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $_id,
         Document|Serializable|AccumulatorInterface|stdClass|array ...$field,
     ) {
         $this->_id = $_id;

--- a/src/Builder/Stage/ProjectStage.php
+++ b/src/Builder/Stage/ProjectStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -30,14 +31,15 @@ final class ProjectStage implements StageInterface, OperatorInterface
     public const NAME = '$project';
     public const PROPERTIES = ['specification' => 'specification'];
 
-    /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $specification */
+    /** @var stdClass<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $specification */
     public readonly stdClass $specification;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$specification
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$specification
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$specification)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$specification,
+    ) {
         if (\count($specification) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $specification, got %d.', 1, \count($specification)));
         }

--- a/src/Builder/Stage/RedactStage.php
+++ b/src/Builder/Stage/RedactStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class RedactStage implements StageInterface, OperatorInterface
     public const NAME = '$redact';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Stage/SetStage.php
+++ b/src/Builder/Stage/SetStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -31,14 +32,15 @@ final class SetStage implements StageInterface, OperatorInterface
     public const NAME = '$set';
     public const PROPERTIES = ['field' => 'field'];
 
-    /** @var stdClass<ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $field */
+    /** @var stdClass<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$field
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$field
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$field)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$field,
+    ) {
         if (\count($field) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $field, got %d.', 1, \count($field)));
         }

--- a/src/Builder/Stage/SetWindowFieldsStage.php
+++ b/src/Builder/Stage/SetWindowFieldsStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
@@ -40,19 +41,19 @@ final class SetWindowFieldsStage implements StageInterface, OperatorInterface
      */
     public readonly Document|Serializable|stdClass|array $output;
 
-    /** @var Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection. */
-    public readonly Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy;
+    /** @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection. */
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy;
 
     /**
      * @param Document|Serializable|array|stdClass $sortBy Specifies the field(s) to sort the documents by in the partition. Uses the same syntax as the $sort stage. Default is no sorting.
      * @param Document|Serializable|array|stdClass $output Specifies the field(s) to append to the documents in the output returned by the $setWindowFields stage. Each field is set to the result returned by the window operator.
      * A field can contain dots to specify embedded document fields and array fields. The semantics for the embedded document dotted notation in the $setWindowFields stage are the same as the $addFields and $set stages.
-     * @param Optional|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $partitionBy Specifies an expression to group the documents. In the $setWindowFields stage, the group of documents is known as a partition. Default is one partition for the entire collection.
      */
     public function __construct(
         Document|Serializable|stdClass|array $sortBy,
         Document|Serializable|stdClass|array $output,
-        Optional|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $partitionBy = Optional::Undefined,
     ) {
         $this->sortBy = $sortBy;
         $this->output = $output;

--- a/src/Builder/Stage/SortByCountStage.php
+++ b/src/Builder/Stage/SortByCountStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -27,14 +28,15 @@ final class SortByCountStage implements StageInterface, OperatorInterface
     public const NAME = '$sortByCount';
     public const PROPERTIES = ['expression' => 'expression'];
 
-    /** @var ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
-    public readonly Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
     /**
-     * @param ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
      */
-    public function __construct(Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
+    ) {
         $this->expression = $expression;
     }
 }

--- a/src/Builder/Stage/SortStage.php
+++ b/src/Builder/Stage/SortStage.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
@@ -31,14 +32,15 @@ final class SortStage implements StageInterface, OperatorInterface
     public const NAME = '$sort';
     public const PROPERTIES = ['sort' => 'sort'];
 
-    /** @var stdClass<ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string> $sort */
+    /** @var stdClass<DateTimeInterface|ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string> $sort */
     public readonly stdClass $sort;
 
     /**
-     * @param ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
+     * @param DateTimeInterface|ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
      */
-    public function __construct(Type|ExpressionInterface|Sort|stdClass|array|bool|float|int|null|string ...$sort)
-    {
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|Sort|stdClass|array|bool|float|int|null|string ...$sort,
+    ) {
         if (\count($sort) < 1) {
             throw new InvalidArgumentException(\sprintf('Expected at least %d values for $sort, got %d.', 1, \count($sort)));
         }

--- a/src/Builder/Type/QueryObject.php
+++ b/src/Builder/Type/QueryObject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Type;
 
+use DateTimeInterface;
 use MongoDB\BSON\Type;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
@@ -25,7 +26,7 @@ final class QueryObject implements QueryInterface
 {
     public readonly array $queries;
 
-    /** @param array<QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null> $queries */
+    /** @param array<DateTimeInterface|QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null> $queries */
     public static function create(array $queries): QueryInterface
     {
         // We don't wrap a single query in a QueryObject
@@ -36,7 +37,7 @@ final class QueryObject implements QueryInterface
         return new self($queries);
     }
 
-    /** @param array<QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null> $queriesOrArrayOfQueries */
+    /** @param array<DateTimeInterface|QueryInterface|FieldQueryInterface|Type|stdClass|array|bool|float|int|string|null> $queriesOrArrayOfQueries */
     private function __construct(array $queriesOrArrayOfQueries)
     {
         // If the first element is an array and not an operator, we assume variadic arguments were not used


### PR DESCRIPTION
PHPLIB-1634

With a new encoder, we only need to add DateTimeInterface to be accepted for the `date` type, as well as `any`. In addition, the stage factory needs manual updating, as well as some return types in the expression encoders.