### PR TITLE
PHPLIB-1396: Implement convenient transactions prose tests

### DIFF
--- a/tests/SpecTests/TransactionsConvenientApi/Prose1_CallbackRaisesCustomErrorTest.php
+++ b/tests/SpecTests/TransactionsConvenientApi/Prose1_CallbackRaisesCustomErrorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MongoDB\Tests\SpecTests\TransactionsConvenientApi;
+
+use MongoDB\Driver\Session;
+use MongoDB\Tests\SpecTests\FunctionalTestCase;
+use RuntimeException;
+
+use function MongoDB\with_transaction;
+
+/** @see https://github.com/mongodb/specifications/tree/master/source/transactions-convenient-api/tests#callback-raises-a-custom-error */
+class Prose1_CallbackRaisesCustomErrorTest extends FunctionalTestCase
+{
+    public function testCallbackRaisesCustomError(): void
+    {
+        $this->skipIfTransactionsAreNotSupported();
+
+        $attempts = 0;
+
+        $callback = static function (Session $session) use (&$attempts): void {
+            $attempts++;
+
+            throw new RuntimeException('Custom error');
+        };
+
+        $client = self::createTestClient(static::getUri(true));
+
+        $session = $client->startSession();
+
+        try {
+            with_transaction($session, $callback);
+            $this->fail('Expected RuntimeException was not thrown');
+        } catch (RuntimeException $e) {
+            $this->assertSame('Custom error', $e->getMessage());
+        }
+
+        $this->assertSame(1, $attempts);
+    }
+}

--- a/tests/SpecTests/TransactionsConvenientApi/Prose2_ReturnValueTest.php
+++ b/tests/SpecTests/TransactionsConvenientApi/Prose2_ReturnValueTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MongoDB\Tests\SpecTests\TransactionsConvenientApi;
+
+use MongoDB\Driver\Session;
+use MongoDB\Tests\SpecTests\FunctionalTestCase;
+
+use function MongoDB\with_transaction;
+use function random_int;
+
+/** @see https://github.com/mongodb/specifications/tree/master/source/transactions-convenient-api/tests#callback-returns-a-value */
+class Prose2_ReturnValueTest extends FunctionalTestCase
+{
+    public function testCallbackReturnsCustomValue(): void
+    {
+        $this->markTestIncomplete('withTransaction does not return the callback return value (PHPLIB-994)');
+
+        $this->skipIfTransactionsAreNotSupported();
+
+        $value = random_int(0, 1_000_000);
+
+        $callback = static fn (Session $session): int => $value;
+
+        $client = self::createTestClient(static::getUri(true));
+
+        $session = $client->startSession();
+
+        $result = with_transaction($session, $callback);
+
+        $this->assertSame($value, $result, 'withTransaction returns the callback return value');
+    }
+}


### PR DESCRIPTION
PHPLIB-1396

This PR implements prose tests that were previously not implemented. Two notes: 
- prose test two is skipped for now as we don't return callback values from `with_transaction`. This is tracked in PHPLIB-994.
- prose test three is not implemented as we don't have a good way to reduce the timeout. The 120-second timeout for `withTransaction` is fixed in the API, and the only way to customise this would be using client-side operations timeout (CSOT) which we can't implement until it's supported by libmongoc. However, we may want to consider deviating from the spec here as a non-configurable timeout of 120 seconds is not useful in PHP, especially outside of a CLI context.