### PR TITLE
PHPLIB-1708 Cast empty KMS provider into an object

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -231,8 +231,12 @@
       <code><![CDATA[$driverOptions['driver'] ?? []]]></code>
       <code><![CDATA[$pipeline]]></code>
     </MixedArgument>
+    <MixedArrayAssignment>
+      <code><![CDATA[$options['kmsProviders'][$name]]]></code>
+    </MixedArrayAssignment>
     <MixedAssignment>
       <code><![CDATA[$mergedDriver['platform']]]></code>
+      <code><![CDATA[$provider]]></code>
     </MixedAssignment>
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$driverOptions['builderEncoder'] ?? new BuilderEncoder()]]></code>

--- a/src/Client.php
+++ b/src/Client.php
@@ -119,12 +119,8 @@ class Client
             throw InvalidArgumentException::invalidType('"typeMap" driver option', $driverOptions['typeMap'], 'array');
         }
 
-        if (isset($driverOptions['autoEncryption']['keyVaultClient'])) {
-            if ($driverOptions['autoEncryption']['keyVaultClient'] instanceof self) {
-                $driverOptions['autoEncryption']['keyVaultClient'] = $driverOptions['autoEncryption']['keyVaultClient']->manager;
-            } elseif (! $driverOptions['autoEncryption']['keyVaultClient'] instanceof Manager) {
-                throw InvalidArgumentException::invalidType('"keyVaultClient" autoEncryption option', $driverOptions['autoEncryption']['keyVaultClient'], [self::class, Manager::class]);
-            }
+        if (isset($driverOptions['autoEncryption']) && is_array($driverOptions['autoEncryption'])) {
+            $driverOptions['autoEncryption'] = $this->prepareEncryptionOptions($driverOptions['autoEncryption']);
         }
 
         if (isset($driverOptions['builderEncoder']) && ! $driverOptions['builderEncoder'] instanceof Encoder) {
@@ -213,13 +209,7 @@ class Client
      */
     public function createClientEncryption(array $options)
     {
-        if (isset($options['keyVaultClient'])) {
-            if ($options['keyVaultClient'] instanceof self) {
-                $options['keyVaultClient'] = $options['keyVaultClient']->manager;
-            } elseif (! $options['keyVaultClient'] instanceof Manager) {
-                throw InvalidArgumentException::invalidType('"keyVaultClient" option', $options['keyVaultClient'], [self::class, Manager::class]);
-            }
-        }
+        $options = $this->prepareEncryptionOptions($options);
 
         return $this->manager->createClientEncryption($options);
     }
@@ -498,5 +488,27 @@ class Client
         }
 
         return $mergedDriver;
+    }
+
+    private function prepareEncryptionOptions(array $options): array
+    {
+        if (isset($options['keyVaultClient'])) {
+            if ($options['keyVaultClient'] instanceof self) {
+                $options['keyVaultClient'] = $options['keyVaultClient']->manager;
+            } elseif (! $options['keyVaultClient'] instanceof Manager) {
+                throw InvalidArgumentException::invalidType('"keyVaultClient" option', $options['keyVaultClient'], [self::class, Manager::class]);
+            }
+        }
+
+        // The server requires an empty document for automatic credentials.
+        if (isset($options['kmsProviders']) && is_array($options['kmsProviders'])) {
+            foreach ($options['kmsProviders'] as $name => $provider) {
+                if ($provider === []) {
+                    $options['kmsProviders'][$name] = new stdClass();
+                }
+            }
+        }
+
+        return $options;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -37,6 +37,18 @@ class ClientTest extends TestCase
         new Client(static::getUri(), [], ['autoEncryption' => $autoEncryptionOpts]);
     }
 
+    #[DoesNotPerformAssertions]
+    public function testConstructorEmptyKmsProvider(): void
+    {
+        $autoEncryptionOpts = [
+            'keyVaultClient' => new Client(static::getUri()),
+            'keyVaultNamespace' => 'default.keys',
+            'kmsProviders' => ['gcp' => []],
+        ];
+
+        new Client(static::getUri(), [], ['autoEncryption' => $autoEncryptionOpts]);
+    }
+
     #[DataProvider('provideInvalidConstructorDriverOptions')]
     public function testConstructorDriverOptionTypeChecks(array $driverOptions, string $exception = InvalidArgumentException::class): void
     {


### PR DESCRIPTION
Fix PHPLIB-1708

For some KMS providers, all options can be omitted. The authentication is done using the env var or the system.
https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#credentialproviders

The approach in https://github.com/doctrine/mongodb-odm/pull/2801 is not sufficient because Symfony is [not able to dump the empty object instance into the container](https://github.com/symfony/symfony/blob/7ed3a4b57cdf66932417c02cc634eadcc65e4772/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php#L1986).
 

    Unable to dump a service container if a parameter is an object or a resource, got "stdClass".