### PR TITLE
PHPLIB-1698: Remove reference to test-atlas-data-lake task

### DIFF
--- a/.evergreen/config/generated/test-variant/phpc.yml
+++ b/.evergreen/config/generated/test-variant/phpc.yml
@@ -17,7 +17,6 @@ buildvariants:
       - ".replicaset .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
       - ".sharded .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
       - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
-      - "test-atlas-data-lake"
 
   - name: test-debian12-php-8.4-phpc-next-minor
     tags: ["test", "debian", "x64", "php8.4"]

--- a/.evergreen/config/templates/test-variant/phpc.yml
+++ b/.evergreen/config/templates/test-variant/phpc.yml
@@ -15,7 +15,6 @@
       - ".replicaset .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
       - ".sharded .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
       - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
-      - "test-atlas-data-lake"
 
   - name: test-debian12-php-%phpVersion%-phpc-next-minor
     tags: ["test", "debian", "x64", "php%phpVersion%"]


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1698

This was addressed in the original PR (#1778) but missed when merging to v2.1 and up.

I noted the reference is still in the [v2.0](https://github.com/mongodb/mongo-php-library/blob/v2.x/.evergreen/config/templates/test-variant/phpc.yml) branch, but I assume that's intentional as it was already unmaintained at the time this change was implemented (and should no longer be tested in Evergreen).