### PR TITLE
Require ext-mongodb ^2.3 and test against dev branch

### DIFF
--- a/.evergreen/config/generated/build/build-extension.yml
+++ b/.evergreen/config/generated/build/build-extension.yml
@@ -18,8 +18,9 @@ tasks:
         vars:
           PHP_VERSION: "8.5"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_VERSION: "2.2.0"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.5-next-stable"
     tags: ["build", "php8.5", "next-stable", "pr", "tag"]
@@ -28,8 +29,9 @@ tasks:
         vars:
           PHP_VERSION: "8.5"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_BRANCH: "v2.2"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.5-next-minor"
     tags: ["build", "php8.5", "next-minor"]
@@ -59,8 +61,9 @@ tasks:
         vars:
           PHP_VERSION: "8.4"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_VERSION: "2.2.0"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.4-next-stable"
     tags: ["build", "php8.4", "next-stable", "pr", "tag"]
@@ -69,8 +72,9 @@ tasks:
         vars:
           PHP_VERSION: "8.4"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_BRANCH: "v2.2"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.4-next-minor"
     tags: ["build", "php8.4", "next-minor"]
@@ -100,8 +104,9 @@ tasks:
         vars:
           PHP_VERSION: "8.3"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_VERSION: "2.2.0"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.3-next-stable"
     tags: ["build", "php8.3", "next-stable", "pr", "tag"]
@@ -110,8 +115,9 @@ tasks:
         vars:
           PHP_VERSION: "8.3"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_BRANCH: "v2.2"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.3-next-minor"
     tags: ["build", "php8.3", "next-minor"]
@@ -141,8 +147,9 @@ tasks:
         vars:
           PHP_VERSION: "8.2"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_VERSION: "2.2.0"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.2-next-stable"
     tags: ["build", "php8.2", "next-stable", "pr", "tag"]
@@ -151,8 +158,9 @@ tasks:
         vars:
           PHP_VERSION: "8.2"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_BRANCH: "v2.2"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.2-next-minor"
     tags: ["build", "php8.2", "next-minor"]
@@ -182,8 +190,9 @@ tasks:
         vars:
           PHP_VERSION: "8.1"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_VERSION: "2.2.0"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.1-next-stable"
     tags: ["build", "php8.1", "next-stable", "pr", "tag"]
@@ -192,8 +201,9 @@ tasks:
         vars:
           PHP_VERSION: "8.1"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_BRANCH: "v2.2"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.1-next-minor"
     tags: ["build", "php8.1", "next-minor"]

--- a/.evergreen/config/generated/build/build-extension.yml
+++ b/.evergreen/config/generated/build/build-extension.yml
@@ -7,6 +7,9 @@ tasks:
         vars:
           PHP_VERSION: "8.5"
       - func: "compile extension"
+        # TODO: Remove vars to switch to latest stable version when 2.3.0 is released
+        vars:
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.5-lowest"
     tags: ["build", "php8.5", "lowest", "pr", "tag"]
@@ -45,6 +48,9 @@ tasks:
         vars:
           PHP_VERSION: "8.4"
       - func: "compile extension"
+        # TODO: Remove vars to switch to latest stable version when 2.3.0 is released
+        vars:
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.4-lowest"
     tags: ["build", "php8.4", "lowest", "pr", "tag"]
@@ -83,6 +89,9 @@ tasks:
         vars:
           PHP_VERSION: "8.3"
       - func: "compile extension"
+        # TODO: Remove vars to switch to latest stable version when 2.3.0 is released
+        vars:
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.3-lowest"
     tags: ["build", "php8.3", "lowest", "pr", "tag"]
@@ -121,6 +130,9 @@ tasks:
         vars:
           PHP_VERSION: "8.2"
       - func: "compile extension"
+        # TODO: Remove vars to switch to latest stable version when 2.3.0 is released
+        vars:
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.2-lowest"
     tags: ["build", "php8.2", "lowest", "pr", "tag"]
@@ -159,6 +171,9 @@ tasks:
         vars:
           PHP_VERSION: "8.1"
       - func: "compile extension"
+        # TODO: Remove vars to switch to latest stable version when 2.3.0 is released
+        vars:
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-8.1-lowest"
     tags: ["build", "php8.1", "lowest", "pr", "tag"]

--- a/.evergreen/config/templates/build/build-extension.yml
+++ b/.evergreen/config/templates/build/build-extension.yml
@@ -5,6 +5,9 @@
         vars:
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
+        # TODO: Remove vars to switch to latest stable version when 2.3.0 is released
+        vars:
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-lowest"
     tags: ["build", "php%phpVersion%", "lowest", "pr", "tag"]

--- a/.evergreen/config/templates/build/build-extension.yml
+++ b/.evergreen/config/templates/build/build-extension.yml
@@ -16,8 +16,9 @@
         vars:
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_VERSION: "2.2.0"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-next-stable"
     tags: ["build", "php%phpVersion%", "next-stable", "pr", "tag"]
@@ -26,8 +27,9 @@
         vars:
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
+        # TODO: Switch to EXTENSION_VERSION: "2.3.0" when 2.3.0 is released on PECL
         vars:
-          EXTENSION_BRANCH: "v2.2"
+          EXTENSION_BRANCH: "v2.x"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-next-minor"
     tags: ["build", "php%phpVersion%", "next-minor"]

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -13,7 +13,9 @@ on:
 
 env:
   PHP_VERSION: "8.2"
-  DRIVER_VERSION: "stable"
+  # TODO: change to "stable" once 2.3.0 is released
+  # DRIVER_VERSION: "stable"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v2.x"
 
 jobs:
   phpcs:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -13,7 +13,9 @@ on:
 
 env:
   PHP_VERSION: "8.2"
-  DRIVER_VERSION: "stable"
+  # TODO: change to "stable" once 2.3.0 is released
+  # DRIVER_VERSION: "stable"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v2.x"
 
 jobs:
   diff:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,9 @@ on:
 
 env:
   PHP_VERSION: "8.5"
-  DRIVER_VERSION: "stable"
+  # TODO: change to "stable" once 2.3.0 is released
+  # DRIVER_VERSION: "stable"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v2.x"
 
 jobs:
   psalm:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,9 @@ on:
       - "feature/*"
 
 env:
-  DRIVER_VERSION: "stable"
+  # TODO: change to "stable" once 2.3.0 is released
+  # DRIVER_VERSION: "stable"
+  DRIVER_VERSION: "mongodb/mongo-php-driver@v2.x"
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-mongodb": "^2.2",
+        "ext-mongodb": "^2.3",
         "composer-runtime-api": "^2.0",
         "psr/log": "^1.1.4|^2|^3",
         "symfony/polyfill-php85": "^1.33"


### PR DESCRIPTION
Bumps the minimum required `ext-mongodb` version from `^2.2` to `^2.3` and tests against the `v2.x` development branch of the extension in CI (Evergreen and GitHub Actions), in anticipation of the 2.3.0 release.