### PR TITLE
PHPLIB-1740: Accept iterable for custom encoders

### DIFF
--- a/src/Builder/BuilderEncoder.php
+++ b/src/Builder/BuilderEncoder.php
@@ -32,7 +32,9 @@ use stdClass;
 use WeakReference;
 
 use function array_key_exists;
+use function is_array;
 use function is_object;
+use function iterator_to_array;
 
 /** @template-implements Encoder<Type|stdClass|array|string|int, Pipeline|StageInterface|ExpressionInterface|QueryInterface> */
 final class BuilderEncoder implements Encoder
@@ -46,10 +48,14 @@ final class BuilderEncoder implements Encoder
     /** @var array<class-string, Encoder|null> */
     private array $cachedEncoders = [];
 
-    /** @param array<class-string, Encoder> $encoders */
-    public function __construct(array $encoders = [])
+    /** @param iterable<class-string, Encoder> $encoders */
+    public function __construct(iterable $encoders = [])
     {
         $self = WeakReference::create($this);
+
+        if (! is_array($encoders)) {
+            $encoders = iterator_to_array($encoders);
+        }
 
         $this->encoders = $encoders + [
             Pipeline::class => new PipelineEncoder($self),

--- a/tests/Builder/BuilderEncoderTest.php
+++ b/tests/Builder/BuilderEncoderTest.php
@@ -423,6 +423,48 @@ class BuilderEncoderTest extends TestCase
         $this->assertSamePipeline($expected, $pipeline, $codec);
     }
 
+    public function testCustomEncoderIterable(): void
+    {
+        $customEncoders = static function (): Generator {
+            yield FieldPathInterface::class => new class implements Encoder {
+                use EncodeIfSupported;
+
+                public function canEncode(mixed $value): bool
+                {
+                    return $value instanceof FieldPathInterface;
+                }
+
+                public function encode(mixed $value): mixed
+                {
+                    return '$prefix.' . $value->name;
+                }
+            };
+        };
+
+        $codec = new BuilderEncoder($customEncoders());
+
+        $pipeline = new Pipeline(
+            Stage::project(
+                threeFavorites: Expression::slice(
+                    Expression::arrayFieldPath('items'),
+                    n: 3,
+                ),
+            ),
+        );
+
+        $expected = [
+            [
+                '$project' => [
+                    'threeFavorites' => [
+                        '$slice' => ['$prefix.items', 3],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSamePipeline($expected, $pipeline, $codec);
+    }
+
     /** @param list<array<string, mixed>> $expected */
     private static function assertSamePipeline(array $expected, Pipeline $pipeline, $codec = new BuilderEncoder()): void
     {


### PR DESCRIPTION
PHPLIB-1740

This allows using tagged services in the Symfony DIC.