### PR TITLE
PHPLIB-1674: Fix timeouts in CSE custom endpoint test

### DIFF
--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -762,7 +762,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             'kmsProviders' => [
                 'azure' => Context::getAzureCredentials() + ['identityPlatformEndpoint' => 'doesnotexist.invalid:443'],
                 'gcp' => Context::getGCPCredentials() + ['endpoint' => 'doesnotexist.invalid:443'],
-                'kmip' => ['endpoint' => 'doesnotexist.local:5698'],
+                'kmip' => ['endpoint' => 'doesnotexist.invalid:5698'],
             ],
             'tlsOptions' => [
                 'kmip' => Context::getKmsTlsOptions(),
@@ -810,9 +810,9 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         ];
 
         yield 'Test 4' => [
-            static function (self $test, ClientEncryption $clientEncryption, ClientEncryption $clientEncryptionInvalid) use ($awsMasterKey): void {
+            static function (self $test, ClientEncryption $clientEncryption, ClientEncryption $clientEncryptionInvalid) use ($kmipMasterKey): void {
                 $test->expectException(ConnectionException::class);
-                $clientEncryption->createDataKey('aws', ['masterKey' => $awsMasterKey + ['endpoint' => 'kms.us-east-1.amazonaws.com:12345']]);
+                $clientEncryption->createDataKey('kmip', ['masterKey' => $kmipMasterKey + ['endpoint' => 'localhost:12345']]);
             },
         ];
 
@@ -873,7 +873,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                 $test->assertSame('test', $clientEncryption->decrypt($encrypted));
 
                 $test->expectException(RuntimeException::class);
-                $test->expectExceptionMessageMatches('#doesnotexist.local#');
+                $test->expectExceptionMessageMatches('#doesnotexist.invalid#');
                 $clientEncryptionInvalid->createDataKey('kmip', ['masterKey' => $kmipMasterKey]);
             },
         ];
@@ -890,10 +890,10 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         yield 'Test 12' => [
             static function (self $test, ClientEncryption $clientEncryption, ClientEncryption $clientEncryptionInvalid) use ($kmipMasterKey): void {
-                $kmipMasterKey['endpoint'] = 'doesnotexist.local:5698';
+                $kmipMasterKey['endpoint'] = 'doesnotexist.invalid:5698';
 
                 $test->expectException(RuntimeException::class);
-                $test->expectExceptionMessageMatches('#doesnotexist.local#');
+                $test->expectExceptionMessageMatches('#doesnotexist.invalid#');
                 $clientEncryption->createDataKey('kmip', ['masterKey' => $kmipMasterKey]);
             },
         ];


### PR DESCRIPTION
PHPLIB-1674

This should speed up our builds as each build is currently spending ~4 minutes waiting for timeouts.