### PR TITLE
PHPLIB-1648: initialData.createOptions and $$lte operator

### DIFF
--- a/tests/UnifiedSpecTests/CollectionData.php
+++ b/tests/UnifiedSpecTests/CollectionData.php
@@ -14,8 +14,10 @@ use stdClass;
 
 use function PHPUnit\Framework\assertContainsOnly;
 use function PHPUnit\Framework\assertIsArray;
+use function PHPUnit\Framework\assertIsObject;
 use function PHPUnit\Framework\assertIsString;
 use function PHPUnit\Framework\assertNotNull;
+use function PHPUnit\Framework\assertObjectNotHasProperty;
 use function PHPUnit\Framework\assertThat;
 use function sprintf;
 
@@ -26,6 +28,8 @@ class CollectionData
     private string $databaseName;
 
     private array $documents;
+
+    private array $createOptions = [];
 
     public function __construct(stdClass $o)
     {
@@ -38,6 +42,15 @@ class CollectionData
         assertIsArray($o->documents);
         assertContainsOnly('object', $o->documents);
         $this->documents = $o->documents;
+
+        if (isset($o->createOptions)) {
+            assertIsObject($o->createOptions);
+            /* The writeConcern option is prohibited here, as prepareInitialData() applies w:majority. Since a session
+             * option would be ignored by prepareInitialData() we can assert that it is also omitted. */
+            assertObjectNotHasProperty('writeConcern', $o->createOptions);
+            assertObjectNotHasProperty('session', $o->createOptions);
+            $this->createOptions = (array) $o->createOptions;
+        }
     }
 
     public function prepareInitialData(Client $client, ?Session $session = null): void
@@ -49,13 +62,13 @@ class CollectionData
 
         $database->dropCollection($this->collectionName, ['session' => $session]);
 
-        if (empty($this->documents)) {
-            $database->createCollection($this->collectionName, ['session' => $session]);
-
-            return;
+        if (empty($this->documents) || ! empty($this->createOptions)) {
+            $database->createCollection($this->collectionName, ['session' => $session] + $this->createOptions);
         }
 
-        $database->selectCollection($this->collectionName)->insertMany($this->documents, ['session' => $session]);
+        if (! empty($this->documents)) {
+            $database->selectCollection($this->collectionName)->insertMany($this->documents, ['session' => $session]);
+        }
     }
 
     public function assertOutcome(Client $client): void

--- a/tests/UnifiedSpecTests/Constraint/Matches.php
+++ b/tests/UnifiedSpecTests/Constraint/Matches.php
@@ -4,6 +4,7 @@ namespace MongoDB\Tests\UnifiedSpecTests\Constraint;
 
 use LogicException;
 use MongoDB\BSON\Document;
+use MongoDB\BSON\Int64;
 use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
 use MongoDB\Model\BSONArray;

--- a/tests/UnifiedSpecTests/Constraint/Matches.php
+++ b/tests/UnifiedSpecTests/Constraint/Matches.php
@@ -30,10 +30,12 @@ use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertIsBool;
 use function PHPUnit\Framework\assertIsString;
 use function PHPUnit\Framework\assertJson;
+use function PHPUnit\Framework\assertLessThanOrEqual;
 use function PHPUnit\Framework\assertMatchesRegularExpression;
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertStringStartsWith;
 use function PHPUnit\Framework\assertThat;
+use function PHPUnit\Framework\assertTrue;
 use function PHPUnit\Framework\containsOnly;
 use function PHPUnit\Framework\isInstanceOf;
 use function PHPUnit\Framework\isType;
@@ -348,6 +350,14 @@ class Matches extends Constraint
             $lsid = $this->entityMap->getLogicalSessionId($operator['$$sessionLsid']);
 
             $this->assertEquals(self::prepare($lsid), $actual, $keyPath);
+
+            return;
+        }
+
+        if ($name === '$$lte') {
+            assertTrue(self::isNumeric($operator['$$lte']), '$$lte requires number');
+            assertTrue(self::isNumeric($actual), '$actual operand for $$lte should be a number');
+            assertLessThanOrEqual($operator['$$lte'], $actual);
 
             return;
         }

--- a/tests/UnifiedSpecTests/Context.php
+++ b/tests/UnifiedSpecTests/Context.php
@@ -492,6 +492,10 @@ final class Context
 
     private static function prepareCollectionOrDatabaseOptions(array $options): array
     {
+        if (array_key_exists('timeoutMS', $options)) {
+            Assert::markTestIncomplete('CSOT is not yet implemented (PHPC-1760)');
+        }
+
         Util::assertHasOnlyKeys($options, ['readConcern', 'readPreference', 'writeConcern']);
 
         return Util::prepareCommonOptions($options);

--- a/tests/UnifiedSpecTests/ExpectedError.php
+++ b/tests/UnifiedSpecTests/ExpectedError.php
@@ -81,6 +81,10 @@ final class ExpectedError
             $this->isClientError = $o->isClientError;
         }
 
+        if (property_exists($o, 'isTimeoutError')) {
+            Assert::markTestIncomplete('CSOT is not yet implemented (PHPC-1760)');
+        }
+
         if (isset($o->errorContains)) {
             assertIsString($o->errorContains);
             $this->messageContains = $o->errorContains;

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -53,9 +53,6 @@ class UnifiedSpecTest extends FunctionalTestCase
         'valid-pass/entity-client-cmap-events: events are captured during an operation' => 'PHPC does not implement CMAP',
         'valid-pass/expectedEventsForClient-eventType: eventType can be set to command and cmap' => 'PHPC does not implement CMAP',
         'valid-pass/expectedEventsForClient-eventType: eventType defaults to command if unset' => 'PHPC does not implement CMAP',
-        // CSOT is not yet implemented (PHPC-1760)
-        'valid-pass/collectionData-createOptions: collection is created with the correct options' => 'CSOT is not yet implemented (PHPC-1760)',
-        'valid-pass/operator-lte: special lte matching operator' => 'CSOT is not yet implemented (PHPC-1760)',
         // libmongoc always adds readConcern to aggregate command
         'index-management/search index operations ignore read and write concern: listSearchIndexes ignores read and write concern' => 'libmongoc appends readConcern to aggregate command',
         // Uses an invalid object name

--- a/tests/UnifiedSpecTests/UnifiedTestRunner.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunner.php
@@ -58,7 +58,7 @@ final class UnifiedTestRunner
     /**
      * Support for the following schema versions is incomplete:
      *
-     *   - 1.9: Only createEntities operation is implemented
+     *   - 1.9: collectionOrDatabaseOptions.timeoutMS and expectedError.isTimeoutError are not implemented
      *   - 1.10: Not implemented
      *   - 1.11: Not implemented, but CMAP is not applicable
      *   - 1.13: Only $$matchAsDocument and $$matchAsRoot is implemented


### PR DESCRIPTION
Adds support for UTF schema 1.9, sans two very specific CSOT options. Also fixes an outstanding bug detecting numerics in the Matches constraint.

https://jira.mongodb.org/browse/PHPLIB-1648
https://jira.mongodb.org/browse/PHPLIB-1650