### PR TITLE
PHPLIB-1680: Remove obsolete wire version checks for MongoDB 4.2

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -809,9 +809,6 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Operation/Update.php">
-    <MixedArgument>
-      <code><![CDATA[$this->options['writeConcern']]]></code>
-    </MixedArgument>
     <MixedAssignment>
       <code><![CDATA[$cmd['bypassDocumentValidation']]]></code>
       <code><![CDATA[$options[$option]]]></code>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -85,8 +85,6 @@ class Collection
         'root' => BSONDocument::class,
     ];
 
-    private const WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE = 8;
-
     /** @psalm-var Encoder<array|stdClass|Document|PackedArray, mixed> */
     private readonly Encoder $builderEncoder;
 
@@ -227,23 +225,16 @@ class Collection
         $hasWriteStage = is_last_pipeline_operator_write($pipeline);
 
         $options = $this->inheritReadPreference($options);
-
-        $server = $hasWriteStage
-            ? select_server_for_aggregate_write_stage($this->manager, $options)
-            : select_server($this->manager, $options);
-
-        /* MongoDB 4.2 and later supports a read concern when an $out stage is
-         * being used, but earlier versions do not.
-         */
-        if (! $hasWriteStage || server_supports_feature($server, self::WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE)) {
-            $options = $this->inheritReadConcern($options);
-        }
-
+        $options = $this->inheritReadConcern($options);
         $options = $this->inheritCodecOrTypeMap($options);
 
         if ($hasWriteStage) {
             $options = $this->inheritWriteOptions($options);
         }
+
+        $server = $hasWriteStage
+            ? select_server_for_aggregate_write_stage($this->manager, $options)
+            : select_server($this->manager, $options);
 
         $operation = new Aggregate($this->databaseName, $this->collectionName, $pipeline, $options);
 

--- a/src/Database.php
+++ b/src/Database.php
@@ -64,8 +64,6 @@ class Database
         'root' => BSONDocument::class,
     ];
 
-    private const WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE = 8;
-
     /** @psalm-var Encoder<array|stdClass|Document|PackedArray, mixed> */
     private readonly Encoder $builderEncoder;
 
@@ -220,8 +218,7 @@ class Database
          */
         if (
             ! isset($options['readConcern']) &&
-            ! is_in_transaction($options) &&
-            ( ! $hasWriteStage || server_supports_feature($server, self::WIRE_VERSION_FOR_READ_CONCERN_WITH_WRITE_STAGE))
+            ! is_in_transaction($options)
         ) {
             $options['readConcern'] = $this->readConcern;
         }

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -55,8 +55,6 @@ final class FindAndModify implements Explainable
 {
     private const WIRE_VERSION_FOR_HINT = 9;
 
-    private const WIRE_VERSION_FOR_UNSUPPORTED_OPTION_SERVER_SIDE_ERROR = 8;
-
     private array $options;
 
     /**
@@ -227,12 +225,6 @@ final class FindAndModify implements Explainable
      */
     public function execute(Server $server): array|object|null
     {
-        /* Server versions >= 4.2.0 raise errors for unsupported update options.
-         * For previous versions, the CRUD spec requires a client-side error. */
-        if (isset($this->options['hint']) && ! server_supports_feature($server, self::WIRE_VERSION_FOR_UNSUPPORTED_OPTION_SERVER_SIDE_ERROR)) {
-            throw UnsupportedException::hintNotSupported();
-        }
-
         /* CRUD spec requires a client-side error when using "hint" with an
          * unacknowledged write concern on an unsupported server. */
         if (

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -32,8 +32,6 @@ use function is_string;
 use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
-use function MongoDB\is_write_concern_acknowledged;
-use function MongoDB\server_supports_feature;
 
 /**
  * Operation for the update command.
@@ -46,8 +44,6 @@ use function MongoDB\server_supports_feature;
  */
 final class Update implements Explainable
 {
-    private const WIRE_VERSION_FOR_HINT = 8;
-
     private array $options;
 
     /**
@@ -176,15 +172,6 @@ final class Update implements Explainable
      */
     public function execute(Server $server): UpdateResult
     {
-        /* CRUD spec requires a client-side error when using "hint" with an
-         * unacknowledged write concern on an unsupported server. */
-        if (
-            isset($this->options['writeConcern']) && ! is_write_concern_acknowledged($this->options['writeConcern']) &&
-            isset($this->options['hint']) && ! server_supports_feature($server, self::WIRE_VERSION_FOR_HINT)
-        ) {
-            throw UnsupportedException::hintNotSupported();
-        }
-
         $inTransaction = isset($this->options['session']) && $this->options['session']->isInTransaction();
         if ($inTransaction && isset($this->options['writeConcern'])) {
             throw UnsupportedException::writeConcernNotSupportedInTransaction();


### PR DESCRIPTION
PHPLIB-1680