### PR TITLE
Fix PHP 8.5 deprecations of `(integer)`, `(long)` and `(boolean)` casts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
         "phpunit/phpunit": "^10.5.35",
-        "rector/rector": "^1.2",
+        "rector/rector": "^2.1.4",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "6.5.*"
     },

--- a/rector.php
+++ b/rector.php
@@ -5,38 +5,29 @@ use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
-use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
-use Rector\PHPUnit\Set\PHPUnitSetList;
-use Rector\Set\ValueObject\LevelSetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
+return RectorConfig::configure()
+    ->withPaths([
         __DIR__ . '/examples',
         __DIR__ . '/src',
         __DIR__ . '/tests',
         __DIR__ . '/tools',
-    ]);
-
-    // Modernize code
-    $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_74,
-        PHPUnitSetList::PHPUNIT_100,
-    ]);
-
-    $rectorConfig->rule(ChangeSwitchToMatchRector::class);
-    $rectorConfig->rule(StaticDataProviderClassMethodRector::class);
-
+    ])
+    ->withPhpSets(php74: true)
+    ->withComposerBased(phpunit: true)
+    ->withRules([
+        ChangeSwitchToMatchRector::class,
+    ])
+    // All classes are public API by default, unless marked with @internal.
+    ->withConfiguredRule(RemoveAnnotationRector::class, ['api'])
     // phpcs:disable Squiz.Arrays.ArrayDeclaration.KeySpecified
-    $rectorConfig->skip([
+    ->withSkip([
         RemoveExtraParametersRector::class,
         // Do not use ternaries extensively
         IfIssetToCoalescingRector::class,
         ChangeSwitchToMatchRector::class => [
             __DIR__ . '/tests/SpecTests/Operation.php',
         ],
-    ]);
+    ])
     // phpcs:enable
-
-    // All classes are public API by default, unless marked with @internal.
-    $rectorConfig->ruleWithConfiguration(RemoveAnnotationRector::class, ['api']);
-};
+    ->withImportNames(importNames: false, removeUnusedImports: true);

--- a/rector.php
+++ b/rector.php
@@ -1,10 +1,15 @@
 <?php
 
+use PhpParser\Node\Expr\Cast\Bool_;
+use PhpParser\Node\Expr\Cast\Double;
+use PhpParser\Node\Expr\Cast\Int_;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\Renaming\Rector\Cast\RenameCastRector;
+use Rector\Renaming\ValueObject\RenameCast;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -20,6 +25,15 @@ return RectorConfig::configure()
     ])
     // All classes are public API by default, unless marked with @internal.
     ->withConfiguredRule(RemoveAnnotationRector::class, ['api'])
