### PR TITLE
Skip large encryption tests on mongocryptd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
         "phpunit/phpunit": "^10.5.35",
-        "rector/rector": "^2.1.4",
+        "rector/rector": "^2.3.4",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "6.5.*"
     },

--- a/rector.php
+++ b/rector.php
@@ -20,6 +20,9 @@ return RectorConfig::configure()
     ])
     ->withPhpSets(php74: true)
     ->withComposerBased(phpunit: true)
+    // Error with StaticCallOnNonStaticToInstanceCallRector
+    // https://github.com/rectorphp/rector/issues/9608
+    ->withSkipPath(__DIR__ . '/tests/Builder/BuilderEncoderTest.php')
     ->withRules([
         ChangeSwitchToMatchRector::class,
     ])

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -566,7 +566,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     #[DataProvider('provideBSONSizeLimitsAndBatchSplittingTests')]
     public function testBSONSizeLimitsAndBatchSplitting(Closure $test): void
     {
-        $this->markTestSkipped('Encryption tests sending large payloads fail on some mongocryptd versions (See DRIVERS-3382)');
+        $this->skipIfServerVersion('>=', '7.0.29', 'Encryption tests sending large payloads fail on some mongocryptd versions (See DRIVERS-3382)');
 
         $client = static::createTestClient();
 
@@ -635,7 +635,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     #[TestWith([false])]
     public function testCorpus($schemaMap = true): void
     {
-        $this->markTestSkipped('Encryption tests sending large payloads fail on some mongocryptd versions (See DRIVERS-3382)');
+        $this->skipIfServerVersion('>=', '7.0.29', 'Encryption tests sending large payloads fail on some mongocryptd versions (See DRIVERS-3382)');
 
         $client = static::createTestClient();
         $client->selectDatabase('db')->dropCollection('coll');

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -566,6 +566,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     #[DataProvider('provideBSONSizeLimitsAndBatchSplittingTests')]
     public function testBSONSizeLimitsAndBatchSplitting(Closure $test): void
     {
+        $this->markTestSkipped('Encryption tests sending large payloads fail on some mongocryptd versions (See DRIVERS-3382)');
+
         $client = static::createTestClient();
 
         $client->selectCollection('db', 'coll')->drop();

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -635,6 +635,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     #[TestWith([false])]
     public function testCorpus($schemaMap = true): void
     {
+        $this->markTestSkipped('Encryption tests sending large payloads fail on some mongocryptd versions (See DRIVERS-3382)');
+
         $client = static::createTestClient();
         $client->selectDatabase('db')->dropCollection('coll');
 


### PR DESCRIPTION
Encryption tests sending large payloads fail on mongocryptd 8.2.4, 8.0.18, and 7.0.29 due to SERVER-118428

To be reverted by DRIVERS-3382