### PR TITLE
PHPLIB-1725 Add `Session::getSnapshotTime` in spec tests

### DIFF
--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -750,6 +750,9 @@ final class Operation
             case 'endSession':
                 return $session->endSession();
 
+            case 'getSnapshotTime':
+                throw new \RuntimeException('TODO: Implement getSnapshotTime');
+
             case 'startTransaction':
                 return $session->startTransaction($args);
 

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -128,6 +128,7 @@ final class Util
             'abortTransaction' => [],
             'commitTransaction' => [],
             'endSession' => [],
+            'getSnapshotTime' => [],
             'startTransaction' => ['maxCommitTimeMS', 'readConcern', 'readPreference', 'writeConcern'],
             'withTransaction' => ['callback', 'maxCommitTimeMS', 'readConcern', 'readPreference', 'writeConcern'],
         ],


### PR DESCRIPTION
Fix PHPLIB-1725

Implement https://github.com/mongodb/specifications/blob/master/source/sessions/tests/README.md#specific-operations-and-behaviour-for-unified-tests

Need the value of `snapshotTime` to be exposed by `MongoDB\Driver\Session`.