### PR TITLE
PHPLIB-1770 Fix atlas search exception support detection for MongoDB 5 shared cluster

### DIFF
--- a/src/Exception/SearchNotSupportedException.php
+++ b/src/Exception/SearchNotSupportedException.php
@@ -5,16 +5,19 @@ namespace MongoDB\Exception;
 use MongoDB\Driver\Exception\ServerException;
 use Throwable;
 
+use function preg_match;
+
 final class SearchNotSupportedException extends ServerException
 {
     /** @internal */
     public static function create(ServerException $e): self
     {
-        $message = $e->getCode() === 31082
-            ? $e->getMessage()
-            : 'Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration. '
+        $message = match ($e->getCode()) {
+            31082, 7501001 => $e->getMessage(),
+            default => 'Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration. '
                 . 'Please connect to Atlas or an AtlasCLI local deployment to enable. '
-                . 'For more information on how to connect, see https://dochub.mongodb.org/core/atlas-cli-deploy-local-reqs';
+                . 'For more information on how to connect, see https://dochub.mongodb.org/core/atlas-cli-deploy-local-reqs',
+        };
 
         return new self($message, $e->getCode(), $e);
     }
@@ -34,23 +37,11 @@ final class SearchNotSupportedException extends ServerException
             // MongoDB 7-ent: Search index commands are only supported with Atlas.
             115 => true,
             // MongoDB 4 to 6, 7-community
-            59 => match ($exception->getMessage()) {
-                'no such command: \'createSearchIndexes\'' => true,
-                'no such command: createSearchIndexes' => true,
-                'no such command: \'updateSearchIndex\'' => true,
-                'no such command: updateSearchIndex' => true,
-                'no such command: \'dropSearchIndex\'' => true,
-                'no such command: dropSearchIndex' => true,
-                default => false,
-            },
+            59 => preg_match('/^no such (command|cmd): \'?(createSearchIndexes|updateSearchIndex|dropSearchIndex)\'?$/', $exception->getMessage()) === 1,
             // MongoDB 4 to 6
-            40324 => match ($exception->getMessage()) {
-                'Unrecognized pipeline stage name: \'$listSearchIndexes\'' => true,
-                'Unrecognized pipeline stage name: \'$search\'' => true,
-                'Unrecognized pipeline stage name: \'$searchMeta\'' => true,
-                'Unrecognized pipeline stage name: \'$vectorSearch\'' => true,
-                default => false,
-            },
+            40324 => preg_match('/^Unrecognized pipeline stage name: \'?\$(listSearchIndexes|search|searchMeta|vectorSearch)\'?$/', $exception->getMessage()) === 1,
+            // MongoDB 5 sharded cluster: $search not enabled! Enable Search by setting serverParameter mongotHost to a valid "host:port" string
+            7501001 => true,
             // Not a Search error
             default => false,
         };


### PR DESCRIPTION
Related to PHPLIB-1770.

The exception message in sharded clusters is "no such cmd: createSearchIndexes", with `cmd` instead of `command`.