### PR TITLE
PHPLIB-1714: implement backoff for withTransaction

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -756,10 +756,12 @@
   </file>
   <file src="src/Operation/WithTransaction.php">
     <InvalidOperand>
+      <code><![CDATA[$backoffMs * 1e6]]></code>
       <code><![CDATA[$this->getJitter() * min(self::BACKOFF_INITIAL * (1.5 ** ($transactionAttempt - 1)), self::BACKOFF_MAX)]]></code>
       <code><![CDATA[1.5 ** ($transactionAttempt - 1)]]></code>
+      <code><![CDATA[hrtime(true) + ($backoffMs * 1e6)]]></code>
       <code><![CDATA[self::BACKOFF_INITIAL * (1.5 ** ($transactionAttempt - 1))]]></code>
-      <code><![CDATA[time() + ($backoffMs / 1000)]]></code>
+      <code><![CDATA[self::MAX_TIME * 1e9]]></code>
     </InvalidOperand>
   </file>
   <file src="src/UpdateResult.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.14.2@bbd217fc98c0daa0a13aea2a7f119d03ba3fc9a0">
+<files psalm-version="6.14.3@d0b040a91f280f071c1abcb1b77ce3822058725a">
   <file src="examples/atlas_search.php">
     <MixedArgument>
       <code><![CDATA[$document['name']]]></code>
@@ -210,12 +210,6 @@
       <code><![CDATA[$queries[$fieldPath]]]></code>
       <code><![CDATA[$query]]></code>
     </MixedAssignment>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[count($queriesOrArrayOfQueries) === 1 &&
-            isset($queriesOrArrayOfQueries[0]) &&
-            is_array($queriesOrArrayOfQueries[0]) &&
-            count($queriesOrArrayOfQueries[0]) > 0]]></code>
-    </RedundantConditionGivenDocblockType>
     <UndefinedConstant>
       <code><![CDATA[$query::NAME]]></code>
       <code><![CDATA[$query::NAME]]></code>
@@ -759,6 +753,14 @@
       <code><![CDATA[$this->changeStreamOptions['resumeAfter']]]></code>
       <code><![CDATA[$this->changeStreamOptions['startAfter']]]></code>
     </MixedReturnStatement>
+  </file>
+  <file src="src/Operation/WithTransaction.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getJitter() * min(self::BACKOFF_INITIAL * (1.5 ** ($transactionAttempt - 1)), self::BACKOFF_MAX)]]></code>
+      <code><![CDATA[1.5 ** ($transactionAttempt - 1)]]></code>
+      <code><![CDATA[self::BACKOFF_INITIAL * (1.5 ** ($transactionAttempt - 1))]]></code>
+      <code><![CDATA[time() + ($backoffMs / 1000)]]></code>
+    </InvalidOperand>
   </file>
   <file src="src/UpdateResult.php">
     <MixedAssignment>

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -19,8 +19,13 @@ use function usleep;
 /** @internal */
 final class WithTransaction
 {
+    /** Initial backoff time in ms */
     private const BACKOFF_INITIAL = 5;
+
+    /** Maximum backoff time in ms */
     private const BACKOFF_MAX = 500;
+
+    /** Default transaction timeout in seconds */
     private const MAX_TIME = 120;
 
     /** @var callable */
@@ -117,7 +122,7 @@ final class WithTransaction
     }
 
     /**
-     * Checks if the given exception is an error that allows for retrying the connection
+     * Checks if the given exception is an error that allows for retrying the transaction
      *
      * This method is called when an error happens during the transaction callback. If the error is not retryable, or if
      * the time limit for retries has been exceeded, it re-throws the caught exception to break out of the transaction
@@ -151,7 +156,7 @@ final class WithTransaction
      * This method attempts to commit the transaction, retrying the commit if an unknown commit result was encountered.
      * If the transaction was committed successfully, it returns true. If a transient transaction error has occurred and
      * the time limit for retries has not been exceeded, it returns false to indicate that the entire transaction should
-     * be retried. If a none-retryable error is encountered, or if the time limit for retries has been exceeded, it
+     * be retried. If a non-retryable error is encountered, or if the time limit for retries has been exceeded, it
      * throws the last exception encountered to break out of the transaction loop.
      *
      * @return bool Returns true if the transaction was successfully committed, or false if the transaction should be retried

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -31,7 +31,11 @@ final class WithTransaction
     /** @var callable */
     private $callback;
 
