### PR TITLE
PHPLIB-1647: Add `Database::getGridFSBucket()`

### DIFF
--- a/benchmark/src/DriverBench/GridFSBench.php
+++ b/benchmark/src/DriverBench/GridFSBench.php
@@ -33,7 +33,7 @@ final class GridFSBench
         $database = Utils::getDatabase();
         $database->drop();
 
-        $this->bucket = $database->selectGridFSBucket();
+        $this->bucket = $database->getGridFSBucket();
         // Init the GridFS bucket
         $this->bucket->uploadFromStream('init', Data::getStream(1));
         // Prepare the 50MB stream to upload
@@ -52,7 +52,7 @@ final class GridFSBench
         $database = Utils::getDatabase();
         $database->drop();
 
-        $this->bucket = $database->selectGridFSBucket();
+        $this->bucket = $database->getGridFSBucket();
         // Upload a 50MB file
         $this->id = $this->bucket->uploadFromStream('init', Data::getStream(50 * 1024 * 1024));
         // Prepare the stream to receive the download

--- a/benchmark/src/DriverBench/ParallelGridFSBench.php
+++ b/benchmark/src/DriverBench/ParallelGridFSBench.php
@@ -48,7 +48,7 @@ final class ParallelGridFSBench
         foreach (self::getFileNames() as $file) {
             $pid = pcntl_fork();
             if ($pid === 0) {
-                Utils::getDatabase()->selectGridFSBucket()->uploadFromStream(basename($file), fopen($file, 'r'));
+                Utils::getDatabase()->getGridFSBucket()->uploadFromStream(basename($file), fopen($file, 'r'));
 
                 // Exit the child process
                 exit(0);
@@ -78,7 +78,7 @@ final class ParallelGridFSBench
         $database = Utils::getDatabase();
         $database->drop();
 
-        $bucket = $database->selectGridFSBucket();
+        $bucket = $database->getGridFSBucket();
         $bucket->uploadFromStream('init', Data::getStream(1));
 
         Utils::reset();
@@ -97,7 +97,7 @@ final class ParallelGridFSBench
             $pid = pcntl_fork();
             if ($pid === 0) {
                 $stream = Utils::getDatabase()
-                    ->selectGridFSBucket()
+                    ->getGridFSBucket()
                     ->openDownloadStreamByName(basename($file));
                 stream_copy_to_stream($stream, fopen($file, 'w'));
 

--- a/examples/gridfs_stream.php
+++ b/examples/gridfs_stream.php
@@ -23,7 +23,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 // Disable MD5 computation for faster uploads, this feature is deprecated
-$bucket = $client->test->selectGridFSBucket(['disableMD5' => true]);
+$bucket = $client->test->getGridFSBucket(['disableMD5' => true]);
 
 // Open a stream for writing, similar to fopen with mode 'w'
 $stream = $bucket->openUploadStream('hello.txt');

--- a/examples/gridfs_stream_wrapper.php
+++ b/examples/gridfs_stream_wrapper.php
@@ -22,7 +22,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 // Disable MD5 computation for faster uploads, this feature is deprecated
-$bucket = $client->test->selectGridFSBucket(['disableMD5' => true]);
+$bucket = $client->test->getGridFSBucket(['disableMD5' => true]);
 $bucket->drop();
 
 // Register the alias "mybucket" for default bucket of the "test" database

--- a/examples/gridfs_upload.php
+++ b/examples/gridfs_upload.php
@@ -24,7 +24,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $client = new Client(getenv('MONGODB_URI') ?: 'mongodb://127.0.0.1/');
 
 // Disable MD5 computation for faster uploads, this feature is deprecated
-$gridfs = $client->test->selectGridFSBucket(['disableMD5' => true]);
+$gridfs = $client->test->getGridFSBucket(['disableMD5' => true]);
 
 // Create an in-memory stream, this can be any stream source like STDIN or php://input for web requests
 $stream = fopen('php://temp', 'w+');

--- a/src/Database.php
+++ b/src/Database.php
@@ -423,6 +423,25 @@ class Database implements Stringable
     }
 
     /**
+     * Returns a GridFS bucket instance.
+     *
+     * @see Bucket::__construct() for supported options
+     * @param array $options Bucket constructor options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     */
+    public function getGridFSBucket(array $options = []): Bucket
+    {
+        $options += [
+            'readConcern' => $this->readConcern,
+            'readPreference' => $this->readPreference,
+            'typeMap' => $this->typeMap,
+            'writeConcern' => $this->writeConcern,
+        ];
+
+        return new Bucket($this->manager, $this->databaseName, $options);
+    }
+
+    /**
      * Return the Manager.
      */
     public function getManager(): Manager
@@ -576,14 +595,7 @@ class Database implements Stringable
      */
     public function selectGridFSBucket(array $options = []): Bucket
     {
-        $options += [
-            'readConcern' => $this->readConcern,
-            'readPreference' => $this->readPreference,
-            'typeMap' => $this->typeMap,
-            'writeConcern' => $this->writeConcern,
-        ];
-
-        return new Bucket($this->manager, $this->databaseName, $options);
+        return $this->getGridFSBucket($options);
     }
 
     /**

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -317,7 +317,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
     }
 
-    public function testSelectGridFSBucketInheritsOptions(): void
+    public function testGetGridFSBucketInheritsOptions(): void
     {
         $databaseOptions = [
             'readConcern' => new ReadConcern(ReadConcern::LOCAL),
@@ -326,13 +326,38 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         ];
 
         $database = new Database($this->manager, $this->getDatabaseName(), $databaseOptions);
-        $bucket = $database->selectGridFSBucket();
+        $bucket = $database->getGridFSBucket();
         $debug = $bucket->__debugInfo();
 
         $this->assertSame($this->manager, $debug['manager']);
         $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
         $this->assertSame('fs', $debug['bucketName']);
         $this->assertSame(261120, $debug['chunkSizeBytes']);
+        $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
+        $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
+        $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);
+        $this->assertSame(ReadPreference::SECONDARY_PREFERRED, $debug['readPreference']->getModeString());
+        $this->assertInstanceOf(WriteConcern::class, $debug['writeConcern']);
+        $this->assertSame(WriteConcern::MAJORITY, $debug['writeConcern']->getW());
+    }
+
+    public function testGetGridFSBucketPassesOptions(): void
+    {
+        $bucketOptions = [
+            'bucketName' => 'custom_fs',
+            'chunkSizeBytes' => 8192,
+            'readConcern' => new ReadConcern(ReadConcern::LOCAL),
+            'readPreference' => new ReadPreference(ReadPreference::SECONDARY_PREFERRED),
+            'writeConcern' => new WriteConcern(WriteConcern::MAJORITY),
+        ];
+
+        $database = new Database($this->manager, $this->getDatabaseName());
+        $bucket = $database->getGridFSBucket($bucketOptions);
+        $debug = $bucket->__debugInfo();
+
+        $this->assertSame($this->getDatabaseName(), $debug['databaseName']);
+        $this->assertSame('custom_fs', $debug['bucketName']);
+        $this->assertSame(8192, $debug['chunkSizeBytes']);
         $this->assertInstanceOf(ReadConcern::class, $debug['readConcern']);
         $this->assertSame(ReadConcern::LOCAL, $debug['readConcern']->getLevel());
         $this->assertInstanceOf(ReadPreference::class, $debug['readPreference']);

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -893,7 +893,7 @@ class BucketFunctionalTest extends FunctionalTestCase
             error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
             $client = MongoDB\Tests\FunctionalTestCase::createTestClient();
             $database = $client->selectDatabase(getenv('MONGODB_DATABASE') ?: 'phplib_test');
-            $gridfs = $database->selectGridFSBucket();
+            $gridfs = $database->getGridFSBucket();
             $stream = $gridfs->openUploadStream('hello.txt');
             fwrite($stream, 'Hello MongoDB!');
             PHP;
@@ -936,7 +936,7 @@ class BucketFunctionalTest extends FunctionalTestCase
             error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
             $client = MongoDB\Tests\FunctionalTestCase::createTestClient();
             $database = $client->selectDatabase(getenv('MONGODB_DATABASE') ?: 'phplib_test');
-            $database->selectGridFSBucket()->registerGlobalStreamWrapperAlias('alias');
+            $database->getGridFSBucket()->registerGlobalStreamWrapperAlias('alias');
             $stream = fopen('gridfs://alias/hello.txt', 'w');
             fwrite($stream, 'Hello MongoDB!');
             PHP;

--- a/tests/SpecTests/Context.php
+++ b/tests/SpecTests/Context.php
@@ -398,7 +398,7 @@ final class Context
 
     public function selectGridFSBucket($databaseName, $bucketName, array $bucketOptions = [])
     {
-        return $this->selectDatabase($databaseName)->selectGridFSBucket($this->prepareGridFSBucketOptions($bucketOptions, $bucketName));
+        return $this->selectDatabase($databaseName)->getGridFSBucket($this->prepareGridFSBucketOptions($bucketOptions, $bucketName));
     }
 
     private static function createTestClient(?string $uri = null, array $options = [], array $driverOptions = []): Client

--- a/tests/UnifiedSpecTests/Context.php
+++ b/tests/UnifiedSpecTests/Context.php
@@ -476,7 +476,7 @@ final class Context
             $options = self::prepareBucketOptions((array) $o->bucketOptions);
         }
 
-        $this->entityMap->set($id, $database->selectGridFSBucket($options), $databaseId);
+        $this->entityMap->set($id, $database->getGridFSBucket($options), $databaseId);
     }
 
     private static function getEnv(string $name): string


### PR DESCRIPTION
PHPLIB-1647

This applies the same renaming to `selectGridFSBucket` as we've already done with `selectCollection` and `Client::selectDatabase` in PHPLIB-1185. Note that we're not deprecating the old method yet -- this will be done in a future release as part of PHPLIB-1553.