### PR TITLE
Fix `readPreference` option in benchmark

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -16,7 +16,7 @@ env:
   DRIVER_VERSION: "mongodb/mongo-php-driver@v1.21"
 
 jobs:
-  psalm:
+  diff:
     name: "Diff check"
     runs-on: "ubuntu-22.04"
 

--- a/benchmark/src/Extension/EnvironmentProvider.php
+++ b/benchmark/src/Extension/EnvironmentProvider.php
@@ -62,7 +62,7 @@ class EnvironmentProvider implements ProviderInterface
         $buildInfo = $manager->executeCommand(
             Utils::getDatabaseName(),
             new Command(['buildInfo' => 1]),
-            new ReadPreference(ReadPreference::PRIMARY),
+            ['readPreference' => new ReadPreference(ReadPreference::PRIMARY)],
         )->toArray()[0];
 
         return [


### PR DESCRIPTION
Passing a `ReadPreference` to `executeCommand` is deprecated. The driver version 2 requires an array of options.