### PR TITLE
Add ClassPrinter to allow single-line method docblocks

### DIFF
--- a/generator/src/AbstractGenerator.php
+++ b/generator/src/AbstractGenerator.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 use Nette\PhpGenerator\PhpFile;
 use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\Printer;
-use Nette\PhpGenerator\PsrPrinter;
 
 use function array_pop;
 use function assert;
@@ -34,7 +33,7 @@ abstract class AbstractGenerator
     public function __construct(
         private string $rootDir,
     ) {
-        $this->printer = new PsrPrinter();
+        $this->printer = new ClassPrinter();
     }
 
     /**

--- a/generator/src/ClassPrinter.php
+++ b/generator/src/ClassPrinter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\CodeGenerator;
+
+use Nette\PhpGenerator\Helpers;
+use Nette\PhpGenerator\Method;
+use Nette\PhpGenerator\PsrPrinter;
+
+/**
+ * Custom printer that allows single-line docblocks for methods with single-line content.
+ * Nette's default PsrPrinter forces multi-line format for all Method docblocks.
+ */
+class ClassPrinter extends PsrPrinter
+{
+    protected function printDocComment(mixed $commentable): string
+    {
+        if ($commentable instanceof Method) {
+            return Helpers::formatDocComment((string) $commentable->getComment(), false);
+        }
+
+        return parent::printDocComment($commentable);
+    }
+}

--- a/src/Builder/Accumulator/AddToSetAccumulator.php
+++ b/src/Builder/Accumulator/AddToSetAccumulator.php
@@ -33,9 +33,7 @@ final class AddToSetAccumulator implements AccumulatorInterface, WindowInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Accumulator/AvgAccumulator.php
+++ b/src/Builder/Accumulator/AvgAccumulator.php
@@ -36,9 +36,7 @@ final class AvgAccumulator implements AccumulatorInterface, WindowInterface, Ope
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $expression;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Accumulator/FirstAccumulator.php
+++ b/src/Builder/Accumulator/FirstAccumulator.php
@@ -33,9 +33,7 @@ final class FirstAccumulator implements AccumulatorInterface, WindowInterface, O
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Accumulator/LastAccumulator.php
+++ b/src/Builder/Accumulator/LastAccumulator.php
@@ -33,9 +33,7 @@ final class LastAccumulator implements AccumulatorInterface, WindowInterface, Op
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Accumulator/LinearFillAccumulator.php
+++ b/src/Builder/Accumulator/LinearFillAccumulator.php
@@ -37,9 +37,7 @@ final class LinearFillAccumulator implements WindowInterface, OperatorInterface
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $expression;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Accumulator/LocfAccumulator.php
+++ b/src/Builder/Accumulator/LocfAccumulator.php
@@ -34,9 +34,7 @@ final class LocfAccumulator implements WindowInterface, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Accumulator/MaxAccumulator.php
+++ b/src/Builder/Accumulator/MaxAccumulator.php
@@ -33,9 +33,7 @@ final class MaxAccumulator implements AccumulatorInterface, WindowInterface, Ope
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Accumulator/MergeObjectsAccumulator.php
+++ b/src/Builder/Accumulator/MergeObjectsAccumulator.php
@@ -35,9 +35,7 @@ final class MergeObjectsAccumulator implements AccumulatorInterface, OperatorInt
     /** @var Document|ResolvesToObject|Serializable|array|stdClass|string $document Any valid expression that resolves to a document. */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array|string $document;
 
