### PR TITLE
Update rst spec links to markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,21 +58,21 @@ The test suite references the following environment variables:
    `username` URI option for clients constructed by the test suite, which will
    override any credentials in the connection string itself.
 
-The following environment variable is used for [stable API testing](https://github.com/mongodb/specifications/blob/master/source/versioned-api/tests/README.rst):
+The following environment variable is used for [stable API testing](https://github.com/mongodb/specifications/blob/master/source/versioned-api/tests/README.md):
 
  * `API_VERSION`: If defined, this value will be used to construct a
    [`MongoDB\Driver\ServerApi`](https://www.php.net/manual/en/mongodb-driver-serverapi.construct.php),
    which will then be specified as the `serverApi` driver option for clients
    created by the test suite.
 
-The following environment variables are used for [load balancer testing](https://github.com/mongodb/specifications/blob/master/source/load-balancers/tests/README.rst):
+The following environment variables are used for [load balancer testing](https://github.com/mongodb/specifications/blob/master/source/load-balancers/tests/README.md):
 
  * `MONGODB_SINGLE_MONGOS_LB_URI`: Connection string to a load balancer backed
    by a single mongos host.
  * `MONGODB_MULTI_MONGOS_LB_URI`: Connection string to a load balancer backed by
    multiple mongos hosts.
 
-The following environment variables are used for [CSFLE testing](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst):
+The following environment variables are used for [CSFLE testing](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md):
 
  * `AWS_ACCESS_KEY_ID`
  * `AWS_SECRET_ACCESS_KEY`

--- a/benchmark/src/DriverBench/MultiDocBench.php
+++ b/benchmark/src/DriverBench/MultiDocBench.php
@@ -20,7 +20,7 @@ use function file_get_contents;
 final class MultiDocBench
 {
     /**
-     * @see https://github.com/mongodb/specifications/blob/master/source/benchmarking/benchmarking.rst#find-many-and-empty-the-cursor
+     * @see https://github.com/mongodb/specifications/blob/master/source/benchmarking/benchmarking.md#find-many-and-empty-the-cursor
      * @param array{options: array} $params
      */
     #[BeforeMethods('beforeFindMany')]

--- a/src/ChangeStream.php
+++ b/src/ChangeStream.php
@@ -173,7 +173,7 @@ class ChangeStream implements Iterator
     /**
      * Determines if an exception is a resumable error.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resumable-error
+     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md#resumable-error
      */
     private function isResumableError(RuntimeException $exception): bool
     {

--- a/src/Database.php
+++ b/src/Database.php
@@ -268,7 +268,7 @@ class Database
      * collection.
      *
      * @see CreateCollection::__construct() for supported options
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#create-collection-helper
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#create-collection-helper
      * @see https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/manage-collections/
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors

--- a/src/Model/ChangeStreamIterator.php
+++ b/src/Model/ChangeStreamIterator.php
@@ -270,7 +270,7 @@ final class ChangeStreamIterator extends IteratorIterator implements CommandSubs
     /**
      * Perform housekeeping after an iteration event.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#updating-the-cached-resume-token
+     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md#updating-the-cached-resume-token
      */
     private function onIteration(bool $incrementBatchPosition): void
     {

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -30,7 +30,7 @@ use function array_key_exists;
  * collection. It provides methods to access options for the collection.
  *
  * @see \MongoDB\Database::listCollections()
- * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-collections.rst
+ * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-collections.md
  * @template-implements ArrayAccess<string, mixed>
  */
 class CollectionInfo implements ArrayAccess

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -34,7 +34,7 @@ use function array_search;
  * db.collection.createIndex() documentation.
  *
  * @see \MongoDB\Collection::listIndexes()
- * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst
+ * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.md
  * @see https://mongodb.com/docs/manual/reference/method/db.collection.createIndex/
  * @template-implements ArrayAccess<string, mixed>
  */
@@ -152,7 +152,7 @@ class IndexInfo implements ArrayAccess
      * also be used to access fields that do not have a helper method.
      *
      * @see https://php.net/arrayaccess.offsetget
-     * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst#getting-full-index-information
+     * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.md#getting-full-index-information
      * @psalm-param array-key $offset
      */
     public function offsetGet(mixed $offset): mixed

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -35,7 +35,7 @@ use function sprintf;
  *
  * @internal
  * @see \MongoDB\Collection::createIndexes()
- * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst
+ * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.md
  * @see https://mongodb.com/docs/manual/reference/method/db.collection.createIndex/
  */
 final class IndexInput implements Serializable

--- a/src/Model/SearchIndexInput.php
+++ b/src/Model/SearchIndexInput.php
@@ -31,7 +31,7 @@ use function MongoDB\is_document;
  *
  * @internal
  * @see \MongoDB\Collection::createSearchIndexes()
- * @see https://github.com/mongodb/specifications/blob/master/source/index-management/index-management.rst#search-indexes
+ * @see https://github.com/mongodb/specifications/blob/master/source/index-management/index-management.md#search-indexes
  * @see https://mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/
  */
 final class SearchIndexInput implements Serializable

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -35,7 +35,7 @@ use function MongoDB\is_document;
  * Operation for obtaining an exact count of documents in a collection
  *
  * @see \MongoDB\Collection::countDocuments()
- * @see https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#countdocuments
+ * @see https://github.com/mongodb/specifications/blob/master/source/crud/crud.md#countdocuments
  */
 final class CountDocuments
 {

--- a/src/Operation/CreateEncryptedCollection.php
+++ b/src/Operation/CreateEncryptedCollection.php
@@ -44,8 +44,8 @@ use function MongoDB\server_supports_feature;
  * @internal
  * @see \MongoDB\Database::createCollection()
  * @see \MongoDB\Database::createEncryptedCollection()
- * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#create-collection-helper
- * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#create-encrypted-collection-helper
+ * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#create-collection-helper
+ * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#create-encrypted-collection-helper
  * @see https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/manage-collections/
  */
 final class CreateEncryptedCollection

--- a/src/Operation/DropEncryptedCollection.php
+++ b/src/Operation/DropEncryptedCollection.php
@@ -34,7 +34,7 @@ use function MongoDB\is_document;
  * @internal
  * @see \MongoDB\Database::dropCollection()
  * @see \MongoDB\Collection::drop()
- * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#drop-collection-helper
+ * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#drop-collection-helper
  * @see https://www.mongodb.com/docs/manual/core/queryable-encryption/fundamentals/manage-collections/
  */
 final class DropEncryptedCollection

--- a/src/Operation/Watch.php
+++ b/src/Operation/Watch.php
@@ -364,7 +364,7 @@ final class Watch implements /* @internal */ CommandSubscriber
     /**
      * Return the initial resume token for creating the ChangeStreamIterator.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#updating-the-cached-resume-token
+     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md#updating-the-cached-resume-token
      */
     private function getInitialResumeToken(): array|object|null
     {
@@ -386,7 +386,7 @@ final class Watch implements /* @internal */ CommandSubscriber
     /**
      * Resumes a change stream.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resume-process
+     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md#resume-process
      * @throws InvalidArgumentException
      */
     private function resume(array|object|null $resumeToken = null, bool $hasAdvanced = false): ChangeStreamIterator
@@ -422,7 +422,7 @@ final class Watch implements /* @internal */ CommandSubscriber
     /**
      * Determine whether to capture operation time from an aggregate response.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#startatoperationtime
+     * @see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md#startatoperationtime
      */
     private function shouldCaptureOperationTime(): bool
     {

--- a/src/functions.php
+++ b/src/functions.php
@@ -178,7 +178,7 @@ function document_to_array(array|object $document): array
  * autoEncryption driver option (if available).
  *
  * @internal
- * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#collection-encryptedfields-lookup-getencryptedfields
+ * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#collection-encryptedfields-lookup-getencryptedfields
  * @see Collection::drop()
  * @see Database::createCollection()
  * @see Database::dropCollection()
@@ -194,7 +194,7 @@ function get_encrypted_fields_from_driver(string $databaseName, string $collecti
  * Return a collection's encryptedFields option from the server (if any).
  *
  * @internal
- * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#collection-encryptedfields-lookup-getencryptedfields
+ * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#collection-encryptedfields-lookup-getencryptedfields
  * @see Collection::drop()
  * @see Database::dropCollection()
  */
@@ -611,7 +611,7 @@ function select_server(Manager $manager, array $options): Server
  * must be forced due to the existence of pre-5.0 servers in the topology.
  *
  * @internal
- * @see https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#aggregation-pipelines-with-write-stages
+ * @see https://github.com/mongodb/specifications/blob/master/source/crud/crud.md#aggregation-pipelines-with-write-stages
  */
 function select_server_for_aggregate_write_stage(Manager $manager, array &$options): Server
 {

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -1008,7 +1008,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     /**
      * Prose test 8: Bypass spawning mongocryptd (via bypassQueryAnalysis)
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#via-bypassqueryanalysis
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#via-bypassqueryanalysis
      */
     public function testBypassSpawningMongocryptdViaBypassQueryAnalysis(): void
     {
@@ -1042,7 +1042,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     /**
      * Prose test 10: KMS TLS Tests (Invalid KMS Certificate)
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#invalid-kms-certificate
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#invalid-kms-certificate
      */
     public function testInvalidKmsCertificate(): void
     {
@@ -1070,7 +1070,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     /**
      * Prose test 10: KMS TLS Tests (Invalid Hostname in KMS Certificate)
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#invalid-hostname-in-kms-certificate
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#invalid-hostname-in-kms-certificate
      */
     public function testInvalidHostnameInKmsCertificate(): void
     {
@@ -1098,7 +1098,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     /**
      * Prose test 11: KMS TLS Options
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#kms-tls-options-tests
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#kms-tls-options-tests
      */
     #[DataProvider('provideKmsTlsOptionsTests')]
     public function testKmsTlsOptions(Closure $test): void
@@ -1181,7 +1181,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         // Note: expected exception messages below assume OpenSSL is used
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-1-aws
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-1-aws
         yield 'AWS: client_encryption_no_client_cert' => [
             static function (self $test, ClientEncryption $clientEncryptionNoClientCert, ClientEncryption $clientEncryptionWithTls, ClientEncryption $clientEncryptionExpired, ClientEncryption $clientEncryptionInvalidHostname) use ($awsMasterKey): void {
                 $test->expectException(ConnectionException::class);
@@ -1214,7 +1214,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             },
         ];
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-2-azure
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-2-azure
         yield 'Azure: client_encryption_no_client_cert' => [
             static function (self $test, ClientEncryption $clientEncryptionNoClientCert, ClientEncryption $clientEncryptionWithTls, ClientEncryption $clientEncryptionExpired, ClientEncryption $clientEncryptionInvalidHostname) use ($azureMasterKey): void {
                 $test->expectException(ConnectionException::class);
@@ -1247,7 +1247,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             },
         ];
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-3-gcp
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-3-gcp
         yield 'GCP: client_encryption_no_client_cert' => [
             static function (self $test, ClientEncryption $clientEncryptionNoClientCert, ClientEncryption $clientEncryptionWithTls, ClientEncryption $clientEncryptionExpired, ClientEncryption $clientEncryptionInvalidHostname) use ($gcpMasterKey): void {
                 $test->expectException(ConnectionException::class);
@@ -1280,7 +1280,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             },
         ];
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-4-kmip
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-4-kmip
         yield 'KMIP: client_encryption_no_client_cert' => [
             static function (self $test, ClientEncryption $clientEncryptionNoClientCert, ClientEncryption $clientEncryptionWithTls, ClientEncryption $clientEncryptionExpired, ClientEncryption $clientEncryptionInvalidHostname) use ($kmipMasterKey): void {
                 $test->expectException(ConnectionException::class);
@@ -1316,7 +1316,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     /**
      * Prose test 12: Explicit Encryption
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#explicit-encryption
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#explicit-encryption
      */
     #[DataProvider('provideExplicitEncryptionTests')]
     public function testExplicitEncryption(Closure $test): void
@@ -1365,7 +1365,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
     public static function provideExplicitEncryptionTests()
     {
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-1-can-insert-encrypted-indexed-and-find
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-1-can-insert-encrypted-indexed-and-find
         yield 'Case 1: can insert encrypted indexed and find' => [
             static function (self $test, ClientEncryption $clientEncryption, Client $encryptedClient, Client $keyVaultClient, Binary $key1Id): void {
                 $value = 'encrypted indexed value';
@@ -1393,7 +1393,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             },
         ];
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-2-can-insert-encrypted-indexed-and-find-with-non-zero-contention
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-2-can-insert-encrypted-indexed-and-find-with-non-zero-contention
         yield 'Case 2: can insert encrypted indexed and find with non-zero contention' => [
             static function (self $test, ClientEncryption $clientEncryption, Client $encryptedClient, Client $keyVaultClient, Binary $key1Id): void {
                 $value = 'encrypted indexed value';
@@ -1442,7 +1442,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             },
         ];
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-3-can-insert-encrypted-unindexed
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-3-can-insert-encrypted-unindexed
         yield 'Case 3: can insert encrypted unindexed' => [
             static function (self $test, ClientEncryption $clientEncryption, Client $encryptedClient, Client $keyVaultClient, Binary $key1Id): void {
                 $value = 'encrypted unindexed value';
@@ -1462,7 +1462,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             },
         ];
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-4-can-roundtrip-encrypted-indexed
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-4-can-roundtrip-encrypted-indexed
         yield 'Case 4: can roundtrip encrypted indexed' => [
             static function (self $test, ClientEncryption $clientEncryption, Client $encryptedClient, Client $keyVaultClient, Binary $key1Id): void {
                 $value = 'encrypted indexed value';
@@ -1477,7 +1477,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             },
         ];
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-5-can-roundtrip-encrypted-unindexed
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-5-can-roundtrip-encrypted-unindexed
         yield 'Case 5: can roundtrip encrypted unindexed' => [
             static function (self $test, ClientEncryption $clientEncryption, Client $encryptedClient, Client $keyVaultClient, Binary $key1Id): void {
                 $value = 'encrypted unindexed value';
@@ -1495,7 +1495,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     /**
      * Prose test 13: Unique Index on keyAltNames
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#unique-index-on-keyaltnames
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#unique-index-on-keyaltnames
      */
     #[DataProvider('provideUniqueIndexOnKeyAltNamesTests')]
     public function testUniqueIndexOnKeyAltNames(Closure $test): void
@@ -1528,7 +1528,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
     public static function provideUniqueIndexOnKeyAltNamesTests()
     {
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-1-createdatakey
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-1-createdatakey
         yield 'Case 1: createDataKey()' => [
             static function (self $test, Client $client, ClientEncryption $clientEncryption): void {
                 $clientEncryption->createDataKey('local', ['keyAltNames' => ['abc']]);
@@ -1549,7 +1549,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             },
         ];
 
-        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#case-2-addkeyaltname
+        // See: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-2-addkeyaltname
         yield 'Case 2: addKeyAltName()' => [
             static function (self $test, Client $client, ClientEncryption $clientEncryption): void {
                 $keyId = $clientEncryption->createDataKey('local');
@@ -1774,7 +1774,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     /**
      * Prose test 16: RewrapManyDataKey
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.rst#rewrap
+     * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#rewrap
      */
     #[DataProvider('provideRewrapManyDataKeySrcAndDstProviders')]
     public function testRewrapManyDataKey(string $srcProvider, string $dstProvider): void

--- a/tests/SpecTests/FunctionalTestCase.php
+++ b/tests/SpecTests/FunctionalTestCase.php
@@ -97,7 +97,7 @@ class FunctionalTestCase extends BaseFunctionalTestCase
      *
      * Note: this method may modify the $expected object.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst#null-values
+     * @see https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.md#null-values
      * @see https://github.com/mongodb/specifications/blob/09ee1ebc481f1502e3246971a9419e484d736207/source/command-monitoring/tests/README.rst#additional-values
      */
     protected static function assertCommandOmittedFields(stdClass $expected, stdClass $actual): void

--- a/tests/SpecTests/ResultExpectation.php
+++ b/tests/SpecTests/ResultExpectation.php
@@ -328,7 +328,7 @@ final class ResultExpectation
     /**
      * Determines whether the result is actually an error expectation.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst#test-format
+     * @see https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.md#test-format
      */
     private static function isErrorResult(mixed $result): bool
     {

--- a/tests/SpecTests/SearchIndexSpecTest.php
+++ b/tests/SpecTests/SearchIndexSpecTest.php
@@ -19,7 +19,7 @@ use function sprintf;
 /**
  * Functional tests for the Atlas Search index management.
  *
- * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.rst#search-index-management-helpers
+ * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.md#search-index-management-helpers
  */
 #[Group('atlas')]
 class SearchIndexSpecTest extends FunctionalTestCase
@@ -37,7 +37,7 @@ class SearchIndexSpecTest extends FunctionalTestCase
     /**
      * Case 1: Driver can successfully create and list search indexes
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.rst#case-1-driver-can-successfully-create-and-list-search-indexes
+     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.md#case-1-driver-can-successfully-create-and-list-search-indexes
      */
     public function testCreateAndListSearchIndexes(): void
     {
@@ -61,7 +61,7 @@ class SearchIndexSpecTest extends FunctionalTestCase
     /**
      * Case 2: Driver can successfully create multiple indexes in batch
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.rst#case-2-driver-can-successfully-create-multiple-indexes-in-batch
+     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.md#case-2-driver-can-successfully-create-multiple-indexes-in-batch
      */
     public function testCreateMultipleIndexesInBatch(): void
     {
@@ -88,7 +88,7 @@ class SearchIndexSpecTest extends FunctionalTestCase
     /**
      * Case 3: Driver can successfully drop search indexes
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.rst#case-3-driver-can-successfully-drop-search-indexes
+     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.md#case-3-driver-can-successfully-drop-search-indexes
      */
     public function testDropSearchIndexes(): void
     {
@@ -114,7 +114,7 @@ class SearchIndexSpecTest extends FunctionalTestCase
     /**
      * Case 4: Driver can update a search index
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.rst#case-4-driver-can-update-a-search-index
+     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.md#case-4-driver-can-update-a-search-index
      */
     public function testUpdateSearchIndex(): void
     {
@@ -144,7 +144,7 @@ class SearchIndexSpecTest extends FunctionalTestCase
     /**
      * Case 5: dropSearchIndex suppresses namespace not found errors
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.rst#case-5-dropsearchindex-suppresses-namespace-not-found-errors
+     * @see https://github.com/mongodb/specifications/blob/master/source/index-management/tests/README.md#case-5-dropsearchindex-suppresses-namespace-not-found-errors
      */
     public function testDropSearchIndexSuppressNamespaceNotFoundError(): void
     {

--- a/tests/SpecTests/TransactionsSpecTest.php
+++ b/tests/SpecTests/TransactionsSpecTest.php
@@ -10,7 +10,7 @@ use function count;
 /**
  * Transactions spec prose tests.
  *
- * @see https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst#mongos-pinning-prose-tests
+ * @see https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.md#mongos-pinning-prose-tests
  */
 class TransactionsSpecTest extends FunctionalTestCase
 {

--- a/tests/UnifiedSpecTests/EventObserver.php
+++ b/tests/UnifiedSpecTests/EventObserver.php
@@ -42,7 +42,7 @@ final class EventObserver implements CommandSubscriber
      * These commands are always considered sensitive (i.e. command and reply
      * documents should be redacted).
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.rst#security
+     * @see https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.md#security
      */
     private static array $sensitiveCommands = [
         'authenticate' => 1,
@@ -60,7 +60,7 @@ final class EventObserver implements CommandSubscriber
      * These commands are only considered sensitive when the command or reply
      * document includes a speculativeAuthenticate field.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.rst#security
+     * @see https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.md#security
      */
     private static array $sensitiveCommandsWithSpeculativeAuthenticate = [
         'ismaster' => 1,

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -18,7 +18,7 @@ use function strtolower;
 /**
  * Unified test format spec tests.
  *
- * @see https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst
+ * @see https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.md
  */
 class UnifiedSpecTest extends FunctionalTestCase
 {

--- a/tests/UnifiedSpecTests/UnifiedTestCase.php
+++ b/tests/UnifiedSpecTests/UnifiedTestCase.php
@@ -20,7 +20,7 @@ use function PHPUnit\Framework\assertIsString;
  * within a JSON object conforming to the unified test format's JSON schema.
  * This test case may be executed by UnifiedTestRunner::run().
  *
- * @see https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst
+ * @see https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.md
  */
 final class UnifiedTestCase implements IteratorAggregate
 {

--- a/tests/UnifiedSpecTests/UnifiedTestRunner.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunner.php
@@ -43,7 +43,7 @@ use function version_compare;
 /**
  * Unified test runner.
  *
- * @see https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst
+ * @see https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.md
  */
 final class UnifiedTestRunner
 {
@@ -456,7 +456,7 @@ final class UnifiedTestRunner
     /**
      * Work around potential error executing distinct on sharded clusters.
      *
-     * @see https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst#staledbversion-errors-on-sharded-clusters
+     * @see https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.md#staledbversion-errors-on-sharded-clusters
      */
     private function preventStaleDbVersionError(array $operations, Context $context): void
     {

--- a/tools/connect.php
+++ b/tools/connect.php
@@ -9,7 +9,7 @@ function getHosts(string $uri): array
     $parsed = parse_url($uri);
 
     if (isset($parsed['scheme']) && $parsed['scheme'] !== 'mongodb') {
-        // TODO: Resolve SRV records (https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst)
+        // TODO: Resolve SRV records (https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.md)
         throw new RuntimeException('Unsupported scheme: ' . $parsed['scheme']);
     }
 


### PR DESCRIPTION
I noticed that many spec links were still pointing to the RST files, which breaks anchors. This PR changes all links to markdown, except for the ones that reference a specific commit (as the markdown file probably doesn't exist there). We can consider changing those to point to the latest version separately.