### PR TITLE
Improve flakey index version test

### DIFF
--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -28,8 +28,8 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
         $this->assertEquals($indexName, $index->getName());
         $this->assertTrue($index->is2dSphere());
 
-        // MongoDB 3.2+ reports index version 3
-        $this->assertEquals(3, $index['2dsphereIndexVersion']);
+        // MongoDB 3.2+ reports index version 3, MongoDB 8.3+ reports version 4
+        $this->assertGreaterThanOrEqual(3, $index['2dsphereIndexVersion']);
     }
 
     public function testIsText(): void


### PR DESCRIPTION
The mongodb-latest build is failing because the current latest server version uses a newer index version for 2d sphere indexes. We don't need to check for a precise version, we only need to assert it's there.