### PR TITLE
Add missing polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
         "ext-mongodb": "^2.2",
         "composer-runtime-api": "^2.0",
         "psr/log": "^1.1.4|^2|^3",
-        "symfony/polyfill-php85": "^1.32"
+        "symfony/polyfill-php82": "^1.33",
+        "symfony/polyfill-php83": "^1.33",
+        "symfony/polyfill-php84": "^1.33",
+        "symfony/polyfill-php85": "^1.33"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",


### PR DESCRIPTION
#1851 added a call to `array_first`, which is technically covered by Symfony's PHP 8.5 polyfill. However, `array_first` and `array_last` were only added in the latest version of the package, causing failures on the lowest dependency builds. To work around this, this PR bumps the version requirement to 1.33, and adds the other polyfills so we can rely on other features, for example:
* `array_any` and `array_all`, introduced in PHP 8.4
* The `Deprecated` attribute introduced in PHP 8.4
* The `Override` attribute introduced in PHP 8.3
* `AllowDynamicProperties` and some `Random\Engine` functionality introduced in PHP 8.2.

I would suggest that going forward, we always add polyfills for new PHP versions and remove them once we bump the minimum PHP version.

Note: I've manually scheduled the [previously failing test](https://spruce.corp.mongodb.com/task/mongo_php_library_2.x_test_rhel80_php_8.1_local_lowest_test_mongodb_4.2_replicaset_noauth_nossl_f36676fc60e2c2a67510ac1710e2796591bd2efe_26_03_12_10_28_44/tests?execution=0&sorts=STATUS%3AASC) to ensure the issue is fixed.