### PR TITLE
Make serverless tasks patch-only

### DIFF
--- a/.evergreen/config/test-tasks.yml
+++ b/.evergreen/config/test-tasks.yml
@@ -10,6 +10,7 @@ tasks:
   - name: "test-serverless"
     tags: ["serverless"]
     exec_timeout_secs: 10800
+    patch_only: true
     commands:
       - func: "start kms servers"
       - func: "set aws temp creds"
@@ -18,6 +19,7 @@ tasks:
   - name: "test-serverless-proxy"
     tags: ["serverless"]
     exec_timeout_secs: 10800
+    patch_only: true
     commands:
       - func: "start kms servers"
       - func: "set aws temp creds"


### PR DESCRIPTION
This makes serverless tasks patch-only, as they're currently failing with an auth failure. This allows us to run patches on Evergreen for serverless while removing the failures from the waterfall.

Note: serverless tests will be removed in PHPLIB-1667 sometime in the future.