### PR TITLE
PHPLIB-1736: Add `$scoreFusion` stage

### DIFF
--- a/generator/config/stage/scoreFusion.yaml
+++ b/generator/config/stage/scoreFusion.yaml
@@ -1,16 +1,36 @@
-# $schema: ../schema.json
+# yaml-language-server: $schema=../schema.json
 name: $scoreFusion
 link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/'
 type:
     - stage
-encode: single
+encode: object
 description: |
-    Skips the first n documents where n is the specified skip number and passes the remaining documents unmodified to the pipeline. For each input document, outputs either zero documents (for the first n documents) or one document (if after the first n documents).
+    Combines multiple pipelines using relative score fusion to create hybrid search results.
 arguments:
     -
-        name: skip
+        name: input
         type:
-            - int
+            - object
+        description: |
+            An object with the following required fields:
+            - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
+            - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
+    -
+        name: combination
+        optional: true
+        type:
+            - object
+        description: |
+            An object with the following optional fields:
+            - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+            - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
+            - combination.expression: This is the custom expression that is used when combination.method is set to expression.
+    -
+        name: scoreDetails
+        type:
+            - bool
+        default: false
+        description: Set to true to include detailed scoring information.
 tests:
     -
         name: 'Example'

--- a/generator/config/stage/scoreFusion.yaml
+++ b/generator/config/stage/scoreFusion.yaml
@@ -1,0 +1,57 @@
+# $schema: ../schema.json
+name: $scoreFusion
+link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/'
+type:
+    - stage
+encode: single
+description: |
+    Skips the first n documents where n is the specified skip number and passes the remaining documents unmodified to the pipeline. For each input document, outputs either zero documents (for the first n documents) or one document (if after the first n documents).
+arguments:
+    -
+        name: skip
+        type:
+            - int
+tests:
+    -
+        name: 'Example'
+        link: 'https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/#examples'
+        pipeline:
+        -
+            $scoreFusion:
+                input:
+                    pipelines:
+                        searchOne:
+                            -
+                                $vectorSearch:
+                                    index: 'vector_index'
+                                    path: 'plot_embedding'
+                                    queryVector: [-0.0016261312, -0.028070757, -0.011342932]
+                                    numCandidates: 150
+                                    limit: 10
+                        searchTwo:
+                            -
+                                $search:
+                                    index: '<INDEX_NAME>'
+                                    text:
+                                        query: '<QUERY_TERM>'
+                                        path: '<FIELD_NAME>'
+                    normalization: 'sigmoid'
+                combination:
+                    method: 'expression'
+                    expression:
+                        $sum:
+                            -
+                                $multiply:
+                                    - '$$searchOne'
+                                    - 10
+                            - '$$searchTwo'
+                scoreDetails: true
+        -
+            $project:
+                _id: 1
+                title: 1
+                plot: 1
+                scoreDetails:
+                    $meta: 'scoreDetails'
+        -
+            $limit: 20

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -535,6 +535,27 @@ trait FactoryTrait
     }
 
     /**
+     * Combines multiple pipelines using relative score fusion to create hybrid search results.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/
+     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
+     * - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
+     * - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
+     * @param bool $scoreDetails Set to true to include detailed scoring information.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
+     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+     * - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
+     * - combination.expression: This is the custom expression that is used when combination.method is set to expression.
+     */
+    public static function scoreFusion(
+        Document|Serializable|stdClass|array $input,
+        bool $scoreDetails = false,
+        Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+    ): ScoreFusionStage {
+        return new ScoreFusionStage($input, $scoreDetails, $combination);
+    }
+
+    /**
      * Performs a full-text search of the field or fields in an Atlas collection.
      * NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
      *

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -604,6 +604,29 @@ trait FluentFactoryTrait
     }
 
     /**
+     * Combines multiple pipelines using relative score fusion to create hybrid search results.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/
+     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
+     * - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
+     * - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
+     * @param bool $scoreDetails Set to true to include detailed scoring information.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
+     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+     * - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
+     * - combination.expression: This is the custom expression that is used when combination.method is set to expression.
+     */
+    public function scoreFusion(
+        Document|Serializable|stdClass|array $input,
+        bool $scoreDetails = false,
+        Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+    ): static {
+        $this->pipeline[] = Stage::scoreFusion($input, $scoreDetails, $combination);
+
+        return $this;
+    }
+
+    /**
      * Performs a full-text search of the field or fields in an Atlas collection.
      * NOTE: $search is only available for MongoDB Atlas clusters, and is not available for self-managed deployments.
      *

--- a/src/Builder/Stage/ScoreFusionStage.php
+++ b/src/Builder/Stage/ScoreFusionStage.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Stage;
+
+use MongoDB\BSON\Document;
+use MongoDB\BSON\Serializable;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\StageInterface;
+use stdClass;
+
+/**
+ * Combines multiple pipelines using relative score fusion to create hybrid search results.
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/
+ * @internal
+ */
+final class ScoreFusionStage implements StageInterface, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$scoreFusion';
+    public const PROPERTIES = ['input' => 'input', 'scoreDetails' => 'scoreDetails', 'combination' => 'combination'];
+
+    /**
+     * @var Document|Serializable|array|stdClass $input An object with the following required fields:
+     * - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
+     * - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
+     */
+    public readonly Document|Serializable|stdClass|array $input;
+
+    /** @var bool $scoreDetails Set to true to include detailed scoring information. */
+    public readonly bool $scoreDetails;
+
+    /**
+     * @var Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
+     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+     * - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
+     * - combination.expression: This is the custom expression that is used when combination.method is set to expression.
+     */
+    public readonly Optional|Document|Serializable|stdClass|array $combination;
+
+    /**
+     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
+     * - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
+     * - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
+     * @param bool $scoreDetails Set to true to include detailed scoring information.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
+     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+     * - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
+     * - combination.expression: This is the custom expression that is used when combination.method is set to expression.
+     */
+    public function __construct(
+        Document|Serializable|stdClass|array $input,
+        bool $scoreDetails = false,
+        Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+    ) {
+        $this->input = $input;
+        $this->scoreDetails = $scoreDetails;
+        $this->combination = $combination;
+    }
+}

