### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,9 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-hash": "*",
-        "ext-json": "*",
         "ext-mongodb": "^1.21.0",
         "composer-runtime-api": "^2.0",
-        "psr/log": "^1.1.4|^2|^3",
-        "symfony/polyfill-php80": "^1.27",
-        "symfony/polyfill-php81": "^1.27"
+        "psr/log": "^1.1.4|^2|^3"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",


### PR DESCRIPTION
- hash is always present (cannot be disabled)
- json is always present since 8.0
- polyfills no more needed as 8.1 is required