### PR TITLE
Upload evergreen test results to codecov.io

### DIFF
--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -139,6 +139,7 @@ functions:
               --disable-search \
               --fail-on-error \
               --token ${CODECOV_TOKEN} \
+              --flag "${MONGODB_VERSION}-${TOPOLOGY}" \
               --file test-results.xml || \
               echo "Skipping codecov test result upload due to error"
 

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -126,6 +126,21 @@ functions:
     - command: attach.results
       params:
         file_location: "${DRIVERS_TOOLS}/results.json"
+    - command: shell.exec
+      params:
+        working_dir: src
+        script: |
+          ${PREPARE_SHELL}
+          curl -Os https://cli.codecov.io/latest/linux/codecov
+          sudo chmod +x codecov
+          [[ -f test-results.xml ]] && \
+            ./codecov upload-process \
+              --report-type test_results \
+              --disable-search \
+              --fail-on-error \
+              --token ${CODECOV_TOKEN} \
+              --file test-results.xml || \
+              echo "Skipping codecov test result upload due to error"
 
   "bootstrap mongo-orchestration":
     - command: shell.exec

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -131,19 +131,21 @@ functions:
         working_dir: src
         script: |
           ${PREPARE_SHELL}
-          curl -Os https://cli.codecov.io/latest/linux/codecov
-          curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
-          shasum -a 256 -c codecov.SHA256SUM
-          sudo chmod +x codecov
-          [[ -f test-results.xml ]] && \
+          if [ -f test-results.xml ]; then
+            curl -Os https://cli.codecov.io/latest/linux/codecov
+            curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            sudo chmod +x codecov
             ./codecov upload-process \
               --report-type test_results \
               --disable-search \
               --fail-on-error \
               --token ${CODECOV_TOKEN} \
               --flag "${MONGODB_VERSION}-${TOPOLOGY}" \
-              --file test-results.xml || \
-              echo "Skipping codecov test result upload due to error"
+              --file test-results.xml
+          else
+            echo "Skipping codecov test result upload"
+          fi
 
   "bootstrap mongo-orchestration":
     - command: shell.exec
@@ -167,7 +169,6 @@ functions:
           printf "\n" >> mo-expansion.yml
           printf "MONGODB_VERSION: '%s'\n" "${MONGODB_VERSION}" >> mo-expansion.yml
           printf "TOPOLOGY: '%s'\n" "${TOPOLOGY}" >> mo-expansion.yml
-          cat mo-expansion.yml
     # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -158,6 +158,13 @@ functions:
           LOAD_BALANCER=${LOAD_BALANCER} \
           REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
           bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+    - command: shell.exec
+      params:
+        script: |
+          printf "\n" >> mo-expansion.yml
+          printf "MONGODB_VERSION: '%s'\n" "${MONGODB_VERSION}" >> mo-expansion.yml
+          printf "TOPOLOGY: '%s'\n" "${TOPOLOGY}" >> mo-expansion.yml
+          cat mo-expansion.yml
     # run-orchestration generates expansion file with MONGODB_URI and CRYPT_SHARED_LIB_PATH
     - command: expansions.update
       params:

--- a/.evergreen/config/functions.yml
+++ b/.evergreen/config/functions.yml
@@ -132,6 +132,8 @@ functions:
         script: |
           ${PREPARE_SHELL}
           curl -Os https://cli.codecov.io/latest/linux/codecov
+          curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
+          shasum -a 256 -c codecov.SHA256SUM
           sudo chmod +x codecov
           [[ -f test-results.xml ]] && \
             ./codecov upload-process \


### PR DESCRIPTION
In order to better use the flaky test feature of codecov.io, this PR adds a step to upload the test result file to codecov.io, as is already done for GitHub Actions.