--- a/tests/Builder/Stage/Pipelines.php
+++ b/tests/Builder/Stage/Pipelines.php
@@ -2557,6 +2557,99 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/#examples
+     */
+    case ScoreFusionExample = <<<'JSON'
+    [
+        {
+            "$scoreFusion": {
+                "input": {
+                    "pipelines": {
+                        "searchOne": [
+                            {
+                                "$vectorSearch": {
+                                    "index": "vector_index",
+                                    "path": "plot_embedding",
+                                    "queryVector": [
+                                        {
+                                            "$numberDouble": "-0.0016261311999999999121"
+                                        },
+                                        {
+                                            "$numberDouble": "-0.028070756999999998266"
+                                        },
+                                        {
+                                            "$numberDouble": "-0.011342932000000000015"
+                                        }
+                                    ],
+                                    "numCandidates": {
+                                        "$numberInt": "150"
+                                    },
+                                    "limit": {
+                                        "$numberInt": "10"
+                                    }
+                                }
+                            }
+                        ],
+                        "searchTwo": [
+                            {
+                                "$search": {
+                                    "index": "<INDEX_NAME>",
+                                    "text": {
+                                        "query": "<QUERY_TERM>",
+                                        "path": "<FIELD_NAME>"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "normalization": "sigmoid"
+                },
+                "combination": {
+                    "method": "expression",
+                    "expression": {
+                        "$sum": [
+                            {
+                                "$multiply": [
+                                    "$$searchOne",
+                                    {
+                                        "$numberInt": "10"
+                                    }
+                                ]
+                            },
+                            "$$searchTwo"
+                        ]
+                    }
+                },
+                "scoreDetails": true
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "1"
+                },
+                "title": {
+                    "$numberInt": "1"
+                },
+                "plot": {
+                    "$numberInt": "1"
+                },
+                "scoreDetails": {
+                    "$meta": "scoreDetails"
+                }
+            }
+        },
+        {
+            "$limit": {
+                "$numberInt": "20"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/atlas/atlas-search/query-syntax/#aggregation-variable
      */
     case SearchExample = <<<'JSON'

--- a/tests/Builder/Stage/ScoreFusionStageTest.php
+++ b/tests/Builder/Stage/ScoreFusionStageTest.php
@@ -19,44 +19,36 @@ class ScoreFusionStageTest extends PipelineTestCase
             Stage::scoreFusion(
                 input: [
                     'pipelines' => [
-                        'searchOne' => [
-                            [
-                                '$vectorSearch' => [
-                                    'index' => 'vector_index',
-                                    'path' => 'plot_embedding',
-                                    'queryVector' => [-0.0016261312, -0.028070757, -0.011342932],
-                                    'numCandidates' => 150,
-                                    'limit' => 10,
-                                ],
-                            ],
-                        ],
-                        'searchTwo' => [
-                            [
-                                '$search' => [
-                                    'index' => '<INDEX_NAME>',
-                                    'text' => [
-                                        'query' => '<QUERY_TERM>',
-                                        'path' => '<FIELD_NAME>',
-                                    ],
-                                ],
-                            ],
-                        ],
+                        'searchOne' => new Pipeline(
+                            Stage::vectorSearch(
+                                index: 'vector_index',
+                                path: 'plot_embedding',
+                                queryVector: [-0.0016261312, -0.028070757, -0.011342932],
+                                numCandidates: 150,
+                                limit: 10,
+                            ),
+                        ),
+                        'searchTwo' => new Pipeline(
+                            Stage::search(
+                                Search::text(
+                                    query: '<QUERY_TERM>',
+                                    path: '<FIELD_NAME>',
+                                ),
+                                index: '<INDEX_NAME>',
+                            ),
+                        ),
                     ],
                     'normalization' => 'sigmoid',
                 ],
                 combination: [
                     'method' => 'expression',
-                    'expression' => [
-                        '$sum' => [
-                            [
-                                '$multiply' => [
-                                    '$$searchOne',
-                                    10,
-                                ],
-                            ],
-                            '$$searchTwo',
-                        ],
-                    ],
+                    'expression' => Expression::sum(
+                        Expression::multiply(
+                            Expression::variable('searchOne'),
+                            10,
+                        ),
+                        Expression::variable('searchTwo'),
+                    ),
                 ],
                 scoreDetails: true,
             ),
@@ -64,10 +56,11 @@ class ScoreFusionStageTest extends PipelineTestCase
                 _id: 1,
                 title: 1,
                 plot: 1,
-                scoreDetails: ['$meta' => 'scoreDetails'],
+                scoreDetails: Expression::meta('scoreDetails'),
             ),
             Stage::limit(20),
         );
+
         $this->assertSamePipeline(Pipelines::ScoreFusionExample, $pipeline);
     }
 }

--- a/tests/Builder/Stage/ScoreFusionStageTest.php
+++ b/tests/Builder/Stage/ScoreFusionStageTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Stage;
 
+use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Search;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 

--- a/tests/Builder/Stage/ScoreFusionStageTest.php
+++ b/tests/Builder/Stage/ScoreFusionStageTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Pipeline;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $scoreFusion stage
+ */
+class ScoreFusionStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline();
+
+        $this->assertSamePipeline(Pipelines::ScoreFusionExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/ScoreFusionStageTest.php
+++ b/tests/Builder/Stage/ScoreFusionStageTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MongoDB\Tests\Builder\Stage;
 
 use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
 /**
@@ -14,8 +15,59 @@ class ScoreFusionStageTest extends PipelineTestCase
 {
     public function testExample(): void
     {
-        $pipeline = new Pipeline();
-
+        $pipeline = new Pipeline(
+            Stage::scoreFusion(
+                input: [
+                    'pipelines' => [
+                        'searchOne' => [
+                            [
+                                '$vectorSearch' => [
+                                    'index' => 'vector_index',
+                                    'path' => 'plot_embedding',
+                                    'queryVector' => [-0.0016261312, -0.028070757, -0.011342932],
+                                    'numCandidates' => 150,
+                                    'limit' => 10,
+                                ],
+                            ],
+                        ],
+                        'searchTwo' => [
+                            [
+                                '$search' => [
+                                    'index' => '<INDEX_NAME>',
+                                    'text' => [
+                                        'query' => '<QUERY_TERM>',
+                                        'path' => '<FIELD_NAME>',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'normalization' => 'sigmoid',
+                ],
+                combination: [
+                    'method' => 'expression',
+                    'expression' => [
+                        '$sum' => [
+                            [
+                                '$multiply' => [
+                                    '$$searchOne',
+                                    10,
+                                ],
+                            ],
+                            '$$searchTwo',
+                        ],
+                    ],
+                ],
+                scoreDetails: true,
+            ),
+            Stage::project(
+                _id: 1,
+                title: 1,
+                plot: 1,
+                scoreDetails: ['$meta' => 'scoreDetails'],
+            ),
+            Stage::limit(20),
+        );
         $this->assertSamePipeline(Pipelines::ScoreFusionExample, $pipeline);
     }
 }


### PR DESCRIPTION
Merging this PR will:
- Add the `$scoreFusion` as per its [documentation](https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/#examples).

Context: Working on COMPASS-8939 adding auto-complete support for `$scoreFusion` to mongosh.