### PR TITLE
PHPLIB-1755: Implement `$hash` and `$hexHash` operators

### DIFF
--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -854,11 +854,11 @@ trait FactoryTrait
      * New in MongoDB 8.3
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hash/
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input
      * @param string $algorithm
      */
     public static function hash(
-        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input,
         string $algorithm,
     ): HashOperator {
         return new HashOperator($input, $algorithm);
@@ -872,11 +872,11 @@ trait FactoryTrait
      * New in MongoDB 8.3
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hexHash/
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input
      * @param string $algorithm
      */
     public static function hexHash(
-        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input,
         string $algorithm,
     ): HexHashOperator {
         return new HexHashOperator($input, $algorithm);

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -847,6 +847,42 @@ trait FactoryTrait
     }
 
     /**
+     * Generates and returns a binary hash value (BinData) from a UTF-8 string or binary data. Use $hash in an aggregation
+     * pipeline to compute binary hashes for storage, verification, or comparison. To get a hexadecimal string instead of
+     * binary data, use $hexHash.
+     *
+     * New in MongoDB 8.3
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hash/
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param string $algorithm
+     */
+    public static function hash(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        string $algorithm,
+    ): HashOperator {
+        return new HashOperator($input, $algorithm);
+    }
+
+    /**
+     * Generates and returns an uppercase hexadecimal string representation of a hash value from a UTF-8 string or binary
+     * data. Use $hexHash in an aggregation pipeline to compute hex-encoded hashes for storage, verification, or comparison.
+     * To get binary data instead of a hexadecimal string, use $hash.
+     *
+     * New in MongoDB 8.3
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hexHash/
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param string $algorithm
+     */
+    public static function hexHash(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        string $algorithm,
+    ): HexHashOperator {
+        return new HexHashOperator($input, $algorithm);
+    }
+
+    /**
      * Returns the hour for a date as a number between 0 and 23.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hour/

--- a/src/Builder/Expression/HashOperator.php
+++ b/src/Builder/Expression/HashOperator.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use DateTimeInterface;
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use stdClass;
+
+/**
+ * Generates and returns a binary hash value (BinData) from a UTF-8 string or binary data. Use $hash in an aggregation
+ * pipeline to compute binary hashes for storage, verification, or comparison. To get a hexadecimal string instead of
+ * binary data, use $hexHash.
+ *
+ * New in MongoDB 8.3
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hash/
+ * @internal
+ */
+final class HashOperator implements ResolvesToBinData, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$hash';
+    public const PROPERTIES = ['input' => 'input', 'algorithm' => 'algorithm'];
+
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
+
+    /** @var string $algorithm */
+    public readonly string $algorithm;
+
+    /**
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param string $algorithm
+     */
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        string $algorithm,
+    ) {
+        $this->input = $input;
+        $this->algorithm = $algorithm;
+    }
+}

--- a/src/Builder/Expression/HashOperator.php
+++ b/src/Builder/Expression/HashOperator.php
@@ -8,12 +8,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
-use DateTimeInterface;
-use MongoDB\BSON\Type;
+use MongoDB\BSON\Binary;
 use MongoDB\Builder\Type\Encode;
-use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
-use stdClass;
 
 /**
  * Generates and returns a binary hash value (BinData) from a UTF-8 string or binary data. Use $hash in an aggregation
@@ -31,18 +28,18 @@ final class HashOperator implements ResolvesToBinData, OperatorInterface
     public const NAME = '$hash';
     public const PROPERTIES = ['input' => 'input', 'algorithm' => 'algorithm'];
 
-    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
-    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
+    /** @var Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input */
+    public readonly Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input;
 
     /** @var string $algorithm */
     public readonly string $algorithm;
 
     /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input
      * @param string $algorithm
      */
     public function __construct(
-        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input,
         string $algorithm,
     ) {
         $this->input = $input;

--- a/src/Builder/Expression/HexHashOperator.php
+++ b/src/Builder/Expression/HexHashOperator.php
@@ -8,12 +8,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
-use DateTimeInterface;
-use MongoDB\BSON\Type;
+use MongoDB\BSON\Binary;
 use MongoDB\Builder\Type\Encode;
-use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
-use stdClass;
 
 /**
  * Generates and returns an uppercase hexadecimal string representation of a hash value from a UTF-8 string or binary
@@ -31,18 +28,18 @@ final class HexHashOperator implements ResolvesToString, OperatorInterface
     public const NAME = '$hexHash';
     public const PROPERTIES = ['input' => 'input', 'algorithm' => 'algorithm'];
 
-    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
-    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
+    /** @var Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input */
+    public readonly Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input;
 
     /** @var string $algorithm */
     public readonly string $algorithm;
 
     /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input
      * @param string $algorithm
      */
     public function __construct(
-        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $input,
         string $algorithm,
     ) {
         $this->input = $input;

--- a/src/Builder/Expression/HexHashOperator.php
+++ b/src/Builder/Expression/HexHashOperator.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use DateTimeInterface;
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use stdClass;
+
+/**
+ * Generates and returns an uppercase hexadecimal string representation of a hash value from a UTF-8 string or binary
+ * data. Use $hexHash in an aggregation pipeline to compute hex-encoded hashes for storage, verification, or comparison.
+ * To get binary data instead of a hexadecimal string, use $hash.
+ *
+ * New in MongoDB 8.3
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hexHash/
+ * @internal
+ */
+final class HexHashOperator implements ResolvesToString, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$hexHash';
+    public const PROPERTIES = ['input' => 'input', 'algorithm' => 'algorithm'];
+
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
+
+    /** @var string $algorithm */
+    public readonly string $algorithm;
+
+    /**
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
+     * @param string $algorithm
+     */
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
+        string $algorithm,
+    ) {
+        $this->input = $input;
+        $this->algorithm = $algorithm;
+    }
+}

