### PR TITLE
Relax assertion when checking exception message

### DIFF
--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -612,7 +612,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             $previous = $e->getPrevious();
 
             $this->assertInstanceOf(EncryptionException::class, $previous);
-            $this->assertSame('cannot auto encrypt a view', $previous->getMessage());
+            $this->assertStringContainsString('cannot auto encrypt a view', $previous->getMessage());
         }
     }
 


### PR DESCRIPTION
This PR updates a test assertion for compatibility with the upcoming minor version of the extension. The newer libmongocrypt version bundled in that version adds the view name to the exception message, so the test would fail. This PR intentionally targets v2.1 as that version is tested with the upcoming minor version of the extension and would cause issues if we have to release a bugfix after merging https://github.com/mongodb/mongo-php-driver/pull/1829.