### PR TITLE
fix(deps): Flask app is run in debug mode vulnerable to possible disclosure of permanent session cookie due to missing Vary: Cookie header

### DIFF
--- a/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
+++ b/.evergreen/ocsp/mock-ocsp-responder-requirements.txt
@@ -1,3 +1,3 @@
 asn1crypto==1.3.0
-flask==1.1.1
+flask==2.2.5
 oscrypto==1.2.0

--- a/.evergreen/ocsp/mock_ocsp_responder.py
+++ b/.evergreen/ocsp/mock_ocsp_responder.py
@@ -583,9 +583,9 @@ def init_responder(issuer_cert: str, responder_cert: str, responder_key: str, fa
     global responder
     responder = OCSPResponder(issuer_cert=issuer_cert, responder_cert=responder_cert, responder_key=responder_key, fault=fault, next_update_seconds=next_update_seconds)
 
-def init(port=8080, debug=False):
-    logger.info('Launching %sserver on port %d', 'debug' if debug else '', port)
-    app.run(port=port, debug=debug)
+def init(port=8080):
+    logger.info('Launching server on port %d', port)
+    app.run(port=port, debug=False)
 
 @app.route('/', methods=['GET'])
 def _handle_root():


### PR DESCRIPTION
When all of the following conditions are met, a response containing data intended for one client may be cached and subsequently sent by a proxy to other clients. If the proxy also caches Set-Cookie headers, it may send one client's session cookie to other clients. The severity depends on the application's use of the session, and the proxy's behavior regarding cookies. The risk depends on all these conditions being met.

- The application must be hosted behind a caching proxy that does not strip cookies or ignore responses with cookies.
- The application sets [session.permanent = True](https://flask.palletsprojects.com/en/2.3.x/api/#flask.session.permanent).
- The application does not access or modify the session at any point during a request.
[SESSION_REFRESH_EACH_REQUEST](https://flask.palletsprojects.com/en/2.3.x/config/#SESSION_REFRESH_EACH_REQUEST) is enabled (the default).
- The application does not set a Cache-Control header to indicate that a page is private or should not be cached.
- This happens because vulnerable versions of Flask only set the Vary: Cookie header when the session is accessed or modified, not when it is refreshed (re-sent to update the expiration) without being accessed or modified.

and fix the problem, we should ensure that the Flask app cannot be run in debug mode, regardless of how the `init` function is called. The best way to do this is to remove the `debug` argument from the `init` function and always run the app with `debug=False`. This change should be made in the `.evergreen/ocsp/mock_ocsp_responder.py` file, specifically in the `init` function definition and the call to `app.run`. No additional imports or definitions are needed.


### References

CVE-2023-30861
Flask Quickstart Documentation: [Debug Mode](http://flask.pocoo.org/docs/1.0/quickstart/#debug-mode)
Werkzeug Documentation: [Debugging Applications](http://werkzeug.pocoo.org/docs/0.14/debug/)
