### PR TITLE
Fix flaky testComputeBackoffMSUsesRandom test

### DIFF
--- a/tests/Operation/WithTransactionTest.php
+++ b/tests/Operation/WithTransactionTest.php
@@ -8,6 +8,13 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 use ReflectionProperty;
 
+use function array_map;
+use function array_unique;
+use function count;
+use function implode;
+use function range;
+use function sprintf;
+
 class WithTransactionTest extends TestCase
 {
     public static function provideComputeBackoffMSValues(): Generator
@@ -46,11 +53,12 @@ class WithTransactionTest extends TestCase
     {
         $operation = new WithTransaction(fn () => 0);
 
+        // The same random number can be generated multiple times,
+        // but we should get different values across multiple calls
         $method = new ReflectionMethod($operation, 'computeBackoffMs');
-        $first = $method->invoke($operation, 13);
-        $second = $method->invoke($operation, 13);
+        $results = array_map(fn () => $method->invoke($operation, 13), range(0, 5));
 
-        $this->assertNotSame($first, $second, 'computeBackoffMs() multiplies backoff with a random value');
+        $this->assertGreaterThan(1, count(array_unique($results)), sprintf('Expected random values, got %s', implode(', ', $results)));
     }
 
     public function testJitter(): void


### PR DESCRIPTION
## Summary

Take 6 samples instead of 2 and assert at least one differs, avoiding false failures when two consecutive random values happen to be equal.

The following failure was observed:

```
1) MongoDB\Tests\Operation\WithTransactionTest::testComputeBackoffMSUsesRandom
computeBackoffMs() multiplies backoff with a random value
Failed asserting that 390 is not identical to 390.
```

## Test plan

- [x] Run `WithTransactionTest` to verify the flaky test no longer fails spuriously