### PR TITLE
PHPLIB-1702: Ensure withOptions preserves autoEncryptionEnabled

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -136,6 +136,10 @@ class Client
         $this->uri = $uri ?? self::DEFAULT_URI;
         $this->builderEncoder = $driverOptions['builderEncoder'] ?? new BuilderEncoder();
         $this->typeMap = $driverOptions['typeMap'];
+
+        /* Database and Collection objects may need to know whether auto
+         * encryption is enabled for dropping collections. Track this via an
+         * internal option until PHPC-2615 is implemented. */
         $this->autoEncryptionEnabled = isset($driverOptions['autoEncryption']['keyVaultNamespace']);
 
         $driverOptions = array_diff_key($driverOptions, ['builderEncoder' => 1, 'typeMap' => 1]);

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1145,6 +1145,7 @@ class Collection
     public function withOptions(array $options = [])
     {
         $options += [
+            'autoEncryptionEnabled' => $this->autoEncryptionEnabled,
             'builderEncoder' => $this->builderEncoder,
             'codec' => $this->codec,
             'readConcern' => $this->readConcern,

--- a/src/Database.php
+++ b/src/Database.php
@@ -689,6 +689,7 @@ class Database
     public function withOptions(array $options = [])
     {
         $options += [
+            'autoEncryptionEnabled' => $this->autoEncryptionEnabled,
             'builderEncoder' => $this->builderEncoder,
             'readConcern' => $this->readConcern,
             'readPreference' => $this->readPreference,

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -20,6 +20,7 @@ use MongoDB\Operation\Count;
 use MongoDB\Tests\CommandObserver;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use ReflectionClass;
 use TypeError;
 
 use function array_filter;
@@ -396,6 +397,16 @@ class CollectionFunctionalTest extends FunctionalTestCase
         foreach ($collectionOptions as $key => $value) {
             $this->assertSame($value, $debug[$key]);
         }
+
+        // autoEncryptionEnabled is an internal option not reported via debug info
+        $collection = new Collection($this->manager, $this->getDatabaseName(), $this->getCollectionName(), ['autoEncryptionEnabled' => true]);
+        $clone = $collection->withOptions();
+
+        $rc = new ReflectionClass($clone);
+        $rp = $rc->getProperty('autoEncryptionEnabled');
+        $rp->setAccessible(true);
+
+        $this->assertSame(true, $rp->getValue($clone));
     }
 
     public function testWithOptionsPassesOptions(): void
@@ -415,6 +426,15 @@ class CollectionFunctionalTest extends FunctionalTestCase
         foreach ($collectionOptions as $key => $value) {
             $this->assertSame($value, $debug[$key]);
         }
+
+        // autoEncryptionEnabled is an internal option not reported via debug info
+        $clone = $this->collection->withOptions(['autoEncryptionEnabled' => true]);
+
+        $rc = new ReflectionClass($clone);
+        $rp = $rc->getProperty('autoEncryptionEnabled');
+        $rp->setAccessible(true);
+
+        $this->assertSame(true, $rp->getValue($clone));
     }
 
     #[Group('matrix-testing-exclude-server-4.4-driver-4.0')]

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -15,6 +15,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateIndexes;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use ReflectionClass;
 use TypeError;
 
 use function array_key_exists;
@@ -389,6 +390,16 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         foreach ($databaseOptions as $key => $value) {
             $this->assertSame($value, $debug[$key]);
         }
+
+        // autoEncryptionEnabled is an internal option not reported via debug info
+        $database = new Database($this->manager, $this->getDatabaseName(), ['autoEncryptionEnabled' => true]);
+        $clone = $database->withOptions();
+
+        $rc = new ReflectionClass($clone);
+        $rp = $rc->getProperty('autoEncryptionEnabled');
+        $rp->setAccessible(true);
+
+        $this->assertSame(true, $rp->getValue($clone));
     }
 
     public function testWithOptionsPassesOptions(): void
@@ -407,5 +418,14 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         foreach ($databaseOptions as $key => $value) {
             $this->assertSame($value, $debug[$key]);
         }
+
+        // autoEncryptionEnabled is an internal option not reported via debug info
+        $clone = $this->database->withOptions(['autoEncryptionEnabled' => true]);
+
+        $rc = new ReflectionClass($clone);
+        $rp = $rc->getProperty('autoEncryptionEnabled');
+        $rp->setAccessible(true);
+
+        $this->assertSame(true, $rp->getValue($clone));
     }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1702

This is something I came across while working on the merge-up PR (https://github.com/mongodb/mongo-php-library/pull/1746). It can be reviewed independently.