### PR TITLE
PHPLIB-1727: Skip CSFLE prose test 25.8 for server 8.2+

### DIFF
--- a/tests/SpecTests/ClientSideEncryption/Prose25_LookupTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose25_LookupTest.php
@@ -334,6 +334,8 @@ class Prose25_LookupTest extends FunctionalTestCase
 
     public function testCase8_CsfleJoinsQeFails(): void
     {
+        $this->skipIfServerVersion('>', '8.2.0', 'Test must be updated for 8.2+ (PHPLIB-1727)');
+
         $this->skipIfServerVersion('<', '8.1.0', 'Lookup test case requires server version 8.1.0 or later');
         $this->skipIfClientSideEncryptionIsNotSupported();
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1727

Test was originally added in d6e08a42969a392e5b68ad5ebac298a863985747

This should resolve build failures observed in https://github.com/mongodb/mongo-php-library/pull/1818