-    /** Used to inject a custom jitter generator for tests */
+    /**
+     * Used to inject a custom jitter generator for tests
+     *
+     * @var (Closure():float)|null
+     */
     private ?Closure $jitterGenerator = null;
 
     /**

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -8,11 +8,20 @@ use MongoDB\Driver\Session;
 use Throwable;
 
 use function call_user_func;
+use function floor;
+use function getrandmax;
+use function min;
+use function rand;
 use function time;
+use function usleep;
 
 /** @internal */
 final class WithTransaction
 {
+    private const BACKOFF_INITIAL = 5;
+    private const BACKOFF_MAX = 500;
+    private const MAX_TIME = 120;
+
     /** @var callable */
     private $callback;
 
@@ -52,15 +61,17 @@ final class WithTransaction
     public function execute(Session $session): void
     {
         $startTime = time();
+        $transactionAttempt = 0;
 
         while (true) {
+            $transactionAttempt++;
             $session->startTransaction($this->transactionOptions);
 
             try {
                 call_user_func($this->callback, $session);
             } catch (Throwable $e) {
                 // If this method returns, this means we're able to retry the entire transaction.
-                $this->checkForRetryableError($session, $e, $startTime);
+                $this->checkForRetryableError($session, $e, $startTime, $transactionAttempt);
 
                 continue;
             }
@@ -71,10 +82,34 @@ final class WithTransaction
             }
 
             // Commit the transaction and return if it was committed successfully
-            if ($this->commitTransaction($session, $startTime)) {
+            if ($this->commitTransaction($session, $startTime, $transactionAttempt)) {
                 return;
             }
         }
+    }
+
+    /**
+     * Handles the backoff logic for retrying transactions according to the backpressure spec
+     *
+     * This method will throw if backing off would cause the total transaction time to exceed the limit. In other cases,
+     * it will simply sleep for the appropriate amount of time and return, allowing withTransaction to continue the
+     * transaction loop.
+     *
+     * @param Throwable $e                  The exception that's causing the backoff. This exception will be thrown if we're unable to back off
+     * @param int       $startTime          The time the transaction loop was started
+     * @param int       $transactionAttempt The current transaction attempt number, used to compute the backoff time according to the backpressure spec
+     */
+    private function backoff(Throwable $e, int $startTime, int $transactionAttempt): void
+    {
+        $backoffMs = $this->computeBackoffMs($transactionAttempt);
+
+        // If backing off for the computed time would exceed the total transaction time limit, do not back off and
+        // throw the original error to break out of the transaction loop instead
+        if ($this->isTransactionTimeLimitExceeded($startTime, $backoffMs)) {
+            throw $e;
+        }
+
+        usleep($backoffMs * 1000);
     }
 
     /**
@@ -84,7 +119,7 @@ final class WithTransaction
      * the time limit for retries has been exceeded, it re-throws the caught exception to break out of the transaction
      * loop. In other cases, it returns without throwing.
      */
-    private function checkForRetryableError(Session $session, Throwable $e, int $startTime): void
+    private function checkForRetryableError(Session $session, Throwable $e, int $startTime, int $transactionAttempt): void
     {
         if ($session->isInTransaction()) {
             $session->abortTransaction();
@@ -95,6 +130,10 @@ final class WithTransaction
             $e->hasErrorLabel('TransientTransactionError') &&
             ! $this->isTransactionTimeLimitExceeded($startTime)
         ) {
+            // Before retrying the transaction, back off according to the backpressure spec. This will throw if we're
+            // unable to back off.
+            $this->backoff($e, $startTime, $transactionAttempt);
+
             return;
         }
 
@@ -114,7 +153,7 @@ final class WithTransaction
      * @return bool Returns true if the transaction was successfully committed, or false if the transaction should be retried
      * @throws Throwable if an error occurs while committing the transaction that should not be retried
      */
-    private function commitTransaction(Session $session, int $startTime): bool
+    private function commitTransaction(Session $session, int $startTime, int $transactionAttempt): bool
     {
         while (true) {
             try {
@@ -133,7 +172,11 @@ final class WithTransaction
                     $e->hasErrorLabel('TransientTransactionError') &&
                     ! $this->isTransactionTimeLimitExceeded($startTime)
                 ) {
-                    // Restart the transaction, invoking the callback again
+                    // Before restarting the transaction, attempt to back off. This will throw if we're unable to back
+                    // off.
+                    $this->backoff($e, $startTime, $transactionAttempt);
+
+                    // Indicate that we can retry the transaction
                     return false;
                 }
 
@@ -145,13 +188,27 @@ final class WithTransaction
         }
     }
 
+    private function computeBackoffMs(int $transactionAttempt): int
+    {
+        return (int) floor($this->getJitter() * min(self::BACKOFF_INITIAL * (1.5 ** ($transactionAttempt - 1)), self::BACKOFF_MAX));
+    }
+
+    private function getJitter(): float
+    {
+        // Jitter is a random float from [0, 1)
+        // Since rand will return an int from 0 to getrandmax(), we can divide the result by getrandmax() + 1 to get a
+        // float in the range [0, 1)
+        return rand() / (getrandmax() + 1);
+    }
+
     /**
      * Returns whether the time limit for retrying transactions in the convenient transaction API has passed
      *
-     * @param int $startTime The time the transaction was started
+     * @param int $startTime The time the transaction loop was started
+     * @param int $backoffMs The amount of time that will be spent backing off before the next retry attempt, in milliseconds
      */
-    private function isTransactionTimeLimitExceeded(int $startTime): bool
+    private function isTransactionTimeLimitExceeded(int $startTime, int $backoffMs = 0): bool
     {
-        return time() - $startTime >= 120;
+        return time() + ($backoffMs / 1000) - $startTime >= self::MAX_TIME;
     }
 }

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -10,10 +10,10 @@ use Throwable;
 
 use function call_user_func;
 use function floor;
+use function hrtime;
 use function min;
 use function mt_getrandmax;
 use function random_int;
-use function time;
 use function usleep;
 
 /** @internal */
@@ -73,7 +73,7 @@ final class WithTransaction
      */
     public function execute(Session $session): void
     {
-        $startTime = time();
+        $startTime = hrtime(true);
         $transactionAttempt = 0;
 
         while (true) {
@@ -226,6 +226,7 @@ final class WithTransaction
      */
     private function isTransactionTimeLimitExceeded(int $startTime, int $backoffMs = 0): bool
     {
-        return time() + ($backoffMs / 1000) - $startTime >= self::MAX_TIME;
+        // hrtime returns nanoseconds, so convert the backoff and maximum time accordingly
+        return hrtime(true) + ($backoffMs * 1e6) - $startTime >= self::MAX_TIME * 1e9;
     }
 }

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -2,6 +2,7 @@
 
 namespace MongoDB\Operation;
 
+use Closure;
 use Exception;
 use MongoDB\Driver\Exception\RuntimeException;
 use MongoDB\Driver\Session;
@@ -24,6 +25,9 @@ final class WithTransaction
 
     /** @var callable */
     private $callback;
+
+    /** Used to inject a custom jitter generator for tests */
+    private ?Closure $jitterGenerator = null;
 
     /**
      * @see Session::startTransaction for supported transaction options
@@ -195,6 +199,10 @@ final class WithTransaction
 
     private function getJitter(): float
     {
+        if ($this->jitterGenerator) {
+            return ($this->jitterGenerator)();
+        }
+
         // Jitter is a random float from [0, 1)
         // Since rand will return an int from 0 to getrandmax(), we can divide the result by getrandmax() + 1 to get a
         // float in the range [0, 1)

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -10,9 +10,9 @@ use Throwable;
 
 use function call_user_func;
 use function floor;
-use function getrandmax;
 use function min;
-use function rand;
+use function mt_getrandmax;
+use function random_int;
 use function time;
 use function usleep;
 
@@ -209,9 +209,9 @@ final class WithTransaction
         }
 
         // Jitter is a random float from [0, 1)
-        // Since rand will return an int from 0 to getrandmax(), we can divide the result by getrandmax() + 1 to get a
-        // float in the range [0, 1)
-        return rand() / (getrandmax() + 1);
+        // Since rand will return an int from 0 to mt_getrandmax(), we can divide the result by mt_getrandmax() + 1 to
+        // get a float in the range [0, 1)
+        return random_int(0, mt_getrandmax()) / (mt_getrandmax() + 1);
     }
 
     /**

--- a/src/Operation/WithTransaction.php
+++ b/src/Operation/WithTransaction.php
@@ -59,19 +59,10 @@ final class WithTransaction
             try {
                 call_user_func($this->callback, $session);
             } catch (Throwable $e) {
-                if ($session->isInTransaction()) {
-                    $session->abortTransaction();
-                }
+                // If this method returns, this means we're able to retry the entire transaction.
+                $this->checkForRetryableError($session, $e, $startTime);
 
-                if (
-                    $e instanceof RuntimeException &&
-                    $e->hasErrorLabel('TransientTransactionError') &&
-                    ! $this->isTransactionTimeLimitExceeded($startTime)
-                ) {
-                    continue;
-                }
-
-                throw $e;
+                continue;
             }
 
             if (! $session->isInTransaction()) {
@@ -79,36 +70,78 @@ final class WithTransaction
                 return;
             }
 
-            while (true) {
-                try {
-                    $session->commitTransaction();
-                } catch (RuntimeException $e) {
-                    if (
-                        $e->getCode() !== 50 /* MaxTimeMSExpired */ &&
-                        $e->hasErrorLabel('UnknownTransactionCommitResult') &&
-                        ! $this->isTransactionTimeLimitExceeded($startTime)
-                    ) {
-                        // Retry committing the transaction
-                        continue;
-                    }
+            // Commit the transaction and return if it was committed successfully
+            if ($this->commitTransaction($session, $startTime)) {
+                return;
+            }
+        }
+    }
 
