### PR TITLE
PHPLIB-1695 Add `$createObjectId` operator to the agg builder

### DIFF
--- a/generator/config/expression/createObjectId.yaml
+++ b/generator/config/expression/createObjectId.yaml
@@ -1,0 +1,17 @@
+# $schema: ../schema.json
+name: $createObjectId
+link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/createObjectId/'
+type:
+  - resolvesToObjectId
+encode: object
+description: |
+  Returns a random object ID
+tests:
+  -
+    name: 'Example'
+    link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/createObjectId/#example'
+    pipeline:
+      -
+        $project:
+          objectId:
+            $createObjectId: {}

--- a/src/Builder/Expression/CreateObjectIdOperator.php
+++ b/src/Builder/Expression/CreateObjectIdOperator.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+
+/**
+ * Returns a random object ID
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/createObjectId/
+ * @internal
+ */
+final class CreateObjectIdOperator implements ResolvesToObjectId, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$createObjectId';
+
+    public function __construct()
+    {
+    }
+}

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -428,6 +428,16 @@ trait FactoryTrait
     }
 
     /**
+     * Returns a random object ID
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/createObjectId/
+     */
+    public static function createObjectId(): CreateObjectIdOperator
+    {
+        return new CreateObjectIdOperator();
+    }
+
+    /**
      * Adds a number of time units to a date object.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/

--- a/tests/Builder/Expression/CreateObjectIdOperatorTest.php
+++ b/tests/Builder/Expression/CreateObjectIdOperatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $createObjectId expression
+ */
+class CreateObjectIdOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                objectId: Expression::createObjectId(),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::CreateObjectIdExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -911,6 +911,23 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/createObjectId/#example
+     */
+    case CreateObjectIdExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "objectId": {
+                    "$createObjectId": {}
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Add a Future Date
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateAdd/#add-a-future-date


### PR DESCRIPTION
Fix PHPLIB-1695

The documentation is not available yet, so I invented an example. To be updated once the documentation is published.