### PR TITLE
PHPLIB-1719 Exponential backoff and jitter in retry loops

### DIFF
--- a/tests/SpecTests/ClientBackpressure/Prose1_OpRetryExponentialBackoffTest.php
+++ b/tests/SpecTests/ClientBackpressure/Prose1_OpRetryExponentialBackoffTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MongoDB\Tests\SpecTests\ClientBackpressure;
+
+use Exception;
+use MongoDB\Driver\Exception\BulkWriteException;
+use MongoDB\Driver\Exception\ServerException;
+use MongoDB\Driver\Session;
+use MongoDB\Operation\WithTransaction;
+use MongoDB\Tests\SpecTests\FunctionalTestCase;
+use MongoDB\Tests\UnifiedSpecTests\Util;
+use ReflectionException;
+
+/**
+ * Prose test 1: Retry operation uses exponential backoff
+ *
+ * @see https://github.com/mongodb/specifications/blob/master/source/client-backpressure/tests/README.md
+ */
+class Prose1_OpRetryExponentialBackoffTest extends FunctionalTestCase
+{
+    /**
+     * @throws ReflectionException
+     */
+    public function testOperationRetryUsesExponentialBackoff()
+    {
+        $this->skipIfTransactionsAreNotSupported();
+
+        $client = self::createTestClient();
+        $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+
+        $callback = static function (Session $session) use ($collection): void {
+            $collection->insertOne(['a' => 1], ['session' => $session]);
+        };
+
+        $operation = new WithTransaction($callback);
+        $session = $client->startSession();
+
+        Util::setFixedJitter($operation, 0);
+        $noBackoffTime = $this->getOperationExecutionTime($session, $operation);
+
+        Util::setFixedJitter($operation, 1);
+        $withBackoffTime = $this->getOperationExecutionTime($session, $operation);
+
+        self::assertEqualsWithDelta($noBackoffTime, $withBackoffTime, 2.1);
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function getOperationExecutionTime(Session $session, WithTransaction $operation): float
+    {
+        $this->configureFailPoint([
+            'configureFailPoint' => 'failCommand',
+            'mode' => 'alwaysOn',
+            'data' => [
+                'failCommands' => ['insert'],
+                'errorCode' => 2,
+                'errorLabels' => ['SystemOverloadedError', 'RetryableError'],
+            ],
+        ]);
+
+        $start = microtime(true);
+
+        try {
+            $operation->execute($session);
+        } catch (BulkWriteException $e) {
+            self::assertInstanceOf(ServerException::class, $e->getPrevious());
+        } finally {
+            return microtime(true) - $start;
+        }
+    }
+}

--- a/tests/SpecTests/ClientBackpressure/Prose3_OverloadErrorMaxRetryTest.php
+++ b/tests/SpecTests/ClientBackpressure/Prose3_OverloadErrorMaxRetryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MongoDB\Tests\SpecTests\ClientBackpressure;
+
+use MongoDB\Driver\Exception\RuntimeException;
+use MongoDB\Driver\Monitoring\CommandFailedEvent;
+use MongoDB\Driver\Monitoring\CommandStartedEvent;
+use MongoDB\Driver\Monitoring\CommandSubscriber;
+use MongoDB\Driver\Monitoring\CommandSucceededEvent;
+use MongoDB\Tests\SpecTests\FunctionalTestCase;
+
+/**
+ * Prose test 3: Overload Errors are Retried a Maximum of MAX_RETRIES times
+ *
+ * @see https://github.com/mongodb/specifications/blob/master/source/client-backpressure/tests/README.md
+ */
+class Prose3_OverloadErrorMaxRetryTest extends FunctionalTestCase
+{
+    private const MAX_RETRIES = 5;
+
+    public function testOverloadErrorsAreRetriedMaxRetryTimes(): void
+    {
+        $client = self::createTestClient();
+        $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+
+        $subscriber = new class implements CommandSubscriber {
+            public int $findCommandsStarted = 0;
+
+            public function commandStarted(CommandStartedEvent $event): void
+            {
+                if ($event->getCommandName() === 'find') {
+                    $this->findCommandsStarted++;
+                }
+            }
+
+            public function commandSucceeded(CommandSucceededEvent $event): void
+            {
+            }
+
+            public function commandFailed(CommandFailedEvent $event): void
+            {
+            }
+        };
+
+        $client->addSubscriber($subscriber);
+
+        $this->configureFailPoint([
+            'configureFailPoint' => 'failCommand',
+            'mode' => 'alwaysOn',
+            'data' => [
+                'failCommands' => ['find'],
+                'errorCode' => 462, // IngressRequestRateLimitExceeded
+                'errorLabels' => ['SystemOverloadedError', 'RetryableError'],
+            ],
+        ]);
+
+        try {
+            $collection->find([]);
+            $this->fail('Expected RuntimeException was not thrown');
+        } catch (RuntimeException $e) {
+            $this->assertTrue($e->hasErrorLabel('RetryableError'));
+            $this->assertTrue($e->hasErrorLabel('SystemOverloadedError'));
+        }
+
+        $client->removeSubscriber($subscriber);
+
+        $this->assertSame(self::MAX_RETRIES + 1, $subscriber->findCommandsStarted);
+    }
+}

--- a/tests/SpecTests/TransactionsConvenientApi/Prose4_RetryBackoffIsEnforcedTest.php
+++ b/tests/SpecTests/TransactionsConvenientApi/Prose4_RetryBackoffIsEnforcedTest.php
@@ -5,6 +5,7 @@ namespace MongoDB\Tests\SpecTests\TransactionsConvenientApi;
 use MongoDB\Driver\Session;
 use MongoDB\Operation\WithTransaction;
 use MongoDB\Tests\SpecTests\FunctionalTestCase;
+use MongoDB\Tests\UnifiedSpecTests\Util;
 use ReflectionProperty;
 
 use function microtime;
@@ -29,7 +30,7 @@ class Prose4_RetryBackoffIsEnforcedTest extends FunctionalTestCase
         $operation = new WithTransaction($callback);
         $session = $client->startSession();
 
-        $this->setFixedJitter($operation, 0);
+        Util::setFixedJitter($operation, 0);
         $noBackoffTime = $this->runOperationWithTiming($operation, $session);
 
         $this->setFixedJitter($operation, 1);
@@ -46,15 +47,6 @@ class Prose4_RetryBackoffIsEnforcedTest extends FunctionalTestCase
         $operation->execute($session);
 
         return microtime(true) - $start;
-    }
-
-    private function setFixedJitter(WithTransaction $operation, float $jitter): void
-    {
-        (new ReflectionProperty($operation, 'jitterGenerator'))
-            ->setValue(
-                $operation,
-                static fn (): float => $jitter,
-            );
     }
 
     private function setUpCommitTransactionFailPoint(): void

--- a/tests/UnifiedSpecTests/Util.php
+++ b/tests/UnifiedSpecTests/Util.php
@@ -13,6 +13,8 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Session;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\GridFS\Bucket;
+use MongoDB\Operation\WithTransaction;
+use ReflectionProperty;
 use stdClass;
 
 use function array_diff_key;
@@ -238,5 +240,14 @@ final class Util
         }
 
         return $options;
+    }
+
+    public static function setFixedJitter(WithTransaction $operation, float $jitter): void
+    {
+        (new ReflectionProperty($operation, 'jitterGenerator'))
+            ->setValue(
+                $operation,
+                static fn (): float => $jitter,
+            );
     }
 }


### PR DESCRIPTION
Close PHPLIB-1719

https://github.com/mongodb/specifications/blob/7039e69945d463a14b1b727d16db063e21f48f53/source/client-backpressure/client-backpressure.md

- [ ] Blocked by https://github.com/mongodb/mongo-php-library/pull/1879