### PR TITLE
PHPLIB-1679 Call `DocumentCodec::encode()` only on objects

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -470,6 +470,10 @@
       <code><![CDATA[$args[0]]]></code>
       <code><![CDATA[$args[0]]]></code>
       <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]]]></code>
@@ -726,9 +730,6 @@
     <MixedAssignment>
       <code><![CDATA[$options['fields']]]></code>
     </MixedAssignment>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$replacement]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/FindOneAndUpdate.php">
     <MixedAssignment>
@@ -745,9 +746,6 @@
     <MixedMethodCall>
       <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$document]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/InsertOne.php">
     <MixedAssignment>
@@ -759,9 +757,6 @@
     <MixedMethodCall>
       <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$document]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/ListIndexes.php">
     <MixedAssignment>
@@ -788,11 +783,6 @@
     <MixedMethodCall>
       <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
-  </file>
-  <file src="src/Operation/ReplaceOne.php">
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$replacement]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/Update.php">
     <MixedArgument>

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -35,6 +35,7 @@ use function count;
 use function current;
 use function is_array;
 use function is_bool;
+use function is_object;
 use function key;
 use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
@@ -305,7 +306,7 @@ final class BulkWrite
                 case self::INSERT_ONE:
                     // $args[0] was already validated above. Since DocumentCodec::encode will always return a Document
                     // instance, there is no need to re-validate the returned value here.
-                    if ($codec) {
+                    if ($codec && is_object($args[0])) {
                         $operations[$i][$type][0] = $codec->encode($args[0]);
                     }
 
@@ -340,7 +341,7 @@ final class BulkWrite
                         throw new InvalidArgumentException(sprintf('Missing second argument for $operations[%d]["%s"]', $i, $type));
                     }
 