+    // Fix PHP 8.5 deprecations
+    ->withConfiguredRule(
+        RenameCastRector::class,
+        [
+            new RenameCast(Int_::class, Int_::KIND_INTEGER, Int_::KIND_INT),
+            new RenameCast(Bool_::class, Bool_::KIND_BOOLEAN, Bool_::KIND_BOOL),
+            new RenameCast(Double::class, Double::KIND_DOUBLE, Double::KIND_FLOAT),
+        ],
+    )
     // phpcs:disable Squiz.Arrays.ArrayDeclaration.KeySpecified
     ->withSkip([
         RemoveExtraParametersRector::class,

--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -35,7 +35,6 @@ use MongoDB\GridFS\Exception\LogicException;
 use MongoDB\GridFS\Exception\StreamException;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
-use MongoDB\Operation\Find;
 
 use function array_intersect_key;
 use function array_key_exists;

--- a/src/GridFS/ReadableStream.php
+++ b/src/GridFS/ReadableStream.php
@@ -82,7 +82,7 @@ class ReadableStream
         $this->length = $file->length;
 
         if ($this->length > 0) {
-            $this->numChunks = (integer) ceil($this->length / $this->chunkSize);
+            $this->numChunks = (int) ceil($this->length / $this->chunkSize);
             $this->expectedLastChunkSize = $this->length - (($this->numChunks - 1) * $this->chunkSize);
         }
     }
@@ -184,7 +184,7 @@ class ReadableStream
          * changed, we'll also need to reset the buffer.
          */
         $lastChunkOffset = $this->chunkOffset;
-        $this->chunkOffset = (integer) floor($offset / $this->chunkSize);
+        $this->chunkOffset = (int) floor($offset / $this->chunkSize);
         $this->bufferOffset = $offset % $this->chunkSize;
 
         if ($lastChunkOffset === $this->chunkOffset) {

--- a/src/MapReduceResult.php
+++ b/src/MapReduceResult.php
@@ -104,7 +104,7 @@ class MapReduceResult implements IteratorAggregate
     public function __construct(callable $getIterator, stdClass $result)
     {
         $this->getIterator = $getIterator;
-        $this->executionTimeMS = isset($result->timeMillis) ? (integer) $result->timeMillis : 0;
+        $this->executionTimeMS = isset($result->timeMillis) ? (int) $result->timeMillis : 0;
         $this->counts = isset($result->counts) ? (array) $result->counts : [];
         $this->timing = isset($result->timing) ? (array) $result->timing : [];
     }

--- a/src/Model/CollectionInfo.php
+++ b/src/Model/CollectionInfo.php
@@ -62,7 +62,7 @@ class CollectionInfo implements ArrayAccess
     public function getCappedMax()
     {
         /* The MongoDB server might return this number as an integer or float */
-        return isset($this->info['options']['max']) ? (integer) $this->info['options']['max'] : null;
+        return isset($this->info['options']['max']) ? (int) $this->info['options']['max'] : null;
     }
 
     /**
@@ -75,7 +75,7 @@ class CollectionInfo implements ArrayAccess
     public function getCappedSize()
     {
         /* The MongoDB server might return this number as an integer or float */
-        return isset($this->info['options']['size']) ? (integer) $this->info['options']['size'] : null;
+        return isset($this->info['options']['size']) ? (int) $this->info['options']['size'] : null;
     }
 
     /**

--- a/src/Model/DatabaseInfo.php
+++ b/src/Model/DatabaseInfo.php
@@ -69,7 +69,7 @@ class DatabaseInfo implements ArrayAccess
     public function getSizeOnDisk()
     {
         /* The MongoDB server might return this number as an integer or float */
-        return (integer) $this->info['sizeOnDisk'];
+        return (int) $this->info['sizeOnDisk'];
     }
 
     /**
@@ -79,7 +79,7 @@ class DatabaseInfo implements ArrayAccess
      */
     public function isEmpty()
     {
-        return (boolean) $this->info['empty'];
+        return (bool) $this->info['empty'];
     }
 
     /**

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -111,7 +111,7 @@ class IndexInfo implements ArrayAccess
      */
     public function getVersion()
     {
-        return (integer) $this->info['v'];
+        return (int) $this->info['v'];
     }
 
     /**

--- a/src/Operation/Count.php
+++ b/src/Operation/Count.php
@@ -147,7 +147,7 @@ class Count implements Executable, Explainable
             throw new UnexpectedValueException('count command did not return a numeric "n" value');
         }
 
-        return (integer) $result->n;
+        return (int) $result->n;
     }
 
     /**

--- a/src/Operation/CountDocuments.php
+++ b/src/Operation/CountDocuments.php
@@ -128,7 +128,7 @@ class CountDocuments implements Executable
             throw new UnexpectedValueException('count command did not return a numeric "n" value');
         }
 
-        return (integer) $result->n;
+        return (int) $result->n;
     }
 
     private function createAggregate(): Aggregate

--- a/src/functions.php
+++ b/src/functions.php
@@ -430,8 +430,8 @@ function is_write_concern_acknowledged(WriteConcern $writeConcern): bool
 function server_supports_feature(Server $server, int $feature): bool
 {
     $info = $server->getInfo();
-    $maxWireVersion = isset($info['maxWireVersion']) ? (integer) $info['maxWireVersion'] : 0;
-    $minWireVersion = isset($info['minWireVersion']) ? (integer) $info['minWireVersion'] : 0;
+    $maxWireVersion = isset($info['maxWireVersion']) ? (int) $info['maxWireVersion'] : 0;
+    $minWireVersion = isset($info['minWireVersion']) ? (int) $info['minWireVersion'] : 0;
 
     return $minWireVersion <= $feature && $maxWireVersion >= $feature;
 }

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -852,7 +852,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         for ($i = 1; $i <= $n; $i++) {
             $bulkWrite->insert([
                 '_id' => $i,
-                'x' => (integer) ($i . $i),
+                'x' => (int) ($i . $i),
             ]);
         }
 

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -500,7 +500,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
         for ($i = 1; $i <= $n; $i++) {
             $bulkWrite->insert([
                 '_id' => $i,
-                'x' => (integer) ($i . $i),
+                'x' => (int) ($i . $i),
             ]);
         }
 

--- a/tests/Operation/DeleteFunctionalTest.php
+++ b/tests/Operation/DeleteFunctionalTest.php
@@ -153,7 +153,7 @@ class DeleteFunctionalTest extends FunctionalTestCase
         for ($i = 1; $i <= $n; $i++) {
             $bulkWrite->insert([
                 '_id' => $i,
-                'x' => (integer) ($i . $i),
+                'x' => (int) ($i . $i),
             ]);
         }
 

--- a/tests/Operation/ExplainFunctionalTest.php
+++ b/tests/Operation/ExplainFunctionalTest.php
@@ -406,7 +406,7 @@ class ExplainFunctionalTest extends FunctionalTestCase
         for ($i = 1; $i <= $n; $i++) {
             $bulkWrite->insert([
                 '_id' => $i,
-                'x' => (integer) ($i . $i),
+                'x' => (int) ($i . $i),
             ]);
         }
 

--- a/tests/Operation/UpdateFunctionalTest.php
+++ b/tests/Operation/UpdateFunctionalTest.php
@@ -326,7 +326,7 @@ class UpdateFunctionalTest extends FunctionalTestCase
         for ($i = 1; $i <= $n; $i++) {
             $bulkWrite->insert([
                 '_id' => $i,
-                'x' => (integer) ($i . $i),
+                'x' => (int) ($i . $i),
             ]);
         }
 

--- a/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
@@ -425,7 +425,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
     {
         return match ($type) {
             'DecimalNoPrecision', 'DecimalPrecision' => new Decimal128((string) $value),
-            'DoubleNoPrecision', 'DoublePrecision' => (double) $value,
+            'DoubleNoPrecision', 'DoublePrecision' => (float) $value,
             'Date' => new UTCDateTime($value),
             'Int' => $value,
             'Long' => new Int64($value),

--- a/tools/connect.php
+++ b/tools/connect.php
@@ -2,7 +2,7 @@
 
 function getHosts(string $uri): array
 {
-    if (strpos($uri, '://') === false) {
+    if (! str_contains($uri, '://')) {
         return [$uri];
     }
 

--- a/tools/detect-extension.php
+++ b/tools/detect-extension.php
@@ -5,11 +5,11 @@ function grepIniFile(string $filename, string $extension): int
     $lines = [];
 
     foreach (new SplFileObject($filename) as $i => $line) {
-        if (strpos($line, 'extension') === false) {
+        if (! str_contains($line, 'extension')) {
             continue;
         }
 
-        if (strpos($line, $extension) === false) {
+        if (! str_contains($line, $extension)) {
             continue;
         }
 


### PR DESCRIPTION
My goal was to fix the following deprecations when using this library on PHP 8.5(-rc):

```
Deprecated: Non-canonical cast (integer) is deprecated, use the (int) cast instead in /app/vendor/mongodb/mongodb/src/functions.php on line 412
Deprecated: Non-canonical cast (integer) is deprecated, use the (int) cast instead in /app/vendor/mongodb/mongodb/src/functions.php on line 413
```

In order to do this, I updated `rector/rector` to `^2.1.4` so that I could make use of the `RenameCastRector`-rule. In the meantime, I also modernized the rector configuration.

I opted to fix this on the v1.21 branch, I could rebase this on any other branch if deemed required.