### PR TITLE
PHPLIB-1699: Support builder pipelines in findOneAndUpdate

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -754,6 +754,7 @@ class Collection implements Stringable
     public function findOneAndUpdate(array|object $filter, array|object $update, array $options = []): array|object|null
     {
         $filter = $this->builderEncoder->encodeIfSupported($filter);
+        $update = $this->builderEncoder->encodeIfSupported($update);
         $options = $this->inheritWriteOptions($options);
         $options = $this->inheritCodecOrTypeMap($options);
 

--- a/tests/Collection/BuilderCollectionFunctionalTest.php
+++ b/tests/Collection/BuilderCollectionFunctionalTest.php
@@ -186,6 +186,20 @@ class BuilderCollectionFunctionalTest extends FunctionalTestCase
         $this->assertEquals(3, $result->x);
     }
 
+    public function testFindOneAndUpdateWithPipelineUpdate(): void
+    {
+        $result = $this->collection->findOneAndUpdate(
+            Query::query(x: Query::lt(2)),
+            new Pipeline(
+                Stage::set(x: 3),
+            ),
+        );
+        $this->assertEquals(1, $result->x);
+
+        $result = $this->collection->findOne(Query::query(x: Query::eq(3)));
+        $this->assertEquals(3, $result->x);
+    }
+
     public function testReplaceOne(): void
     {
         $this->collection->insertOne(['x' => 1]);


### PR DESCRIPTION
PHPLIB-1699

This adds missing encoding of builder pipelines when passed as an `update` to `findAndModify` operations.