-                    if ($codec) {
+                    if ($codec && is_object($args[1])) {
                         $operations[$i][$type][1] = $codec->encode($args[1]);
                     }
 

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -28,6 +28,7 @@ use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Exception\UnsupportedValueException;
 
 use function array_is_list;
 use function array_key_exists;
@@ -306,7 +307,11 @@ final class BulkWrite
                 case self::INSERT_ONE:
                     // $args[0] was already validated above. Since DocumentCodec::encode will always return a Document
                     // instance, there is no need to re-validate the returned value here.
-                    if ($codec && is_object($args[0])) {
+                    if ($codec) {
+                        if (! is_object($args[0])) {
+                            throw UnsupportedValueException::invalidEncodableValue($args[0]);
+                        }
+
                         $operations[$i][$type][0] = $codec->encode($args[0]);
                     }
 
@@ -341,7 +346,11 @@ final class BulkWrite
                         throw new InvalidArgumentException(sprintf('Missing second argument for $operations[%d]["%s"]', $i, $type));
                     }
 
-                    if ($codec && is_object($args[1])) {
+                    if ($codec) {
+                        if (! is_object($args[1])) {
+                            throw UnsupportedValueException::invalidEncodableValue($args[1]);
+                        }
+
                         $operations[$i][$type][1] = $codec->encode($args[1]);
                     }
 

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -25,6 +25,7 @@ use MongoDB\Exception\UnsupportedException;
 
 use function array_key_exists;
 use function is_integer;
+use function is_object;
 use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
@@ -170,11 +171,9 @@ final class FindOneAndReplace implements Explainable
 
     private function validateReplacement(array|object $replacement, ?DocumentCodec $codec): array|object
     {
-        if (isset($codec)) {
+        if ($codec && is_object($replacement)) {
             $replacement = $codec->encode($replacement);
-        }
-
-        if (! is_document($replacement)) {
+        } elseif (! is_document($replacement)) {
             throw InvalidArgumentException::expectedDocumentType('$replacement', $replacement);
         }
 

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -22,6 +22,7 @@ use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Exception\UnsupportedValueException;
 
 use function array_key_exists;
 use function is_integer;
@@ -172,6 +173,10 @@ final class FindOneAndReplace implements Explainable
     private function validateReplacement(array|object $replacement, ?DocumentCodec $codec): array|object
     {
         if ($codec && is_object($replacement)) {
+            if (! is_object($replacement)) {
+                throw UnsupportedValueException::invalidEncodableValue($replacement);
+            }
+
             $replacement = $codec->encode($replacement);
         } elseif (! is_document($replacement)) {
             throw InvalidArgumentException::expectedDocumentType('$replacement', $replacement);

--- a/src/Operation/FindOneAndReplace.php
+++ b/src/Operation/FindOneAndReplace.php
@@ -172,7 +172,7 @@ final class FindOneAndReplace implements Explainable
 
     private function validateReplacement(array|object $replacement, ?DocumentCodec $codec): array|object
     {
-        if ($codec && is_object($replacement)) {
+        if ($codec) {
             if (! is_object($replacement)) {
                 throw UnsupportedValueException::invalidEncodableValue($replacement);
             }

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -29,6 +29,7 @@ use MongoDB\InsertManyResult;
 
 use function array_is_list;
 use function is_bool;
+use function is_object;
 use function MongoDB\is_document;
 use function sprintf;
 
@@ -189,11 +190,9 @@ final class InsertMany
         }
 
         foreach ($documents as $i => $document) {
-            if ($codec) {
-                $document = $documents[$i] = $codec->encode($document);
-            }
-
-            if (! is_document($document)) {
+            if ($codec && is_object($document)) {
+                $documents[$i] = $codec->encode($document);
+            } elseif (! is_document($document)) {
                 throw InvalidArgumentException::expectedDocumentType(sprintf('$documents[%d]', $i), $document);
             }
         }

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -25,6 +25,7 @@ use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\InsertManyResult;
 
 use function array_is_list;
@@ -190,7 +191,11 @@ final class InsertMany
         }
 
         foreach ($documents as $i => $document) {
-            if ($codec && is_object($document)) {
+            if ($codec) {
+                if (! is_object($document)) {
+                    throw UnsupportedValueException::invalidEncodableValue($document);
+                }
+
                 $documents[$i] = $codec->encode($document);
             } elseif (! is_document($document)) {
                 throw InvalidArgumentException::expectedDocumentType(sprintf('$documents[%d]', $i), $document);

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -25,6 +25,7 @@ use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\InsertOneResult;
 
 use function is_bool;
@@ -157,7 +158,11 @@ final class InsertOne
 
     private function validateDocument(array|object $document, ?DocumentCodec $codec): array|object
     {
-        if ($codec && is_object($document)) {
+        if ($codec) {
+            if (! is_object($document)) {
+                throw UnsupportedValueException::invalidEncodableValue($document);
+            }
+
             $document = $codec->encode($document);
         } elseif (! is_document($document)) {
             throw InvalidArgumentException::expectedDocumentType('$document', $document);

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -28,6 +28,7 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\InsertOneResult;
 
 use function is_bool;
+use function is_object;
 use function MongoDB\is_document;
 
 /**
@@ -156,11 +157,9 @@ final class InsertOne
 
     private function validateDocument(array|object $document, ?DocumentCodec $codec): array|object
     {
-        if ($codec) {
+        if ($codec && is_object($document)) {
             $document = $codec->encode($document);
-        }
-
-        if (! is_document($document)) {
+        } elseif (! is_document($document)) {
             throw InvalidArgumentException::expectedDocumentType('$document', $document);
         }
 

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -24,6 +24,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 use MongoDB\UpdateResult;
 
+use function is_object;
 use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
@@ -119,11 +120,9 @@ final class ReplaceOne
 
     private function validateReplacement(array|object $replacement, ?DocumentCodec $codec): array|object
     {
-        if ($codec) {
+        if ($codec && is_object($replacement)) {
             $replacement = $codec->encode($replacement);
-        }
-
-        if (! is_document($replacement)) {
+        } elseif (! is_document($replacement)) {
             throw InvalidArgumentException::expectedDocumentType('$replacement', $replacement);
         }
 

--- a/src/Operation/ReplaceOne.php
+++ b/src/Operation/ReplaceOne.php
@@ -22,6 +22,7 @@ use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Server;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\UpdateResult;
 
 use function is_object;
@@ -120,7 +121,11 @@ final class ReplaceOne
 
     private function validateReplacement(array|object $replacement, ?DocumentCodec $codec): array|object
     {
-        if ($codec && is_object($replacement)) {
+        if ($codec) {
+            if (! is_object($replacement)) {
+                throw UnsupportedValueException::invalidEncodableValue($replacement);
+            }
+
             $replacement = $codec->encode($replacement);
         } elseif (! is_document($replacement)) {
             throw InvalidArgumentException::expectedDocumentType('$replacement', $replacement);

--- a/tests/Collection/CodecCollectionFunctionalTest.php
+++ b/tests/Collection/CodecCollectionFunctionalTest.php
@@ -8,6 +8,7 @@ use MongoDB\BulkWriteResult;
 use MongoDB\Collection;
 use MongoDB\Driver\BulkWrite;
 use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnsupportedValueException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\FindOneAndReplace;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
@@ -264,6 +265,12 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $this->collection->findOneAndReplace(['_id' => 1], TestObject::createForFixture(1), $options);
     }
 
+    public function testFindOneAndReplaceWithArray(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+        $this->collection->findOneAndReplace(['_id' => 1], ['foo' => 'bar']);
+    }
+
     public static function provideFindOptions(): Generator
     {
         yield 'Default codec' => [
@@ -413,6 +420,12 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         $this->assertEquals($expected, $this->collection->find([], $options)->toArray());
     }
 
+    public function testInsertManyWithArray(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+        $this->collection->insertMany([['foo' => 'bar']]);
+    }
+
     public static function provideInsertOneOptions(): Generator
     {
         yield 'Default codec' => [
@@ -450,6 +463,12 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         }
 
         $this->assertEquals($expected, $this->collection->findOne([], $options));
+    }
+
+    public function testInsertOneWithArray(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+        $this->collection->insertOne(['foo' => 'bar']);
     }
 
     public static function provideReplaceOneOptions(): Generator
@@ -499,7 +518,13 @@ class CodecCollectionFunctionalTest extends FunctionalTestCase
         ];
 
         $this->expectExceptionObject(InvalidArgumentException::cannotCombineCodecAndTypeMap());
-        $this->collection->replaceOne(['_id' => 1], ['foo' => 'bar'], $options);
+        $this->collection->replaceOne(['_id' => 1], (object) ['foo' => 'bar'], $options);
+    }
+
+    public function testReplaceOneWithArray(): void
+    {
+        $this->expectExceptionObject(UnsupportedValueException::invalidEncodableValue([]));
+        $this->collection->replaceOne(['_id' => 1], ['foo' => 'bar']);
     }
 
     /**


### PR DESCRIPTION
Fix PHPLIB-1679

- Check if the input document is an object before calling `DocumentCodec::encode()`
- Never validate the value returned by `DocumentCodec::encode()` as the type `MongoDB\BSON\Document` is enforced.