### PR TITLE
PHPLIB-1662 Update GHA test jobs to newer ubuntu version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,7 +24,7 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         extensions: "mongodb-${{ inputs.driver-version }}"
-        key: "extcache-v1"
+        key: "extcache-${{ inputs.driver-version }}"
 
     - name: Cache extensions
       uses: actions/cache@v4

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   phpcs:
     name: "phpcs"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: "Checkout"
@@ -36,7 +36,7 @@ jobs:
 
   rector:
     name: "Rector"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   diff:
     name: "Diff check"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   psalm:
     name: "Psalm"
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
             php-version: "8.1"
             mongodb-version: "6.0"
             topology: "sharded_cluster"
-          - os: "ubuntu-22.04"
+          - os: "ubuntu-24.04"
             php-version: "8.1"
             mongodb-version: "8.0"
             topology: "server"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - "ubuntu-20.04"
+          - "ubuntu-22.04"
         php-version:
           - "8.1"
           - "8.2"
@@ -34,23 +34,23 @@ jobs:
         topology:
           - "server"
         include:
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             php-version: "8.1"
             mongodb-version: "6.0"
             topology: "replica_set"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             php-version: "8.1"
             mongodb-version: "6.0"
             topology: "sharded_cluster"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             php-version: "8.1"
             mongodb-version: "5.0"
             topology: "server"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             php-version: "8.1"
             mongodb-version: "4.4"
             topology: "replica_set"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             php-version: "8.1"
             mongodb-version: "4.4"
             topology: "sharded_cluster"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           - "8.3"
           - "8.4"
         mongodb-version:
-          - "4.4"
+          - "6.0"
         topology:
           - "server"
         include:
@@ -44,15 +44,15 @@ jobs:
             topology: "sharded_cluster"
           - os: "ubuntu-22.04"
             php-version: "8.1"
-            mongodb-version: "5.0"
+            mongodb-version: "8.0"
             topology: "server"
-          - os: "ubuntu-22.04"
+          - os: "ubuntu-24.04"
             php-version: "8.1"
-            mongodb-version: "4.4"
+            mongodb-version: "8.0"
             topology: "replica_set"
-          - os: "ubuntu-22.04"
+          - os: "ubuntu-24.04"
             php-version: "8.1"
-            mongodb-version: "4.4"
+            mongodb-version: "8.0"
             topology: "sharded_cluster"
 
     steps:


### PR DESCRIPTION
Fix PHPLIB-1662

- MongoDB version < 6.0 are not available on ubuntu 22.04.
- Add build on MongoDB 8.0 using ubuntu 24.04

We could run legacy versions of the server in docker, as done in the [laravel package](https://github.com/mongodb/laravel-mongodb/blob/5.3/.github/workflows/build-ci.yml).