### PR TITLE
Support mongodb+srv connection string in connection test tool

### DIFF
--- a/tools/connect.php
+++ b/tools/connect.php
@@ -38,21 +38,17 @@ function getHostsFromSrv(string $uri): array
         throw new RuntimeException('SRV URI must contain a host');
     }
 
-    $domain = $parsed['host'];
-    $srvRecord = '_mongodb._tcp.' . $domain;
+    $srvRecord = '_mongodb._tcp.' . $parsed['host'];
 
     $records = dns_get_record($srvRecord, DNS_SRV);
     if ($records === false || count($records) === 0) {
         throw new RuntimeException('No SRV records found for ' . $srvRecord);
     }
 
-    $hosts = [];
-    foreach ($records as $record) {
-        $port = $record['port'] ?? 27017;
-        $hosts[] = $record['target'] . ':' . $port;
-    }
-
-    return $hosts;
+    return array_map(
+        static fn (array $record) => $record['target'] . ':' . ($record['port'] ?? 27017),
+        $records,
+    );
 }
 
 /** @param resource $stream */
@@ -167,7 +163,7 @@ $hosts = getHosts($uri);
 
 if (str_starts_with($uri, 'mongodb+srv://')) {
     // For mongodb+srv, SSL is always true unless explicitly set to false
-    $ssl = stripos(parse_url($uri, PHP_URL_QUERY) ?? '', 'ssl=false') !== false;
+    $ssl = stripos(parse_url($uri, PHP_URL_QUERY) ?? '', 'ssl=false') === false;
 } else {
     // For other connection strings, SSL is true if indicated
     $ssl = stripos(parse_url($uri, PHP_URL_QUERY) ?? '', 'ssl=true') !== false;

--- a/tools/connect.php
+++ b/tools/connect.php
@@ -8,14 +8,51 @@ function getHosts(string $uri): array
 
     $parsed = parse_url($uri);
 
-    if (isset($parsed['scheme']) && $parsed['scheme'] !== 'mongodb') {
-        // TODO: Resolve SRV records (https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.md)
+    if (! isset($parsed['scheme'])) {
+        throw new RuntimeException('URI must contain a scheme');
+    }
+
+    if ($parsed['scheme'] === 'mongodb+srv') {
+        return getHostsFromSrv($uri);
+    }
+
+    if ($parsed['scheme'] !== 'mongodb') {
         throw new RuntimeException('Unsupported scheme: ' . $parsed['scheme']);
     }
 
     $hosts = sprintf('%s:%d', $parsed['host'], $parsed['port'] ?? 27017);
 
     return explode(',', $hosts);
+}
+
+/**
+ * Resolves SRV records for a MongoDB+SRV URI according to the specification:
+ * https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.md
+ *
+ * @return list<string> List of host:port strings
+ */
+function getHostsFromSrv(string $uri): array
+{
+    $parsed = parse_url($uri);
+    if (! isset($parsed['host'])) {
+        throw new RuntimeException('SRV URI must contain a host');
+    }
+
+    $domain = $parsed['host'];
+    $srvRecord = '_mongodb._tcp.' . $domain;
+
+    $records = dns_get_record($srvRecord, DNS_SRV);
+    if ($records === false || count($records) === 0) {
+        throw new RuntimeException('No SRV records found for ' . $srvRecord);
+    }
+
+    $hosts = [];
+    foreach ($records as $record) {
+        $port = $record['port'] ?? 27017;
+        $hosts[] = $record['target'] . ':' . $port;
+    }
+
+    return $hosts;
 }
 
 /** @param resource $stream */
@@ -127,7 +164,14 @@ function connect(string $host, bool $ssl): void
 $uri = $argv[1] ?? 'mongodb://127.0.0.1';
 printf("Looking up MongoDB at %s\n", $uri);
 $hosts = getHosts($uri);
-$ssl = stripos(parse_url($uri, PHP_URL_QUERY) ?? '', 'ssl=true') !== false;
+
+if (str_starts_with($uri, 'mongodb+srv://')) {
+    // For mongodb+srv, SSL is always true unless explicitly set to false
+    $ssl = stripos(parse_url($uri, PHP_URL_QUERY) ?? '', 'ssl=false') !== false;
+} else {
+    // For other connection strings, SSL is true if indicated
+    $ssl = stripos(parse_url($uri, PHP_URL_QUERY) ?? '', 'ssl=true') !== false;
+}
 
 printf("Found %d host(s) in the URI. Will attempt to connect to each.\n", count($hosts));
 


### PR DESCRIPTION
I had GitHub Copilot implement this while I was busy with other things. I successfully tested this with one of my Atlas clusters.