### PR TITLE
PHPLIB-1660: Remove redundant CSFLE checks

### DIFF
--- a/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
+++ b/tests/Operation/CreateEncryptedCollectionFunctionalTest.php
@@ -27,10 +27,6 @@ class CreateEncryptedCollectionFunctionalTest extends FunctionalTestCase
 
         $this->skipIfClientSideEncryptionIsNotSupported();
 
-        if (! static::isCryptSharedLibAvailable() && ! static::isMongocryptdAvailable()) {
-            $this->markTestSkipped('Neither crypt_shared nor mongocryptd are available');
-        }
-
         if ($this->isStandalone()) {
             $this->markTestSkipped('Queryable Encryption requires replica sets');
         }

--- a/tests/SpecTests/ClientSideEncryption/FunctionalTestCase.php
+++ b/tests/SpecTests/ClientSideEncryption/FunctionalTestCase.php
@@ -25,10 +25,6 @@ abstract class FunctionalTestCase extends BaseFunctionalTestCase
         parent::setUp();
 
         $this->skipIfClientSideEncryptionIsNotSupported();
-
-        if (! static::isCryptSharedLibAvailable() && ! static::isMongocryptdAvailable()) {
-            $this->markTestSkipped('Neither crypt_shared nor mongocryptd are available');
-        }
     }
 
     public static function createTestClient(?string $uri = null, array $options = [], array $driverOptions = []): Client


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1660

skipIfClientSideEncryptionIsNotSupported() already checks for crypt_shared and mongocryptd (since 28f6ee8d37a4649264e1ac748a452a935e8683a3).