### PR TITLE
PHPLIB-1778: Unskip large encryption spec test

### DIFF
--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -566,8 +566,6 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     #[DataProvider('provideBSONSizeLimitsAndBatchSplittingTests')]
     public function testBSONSizeLimitsAndBatchSplitting(Closure $test): void
     {
-        $this->skipIfServerVersion('>=', '7.0.29', 'Encryption tests sending large payloads fail on some mongocryptd versions (See DRIVERS-3382)');
-
         $client = static::createTestClient();
 
         $client->selectCollection('db', 'coll')->drop();
@@ -635,8 +633,6 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     #[TestWith([false])]
     public function testCorpus($schemaMap = true): void
     {
-        $this->skipIfServerVersion('>=', '7.0.29', 'Encryption tests sending large payloads fail on some mongocryptd versions (See DRIVERS-3382)');
-
         $client = static::createTestClient();
         $client->selectDatabase('db')->dropCollection('coll');
 


### PR DESCRIPTION
PHPLIB-1778

This partially reverts changes made in #1831.