### PR TITLE
PHPLIB-1649: Add `CollectionInfo::isView`

### DIFF
--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -131,6 +131,14 @@ class CollectionInfo implements ArrayAccess
     }
 
     /**
+     * Determines whether the collection is a view.
+     */
+    public function isView(): bool
+    {
+        return $this->getType() === 'view';
+    }
+
+    /**
      * Check whether a field exists in the collection information.
      *
      * @see https://php.net/arrayaccess.offsetexists

--- a/tests/Model/CollectionInfoTest.php
+++ b/tests/Model/CollectionInfoTest.php
@@ -10,7 +10,7 @@ class CollectionInfoTest extends TestCase
 {
     public function testGetBasicInformation(): void
     {
-        $info = new CollectionInfo([
+        $viewInfo = new CollectionInfo([
             'name' => 'foo',
             'type' => 'view',
             'options' => ['capped' => true, 'size' => 1_048_576],
@@ -18,20 +18,27 @@ class CollectionInfoTest extends TestCase
             'idIndex' => ['idIndex' => true], // Dummy option
         ]);
 
-        $this->assertSame('foo', $info->getName());
-        $this->assertSame('foo', $info['name']);
+        $this->assertSame('foo', $viewInfo->getName());
+        $this->assertSame('foo', $viewInfo['name']);
 
-        $this->assertSame('view', $info->getType());
-        $this->assertSame('view', $info['type']);
+        $this->assertTrue($viewInfo->isView());
+        $this->assertSame('view', $viewInfo['type']);
 
-        $this->assertSame(['capped' => true, 'size' => 1_048_576], $info->getOptions());
-        $this->assertSame(['capped' => true, 'size' => 1_048_576], $info['options']);
+        $this->assertSame(['capped' => true, 'size' => 1_048_576], $viewInfo->getOptions());
+        $this->assertSame(['capped' => true, 'size' => 1_048_576], $viewInfo['options']);
 
-        $this->assertSame(['readOnly' => true], $info->getInfo());
-        $this->assertSame(['readOnly' => true], $info['info']);
+        $this->assertSame(['readOnly' => true], $viewInfo->getInfo());
+        $this->assertSame(['readOnly' => true], $viewInfo['info']);
 
-        $this->assertSame(['idIndex' => true], $info->getIdIndex());
-        $this->assertSame(['idIndex' => true], $info['idIndex']);
+        $this->assertSame(['idIndex' => true], $viewInfo->getIdIndex());
+        $this->assertSame(['idIndex' => true], $viewInfo['idIndex']);
+
+        $collectionInfo = new CollectionInfo([
+            'name' => 'bar',
+            'type' => 'collection',
+        ]);
+
+        $this->assertFalse($collectionInfo->isView());
     }
 
     public function testMissingFields(): void


### PR DESCRIPTION
To provide a more convenient way of determining if a collection is a view.

Closes PHPLIB-1649