--- a/tests/Builder/Expression/HashOperatorTest.php
+++ b/tests/Builder/Expression/HashOperatorTest.php
@@ -22,7 +22,7 @@ class HashOperatorTest extends PipelineTestCase
             Stage::project(
                 filename: 1,
                 hash: Expression::hash(
-                    Expression::fieldPath('filename'),
+                    Expression::stringFieldPath('filename'),
                     'sha256',
                 ),
             ),

--- a/tests/Builder/Expression/HashOperatorTest.php
+++ b/tests/Builder/Expression/HashOperatorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $hash expression
+ */
+class HashOperatorTest extends PipelineTestCase
+{
+    public function testHashAFieldValue(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                filename: 1,
+                hash: Expression::hash(
+                    Expression::fieldPath('filename'),
+                    'sha256',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::HashHashAFieldValue, $pipeline);
+    }
+
+    public function testHashALiteralString(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::documents([
+                object(val: 'hello'),
+            ]),
+            Stage::project(
+                _id: 0,
+                hash: Expression::hash(
+                    Expression::stringFieldPath('val'),
+                    'xxh64',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::HashHashALiteralString, $pipeline);
+    }
+
+    public function testHashBinData(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                hash: Expression::hash(
+                    Expression::binDataFieldPath('data'),
+                    'sha256',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::HashHashBinData, $pipeline);
+    }
+
+    public function testNullOrMissingInput(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::documents([
+                object(val: null),
+                object(),
+            ]),
+            Stage::project(
+                hash: Expression::hash(
+                    Expression::stringFieldPath('val'),
+                    'sha256',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::HashNullOrMissingInput, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/HexHashOperatorTest.php
+++ b/tests/Builder/Expression/HexHashOperatorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $hexHash expression
+ */
+class HexHashOperatorTest extends PipelineTestCase
+{
+    public function testHashAFieldValue(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                filename: 1,
+                hexHash: Expression::hexHash(
+                    Expression::stringFieldPath('filename'),
+                    'sha256',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::HexHashHashAFieldValue, $pipeline);
+    }
+
+    public function testNullOrMissingInput(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::documents([
+                object(val: null),
+                object(),
+            ]),
+            Stage::project(
+                hexHash: Expression::hexHash(
+                    Expression::stringFieldPath('val'),
+                    'sha256',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::HexHashNullOrMissingInput, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -2244,6 +2244,158 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Hash a Field Value
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hash/#hash-a-field-value
+     */
+    case HashHashAFieldValue = <<<'JSON'
+    [
+        {
+            "$project": {
+                "filename": {
+                    "$numberInt": "1"
+                },
+                "hash": {
+                    "$hash": {
+                        "input": "$filename",
+                        "algorithm": "sha256"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Hash a Literal String
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hash/#hash-a-literal-string
+     */
+    case HashHashALiteralString = <<<'JSON'
+    [
+        {
+            "$documents": [
+                {
+                    "val": "hello"
+                }
+            ]
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "hash": {
+                    "$hash": {
+                        "input": "$val",
+                        "algorithm": "xxh64"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Hash BinData
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hash/#hash-bindata
+     */
+    case HashHashBinData = <<<'JSON'
+    [
+        {
+            "$project": {
+                "hash": {
+                    "$hash": {
+                        "input": "$data",
+                        "algorithm": "sha256"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Null or Missing Input
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hash/#null-or-missing-input
+     */
+    case HashNullOrMissingInput = <<<'JSON'
+    [
+        {
+            "$documents": [
+                {
+                    "val": null
+                },
+                {}
+            ]
+        },
+        {
+            "$project": {
+                "hash": {
+                    "$hash": {
+                        "input": "$val",
+                        "algorithm": "sha256"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Hash a Field Value
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hexHash/#hash-a-field-value
+     */
+    case HexHashHashAFieldValue = <<<'JSON'
+    [
+        {
+            "$project": {
+                "filename": {
+                    "$numberInt": "1"
+                },
+                "hexHash": {
+                    "$hexHash": {
+                        "input": "$filename",
+                        "algorithm": "sha256"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Null or Missing Input
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hexHash/#null-or-missing-input
+     */
+    case HexHashNullOrMissingInput = <<<'JSON'
+    [
+        {
+            "$documents": [
+                {
+                    "val": null
+                },
+                {}
+            ]
+        },
+        {
+            "$project": {
+                "hexHash": {
+                    "$hexHash": {
+                        "input": "$val",
+                        "algorithm": "sha256"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/hour/#example


### PR DESCRIPTION
Fix PHPLIB-1755

Spec update: https://github.com/mongodb/mql-specifications/pull/34