### PR TITLE
Improve type of Collection Bulk Write operations

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -438,95 +438,16 @@
   </file>
   <file src="src/Operation/BulkWrite.php">
     <MixedArgument>
-      <code><![CDATA[$args]]></code>
-      <code><![CDATA[$args]]></code>
-      <code><![CDATA[$args]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
       <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[2]]]></code>
     </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]['upsert']]]></code>
-      <code><![CDATA[$args[2]['upsert']]]></code>
-      <code><![CDATA[$args[2]['upsert']]]></code>
-      <code><![CDATA[$args[2]['upsert']]]></code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[1]['limit']]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]['multi']]]></code>
-      <code><![CDATA[$args[2]['multi']]]></code>
-      <code><![CDATA[$operations[$i][$type][0]]]></code>
-      <code><![CDATA[$operations[$i][$type][0]]]></code>
-      <code><![CDATA[$operations[$i][$type][0]]]></code>
-      <code><![CDATA[$operations[$i][$type][0]]]></code>
-      <code><![CDATA[$operations[$i][$type][1]]]></code>
-      <code><![CDATA[$operations[$i][$type][1]]]></code>
-      <code><![CDATA[$operations[$i][$type][1]]]></code>
-      <code><![CDATA[$operations[$i][$type][2]]]></code>
-      <code><![CDATA[$operations[$i][$type][2]]]></code>
-    </MixedArrayAssignment>
     <MixedAssignment>
-      <code><![CDATA[$args]]></code>
-      <code><![CDATA[$args]]></code>
       <code><![CDATA[$args[1]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
       <code><![CDATA[$insertedIds[$i]]]></code>
-      <code><![CDATA[$operations[$i][$type][0]]]></code>
-      <code><![CDATA[$operations[$i][$type][0]]]></code>
-      <code><![CDATA[$operations[$i][$type][0]]]></code>
-      <code><![CDATA[$operations[$i][$type][1]]]></code>
-      <code><![CDATA[$operations[$i][$type][1]]]></code>
-      <code><![CDATA[$operations[$i][$type][2]]]></code>
-      <code><![CDATA[$operations[$i][$type][2]]]></code>
+      <code><![CDATA[$operation[$type][0]]]></code>
+      <code><![CDATA[$operation[$type][0]]]></code>
+      <code><![CDATA[$operation[$type][0]]]></code>
+      <code><![CDATA[$operation[$type][1]]]></code>
       <code><![CDATA[$options[$option]]]></code>
       <code><![CDATA[$options['session']]]></code>
       <code><![CDATA[$options['writeConcern']]]></code>
@@ -534,10 +455,23 @@
     <MixedMethodCall>
       <code><![CDATA[isInTransaction]]></code>
     </MixedMethodCall>
-    <MixedOperand>
+    <NullArgument>
+      <code><![CDATA[$type]]></code>
+    </NullArgument>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$args[0]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$args[1]]]></code>
+      <code><![CDATA[$args[1]]]></code>
       <code><![CDATA[$args[2]]]></code>
-      <code><![CDATA[$args[2]]]></code>
-    </MixedOperand>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="src/Operation/ClientBulkWriteCommand.php">
     <MixedMethodCall>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -79,6 +79,7 @@ use function is_array;
 use function is_bool;
 use function strlen;
 
