### PR TITLE
PHPLIB-1646: Inherit builderEncoder in Database::withOptions()

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -680,6 +680,7 @@ class Database
     public function withOptions(array $options = [])
     {
         $options += [
+            'builderEncoder' => $this->builderEncoder,
             'readConcern' => $this->readConcern,
             'readPreference' => $this->readPreference,
             'typeMap' => $this->typeMap,

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\Collection;
 
 use Closure;
 use MongoDB\BSON\Javascript;
+use MongoDB\Codec\DocumentCodec;
 use MongoDB\Codec\Encoder;
 use MongoDB\Collection;
 use MongoDB\Database;
@@ -376,6 +377,8 @@ class CollectionFunctionalTest extends FunctionalTestCase
     public function testWithOptionsInheritsOptions(): void
     {
         $collectionOptions = [
+            'builderEncoder' => $this->createMock(Encoder::class),
+            'codec' => $this->createMock(DocumentCodec::class),
             'readConcern' => new ReadConcern(ReadConcern::LOCAL),
             'readPreference' => new ReadPreference(ReadPreference::SECONDARY_PREFERRED),
             'typeMap' => ['root' => 'array'],
@@ -389,20 +392,17 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame($this->getCollectionName(), $debug['collectionName']);
-        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
-        $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
-        $this->assertSame(ReadPreference::SECONDARY_PREFERRED, $debug['readPreference']->getModeString());
-        $this->assertIsArray($debug['typeMap']);
-        $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
-        $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
+
+        foreach ($collectionOptions as $key => $value) {
+            $this->assertSame($value, $debug[$key]);
+        }
     }
 
     public function testWithOptionsPassesOptions(): void
     {
         $collectionOptions = [
-            'builderEncoder' => $builderEncoder = $this->createMock(Encoder::class),
+            'builderEncoder' => $this->createMock(Encoder::class),
+            'codec' => $this->createMock(DocumentCodec::class),
             'readConcern' => new ReadConcern(ReadConcern::LOCAL),
             'readPreference' => new ReadPreference(ReadPreference::SECONDARY_PREFERRED),
             'typeMap' => ['root' => 'array'],
@@ -412,15 +412,9 @@ class CollectionFunctionalTest extends FunctionalTestCase
         $clone = $this->collection->withOptions($collectionOptions);
         $debug = $clone->__debugInfo();
 
-        $this->assertSame($builderEncoder, $debug['builderEncoder']);
-        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
-        $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
-        $this->assertSame(ReadPreference::SECONDARY_PREFERRED, $debug['readPreference']->getModeString());
-        $this->assertIsArray($debug['typeMap']);
-        $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
-        $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
+        foreach ($collectionOptions as $key => $value) {
+            $this->assertSame($value, $debug[$key]);
+        }
     }
 
     #[Group('matrix-testing-exclude-server-4.4-driver-4.0')]

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests\Database;
 
 use MongoDB\BSON\PackedArray;
+use MongoDB\Codec\Encoder;
 use MongoDB\Collection;
 use MongoDB\Database;
 use MongoDB\Driver\BulkWrite;
@@ -50,6 +51,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
     public static function provideInvalidConstructorOptions()
     {
         return self::createOptionDataProvider([
+            'builderEncoder' => self::getInvalidObjectValues(),
             'readConcern' => self::getInvalidReadConcernValues(),
             'readPreference' => self::getInvalidReadPreferenceValues(),
             'typeMap' => self::getInvalidArrayValues(),
@@ -370,6 +372,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
     public function testWithOptionsInheritsOptions(): void
     {
         $databaseOptions = [
+            'builderEncoder' => $this->createMock(Encoder::class),
             'readConcern' => new ReadConcern(ReadConcern::LOCAL),
             'readPreference' => new ReadPreference(ReadPreference::SECONDARY_PREFERRED),
             'typeMap' => ['root' => 'array'],
@@ -382,19 +385,16 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
-        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
-        $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
-        $this->assertSame(ReadPreference::SECONDARY_PREFERRED, $debug['readPreference']->getModeString());
-        $this->assertIsArray($debug['typeMap']);
-        $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
-        $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
+
+        foreach ($databaseOptions as $key => $value) {
+            $this->assertSame($value, $debug[$key]);
+        }
     }
 
     public function testWithOptionsPassesOptions(): void
     {
         $databaseOptions = [
+            'builderEncoder' => $this->createMock(Encoder::class),
             'readConcern' => new ReadConcern(ReadConcern::LOCAL),
             'readPreference' => new ReadPreference(ReadPreference::SECONDARY_PREFERRED),
             'typeMap' => ['root' => 'array'],
@@ -404,13 +404,8 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $clone = $this->database->withOptions($databaseOptions);
         $debug = $clone->__debugInfo();
 
-        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
-        $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
-        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
-        $this->assertSame(ReadPreference::SECONDARY_PREFERRED, $debug['readPreference']->getModeString());
-        $this->assertIsArray($debug['typeMap']);
-        $this->assertSame(['root' => 'array'], $debug['typeMap']);
-        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
-        $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
+        foreach ($databaseOptions as $key => $value) {
+            $this->assertSame($value, $debug[$key]);
+        }
     }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1646

Adds missing options to tests for Database and Collection::withOptions(). Also simplifies assertion logic.