### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ $ composer run checks
 
 ### Coding standards
 
-The library's code is checked using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer),
+The library's code is checked using [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer),
 which is installed as a development dependency by Composer. To check the code
 for style errors, run the `phpcs` binary:
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932