### PR TITLE
Report coverage and test results for GitHub Actions runs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,7 +23,7 @@ runs:
       uses: shivammathur/cache-extensions@v1
       with:
         php-version: ${{ inputs.php-version }}
-        extensions: "mongodb-${{ inputs.driver-version }}"
+        extensions: "xdebug,mongodb-${{ inputs.driver-version }}"
         key: "extcache-${{ inputs.driver-version }}"
 
     - name: Cache extensions
@@ -37,7 +37,7 @@ runs:
       uses: shivammathur/setup-php@v2
       with:
         coverage: none
-        extensions: "mongodb-${{ inputs.driver-version }}"
+        extensions: "xdebug,mongodb-${{ inputs.driver-version }}"
         php-version: "${{ inputs.php-version }}"
         tools: cs2pr
         ini-values: "${{ inputs.php-ini-values }}"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,7 +23,7 @@ runs:
       uses: shivammathur/cache-extensions@v1
       with:
         php-version: ${{ inputs.php-version }}
-        extensions: "xdebug,mongodb-${{ inputs.driver-version }}"
+        extensions: "mongodb-${{ inputs.driver-version }}"
         key: "extcache-${{ inputs.driver-version }}"
 
     - name: Cache extensions
@@ -36,8 +36,8 @@ runs:
     - name: Install PHP
       uses: shivammathur/setup-php@v2
       with:
-        coverage: none
-        extensions: "xdebug,mongodb-${{ inputs.driver-version }}"
+        coverage: xdebug
+        extensions: "mongodb-${{ inputs.driver-version }}"
         php-version: "${{ inputs.php-version }}"
         tools: cs2pr
         ini-values: "${{ inputs.php-ini-values }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
           php-ini-values: "zend.assertions=1"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit --configuration phpunit.evergreen.xml"
+        run: "vendor/bin/phpunit --configuration phpunit.evergreen.xml --coverage-clover coverage.xml"
         env:
           XDEBUG_MODE: "coverage"
           MONGODB_URI: ${{ steps.setup-mongodb.outputs.cluster-uri }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,23 @@ jobs:
           php-ini-values: "zend.assertions=1"
 
       - name: "Run PHPUnit"
-        run: "vendor/bin/phpunit"
+        run: "vendor/bin/phpunit --configuration phpunit.evergreen.xml"
         env:
+          XDEBUG_MODE: "coverage"
           MONGODB_URI: ${{ steps.setup-mongodb.outputs.cluster-uri }}
+
+      - name: "Upload coverage report"
+        uses: codecov/codecov-action@v5
+        with:
+          disable_search: true
+          files: coverage.xml
+          flags: "${{ matrix.mongodb-version }}-${{ matrix.topology }}"
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@v1
+        with:
+          disable_search: true
+          files: test-results.xml
+          flags: "${{ matrix.mongodb-version }}-${{ matrix.topology }}"
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,36 +23,38 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - "ubuntu-22.04"
+          - "ubuntu-24.04"
         php-version:
           - "8.1"
           - "8.2"
           - "8.3"
           - "8.4"
         mongodb-version:
-          - "6.0"
+          - "8.0"
         topology:
-          - "server"
+          - "replica_set"
         include:
-          - os: "ubuntu-22.04"
-            php-version: "8.1"
-            mongodb-version: "6.0"
-            topology: "replica_set"
-          - os: "ubuntu-22.04"
-            php-version: "8.1"
-            mongodb-version: "6.0"
-            topology: "sharded_cluster"
+          # Test additional topologies for MongoDB 8.0
           - os: "ubuntu-24.04"
-            php-version: "8.1"
+            php-version: "8.4"
             mongodb-version: "8.0"
             topology: "server"
           - os: "ubuntu-24.04"
-            php-version: "8.1"
+            php-version: "8.4"
             mongodb-version: "8.0"
+            topology: "sharded_cluster"
+          # Test lowest server/php versions
+          - os: "ubuntu-22.04"
+            php-version: "8.1"
+            mongodb-version: "6.0"
+            topology: "server"
+          - os: "ubuntu-22.04"
+            php-version: "8.1"
+            mongodb-version: "6.0"
             topology: "replica_set"
-          - os: "ubuntu-24.04"
+          - os: "ubuntu-22.04"
             php-version: "8.1"
-            mongodb-version: "8.0"
+            mongodb-version: "6.0"
             topology: "sharded_cluster"
 
     steps:

--- a/phpunit.evergreen.xml
+++ b/phpunit.evergreen.xml
@@ -25,6 +25,18 @@
         </testsuite>
     </testsuites>
 
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
+
+    <coverage>
+        <report>
+            <clover outputFile="coverage.xml" />
+        </report>
+    </coverage>
+
     <logging>
         <junit outputFile="test-results.xml" />
     </logging>

--- a/phpunit.evergreen.xml
+++ b/phpunit.evergreen.xml
@@ -31,12 +31,6 @@
         </include>
     </source>
 
-    <coverage>
-        <report>
-            <clover outputFile="coverage.xml" />
-        </report>
-    </coverage>
-
     <logging>
         <junit outputFile="test-results.xml" />
     </logging>


### PR DESCRIPTION
In this first PR, we start reporting coverage and test results to codecov.io to get baseline coverage information. I'll add coverage reporting to Evergreen in a separate pull request as this requires changes to the toolchain first.

Note that running tests in coverage mode with xdebug is significantly slower, so we should keep an eye on whether the runtime of tests is still acceptable.