+/** @phpstan-import-type OperationType from BulkWrite */
 class Collection implements Stringable
 {
     private const DEFAULT_TYPE_MAP = [
@@ -253,12 +254,13 @@ class Collection implements Stringable
     /**
      * Executes multiple write operations.
      *
-     * @see BulkWrite::__construct() for supported options
-     * @param array[] $operations List of write operations
-     * @param array   $options    Command options
+     * @param list<array{deleteMany: list<array|object>}|array{deleteOne: list<array|object>}|array{insertOne: list<array|object>}|array{replaceOne: list<array|object>}|array{updateMany: list<array|object>}|array{updateOne: list<array|object>}> $operations List of write operations
+     * @psalm-param list<OperationType> $operations List of write operations
+     * @param array                                                                                                                                                                                                                                  $options    Command options
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)
+     * @see BulkWrite::__construct() for supported options
      */
     public function bulkWrite(array $operations, array $options = []): BulkWriteResult
     {

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -45,6 +45,9 @@ use function sprintf;
  * Operation for executing multiple write operations.
  *
  * @see \MongoDB\Collection::bulkWrite()
+ *
+ * @psalm-type Document = object|array
+ * @psalm-type OperationType = array{deleteMany: array{0: Document, 1?: array}}|array{deleteOne: array{0: Document, 1?: array}}|array{insertOne: array{0: Document}}|array{replaceOne: array{0: Document, 1: Document, 2?: array}}|array{updateMany: array{0: Document, 1: Document, 2?: array}}|array{updateOne: array{0: Document, 1: Document, 2?: array}}
  */
 final class BulkWrite
 {
@@ -55,7 +58,7 @@ final class BulkWrite
     public const UPDATE_MANY = 'updateMany';
     public const UPDATE_ONE  = 'updateOne';
 
-    /** @var array[] */
+    /** @psalm-var list<OperationType> */
     private array $operations;
 
     private array $options;
@@ -132,10 +135,11 @@ final class BulkWrite
      *
      *  * writeConcern (MongoDB\Driver\WriteConcern): Write concern.
      *
-     * @param string  $databaseName   Database name
-     * @param string  $collectionName Collection name
-     * @param array[] $operations     List of write operations
-     * @param array   $options        Command options
+     * @param string $databaseName   Database name
+     * @param string $collectionName Collection name
+     * @param array  $operations     List of write operations
+     * @psalm-param list<OperationType> $operations
+     * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
     public function __construct(private string $databaseName, private string $collectionName, array $operations, array $options = [])
@@ -276,12 +280,12 @@ final class BulkWrite
     }
 
     /**
-     * @param array[] $operations
-     * @return array[]
+     * @psalm-param list<OperationType> $operations
+     * @psalm-return list<OperationType>
      */
     private function validateOperations(array $operations, ?DocumentCodec $codec, Encoder $builderEncoder): array
     {
-        foreach ($operations as $i => $operation) {
+        foreach ($operations as $i => &$operation) {
             if (! is_array($operation)) {
                 throw InvalidArgumentException::invalidType(sprintf('$operations[%d]', $i), $operation, 'array');
             }
@@ -306,14 +310,14 @@ final class BulkWrite
                     // $args[0] was already validated above. Since DocumentCodec::encode will always return a Document
                     // instance, there is no need to re-validate the returned value here.
                     if ($codec) {
-                        $operations[$i][$type][0] = $codec->encode($args[0]);
+                        $operation[$type][0] = $codec->encode($args[0]);
                     }
 
                     break;
 
                 case self::DELETE_MANY:
                 case self::DELETE_ONE:
-                    $operations[$i][$type][0] = $builderEncoder->encodeIfSupported($args[0]);
+                    $operation[$type][0] = $builderEncoder->encodeIfSupported($args[0]);
 
                     if (! isset($args[1])) {
                         $args[1] = [];
@@ -329,19 +333,19 @@ final class BulkWrite
                         throw InvalidArgumentException::expectedDocumentType(sprintf('$operations[%d]["%s"][1]["collation"]', $i, $type), $args[1]['collation']);
                     }
 
-                    $operations[$i][$type][1] = $args[1];
+                    $operation[$type][1] = $args[1];
 
                     break;
 
                 case self::REPLACE_ONE:
-                    $operations[$i][$type][0] = $builderEncoder->encodeIfSupported($args[0]);
+                    $operation[$type][0] = $builderEncoder->encodeIfSupported($args[0]);
 
                     if (! isset($args[1]) && ! array_key_exists(1, $args)) {
                         throw new InvalidArgumentException(sprintf('Missing second argument for $operations[%d]["%s"]', $i, $type));
                     }
 
                     if ($codec) {
-                        $operations[$i][$type][1] = $codec->encode($args[1]);
+                        $operation[$type][1] = $codec->encode($args[1]);
                     }
 
                     if (! is_document($args[1])) {
@@ -384,19 +388,19 @@ final class BulkWrite
                         throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["upsert"]', $i, $type), $args[2]['upsert'], 'boolean');
                     }
 
-                    $operations[$i][$type][2] = $args[2];
+                    $operation[$type][2] = $args[2];
 
                     break;
 
                 case self::UPDATE_MANY:
                 case self::UPDATE_ONE:
-                    $operations[$i][$type][0] = $builderEncoder->encodeIfSupported($args[0]);
+                    $operation[$type][0] = $builderEncoder->encodeIfSupported($args[0]);
 
                     if (! isset($args[1]) && ! array_key_exists(1, $args)) {
                         throw new InvalidArgumentException(sprintf('Missing second argument for $operations[%d]["%s"]', $i, $type));
                     }
 
-                    $operations[$i][$type][1] = $args[1] = $builderEncoder->encodeIfSupported($args[1]);
+                    $operation[$type][1] = $args[1] = $builderEncoder->encodeIfSupported($args[1]);
 
                     if ((! is_document($args[1]) || ! is_first_key_operator($args[1])) && ! is_pipeline($args[1])) {
                         throw new InvalidArgumentException(sprintf('Expected update operator(s) or non-empty pipeline for $operations[%d]["%s"][1]', $i, $type));
@@ -433,7 +437,7 @@ final class BulkWrite
                         throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]["upsert"]', $i, $type), $args[2]['upsert'], 'boolean');
                     }
 
-                    $operations[$i][$type][2] = $args[2];
+                    $operation[$type][2] = $args[2];
 
                     break;
 

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -41,6 +41,15 @@ class BulkWriteTest extends TestCase
         ]);
     }
 
+    public function testEmptyOperation(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected one element in $operation[0], actually: 0');
+        new BulkWrite($this->getDatabaseName(), $this->getCollectionName(), [
+            [],
+        ]);
+    }
+
     public function testUnknownOperation(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
The `Collection::bulkWrite($operations)` method requires a complex array structure for the operations list. Describing this type using psalm custom type feature to helps static analysis.

PHPStorm is able to make the completion only with the full `@param` annotation, not `@phpstan-param` nor `@psaml-param`. And only when I start typing the first letter.
<img width="597" height="220" alt="image" src="https://github.com/user-attachments/assets/054e4e09-cd12-4568-b7f9-037aaeae1a97" />
<img width="596" height="291" alt="image" src="https://github.com/user-attachments/assets/18c35e05-c58e-4915-811b-feb05f822ee4" />

Both Psalm and PHPStan detect when the argument is invalid. The PHPStorm inspection does not detect issues when the array does not match the expected `@param` type.

<img width="960" height="263" alt="image" src="https://github.com/user-attachments/assets/55cffe50-b344-43fe-a1e2-cbeb6806ff67" />
