### PR TITLE
Remove calls to `ReflectionProperty::setAccessible(true)`

### DIFF
--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -404,7 +404,6 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
         $rc = new ReflectionClass($clone);
         $rp = $rc->getProperty('autoEncryptionEnabled');
-        $rp->setAccessible(true);
 
         $this->assertSame(true, $rp->getValue($clone));
     }
@@ -432,7 +431,6 @@ class CollectionFunctionalTest extends FunctionalTestCase
 
         $rc = new ReflectionClass($clone);
         $rp = $rc->getProperty('autoEncryptionEnabled');
-        $rp->setAccessible(true);
 
         $this->assertSame(true, $rp->getValue($clone));
     }

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -397,7 +397,6 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $rc = new ReflectionClass($clone);
         $rp = $rc->getProperty('autoEncryptionEnabled');
-        $rp->setAccessible(true);
 
         $this->assertSame(true, $rp->getValue($clone));
     }
@@ -424,7 +423,6 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $rc = new ReflectionClass($clone);
         $rp = $rc->getProperty('autoEncryptionEnabled');
-        $rp->setAccessible(true);
 
         $this->assertSame(true, $rp->getValue($clone));
     }


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all properties are accessible by default. ([doc](https://www.php.net/manual/en/reflectionproperty.setaccessible.php))

A deprecation message is triggered as of PHP 8.5: https://github.com/php/php-src/pull/19273