### PR TITLE
PHPLIB-1770 The unknown command name is not quoted in 5.0.32-enterprise

### DIFF
--- a/src/Exception/SearchNotSupportedException.php
+++ b/src/Exception/SearchNotSupportedException.php
@@ -36,8 +36,11 @@ final class SearchNotSupportedException extends ServerException
             // MongoDB 4 to 6, 7-community
             59 => match ($exception->getMessage()) {
                 'no such command: \'createSearchIndexes\'' => true,
+                'no such command: createSearchIndexes' => true,
                 'no such command: \'updateSearchIndex\'' => true,
+                'no such command: updateSearchIndex' => true,
                 'no such command: \'dropSearchIndex\'' => true,
+                'no such command: dropSearchIndex' => true,
                 default => false,
             },
             // MongoDB 4 to 6


### PR DESCRIPTION
Fix PHPLIB-1770

The error message does not contain the quotes when running in evergreen.