### PR TITLE
Use `Stringable` interface explicitly

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,8 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Renaming\Rector\Cast\RenameCastRector;
 use Rector\Renaming\ValueObject\RenameCast;
@@ -18,11 +20,8 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
         __DIR__ . '/tools',
     ])
-    ->withPhpSets(php74: true)
+    ->withPhpSets(php80: true)
     ->withComposerBased(phpunit: true)
-    ->withRules([
-        ChangeSwitchToMatchRector::class,
-    ])
     // All classes are public API by default, unless marked with @internal.
     ->withConfiguredRule(RemoveAnnotationRector::class, ['api'])
     // Fix PHP 8.5 deprecations
@@ -41,6 +40,10 @@ return RectorConfig::configure()
         IfIssetToCoalescingRector::class,
         ChangeSwitchToMatchRector::class => [
             __DIR__ . '/tests/SpecTests/Operation.php',
+        ],
+        ClassPropertyAssignToConstructorPromotionRector::class,
+        StringableForToStringRector::class => [
+            __DIR__ . '/src/Model/IndexInput.php',
         ],
     ])
     // phpcs:enable

--- a/src/Client.php
+++ b/src/Client.php
@@ -47,13 +47,14 @@ use MongoDB\Operation\ListDatabaseNames;
 use MongoDB\Operation\ListDatabases;
 use MongoDB\Operation\Watch;
 use stdClass;
+use Stringable;
 use Throwable;
 
 use function array_diff_key;
 use function is_array;
 use function is_string;
 
-class Client
+class Client implements Stringable
 {
     public const DEFAULT_URI = 'mongodb://127.0.0.1/';
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -69,6 +69,7 @@ use MongoDB\Operation\UpdateOne;
 use MongoDB\Operation\UpdateSearchIndex;
 use MongoDB\Operation\Watch;
 use stdClass;
+use Stringable;
 
 use function array_diff_key;
 use function array_intersect_key;
@@ -78,7 +79,7 @@ use function is_array;
 use function is_bool;
 use function strlen;
 
-class Collection
+class Collection implements Stringable
 {
     private const DEFAULT_TYPE_MAP = [
         'array' => BSONArray::class,

--- a/src/Database.php
+++ b/src/Database.php
@@ -51,13 +51,14 @@ use MongoDB\Operation\ModifyCollection;
 use MongoDB\Operation\RenameCollection;
 use MongoDB\Operation\Watch;
 use stdClass;
+use Stringable;
 use Throwable;
 
 use function is_array;
 use function is_bool;
 use function strlen;
 
-class Database
+class Database implements Stringable
 {
     private const DEFAULT_TYPE_MAP = [
         'array' => BSONArray::class,

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -19,6 +19,7 @@ namespace MongoDB\Model;
 
 use ArrayAccess;
 use MongoDB\Exception\BadMethodCallException;
+use Stringable;
 
 use function array_key_exists;
 use function array_search;
@@ -38,7 +39,7 @@ use function array_search;
  * @see https://mongodb.com/docs/manual/reference/method/db.collection.createIndex/
  * @template-implements ArrayAccess<string, mixed>
  */
-class IndexInfo implements ArrayAccess
+class IndexInfo implements ArrayAccess, Stringable
 {
     /** @param array $info Index info */
     public function __construct(private array $info)

--- a/src/Model/IndexInput.php
+++ b/src/Model/IndexInput.php
@@ -20,6 +20,7 @@ namespace MongoDB\Model;
 use MongoDB\BSON\Serializable;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
+use Stringable;
 
 use function is_float;
 use function is_int;
@@ -38,7 +39,7 @@ use function sprintf;
  * @see https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst
  * @see https://mongodb.com/docs/manual/reference/method/db.collection.createIndex/
  */
-final class IndexInput implements Serializable
+final class IndexInput implements Serializable, Stringable
 {
     /**
      * @param array $index Index specification

--- a/tests/Model/BSONIteratorTest.php
+++ b/tests/Model/BSONIteratorTest.php
@@ -19,7 +19,7 @@ class BSONIteratorTest extends TestCase
     #[DataProvider('provideTypeMapOptionsAndExpectedDocuments')]
     public function testValidValues(?array $typeMap, array $expectedDocuments): void
     {
-        $binaryString = implode(array_map(
+        $binaryString = implode('', array_map(
             fn ($input) => (string) Document::fromPHP($input),
             [
                 ['_id' => 1, 'x' => ['foo' => 'bar']],


### PR DESCRIPTION
The [Stringable](https://php.watch/versions/8.0/stringable) interface was added in PHP 8.0. It makes it explicit that the class implements the magic method `__toString`.