-    /**
-     * @param Document|ResolvesToObject|Serializable|array|stdClass|string $document Any valid expression that resolves to a document.
-     */
+    /** @param Document|ResolvesToObject|Serializable|array|stdClass|string $document Any valid expression that resolves to a document. */
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array|string $document)
     {
         if (is_string($document) && ! str_starts_with($document, '$')) {

--- a/src/Builder/Accumulator/MinAccumulator.php
+++ b/src/Builder/Accumulator/MinAccumulator.php
@@ -33,9 +33,7 @@ final class MinAccumulator implements AccumulatorInterface, WindowInterface, Ope
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Accumulator/PushAccumulator.php
+++ b/src/Builder/Accumulator/PushAccumulator.php
@@ -33,9 +33,7 @@ final class PushAccumulator implements AccumulatorInterface, WindowInterface, Op
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Accumulator/StdDevPopAccumulator.php
+++ b/src/Builder/Accumulator/StdDevPopAccumulator.php
@@ -37,9 +37,7 @@ final class StdDevPopAccumulator implements AccumulatorInterface, WindowInterfac
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $expression;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Accumulator/StdDevSampAccumulator.php
+++ b/src/Builder/Accumulator/StdDevSampAccumulator.php
@@ -37,9 +37,7 @@ final class StdDevSampAccumulator implements AccumulatorInterface, WindowInterfa
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $expression;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Accumulator/SumAccumulator.php
+++ b/src/Builder/Accumulator/SumAccumulator.php
@@ -36,9 +36,7 @@ final class SumAccumulator implements AccumulatorInterface, WindowInterface, Ope
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $expression;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/AbsOperator.php
+++ b/src/Builder/Expression/AbsOperator.php
@@ -32,9 +32,7 @@ final class AbsOperator implements ResolvesToNumber, OperatorInterface
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $value */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $value;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $value
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $value */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $value)
     {
         if (is_string($value) && ! str_starts_with($value, '$')) {

--- a/src/Builder/Expression/AllElementsTrueOperator.php
+++ b/src/Builder/Expression/AllElementsTrueOperator.php
@@ -34,9 +34,7 @@ final class AllElementsTrueOperator implements ResolvesToBool, OperatorInterface
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $expression */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $expression;
 
-    /**
-     * @param BSONArray|PackedArray|ResolvesToArray|array|string $expression
-     */
+    /** @param BSONArray|PackedArray|ResolvesToArray|array|string $expression */
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/AnyElementTrueOperator.php
+++ b/src/Builder/Expression/AnyElementTrueOperator.php
@@ -34,9 +34,7 @@ final class AnyElementTrueOperator implements ResolvesToBool, OperatorInterface
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $expression */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $expression;
 
-    /**
-     * @param BSONArray|PackedArray|ResolvesToArray|array|string $expression
-     */
+    /** @param BSONArray|PackedArray|ResolvesToArray|array|string $expression */
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/ArrayToObjectOperator.php
+++ b/src/Builder/Expression/ArrayToObjectOperator.php
@@ -34,9 +34,7 @@ final class ArrayToObjectOperator implements ResolvesToObject, OperatorInterface
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $array */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $array;
 
-    /**
-     * @param BSONArray|PackedArray|ResolvesToArray|array|string $array
-     */
+    /** @param BSONArray|PackedArray|ResolvesToArray|array|string $array */
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $array)
     {
         if (is_string($array) && ! str_starts_with($array, '$')) {

--- a/src/Builder/Expression/BinarySizeOperator.php
+++ b/src/Builder/Expression/BinarySizeOperator.php
@@ -29,9 +29,7 @@ final class BinarySizeOperator implements ResolvesToInt, OperatorInterface
     /** @var Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression */
     public readonly Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression;
 
-    /**
-     * @param Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression
-     */
+    /** @param Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression */
     public function __construct(Binary|ResolvesToBinData|ResolvesToNull|ResolvesToString|null|string $expression)
     {
         $this->expression = $expression;

--- a/src/Builder/Expression/BitNotOperator.php
+++ b/src/Builder/Expression/BitNotOperator.php
@@ -33,9 +33,7 @@ final class BitNotOperator implements ResolvesToInt, ResolvesToLong, OperatorInt
     /** @var Int64|ResolvesToInt|ResolvesToLong|int|string $expression */
     public readonly Int64|ResolvesToInt|ResolvesToLong|int|string $expression;
 
-    /**
-     * @param Int64|ResolvesToInt|ResolvesToLong|int|string $expression
-     */
+    /** @param Int64|ResolvesToInt|ResolvesToLong|int|string $expression */
     public function __construct(Int64|ResolvesToInt|ResolvesToLong|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/BsonSizeOperator.php
+++ b/src/Builder/Expression/BsonSizeOperator.php
@@ -35,9 +35,7 @@ final class BsonSizeOperator implements ResolvesToInt, OperatorInterface
     /** @var Document|ResolvesToNull|ResolvesToObject|Serializable|array|null|stdClass|string $object */
     public readonly Document|Serializable|ResolvesToNull|ResolvesToObject|stdClass|array|null|string $object;
 
-    /**
-     * @param Document|ResolvesToNull|ResolvesToObject|Serializable|array|null|stdClass|string $object
-     */
+    /** @param Document|ResolvesToNull|ResolvesToObject|Serializable|array|null|stdClass|string $object */
     public function __construct(
         Document|Serializable|ResolvesToNull|ResolvesToObject|stdClass|array|null|string $object,
     ) {

--- a/src/Builder/Expression/CeilOperator.php
+++ b/src/Builder/Expression/CeilOperator.php
@@ -32,9 +32,7 @@ final class CeilOperator implements ResolvesToInt, OperatorInterface
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $expression If the argument resolves to a value of null or refers to a field that is missing, $ceil returns null. If the argument resolves to NaN, $ceil returns NaN. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $expression;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression If the argument resolves to a value of null or refers to a field that is missing, $ceil returns null. If the argument resolves to NaN, $ceil returns NaN.
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression If the argument resolves to a value of null or refers to a field that is missing, $ceil returns null. If the argument resolves to NaN, $ceil returns NaN. */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/ExpOperator.php
+++ b/src/Builder/Expression/ExpOperator.php
@@ -32,9 +32,7 @@ final class ExpOperator implements ResolvesToDouble, OperatorInterface
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $exponent */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $exponent;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $exponent
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $exponent */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $exponent)
     {
         if (is_string($exponent) && ! str_starts_with($exponent, '$')) {

--- a/src/Builder/Expression/FirstOperator.php
+++ b/src/Builder/Expression/FirstOperator.php
@@ -36,9 +36,7 @@ final class FirstOperator implements ResolvesToAny, OperatorInterface
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $expression */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $expression;
 
-    /**
-     * @param BSONArray|PackedArray|ResolvesToArray|array|string $expression
-     */
+    /** @param BSONArray|PackedArray|ResolvesToArray|array|string $expression */
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/FloorOperator.php
+++ b/src/Builder/Expression/FloorOperator.php
@@ -32,9 +32,7 @@ final class FloorOperator implements ResolvesToInt, OperatorInterface
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $expression;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/IsArrayOperator.php
+++ b/src/Builder/Expression/IsArrayOperator.php
@@ -32,9 +32,7 @@ final class IsArrayOperator implements ResolvesToBool, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/IsNumberOperator.php
+++ b/src/Builder/Expression/IsNumberOperator.php
@@ -33,9 +33,7 @@ final class IsNumberOperator implements ResolvesToBool, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/LastOperator.php
+++ b/src/Builder/Expression/LastOperator.php
@@ -36,9 +36,7 @@ final class LastOperator implements ResolvesToAny, OperatorInterface
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $expression */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $expression;
 
-    /**
-     * @param BSONArray|PackedArray|ResolvesToArray|array|string $expression
-     */
+    /** @param BSONArray|PackedArray|ResolvesToArray|array|string $expression */
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/LiteralOperator.php
+++ b/src/Builder/Expression/LiteralOperator.php
@@ -29,9 +29,7 @@ final class LiteralOperator implements ResolvesToAny, OperatorInterface
     /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression. */
     public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression.
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value If the value is an expression, $literal does not evaluate the expression but instead returns the unparsed expression. */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;

--- a/src/Builder/Expression/LnOperator.php
+++ b/src/Builder/Expression/LnOperator.php
@@ -33,9 +33,7 @@ final class LnOperator implements ResolvesToDouble, OperatorInterface
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $number Any valid expression as long as it resolves to a non-negative number. For more information on expressions, see Expressions. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $number;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $number Any valid expression as long as it resolves to a non-negative number. For more information on expressions, see Expressions.
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $number Any valid expression as long as it resolves to a non-negative number. For more information on expressions, see Expressions. */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $number)
     {
         if (is_string($number) && ! str_starts_with($number, '$')) {

--- a/src/Builder/Expression/Log10Operator.php
+++ b/src/Builder/Expression/Log10Operator.php
@@ -32,9 +32,7 @@ final class Log10Operator implements ResolvesToDouble, OperatorInterface
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $number Any valid expression as long as it resolves to a non-negative number. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $number;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $number Any valid expression as long as it resolves to a non-negative number.
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $number Any valid expression as long as it resolves to a non-negative number. */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $number)
     {
         if (is_string($number) && ! str_starts_with($number, '$')) {

--- a/src/Builder/Expression/MetaOperator.php
+++ b/src/Builder/Expression/MetaOperator.php
@@ -28,9 +28,7 @@ final class MetaOperator implements ResolvesToAny, OperatorInterface
     /** @var string $keyword */
     public readonly string $keyword;
 
-    /**
-     * @param string $keyword
-     */
+    /** @param string $keyword */
     public function __construct(string $keyword)
     {
         $this->keyword = $keyword;

--- a/src/Builder/Expression/NotOperator.php
+++ b/src/Builder/Expression/NotOperator.php
@@ -30,9 +30,7 @@ final class NotOperator implements ResolvesToBool, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|ResolvesToBool|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ResolvesToBool|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ObjectToArrayOperator.php
+++ b/src/Builder/Expression/ObjectToArrayOperator.php
@@ -33,9 +33,7 @@ final class ObjectToArrayOperator implements ResolvesToArray, OperatorInterface
     /** @var Document|ResolvesToObject|Serializable|array|stdClass|string $object Any valid expression as long as it resolves to a document object. $objectToArray applies to the top-level fields of its argument. If the argument is a document that itself contains embedded document fields, the $objectToArray does not recursively apply to the embedded document fields. */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array|string $object;
 
-    /**
-     * @param Document|ResolvesToObject|Serializable|array|stdClass|string $object Any valid expression as long as it resolves to a document object. $objectToArray applies to the top-level fields of its argument. If the argument is a document that itself contains embedded document fields, the $objectToArray does not recursively apply to the embedded document fields.
-     */
+    /** @param Document|ResolvesToObject|Serializable|array|stdClass|string $object Any valid expression as long as it resolves to a document object. $objectToArray applies to the top-level fields of its argument. If the argument is a document that itself contains embedded document fields, the $objectToArray does not recursively apply to the embedded document fields. */
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array|string $object)
     {
         if (is_string($object) && ! str_starts_with($object, '$')) {

--- a/src/Builder/Expression/RadiansToDegreesOperator.php
+++ b/src/Builder/Expression/RadiansToDegreesOperator.php
@@ -32,9 +32,7 @@ final class RadiansToDegreesOperator implements ResolvesToDouble, ResolvesToDeci
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $expression;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $expression */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/ReverseArrayOperator.php
+++ b/src/Builder/Expression/ReverseArrayOperator.php
@@ -34,9 +34,7 @@ final class ReverseArrayOperator implements ResolvesToArray, OperatorInterface
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $expression The argument can be any valid expression as long as it resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $expression;
 
-    /**
-     * @param BSONArray|PackedArray|ResolvesToArray|array|string $expression The argument can be any valid expression as long as it resolves to an array.
-     */
+    /** @param BSONArray|PackedArray|ResolvesToArray|array|string $expression The argument can be any valid expression as long as it resolves to an array. */
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/SizeOperator.php
+++ b/src/Builder/Expression/SizeOperator.php
@@ -34,9 +34,7 @@ final class SizeOperator implements ResolvesToInt, OperatorInterface
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $expression The argument for $size can be any expression as long as it resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $expression;
 
-    /**
-     * @param BSONArray|PackedArray|ResolvesToArray|array|string $expression The argument for $size can be any expression as long as it resolves to an array.
-     */
+    /** @param BSONArray|PackedArray|ResolvesToArray|array|string $expression The argument for $size can be any expression as long as it resolves to an array. */
     public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/SqrtOperator.php
+++ b/src/Builder/Expression/SqrtOperator.php
@@ -32,9 +32,7 @@ final class SqrtOperator implements ResolvesToDouble, OperatorInterface
     /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $number The argument can be any valid expression as long as it resolves to a non-negative number. */
     public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $number;
 
-    /**
-     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $number The argument can be any valid expression as long as it resolves to a non-negative number.
-     */
+    /** @param Decimal128|Int64|ResolvesToNumber|float|int|string $number The argument can be any valid expression as long as it resolves to a non-negative number. */
     public function __construct(Decimal128|Int64|ResolvesToNumber|float|int|string $number)
     {
         if (is_string($number) && ! str_starts_with($number, '$')) {

--- a/src/Builder/Expression/StrLenBytesOperator.php
+++ b/src/Builder/Expression/StrLenBytesOperator.php
@@ -26,9 +26,7 @@ final class StrLenBytesOperator implements ResolvesToInt, OperatorInterface
     /** @var ResolvesToString|string $expression */
     public readonly ResolvesToString|string $expression;
 
-    /**
-     * @param ResolvesToString|string $expression
-     */
+    /** @param ResolvesToString|string $expression */
     public function __construct(ResolvesToString|string $expression)
     {
         $this->expression = $expression;

--- a/src/Builder/Expression/StrLenCPOperator.php
+++ b/src/Builder/Expression/StrLenCPOperator.php
@@ -26,9 +26,7 @@ final class StrLenCPOperator implements ResolvesToInt, OperatorInterface
     /** @var ResolvesToString|string $expression */
     public readonly ResolvesToString|string $expression;
 
-    /**
-     * @param ResolvesToString|string $expression
-     */
+    /** @param ResolvesToString|string $expression */
     public function __construct(ResolvesToString|string $expression)
     {
         $this->expression = $expression;

--- a/src/Builder/Expression/ToBoolOperator.php
+++ b/src/Builder/Expression/ToBoolOperator.php
@@ -30,9 +30,7 @@ final class ToBoolOperator implements ResolvesToBool, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ToDateOperator.php
+++ b/src/Builder/Expression/ToDateOperator.php
@@ -30,9 +30,7 @@ final class ToDateOperator implements ResolvesToDate, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ToDecimalOperator.php
+++ b/src/Builder/Expression/ToDecimalOperator.php
@@ -30,9 +30,7 @@ final class ToDecimalOperator implements ResolvesToDecimal, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ToDoubleOperator.php
+++ b/src/Builder/Expression/ToDoubleOperator.php
@@ -30,9 +30,7 @@ final class ToDoubleOperator implements ResolvesToDouble, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ToHashedIndexKeyOperator.php
+++ b/src/Builder/Expression/ToHashedIndexKeyOperator.php
@@ -32,9 +32,7 @@ final class ToHashedIndexKeyOperator implements ResolvesToLong, OperatorInterfac
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $value key or string to hash */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $value,
     ) {

--- a/src/Builder/Expression/ToIntOperator.php
+++ b/src/Builder/Expression/ToIntOperator.php
@@ -30,9 +30,7 @@ final class ToIntOperator implements ResolvesToInt, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ToLongOperator.php
+++ b/src/Builder/Expression/ToLongOperator.php
@@ -30,9 +30,7 @@ final class ToLongOperator implements ResolvesToLong, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ToLowerOperator.php
+++ b/src/Builder/Expression/ToLowerOperator.php
@@ -26,9 +26,7 @@ final class ToLowerOperator implements ResolvesToString, OperatorInterface
     /** @var ResolvesToString|string $expression */
     public readonly ResolvesToString|string $expression;
 
-    /**
-     * @param ResolvesToString|string $expression
-     */
+    /** @param ResolvesToString|string $expression */
     public function __construct(ResolvesToString|string $expression)
     {
         $this->expression = $expression;

--- a/src/Builder/Expression/ToObjectIdOperator.php
+++ b/src/Builder/Expression/ToObjectIdOperator.php
@@ -30,9 +30,7 @@ final class ToObjectIdOperator implements ResolvesToObjectId, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ToStringOperator.php
+++ b/src/Builder/Expression/ToStringOperator.php
@@ -30,9 +30,7 @@ final class ToStringOperator implements ResolvesToString, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Expression/ToUpperOperator.php
+++ b/src/Builder/Expression/ToUpperOperator.php
@@ -26,9 +26,7 @@ final class ToUpperOperator implements ResolvesToString, OperatorInterface
     /** @var ResolvesToString|string $expression */
     public readonly ResolvesToString|string $expression;
 
-    /**
-     * @param ResolvesToString|string $expression
-     */
+    /** @param ResolvesToString|string $expression */
     public function __construct(ResolvesToString|string $expression)
     {
         $this->expression = $expression;

--- a/src/Builder/Expression/TsIncrementOperator.php
+++ b/src/Builder/Expression/TsIncrementOperator.php
@@ -33,9 +33,7 @@ final class TsIncrementOperator implements ResolvesToLong, OperatorInterface
     /** @var ResolvesToTimestamp|Timestamp|int|string $expression */
     public readonly Timestamp|ResolvesToTimestamp|int|string $expression;
 
-    /**
-     * @param ResolvesToTimestamp|Timestamp|int|string $expression
-     */
+    /** @param ResolvesToTimestamp|Timestamp|int|string $expression */
     public function __construct(Timestamp|ResolvesToTimestamp|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/TsSecondOperator.php
+++ b/src/Builder/Expression/TsSecondOperator.php
@@ -33,9 +33,7 @@ final class TsSecondOperator implements ResolvesToLong, OperatorInterface
     /** @var ResolvesToTimestamp|Timestamp|int|string $expression */
     public readonly Timestamp|ResolvesToTimestamp|int|string $expression;
 
-    /**
-     * @param ResolvesToTimestamp|Timestamp|int|string $expression
-     */
+    /** @param ResolvesToTimestamp|Timestamp|int|string $expression */
     public function __construct(Timestamp|ResolvesToTimestamp|int|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Expression/TypeOperator.php
+++ b/src/Builder/Expression/TypeOperator.php
@@ -30,9 +30,7 @@ final class TypeOperator implements ResolvesToString, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Query/BitsAllClearOperator.php
+++ b/src/Builder/Query/BitsAllClearOperator.php
@@ -34,9 +34,7 @@ final class BitsAllClearOperator implements FieldQueryInterface, OperatorInterfa
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public readonly Binary|PackedArray|BSONArray|array|int|string $bitmask;
 
-    /**
-     * @param BSONArray|Binary|PackedArray|array|int|string $bitmask
-     */
+    /** @param BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public function __construct(Binary|PackedArray|BSONArray|array|int|string $bitmask)
     {
         if (is_array($bitmask) && ! array_is_list($bitmask)) {

--- a/src/Builder/Query/BitsAllSetOperator.php
+++ b/src/Builder/Query/BitsAllSetOperator.php
@@ -34,9 +34,7 @@ final class BitsAllSetOperator implements FieldQueryInterface, OperatorInterface
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public readonly Binary|PackedArray|BSONArray|array|int|string $bitmask;
 
-    /**
-     * @param BSONArray|Binary|PackedArray|array|int|string $bitmask
-     */
+    /** @param BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public function __construct(Binary|PackedArray|BSONArray|array|int|string $bitmask)
     {
         if (is_array($bitmask) && ! array_is_list($bitmask)) {

--- a/src/Builder/Query/BitsAnyClearOperator.php
+++ b/src/Builder/Query/BitsAnyClearOperator.php
@@ -34,9 +34,7 @@ final class BitsAnyClearOperator implements FieldQueryInterface, OperatorInterfa
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public readonly Binary|PackedArray|BSONArray|array|int|string $bitmask;
 
-    /**
-     * @param BSONArray|Binary|PackedArray|array|int|string $bitmask
-     */
+    /** @param BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public function __construct(Binary|PackedArray|BSONArray|array|int|string $bitmask)
     {
         if (is_array($bitmask) && ! array_is_list($bitmask)) {

--- a/src/Builder/Query/BitsAnySetOperator.php
+++ b/src/Builder/Query/BitsAnySetOperator.php
@@ -34,9 +34,7 @@ final class BitsAnySetOperator implements FieldQueryInterface, OperatorInterface
     /** @var BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public readonly Binary|PackedArray|BSONArray|array|int|string $bitmask;
 
-    /**
-     * @param BSONArray|Binary|PackedArray|array|int|string $bitmask
-     */
+    /** @param BSONArray|Binary|PackedArray|array|int|string $bitmask */
     public function __construct(Binary|PackedArray|BSONArray|array|int|string $bitmask)
     {
         if (is_array($bitmask) && ! array_is_list($bitmask)) {

--- a/src/Builder/Query/BoxOperator.php
+++ b/src/Builder/Query/BoxOperator.php
@@ -33,9 +33,7 @@ final class BoxOperator implements GeometryInterface, OperatorInterface
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;
 
-    /**
-     * @param BSONArray|PackedArray|array $value
-     */
+    /** @param BSONArray|PackedArray|array $value */
     public function __construct(PackedArray|BSONArray|array $value)
     {
         if (is_array($value) && ! array_is_list($value)) {

--- a/src/Builder/Query/CenterOperator.php
+++ b/src/Builder/Query/CenterOperator.php
@@ -33,9 +33,7 @@ final class CenterOperator implements GeometryInterface, OperatorInterface
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;
 
-    /**
-     * @param BSONArray|PackedArray|array $value
-     */
+    /** @param BSONArray|PackedArray|array $value */
     public function __construct(PackedArray|BSONArray|array $value)
     {
         if (is_array($value) && ! array_is_list($value)) {

--- a/src/Builder/Query/CenterSphereOperator.php
+++ b/src/Builder/Query/CenterSphereOperator.php
@@ -33,9 +33,7 @@ final class CenterSphereOperator implements GeometryInterface, OperatorInterface
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;
 
-    /**
-     * @param BSONArray|PackedArray|array $value
-     */
+    /** @param BSONArray|PackedArray|array $value */
     public function __construct(PackedArray|BSONArray|array $value)
     {
         if (is_array($value) && ! array_is_list($value)) {

--- a/src/Builder/Query/CommentOperator.php
+++ b/src/Builder/Query/CommentOperator.php
@@ -27,9 +27,7 @@ final class CommentOperator implements QueryInterface, OperatorInterface
     /** @var string $comment */
     public readonly string $comment;
 
-    /**
-     * @param string $comment
-     */
+    /** @param string $comment */
     public function __construct(string $comment)
     {
         $this->comment = $comment;

--- a/src/Builder/Query/ElemMatchOperator.php
+++ b/src/Builder/Query/ElemMatchOperator.php
@@ -34,9 +34,7 @@ final class ElemMatchOperator implements FieldQueryInterface, OperatorInterface
     /** @var DateTimeInterface|FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query */
     public readonly DateTimeInterface|Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query;
 
-    /**
-     * @param DateTimeInterface|FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query
-     */
+    /** @param DateTimeInterface|FieldQueryInterface|QueryInterface|Type|array|bool|float|int|null|stdClass|string $query */
     public function __construct(
         DateTimeInterface|Type|FieldQueryInterface|QueryInterface|stdClass|array|bool|float|int|null|string $query,
     ) {

--- a/src/Builder/Query/EqOperator.php
+++ b/src/Builder/Query/EqOperator.php
@@ -30,9 +30,7 @@ final class EqOperator implements FieldQueryInterface, OperatorInterface
     /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/ExistsOperator.php
+++ b/src/Builder/Query/ExistsOperator.php
@@ -27,9 +27,7 @@ final class ExistsOperator implements FieldQueryInterface, OperatorInterface
     /** @var bool $exists */
     public readonly bool $exists;
 
-    /**
-     * @param bool $exists
-     */
+    /** @param bool $exists */
     public function __construct(bool $exists = true)
     {
         $this->exists = $exists;

--- a/src/Builder/Query/ExprOperator.php
+++ b/src/Builder/Query/ExprOperator.php
@@ -31,9 +31,7 @@ final class ExprOperator implements QueryInterface, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Query/GeoIntersectsOperator.php
+++ b/src/Builder/Query/GeoIntersectsOperator.php
@@ -31,9 +31,7 @@ final class GeoIntersectsOperator implements FieldQueryInterface, OperatorInterf
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;
 
-    /**
-     * @param Document|GeometryInterface|Serializable|array|stdClass $geometry
-     */
+    /** @param Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public function __construct(Document|Serializable|GeometryInterface|stdClass|array $geometry)
     {
         $this->geometry = $geometry;

--- a/src/Builder/Query/GeoWithinOperator.php
+++ b/src/Builder/Query/GeoWithinOperator.php
@@ -31,9 +31,7 @@ final class GeoWithinOperator implements FieldQueryInterface, OperatorInterface
     /** @var Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public readonly Document|Serializable|GeometryInterface|stdClass|array $geometry;
 
-    /**
-     * @param Document|GeometryInterface|Serializable|array|stdClass $geometry
-     */
+    /** @param Document|GeometryInterface|Serializable|array|stdClass $geometry */
     public function __construct(Document|Serializable|GeometryInterface|stdClass|array $geometry)
     {
         $this->geometry = $geometry;

--- a/src/Builder/Query/GtOperator.php
+++ b/src/Builder/Query/GtOperator.php
@@ -30,9 +30,7 @@ final class GtOperator implements FieldQueryInterface, OperatorInterface
     /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/GteOperator.php
+++ b/src/Builder/Query/GteOperator.php
@@ -30,9 +30,7 @@ final class GteOperator implements FieldQueryInterface, OperatorInterface
     /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/InOperator.php
+++ b/src/Builder/Query/InOperator.php
@@ -33,9 +33,7 @@ final class InOperator implements FieldQueryInterface, OperatorInterface
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;
 
-    /**
-     * @param BSONArray|PackedArray|array $value
-     */
+    /** @param BSONArray|PackedArray|array $value */
     public function __construct(PackedArray|BSONArray|array $value)
     {
         if (is_array($value) && ! array_is_list($value)) {

--- a/src/Builder/Query/JsonSchemaOperator.php
+++ b/src/Builder/Query/JsonSchemaOperator.php
@@ -30,9 +30,7 @@ final class JsonSchemaOperator implements QueryInterface, OperatorInterface
     /** @var Document|Serializable|array|stdClass $schema */
     public readonly Document|Serializable|stdClass|array $schema;
 
-    /**
-     * @param Document|Serializable|array|stdClass $schema
-     */
+    /** @param Document|Serializable|array|stdClass $schema */
     public function __construct(Document|Serializable|stdClass|array $schema)
     {
         $this->schema = $schema;

--- a/src/Builder/Query/LtOperator.php
+++ b/src/Builder/Query/LtOperator.php
@@ -30,9 +30,7 @@ final class LtOperator implements FieldQueryInterface, OperatorInterface
     /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/LteOperator.php
+++ b/src/Builder/Query/LteOperator.php
@@ -30,9 +30,7 @@ final class LteOperator implements FieldQueryInterface, OperatorInterface
     /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/MaxDistanceOperator.php
+++ b/src/Builder/Query/MaxDistanceOperator.php
@@ -29,9 +29,7 @@ final class MaxDistanceOperator implements FieldQueryInterface, OperatorInterfac
     /** @var Decimal128|Int64|float|int $value */
     public readonly Decimal128|Int64|float|int $value;
 
-    /**
-     * @param Decimal128|Int64|float|int $value
-     */
+    /** @param Decimal128|Int64|float|int $value */
     public function __construct(Decimal128|Int64|float|int $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/MinDistanceOperator.php
+++ b/src/Builder/Query/MinDistanceOperator.php
@@ -28,9 +28,7 @@ final class MinDistanceOperator implements FieldQueryInterface, OperatorInterfac
     /** @var Int64|float|int $value */
     public readonly Int64|float|int $value;
 
-    /**
-     * @param Int64|float|int $value
-     */
+    /** @param Int64|float|int $value */
     public function __construct(Int64|float|int $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/NeOperator.php
+++ b/src/Builder/Query/NeOperator.php
@@ -30,9 +30,7 @@ final class NeOperator implements FieldQueryInterface, OperatorInterface
     /** @var DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public readonly DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string $value */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/NinOperator.php
+++ b/src/Builder/Query/NinOperator.php
@@ -33,9 +33,7 @@ final class NinOperator implements FieldQueryInterface, OperatorInterface
     /** @var BSONArray|PackedArray|array $value */
     public readonly PackedArray|BSONArray|array $value;
 
-    /**
-     * @param BSONArray|PackedArray|array $value
-     */
+    /** @param BSONArray|PackedArray|array $value */
     public function __construct(PackedArray|BSONArray|array $value)
     {
         if (is_array($value) && ! array_is_list($value)) {

--- a/src/Builder/Query/NotOperator.php
+++ b/src/Builder/Query/NotOperator.php
@@ -30,9 +30,7 @@ final class NotOperator implements FieldQueryInterface, OperatorInterface
     /** @var DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Query/PolygonOperator.php
+++ b/src/Builder/Query/PolygonOperator.php
@@ -33,9 +33,7 @@ final class PolygonOperator implements GeometryInterface, OperatorInterface
     /** @var BSONArray|PackedArray|array $points */
     public readonly PackedArray|BSONArray|array $points;
 
-    /**
-     * @param BSONArray|PackedArray|array $points
-     */
+    /** @param BSONArray|PackedArray|array $points */
     public function __construct(PackedArray|BSONArray|array $points)
     {
         if (is_array($points) && ! array_is_list($points)) {

--- a/src/Builder/Query/RegexOperator.php
+++ b/src/Builder/Query/RegexOperator.php
@@ -28,9 +28,7 @@ final class RegexOperator implements FieldQueryInterface, OperatorInterface
     /** @var Regex $regex */
     public readonly Regex $regex;
 
-    /**
-     * @param Regex $regex
-     */
+    /** @param Regex $regex */
     public function __construct(Regex $regex)
     {
         $this->regex = $regex;

--- a/src/Builder/Query/SizeOperator.php
+++ b/src/Builder/Query/SizeOperator.php
@@ -27,9 +27,7 @@ final class SizeOperator implements FieldQueryInterface, OperatorInterface
     /** @var int $value */
     public readonly int $value;
 
-    /**
-     * @param int $value
-     */
+    /** @param int $value */
     public function __construct(int $value)
     {
         $this->value = $value;

--- a/src/Builder/Query/WhereOperator.php
+++ b/src/Builder/Query/WhereOperator.php
@@ -30,9 +30,7 @@ final class WhereOperator implements QueryInterface, OperatorInterface
     /** @var Javascript|string $function */
     public readonly Javascript|string $function;
 
-    /**
-     * @param Javascript|string $function
-     */
+    /** @param Javascript|string $function */
     public function __construct(Javascript|string $function)
     {
         if (is_string($function)) {

--- a/src/Builder/Stage/AddFieldsStage.php
+++ b/src/Builder/Stage/AddFieldsStage.php
@@ -35,9 +35,7 @@ final class AddFieldsStage implements StageInterface, UpdateStageInterface, Oper
     /** @var stdClass<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $expression Specify the name of each field to add and set its value to an aggregation expression or an empty object. */
     public readonly stdClass $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression Specify the name of each field to add and set its value to an aggregation expression or an empty object.
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$expression Specify the name of each field to add and set its value to an aggregation expression or an empty object. */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$expression,
     ) {

--- a/src/Builder/Stage/CountStage.php
+++ b/src/Builder/Stage/CountStage.php
@@ -28,9 +28,7 @@ final class CountStage implements StageInterface, OperatorInterface
     /** @var string $field Name of the output field which has the count as its value. It must be a non-empty string, must not start with $ and must not contain the . character. */
     public readonly string $field;
 
-    /**
-     * @param string $field Name of the output field which has the count as its value. It must be a non-empty string, must not start with $ and must not contain the . character.
-     */
+    /** @param string $field Name of the output field which has the count as its value. It must be a non-empty string, must not start with $ and must not contain the . character. */
     public function __construct(string $field)
     {
         $this->field = $field;

--- a/src/Builder/Stage/FacetStage.php
+++ b/src/Builder/Stage/FacetStage.php
@@ -34,9 +34,7 @@ final class FacetStage implements StageInterface, OperatorInterface
     /** @var stdClass<BSONArray|PackedArray|Pipeline|array> $facet */
     public readonly stdClass $facet;
 
-    /**
-     * @param BSONArray|PackedArray|Pipeline|array ...$facet
-     */
+    /** @param BSONArray|PackedArray|Pipeline|array ...$facet */
     public function __construct(PackedArray|Pipeline|BSONArray|array ...$facet)
     {
         if (\count($facet) < 1) {

--- a/src/Builder/Stage/LimitStage.php
+++ b/src/Builder/Stage/LimitStage.php
@@ -27,9 +27,7 @@ final class LimitStage implements StageInterface, OperatorInterface
     /** @var int $limit */
     public readonly int $limit;
 
-    /**
-     * @param int $limit
-     */
+    /** @param int $limit */
     public function __construct(int $limit)
     {
         $this->limit = $limit;

--- a/src/Builder/Stage/ListSampledQueriesStage.php
+++ b/src/Builder/Stage/ListSampledQueriesStage.php
@@ -30,9 +30,7 @@ final class ListSampledQueriesStage implements StageInterface, OperatorInterface
     /** @var Optional|string $namespace */
     public readonly Optional|string $namespace;
 
-    /**
-     * @param Optional|string $namespace
-     */
+    /** @param Optional|string $namespace */
     public function __construct(Optional|string $namespace = Optional::Undefined)
     {
         $this->namespace = $namespace;

--- a/src/Builder/Stage/MatchStage.php
+++ b/src/Builder/Stage/MatchStage.php
@@ -31,9 +31,7 @@ final class MatchStage implements StageInterface, OperatorInterface
     /** @var QueryInterface|array $query */
     public readonly QueryInterface|array $query;
 
-    /**
-     * @param QueryInterface|array $query
-     */
+    /** @param QueryInterface|array $query */
     public function __construct(QueryInterface|array $query)
     {
         if (is_array($query)) {

--- a/src/Builder/Stage/OutStage.php
+++ b/src/Builder/Stage/OutStage.php
@@ -30,9 +30,7 @@ final class OutStage implements OutputStageInterface, OperatorInterface
     /** @var Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to. */
     public readonly Document|Serializable|stdClass|array|string $coll;
 
-    /**
-     * @param Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to.
-     */
+    /** @param Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to. */
     public function __construct(Document|Serializable|stdClass|array|string $coll)
     {
         $this->coll = $coll;

--- a/src/Builder/Stage/ProjectStage.php
+++ b/src/Builder/Stage/ProjectStage.php
@@ -35,9 +35,7 @@ final class ProjectStage implements StageInterface, UpdateStageInterface, Operat
     /** @var stdClass<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $specification */
     public readonly stdClass $specification;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$specification
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$specification */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$specification,
     ) {

--- a/src/Builder/Stage/RedactStage.php
+++ b/src/Builder/Stage/RedactStage.php
@@ -31,9 +31,7 @@ final class RedactStage implements StageInterface, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Stage/ReplaceRootStage.php
+++ b/src/Builder/Stage/ReplaceRootStage.php
@@ -36,9 +36,7 @@ final class ReplaceRootStage implements StageInterface, UpdateStageInterface, Op
     /** @var Document|ResolvesToObject|Serializable|array|stdClass|string $newRoot */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array|string $newRoot;
 
-    /**
-     * @param Document|ResolvesToObject|Serializable|array|stdClass|string $newRoot
-     */
+    /** @param Document|ResolvesToObject|Serializable|array|stdClass|string $newRoot */
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array|string $newRoot)
     {
         if (is_string($newRoot) && ! str_starts_with($newRoot, '$')) {

--- a/src/Builder/Stage/ReplaceWithStage.php
+++ b/src/Builder/Stage/ReplaceWithStage.php
@@ -37,9 +37,7 @@ final class ReplaceWithStage implements StageInterface, UpdateStageInterface, Op
     /** @var Document|ResolvesToObject|Serializable|array|stdClass|string $expression */
     public readonly Document|Serializable|ResolvesToObject|stdClass|array|string $expression;
 
-    /**
-     * @param Document|ResolvesToObject|Serializable|array|stdClass|string $expression
-     */
+    /** @param Document|ResolvesToObject|Serializable|array|stdClass|string $expression */
     public function __construct(Document|Serializable|ResolvesToObject|stdClass|array|string $expression)
     {
         if (is_string($expression) && ! str_starts_with($expression, '$')) {

--- a/src/Builder/Stage/SampleStage.php
+++ b/src/Builder/Stage/SampleStage.php
@@ -27,9 +27,7 @@ final class SampleStage implements StageInterface, OperatorInterface
     /** @var int $size The number of documents to randomly select. */
     public readonly int $size;
 
-    /**
-     * @param int $size The number of documents to randomly select.
-     */
+    /** @param int $size The number of documents to randomly select. */
     public function __construct(int $size)
     {
         $this->size = $size;

--- a/src/Builder/Stage/SetStage.php
+++ b/src/Builder/Stage/SetStage.php
@@ -36,9 +36,7 @@ final class SetStage implements StageInterface, UpdateStageInterface, OperatorIn
     /** @var stdClass<DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string ...$field,
     ) {

--- a/src/Builder/Stage/SkipStage.php
+++ b/src/Builder/Stage/SkipStage.php
@@ -27,9 +27,7 @@ final class SkipStage implements StageInterface, OperatorInterface
     /** @var int $skip */
     public readonly int $skip;
 
-    /**
-     * @param int $skip
-     */
+    /** @param int $skip */
     public function __construct(int $skip)
     {
         $this->skip = $skip;

--- a/src/Builder/Stage/SortByCountStage.php
+++ b/src/Builder/Stage/SortByCountStage.php
@@ -31,9 +31,7 @@ final class SortByCountStage implements StageInterface, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $expression */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ) {

--- a/src/Builder/Stage/SortStage.php
+++ b/src/Builder/Stage/SortStage.php
@@ -35,9 +35,7 @@ final class SortStage implements StageInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string> $sort */
     public readonly stdClass $sort;
 
-    /**
-     * @param DateTimeInterface|ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort
-     */
+    /** @param DateTimeInterface|ExpressionInterface|Sort|Type|array|bool|float|int|null|stdClass|string ...$sort */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|Sort|stdClass|array|bool|float|int|null|string ...$sort,
     ) {

--- a/src/Builder/Update/AddToSetOperator.php
+++ b/src/Builder/Update/AddToSetOperator.php
@@ -33,9 +33,7 @@ final class AddToSetOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/IncOperator.php
+++ b/src/Builder/Update/IncOperator.php
@@ -33,9 +33,7 @@ final class IncOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<Decimal128|Int64|float|int> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param Decimal128|Int64|float|int ...$field
-     */
+    /** @param Decimal128|Int64|float|int ...$field */
     public function __construct(Decimal128|Int64|float|int ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/MaxOperator.php
+++ b/src/Builder/Update/MaxOperator.php
@@ -33,9 +33,7 @@ final class MaxOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/MinOperator.php
+++ b/src/Builder/Update/MinOperator.php
@@ -33,9 +33,7 @@ final class MinOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/MulOperator.php
+++ b/src/Builder/Update/MulOperator.php
@@ -33,9 +33,7 @@ final class MulOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<Decimal128|Int64|float|int> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param Decimal128|Int64|float|int ...$field
-     */
+    /** @param Decimal128|Int64|float|int ...$field */
     public function __construct(Decimal128|Int64|float|int ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/PopOperator.php
+++ b/src/Builder/Update/PopOperator.php
@@ -31,9 +31,7 @@ final class PopOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<int> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param int ...$field
-     */
+    /** @param int ...$field */
     public function __construct(int ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/PullAllOperator.php
+++ b/src/Builder/Update/PullAllOperator.php
@@ -33,9 +33,7 @@ final class PullAllOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<BSONArray|PackedArray|array> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param BSONArray|PackedArray|array ...$field
-     */
+    /** @param BSONArray|PackedArray|array ...$field */
     public function __construct(PackedArray|BSONArray|array ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/PullOperator.php
+++ b/src/Builder/Update/PullOperator.php
@@ -34,9 +34,7 @@ final class PullOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|FieldQueryInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(
         DateTimeInterface|Type|FieldQueryInterface|stdClass|array|bool|float|int|null|string ...$field,
     ) {

--- a/src/Builder/Update/PushOperator.php
+++ b/src/Builder/Update/PushOperator.php
@@ -33,9 +33,7 @@ final class PushOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/RenameOperator.php
+++ b/src/Builder/Update/RenameOperator.php
@@ -31,9 +31,7 @@ final class RenameOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param string ...$field
-     */
+    /** @param string ...$field */
     public function __construct(string ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/SetOnInsertOperator.php
+++ b/src/Builder/Update/SetOnInsertOperator.php
@@ -33,9 +33,7 @@ final class SetOnInsertOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/SetOperator.php
+++ b/src/Builder/Update/SetOperator.php
@@ -33,9 +33,7 @@ final class SetOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string ...$field)
     {
         if (\count($field) < 1) {

--- a/src/Builder/Update/UnsetOperator.php
+++ b/src/Builder/Update/UnsetOperator.php
@@ -33,9 +33,7 @@ final class UnsetOperator implements UpdateInterface, OperatorInterface
     /** @var stdClass<DateTimeInterface|Type|array|bool|float|int|null|stdClass|string> $field */
     public readonly stdClass $field;
 
-    /**
-     * @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field
-     */
+    /** @param DateTimeInterface|Type|array|bool|float|int|null|stdClass|string ...$field */
     public function __construct(DateTimeInterface|Type|stdClass|array|bool|float|int|null|string ...$field)
     {
         if (\count($field) < 1) {


### PR DESCRIPTION
## Summary

Nette's default `PsrPrinter` always formats method docblocks in multi-line format, even when the content is a single line. For example, it outputs:

```php
/**
 * @param ResolvesToInt|int $value
 */
```

instead of the more compact:

```php
/** @param ResolvesToInt|int $value */
```

`ClassPrinter` extends `PsrPrinter` and overrides `printDocComment` to call `Helpers::formatDocComment` with `$multiLine = false` for `Method` instances. This allows single-line format `/** @param ... */` when the method has only one comment line.