### PR TITLE
Support creating release branches when releasing new versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
       - name: "Store version numbers in env variables"
         run: |
           echo RELEASE_VERSION=${{ inputs.version }} >> $GITHUB_ENV
+          echo RELEASE_VERSION_WITHOUT_STABILITY=$(echo ${{ inputs.version }} | awk -F- '{print $1}') >> $GITHUB_ENV
           echo RELEASE_BRANCH=v$(echo ${{ inputs.version }} | cut -d '.' -f-2) >> $GITHUB_ENV
+          echo DEVELOPMENT_BRANCH=v$(echo ${{ inputs.version }} | cut -d '.' -f-1).x >> $GITHUB_ENV
 
       - name: "Ensure release tag does not already exist"
         run: |
@@ -66,15 +68,34 @@ jobs:
             exit 1
           fi
 
-      - name: "Fail if branch names don't match"
-        if: ${{ github.ref_name != env.RELEASE_BRANCH }}
+      # For patch releases (A.B.C where C != 0), we expect the release to be
+      # triggered from the vA.B release branch
+      - name: "Fail if patch release is created from wrong release branch"
+        if: ${{ !endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.RELEASE_BRANCH != github.ref_name }}
         run: |
           echo '❌ Release failed due to branch mismatch: expected ${{ inputs.version }} to be released from ${{ env.RELEASE_BRANCH }}, got ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          exit 1
+
+      # For non-patch releases (A.B.C where C == 0), we expect the release to
+      # be triggered from the vA.x development branch or the vA.B release branch.
+      # This includes pre-releases (e.g. alpha, beta, rc)
+      - name: "Fail if non-patch release is created from wrong release branch"
+        if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.RELEASE_BRANCH != github.ref_name && env.DEVELOPMENT_BRANCH != github.ref_name }}
+        run: |
+          echo '❌ Release failed due to branch mismatch: expected ${{ inputs.version }} to be released from ${{ env.RELEASE_BRANCH }} or ${{ env.DEVELOPMENT_BRANCH }}, got ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           exit 1
 
       #
       # Preliminary checks done - commence the release process
       #
+
+      # Create the new release branch if we're releasing from the vA.x
+      # development branch
+      - name: "Create new release branch"
+        if: ${{ github.ref_name != env.RELEASE_BRANCH }}
+        run: |
+          git checkout -b ${{ env.RELEASE_BRANCH }}
+          git push origin ${{ env.RELEASE_BRANCH }}
 
       - name: "Set up drivers-github-tools"
         uses: mongodb-labs/drivers-github-tools/setup@v2
@@ -90,7 +111,7 @@ jobs:
           EOL
 
       - name: "Create draft release"
-        run: echo "RELEASE_URL=$(gh release create ${{ inputs.version }} --target ${{ github.ref_name }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"
+        run: echo "RELEASE_URL=$(gh release create ${{ inputs.version }} --target ${{ env.RELEASE_BRANCH }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"
 
       - name: "Create release tag"
         uses: mongodb-labs/drivers-github-tools/tag-version@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           echo RELEASE_VERSION=${{ inputs.version }} >> $GITHUB_ENV
           echo RELEASE_VERSION_WITHOUT_STABILITY=$(echo ${{ inputs.version }} | awk -F- '{print $1}') >> $GITHUB_ENV
           echo RELEASE_BRANCH=v$(echo ${{ inputs.version }} | cut -d '.' -f-2) >> $GITHUB_ENV
-          echo DEVELOPMENT_BRANCH=v$(echo ${{ inputs.version }} | cut -d '.' -f-1).x >> $GITHUB_ENV
+          echo DEV_BRANCH=v$(echo ${{ inputs.version }} | cut -d '.' -f-1).x >> $GITHUB_ENV
 
       - name: "Ensure release tag does not already exist"
         run: |
@@ -69,7 +69,7 @@ jobs:
           fi
 
       # For patch releases (A.B.C where C != 0), we expect the release to be
-      # triggered from the vA.B release branch
+      # triggered from the A.B maintenance branch
       - name: "Fail if patch release is created from wrong release branch"
         if: ${{ !endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.RELEASE_BRANCH != github.ref_name }}
         run: |
@@ -77,25 +77,25 @@ jobs:
           exit 1
 
       # For non-patch releases (A.B.C where C == 0), we expect the release to
-      # be triggered from the vA.x development branch or the vA.B release branch.
-      # This includes pre-releases (e.g. alpha, beta, rc)
+      # be triggered from the A.x maintenance branch or A.x development branch
       - name: "Fail if non-patch release is created from wrong release branch"
-        if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.RELEASE_BRANCH != github.ref_name && env.DEVELOPMENT_BRANCH != github.ref_name }}
+        if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.RELEASE_BRANCH != github.ref_name && env.DEV_BRANCH != github.ref_name }}
         run: |
-          echo '❌ Release failed due to branch mismatch: expected ${{ inputs.version }} to be released from ${{ env.RELEASE_BRANCH }} or ${{ env.DEVELOPMENT_BRANCH }}, got ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          echo '❌ Release failed due to branch mismatch: expected ${{ inputs.version }} to be released from ${{ env.RELEASE_BRANCH }} or ${{ env.DEV_BRANCH }}, got ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           exit 1
+
+      # If a non-patch release is created from its A.x development branch,
+      # create the A.B maintenance branch from the current one and push it
+      - name: "Create and push new release branch for non-patch release"
+        if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.DEV_BRANCH == github.ref_name }}
+        run: |
+          echo '🆕 Creating new release branch ${RELEASE_BRANCH} from ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          git checkout -b ${RELEASE_BRANCH}
+          git push origin ${RELEASE_BRANCH}
 
       #
       # Preliminary checks done - commence the release process
       #
-
-      # Create the new release branch if we're releasing from the vA.x
-      # development branch
-      - name: "Create new release branch"
-        if: ${{ github.ref_name != env.RELEASE_BRANCH }}
-        run: |
-          git checkout -b ${{ env.RELEASE_BRANCH }}
-          git push origin ${{ env.RELEASE_BRANCH }}
 
       - name: "Set up drivers-github-tools"
         uses: mongodb-labs/drivers-github-tools/setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           exit 1
 
       # For non-patch releases (A.B.C where C == 0), we expect the release to
-      # be triggered from the A.x maintenance branch or A.x development branch
+      # be triggered from the A.B maintenance branch or A.x development branch
       - name: "Fail if non-patch release is created from wrong release branch"
         if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.RELEASE_BRANCH != github.ref_name && env.DEV_BRANCH != github.ref_name }}
         run: |


### PR DESCRIPTION
This PR adds branching logic to the release workflow to support creating new non-patch releases from development branches without having to manually push the release branch.

In summary:
- Non-patch releases (i.e. `A.B.0`), including pre-releases can be created from either the `vA.B` release branch or the `vA.x` development branch.
- Patch releases (i.e. `A.B.C`), including pre-releases have to be created from the `vA.B` release branch
- When creating a release from the development branch, the release branch will be created and pushed. Note that this may lead to a failure if the release branch already exists.