-                    if (
-                        $e->hasErrorLabel('TransientTransactionError') &&
-                        ! $this->isTransactionTimeLimitExceeded($startTime)
-                    ) {
-                        // Restart the transaction, invoking the callback again
-                        continue 2;
-                    }
+    /**
+     * Checks if the given exception is an error that allows for retrying the connection
+     *
+     * This method is called when an error happens during the transaction callback. If the error is not retryable, or if
+     * the time limit for retries has been exceeded, it re-throws the caught exception to break out of the transaction
+     * loop. In other cases, it returns without throwing.
+     */
+    private function checkForRetryableError(Session $session, Throwable $e, int $startTime): void
+    {
+        if ($session->isInTransaction()) {
+            $session->abortTransaction();
+        }
 
-                    throw $e;
+        if (
+            $e instanceof RuntimeException &&
+            $e->hasErrorLabel('TransientTransactionError') &&
+            ! $this->isTransactionTimeLimitExceeded($startTime)
+        ) {
+            return;
+        }
+
+        throw $e;
+    }
+
+    /**
+     * Attempts to commit the transaction until it either succeeds, encounters a non-retryable error, or exceeds the
+     * time limit for retries
+     *
+     * This method attempts to commit the transaction, retrying the commit if an unknown commit result was encountered.
+     * If the transaction was committed successfully, it returns true. If a transient transaction error has occurred and
+     * the time limit for retries has not been exceeded, it returns false to indicate that the entire transaction should
+     * be retried. If a none-retryable error is encountered, or if the time limit for retries has been exceeded, it
+     * throws the last exception encountered to break out of the transaction loop.
+     *
+     * @return bool Returns true if the transaction was successfully committed, or false if the transaction should be retried
+     * @throws Throwable if an error occurs while committing the transaction that should not be retried
+     */
+    private function commitTransaction(Session $session, int $startTime): bool
+    {
+        while (true) {
+            try {
+                $session->commitTransaction();
+            } catch (RuntimeException $e) {
+                if (
+                    $e->getCode() !== 50 /* MaxTimeMSExpired */ &&
+                    $e->hasErrorLabel('UnknownTransactionCommitResult') &&
+                    ! $this->isTransactionTimeLimitExceeded($startTime)
+                ) {
+                    // Retry committing the transaction
+                    continue;
                 }
 
-                // Commit was successful
-                break;
+                if (
+                    $e->hasErrorLabel('TransientTransactionError') &&
+                    ! $this->isTransactionTimeLimitExceeded($startTime)
+                ) {
+                    // Restart the transaction, invoking the callback again
+                    return false;
+                }
+
+                throw $e;
             }
 
-            // Transaction was successful
-            break;
+            // Commit was successful, indicate to break out of the transaction loop
+            return true;
         }
     }
 

