### PR TITLE
Test stable extension version in CI

### DIFF
--- a/.evergreen/config/generated/build/build-extension.yml
+++ b/.evergreen/config/generated/build/build-extension.yml
@@ -7,9 +7,6 @@ tasks:
         vars:
           PHP_VERSION: "8.4"
       - func: "compile extension"
-        # TODO: remove once 1.21.0 is released
-        vars:
-          EXTENSION_BRANCH: "v1.x"
       - func: "upload extension"
   - name: "build-php-8.4-lowest"
     tags: ["build", "php8.4", "lowest", "pr", "tag"]
@@ -19,9 +16,7 @@ tasks:
           PHP_VERSION: "8.4"
       - func: "compile extension"
         vars:
-          # TODO: change to "EXTENSION_VERSION: 1.21.0" once 1.21.0 is released
-          # EXTENSION_VERSION: "1.21.0"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_VERSION: "1.21.0"
       - func: "upload extension"
   - name: "build-php-8.4-next-stable"
     tags: ["build", "php8.4", "next-stable", "pr", "tag"]
@@ -31,9 +26,7 @@ tasks:
           PHP_VERSION: "8.4"
       - func: "compile extension"
         vars:
-          # TODO: change to "v1.21" once 1.21.0 is released
-          # EXTENSION_BRANCH: "v1.21"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.4-next-minor"
     tags: ["build", "php8.4", "next-minor"]
@@ -52,9 +45,6 @@ tasks:
         vars:
           PHP_VERSION: "8.3"
       - func: "compile extension"
-        # TODO: remove once 1.21.0 is released
-        vars:
-          EXTENSION_BRANCH: "v1.x"
       - func: "upload extension"
   - name: "build-php-8.3-lowest"
     tags: ["build", "php8.3", "lowest", "pr", "tag"]
@@ -64,9 +54,7 @@ tasks:
           PHP_VERSION: "8.3"
       - func: "compile extension"
         vars:
-          # TODO: change to "EXTENSION_VERSION: 1.21.0" once 1.21.0 is released
-          # EXTENSION_VERSION: "1.21.0"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_VERSION: "1.21.0"
       - func: "upload extension"
   - name: "build-php-8.3-next-stable"
     tags: ["build", "php8.3", "next-stable", "pr", "tag"]
@@ -76,9 +64,7 @@ tasks:
           PHP_VERSION: "8.3"
       - func: "compile extension"
         vars:
-          # TODO: change to "v1.21" once 1.21.0 is released
-          # EXTENSION_BRANCH: "v1.21"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.3-next-minor"
     tags: ["build", "php8.3", "next-minor"]
@@ -97,9 +83,6 @@ tasks:
         vars:
           PHP_VERSION: "8.2"
       - func: "compile extension"
-        # TODO: remove once 1.21.0 is released
-        vars:
-          EXTENSION_BRANCH: "v1.x"
       - func: "upload extension"
   - name: "build-php-8.2-lowest"
     tags: ["build", "php8.2", "lowest", "pr", "tag"]
@@ -109,9 +92,7 @@ tasks:
           PHP_VERSION: "8.2"
       - func: "compile extension"
         vars:
-          # TODO: change to "EXTENSION_VERSION: 1.21.0" once 1.21.0 is released
-          # EXTENSION_VERSION: "1.21.0"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_VERSION: "1.21.0"
       - func: "upload extension"
   - name: "build-php-8.2-next-stable"
     tags: ["build", "php8.2", "next-stable", "pr", "tag"]
@@ -121,9 +102,7 @@ tasks:
           PHP_VERSION: "8.2"
       - func: "compile extension"
         vars:
-          # TODO: change to "v1.21" once 1.21.0 is released
-          # EXTENSION_BRANCH: "v1.21"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.2-next-minor"
     tags: ["build", "php8.2", "next-minor"]
@@ -142,9 +121,6 @@ tasks:
         vars:
           PHP_VERSION: "8.1"
       - func: "compile extension"
-        # TODO: remove once 1.21.0 is released
-        vars:
-          EXTENSION_BRANCH: "v1.x"
       - func: "upload extension"
   - name: "build-php-8.1-lowest"
     tags: ["build", "php8.1", "lowest", "pr", "tag"]
@@ -154,9 +130,7 @@ tasks:
           PHP_VERSION: "8.1"
       - func: "compile extension"
         vars:
-          # TODO: change to "EXTENSION_VERSION: 1.21.0" once 1.21.0 is released
-          # EXTENSION_VERSION: "1.21.0"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_VERSION: "1.21.0"
       - func: "upload extension"
   - name: "build-php-8.1-next-stable"
     tags: ["build", "php8.1", "next-stable", "pr", "tag"]
@@ -166,9 +140,7 @@ tasks:
           PHP_VERSION: "8.1"
       - func: "compile extension"
         vars:
-          # TODO: change to "v1.21" once 1.21.0 is released
-          # EXTENSION_BRANCH: "v1.21"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.1-next-minor"
     tags: ["build", "php8.1", "next-minor"]

--- a/.evergreen/config/templates/build/build-extension.yml
+++ b/.evergreen/config/templates/build/build-extension.yml
@@ -5,9 +5,6 @@
         vars:
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
-        # TODO: remove once 1.21.0 is released
-        vars:
-          EXTENSION_BRANCH: "v1.x"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-lowest"
     tags: ["build", "php%phpVersion%", "lowest", "pr", "tag"]
@@ -17,9 +14,7 @@
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
         vars:
-          # TODO: change to "EXTENSION_VERSION: 1.21.0" once 1.21.0 is released
-          # EXTENSION_VERSION: "1.21.0"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_VERSION: "1.21.0"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-next-stable"
     tags: ["build", "php%phpVersion%", "next-stable", "pr", "tag"]
@@ -29,9 +24,7 @@
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
         vars:
-          # TODO: change to "v1.21" once 1.21.0 is released
-          # EXTENSION_BRANCH: "v1.21"
-          EXTENSION_BRANCH: "v1.x"
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-next-minor"
     tags: ["build", "php%phpVersion%", "next-minor"]

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -13,9 +13,7 @@ on:
 
 env:
   PHP_VERSION: "8.2"
-  # TODO: change to "stable" once 1.21.0 is released
-  # DRIVER_VERSION: "stable"
-  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.x"
+  DRIVER_VERSION: "stable"
 
 jobs:
   phpcs:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -13,9 +13,7 @@ on:
 
 env:
   PHP_VERSION: "8.2"
-  # TODO: change to "stable" once 1.21.0 is released
-  # DRIVER_VERSION: "stable"
-  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.x"
+  DRIVER_VERSION: "stable"
 
 jobs:
   psalm:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,9 +19,7 @@ on:
 
 env:
   PHP_VERSION: "8.2"
-  # TODO: change to "stable" once 1.21.0 is released
-  # DRIVER_VERSION: "stable"
-  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.x"
+  DRIVER_VERSION: "stable"
 
 jobs:
   psalm:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,7 @@ on:
       - "feature/*"
 
 env:
-  # TODO: change to "stable" once 1.21.0 is released
-  # DRIVER_VERSION: "stable"
-  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.x"
+  DRIVER_VERSION: "stable"
 
 jobs:
   phpunit:


### PR DESCRIPTION
This PR changes CI configuration to test against the stable version and branches of ext-mongodb 1.21. The merge needs to wait until that version has been released.