### PR TITLE
Test against 1.x branches/releases only

### DIFF
--- a/.evergreen/config/generated/build/build-extension.yml
+++ b/.evergreen/config/generated/build/build-extension.yml
@@ -7,6 +7,8 @@ tasks:
         vars:
           PHP_VERSION: "8.4"
       - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.4-lowest"
     tags: ["build", "php8.4", "lowest", "pr", "tag"]
@@ -17,16 +19,6 @@ tasks:
       - func: "compile extension"
         vars:
           EXTENSION_VERSION: "1.21.0"
-      - func: "upload extension"
-  - name: "build-php-8.4-next-stable"
-    tags: ["build", "php8.4", "next-stable", "pr", "tag"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "8.4"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.4-next-minor"
     tags: ["build", "php8.4", "next-minor"]
@@ -45,6 +37,8 @@ tasks:
         vars:
           PHP_VERSION: "8.3"
       - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.3-lowest"
     tags: ["build", "php8.3", "lowest", "pr", "tag"]
@@ -55,16 +49,6 @@ tasks:
       - func: "compile extension"
         vars:
           EXTENSION_VERSION: "1.21.0"
-      - func: "upload extension"
-  - name: "build-php-8.3-next-stable"
-    tags: ["build", "php8.3", "next-stable", "pr", "tag"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "8.3"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.3-next-minor"
     tags: ["build", "php8.3", "next-minor"]
@@ -83,6 +67,8 @@ tasks:
         vars:
           PHP_VERSION: "8.2"
       - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.2-lowest"
     tags: ["build", "php8.2", "lowest", "pr", "tag"]
@@ -93,16 +79,6 @@ tasks:
       - func: "compile extension"
         vars:
           EXTENSION_VERSION: "1.21.0"
-      - func: "upload extension"
-  - name: "build-php-8.2-next-stable"
-    tags: ["build", "php8.2", "next-stable", "pr", "tag"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "8.2"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.2-next-minor"
     tags: ["build", "php8.2", "next-minor"]
@@ -121,6 +97,8 @@ tasks:
         vars:
           PHP_VERSION: "8.1"
       - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.1-lowest"
     tags: ["build", "php8.1", "lowest", "pr", "tag"]
@@ -131,16 +109,6 @@ tasks:
       - func: "compile extension"
         vars:
           EXTENSION_VERSION: "1.21.0"
-      - func: "upload extension"
-  - name: "build-php-8.1-next-stable"
-    tags: ["build", "php8.1", "next-stable", "pr", "tag"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "8.1"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-8.1-next-minor"
     tags: ["build", "php8.1", "next-minor"]

--- a/.evergreen/config/generated/test-variant/phpc.yml
+++ b/.evergreen/config/generated/test-variant/phpc.yml
@@ -1,26 +1,6 @@
 # This file is generated automatically - please edit the "templates/test-variant/phpc.yml" template file instead.
 buildvariants:
   # Variants with different PHPC versions
-  - name: test-debian12-php-8.3-phpc-next-stable
-    tags: ["test", "debian", "x64", "php8.3", "pr", "tag"]
-    display_name: "Test: Debian 12, PHP 8.3, PHPC next-stable"
-    run_on: debian12-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian12"
-      FETCH_BUILD_TASK: "build-php-8.3-next-stable"
-      PHP_VERSION: "8.3"
-    depends_on:
-      - variant: "build-debian12"
-        name: "build-php-8.3-next-stable"
-    tasks:
-      - ".standalone .local !.csfle !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - "test_serverless_task_group"
-      - "test_serverless_proxy_task_group"
-      - "test-atlas-data-lake"
-
   - name: test-debian12-php-8.3-phpc-next-minor
     tags: ["test", "debian", "x64", "php8.3"]
     display_name: "Test: Debian 12, PHP 8.3, PHPC next-minor"

--- a/.evergreen/config/templates/build/build-extension.yml
+++ b/.evergreen/config/templates/build/build-extension.yml
@@ -5,6 +5,8 @@
         vars:
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
+        vars:
+          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-lowest"
     tags: ["build", "php%phpVersion%", "lowest", "pr", "tag"]
@@ -15,16 +17,6 @@
       - func: "compile extension"
         vars:
           EXTENSION_VERSION: "1.21.0"
-      - func: "upload extension"
-  - name: "build-php-%phpVersion%-next-stable"
-    tags: ["build", "php%phpVersion%", "next-stable", "pr", "tag"]
-    commands:
-      - func: "locate PHP binaries"
-        vars:
-          PHP_VERSION: "%phpVersion%"
-      - func: "compile extension"
-        vars:
-          EXTENSION_BRANCH: "v1.21"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-next-minor"
     tags: ["build", "php%phpVersion%", "next-minor"]

--- a/.evergreen/config/templates/test-variant/phpc.yml
+++ b/.evergreen/config/templates/test-variant/phpc.yml
@@ -1,24 +1,4 @@
   # Variants with different PHPC versions
-  - name: test-debian12-php-%phpVersion%-phpc-next-stable
-    tags: ["test", "debian", "x64", "php%phpVersion%", "pr", "tag"]
-    display_name: "Test: Debian 12, PHP %phpVersion%, PHPC next-stable"
-    run_on: debian12-small
-    expansions:
-      FETCH_BUILD_VARIANT: "build-debian12"
-      FETCH_BUILD_TASK: "build-php-%phpVersion%-next-stable"
-      PHP_VERSION: "%phpVersion%"
-    depends_on:
-      - variant: "build-debian12"
-        name: "build-php-%phpVersion%-next-stable"
-    tasks:
-      - ".standalone .local !.csfle !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".replicaset .local !.csfle !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".sharded .local !.csfle !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - ".loadbalanced .local !.csfle !.4.0 !.4.2 !.4.4 !.5.0 !.6.0"
-      - "test_serverless_task_group"
-      - "test_serverless_proxy_task_group"
-      - "test-atlas-data-lake"
-
   - name: test-debian12-php-%phpVersion%-phpc-next-minor
     tags: ["test", "debian", "x64", "php%phpVersion%"]
     display_name: "Test: Debian 12, PHP %phpVersion%, PHPC next-minor"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   PHP_VERSION: "8.2"
-  DRIVER_VERSION: "stable"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.21"
 
 jobs:
   phpcs:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   PHP_VERSION: "8.2"
-  DRIVER_VERSION: "stable"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.21"
 
 jobs:
   psalm:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   PHP_VERSION: "8.2"
-  DRIVER_VERSION: "stable"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.21"
 
 jobs:
   psalm:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
       - "feature/*"
 
 env:
-  DRIVER_VERSION: "stable"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v1.21"
 
 jobs:
   phpunit:


### PR DESCRIPTION
With the 2.0.0 release of the extension imminent, testing against "stable" can result in installing the 2.0 extension version if that is the last version uploaded to PECL. To avoid this, we now test with the following extension versions:
- 1.21-dev by default
- 1.21.0 as the lowest
- 1.x-dev as upcoming minor (which shouldn't be the case anymore)