### PR TITLE
Fix missing placeholder replacement in release output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: "Create and push new release branch for non-patch release"
         if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.DEV_BRANCH == github.ref_name }}
         run: |
-          echo '🆕 Creating new release branch ${RELEASE_BRANCH} from ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          echo '🆕 Creating new release branch ${{ env.RELEASE_BRANCH }} from ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           git checkout -b ${RELEASE_BRANCH}
           git push origin ${RELEASE_BRANCH}
 


### PR DESCRIPTION
This fixes a missing variable replacement in the release output:
![image](https://github.com/user-attachments/assets/7c8e29ac-e9e4-43a6-8d46-b50dec8850a7)