--- a/tests/Operation/WithTransactionTest.php
+++ b/tests/Operation/WithTransactionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MongoDB\Tests\Operation;
+
+use Generator;
+use MongoDB\Operation\WithTransaction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class WithTransactionTest extends TestCase
+{
+    public static function provideComputeBackoffMSValues(): Generator
+    {
+        yield [5, 1];
+        yield [7, 2];
+        yield [11, 3];
+        yield [16, 4];
+        yield [25, 5];
+        yield [192, 10];
+        yield [432, 12];
+
+        // We run into the 500 ms maximum after 13 attempts
+        yield [500, 13];
+        yield [500, 20];
+    }
+
+    #[DataProvider('provideComputeBackoffMSValues')]
+    public function testComputeBackoffMS(int $expected, int $attempt): void
+    {
+        $operation = new WithTransaction(fn () => 0);
+
+        // Set a fixed jitter value instead of a random one
+        (new ReflectionProperty($operation, 'jitterGenerator'))
+            ->setValue(
+                $operation,
+                static fn (): float => 1,
+            );
+
+        $method = new ReflectionMethod($operation, 'computeBackoffMs');
+
+        $this->assertSame($expected, $method->invoke($operation, $attempt));
+    }
+
+    public function testComputeBackoffMSUsesRandom(): void
+    {
+        $operation = new WithTransaction(fn () => 0);
+
+        $method = new ReflectionMethod($operation, 'computeBackoffMs');
+        $first = $method->invoke($operation, 5);
+        $second = $method->invoke($operation, 5);
+
+        $this->assertNotSame($first, $second, 'computeBackoffMs() multiplies backoff with a random value');
+    }
+}

