### PR TITLE
PHPLIB-1678: Fix failing builds

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -9,9 +9,9 @@ command_type: system
 # Fail builds when pre tasks fail.
 pre_error_fails_task: true
 
-# Protect ourselves against rogue test case that runs forever. Tasks are killed after 20 minutes, which shouldn't occur
+# Protect ourselves against rogue test case that runs forever. Tasks are killed after 30 minutes, which shouldn't occur
 # under normal circumstances.
-exec_timeout_secs: 1200
+exec_timeout_secs: 1800
 
 # These pre and post rules apply to all tasks not part of a task group, which should only ever be tests against local
 # MongoDB instances. All other tasks that require special preparation should be run from within a task group

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -158,6 +158,7 @@ functions:
   "bootstrap mongohoused":
     - command: shell.exec
       params:
+        include_expansions_in_env: [AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, AWS_SESSION_TOKEN]
         script: |
           cd ${DRIVERS_TOOLS}/.evergreen/atlas_data_lake
 

--- a/.evergreen/config/test-tasks.yml
+++ b/.evergreen/config/test-tasks.yml
@@ -25,6 +25,9 @@ tasks:
 
   - name: "test-atlas-data-lake"
     commands:
+      - command: ec2.assume_role
+        params:
+          role_arn: ${aws_test_secrets_role}
       - func: "bootstrap mongohoused"
       - func: "run atlas data lake test"
 


### PR DESCRIPTION
PHPLIB-1678

This backports the commit added to the merge-up PR as I didn't realise this also affects 1.21 (and was incomplete on top of that). I also increased the timeout as we've run into some build timeouts during peak Evergreen usage.