### PR TITLE
Pre-init all sub-encoders of the builder encoder

### DIFF
--- a/src/Builder/Encoder/QueryEncoder.php
+++ b/src/Builder/Encoder/QueryEncoder.php
@@ -53,7 +53,7 @@ final class QueryEncoder implements Encoder
                     throw new LogicException(sprintf('Duplicate key "%s" in query object', $key));
                 }
 
-                $result->{$key} = $this->encoder->encodeIfSupported($value);
+                $result->{$key} = $this->recursiveEncode($value);
             }
         }
 

--- a/src/Builder/Encoder/RecursiveEncode.php
+++ b/src/Builder/Encoder/RecursiveEncode.php
@@ -11,6 +11,7 @@ use WeakReference;
 use function get_object_vars;
 use function is_array;
 
+/** @internal */
 trait RecursiveEncode
 {
     /** @param WeakReference<Encoder> $encoder */
@@ -46,6 +47,13 @@ trait RecursiveEncode
             return $value;
         }
 
+        /**
+         * If the BuilderEncoder instance is removed from the memory, the
+         * instances of the classes using this trait will be removed as well.
+         * Therefore, the weak reference will never return null.
+         *
+         * @psalm-suppress PossiblyNullReference
+         */
         return $this->encoder->get()->encodeIfSupported($value);
     }
 }

--- a/src/Builder/Encoder/RecursiveEncode.php
+++ b/src/Builder/Encoder/RecursiveEncode.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Encoder;
 
-use MongoDB\Builder\BuilderEncoder;
+use MongoDB\Codec\Encoder;
 use stdClass;
+use WeakReference;
 
 use function get_object_vars;
 use function is_array;
 
 trait RecursiveEncode
 {
-    final public function __construct(protected readonly BuilderEncoder $encoder)
+    /** @param WeakReference<Encoder> $encoder */
+    final public function __construct(private readonly WeakReference $encoder)
     {
     }
 
@@ -44,6 +46,6 @@ trait RecursiveEncode
             return $value;
         }
 
-        return $this->encoder->encodeIfSupported($value);
+        return $this->encoder->get()->encodeIfSupported($value);
     }
 }


### PR DESCRIPTION
- Use `WeakReference` to prevent circular reference
- Avoid having the same encoder initialized multiple times for all the stage and operator classes

The overhead of instantiating all these objects in the constructor is offset by the fact that we don't have to check each call.

![image](https://github.com/user-attachments/assets/4b0746b2-09c7-4f5b-bf30-292e81f9ad96)
