### PR TITLE
PHPLIB-1659: Fix dropping collections after successful tests

### DIFF
--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -17,7 +17,6 @@ use MongoDB\Operation\CreateCollection;
 use MongoDB\Operation\DatabaseCommand;
 use MongoDB\Operation\ListCollections;
 use stdClass;
-use Throwable;
 use UnexpectedValueException;
 
 use function array_intersect_key;
@@ -70,15 +69,12 @@ abstract class FunctionalTestCase extends TestCase
         $this->configuredFailPoints = [];
     }
 
-    protected function onNotSuccessfulTest(Throwable $t): never
-    {
-        $this->cleanupCollections();
-
-        throw $t;
-    }
-
     public function tearDown(): void
     {
+        if ($this->status()->isSuccess()) {
+            $this->cleanupCollections();
+        }
+
         $this->disableFailPoints();
 
         parent::tearDown();


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1659

cb33c1c92b5d5cead5f18996db5825cc6064e81f introduced onNotSuccessfulTest(), but that is the inverse logic. The internal TestCase::status() method seems to be the only replacement for TestCase::hasFailed(), which was removed in PHPUnit 10.