--- a/tests/Operation/WithTransactionTest.php
+++ b/tests/Operation/WithTransactionTest.php
@@ -47,8 +47,8 @@ class WithTransactionTest extends TestCase
         $operation = new WithTransaction(fn () => 0);
 
         $method = new ReflectionMethod($operation, 'computeBackoffMs');
-        $first = $method->invoke($operation, 5);
-        $second = $method->invoke($operation, 5);
+        $first = $method->invoke($operation, 13);
+        $second = $method->invoke($operation, 13);
 
         $this->assertNotSame($first, $second, 'computeBackoffMs() multiplies backoff with a random value');
     }

--- a/tests/SpecTests/TransactionsConvenientApi/Prose4_RetryBackoffIsEnforcedTest.php
+++ b/tests/SpecTests/TransactionsConvenientApi/Prose4_RetryBackoffIsEnforcedTest.php
@@ -16,7 +16,7 @@ class Prose4_RetryBackoffIsEnforcedTest extends FunctionalTestCase
     {
         $this->skipIfTransactionsAreNotSupported();
 
-        $client = self::createTestClient(static::getUri(true));
+        $client = self::createTestClient(static::getUri());
         $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
 
         // Create collection before transaction, as MongoDB 4.2 doesn't allow creating collections in transactions

--- a/tests/SpecTests/TransactionsConvenientApi/Prose4_RetryBackoffIsEnforcedTest.php
+++ b/tests/SpecTests/TransactionsConvenientApi/Prose4_RetryBackoffIsEnforcedTest.php
@@ -19,6 +19,9 @@ class Prose4_RetryBackoffIsEnforcedTest extends FunctionalTestCase
         $client = self::createTestClient(static::getUri(true));
         $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
 
+        // Create collection before transaction, as MongoDB 4.2 doesn't allow creating collections in transactions
+        $collection->insertOne([]);
+
         $callback = static function (Session $session) use ($collection): void {
             $collection->insertOne([], ['session' => $session]);
         };

--- a/tests/SpecTests/TransactionsConvenientApi/Prose4_RetryBackoffIsEnforcedTest.php
+++ b/tests/SpecTests/TransactionsConvenientApi/Prose4_RetryBackoffIsEnforcedTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MongoDB\Tests\SpecTests\TransactionsConvenientApi;
+
+use MongoDB\Driver\Session;
+use MongoDB\Operation\WithTransaction;
+use MongoDB\Tests\SpecTests\FunctionalTestCase;
+use ReflectionProperty;
+
+use function microtime;
+
+/** @see https://github.com/mongodb/specifications/tree/master/source/transactions-convenient-api/tests#retry-backoff-is-enforced */
+class Prose4_RetryBackoffIsEnforcedTest extends FunctionalTestCase
+{
+    public function testBackoffIsEnforced(): void
+    {
+        $this->skipIfTransactionsAreNotSupported();
+
+        $client = self::createTestClient(static::getUri(true));
+        $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+
+        $callback = static function (Session $session) use ($collection): void {
+            $collection->insertOne([], ['session' => $session]);
+        };
+
+        $operation = new WithTransaction($callback);
+        $session = $client->startSession();
+
+        $this->setFixedJitter($operation, 0);
+        $noBackoffTime = $this->runOperationWithTiming($operation, $session);
+
+        $this->setFixedJitter($operation, 1);
+        $withBackoffTime = $this->runOperationWithTiming($operation, $session);
+
+        self::assertEqualsWithDelta($noBackoffTime + 1.8, $withBackoffTime, 0.5);
+    }
+
+    private function runOperationWithTiming(WithTransaction $operation, Session $session): float
+    {
+        $this->setUpCommitTransactionFailPoint();
+
+        $start = microtime(true);
+        $operation->execute($session);
+
+        return microtime(true) - $start;
+    }
+
+    private function setFixedJitter(WithTransaction $operation, float $jitter): void
+    {
+        (new ReflectionProperty($operation, 'jitterGenerator'))
+            ->setValue(
+                $operation,
+                static fn (): float => $jitter,
+            );
+    }
+
+    private function setUpCommitTransactionFailPoint(): void
+    {
+        $this->configureFailPoint([
+            'configureFailPoint' => 'failCommand',
+            'mode' => ['times' => 13],
+            'data' => [
+                'failCommands' => ['commitTransaction'],
+                'errorCode' => 251,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
PHPLIB-1714

This implements the backoff algorithm as described in the convenient transaction API. The PR is best reviewed commit-by-commit:
- The first commit refactors the `withTransaction` class to extract the error checking and commit logic into smaller methods that will throw if the transaction loop is to be aborted or return if it is to be retried
- The second commit implements the backoff logic
- The third commit implements the prose test for the backoff logic, including a change in `withTransaction` itself to allow injecting a fixed jitter for testing.