### PR TITLE
 PHPLIB-1763 Add `$rerank` stage

### DIFF
--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -505,11 +505,9 @@ trait FactoryTrait
      * New in MongoDB 8.1
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rankFusion/
-     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
-     * - input.pipelines: Map from name to ranked input pipeline. Each pipeline must operate on the same collection. Minimum of one pipeline.
+     * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with rank fusion.
      * @param bool $scoreDetails Set to true to include detailed scoring information.
-     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
-     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the ranked results.
      */
     public static function rankFusion(
         Document|Serializable|stdClass|array $input,
@@ -557,6 +555,26 @@ trait FactoryTrait
     }
 
     /**
+     * Reranks documents using a Voyage AI reranking model to improve relevance scoring.
+     *
+     * New in MongoDB 8.3
+     *
+     * @see https://www.mongodb.com/docs/vector-search/query/aggregation-stages/rerank/
+     * @param string $model Name of the Voyage AI reranking model to use (e.g. rerank-2.5, rerank-2.5-lite).
+     * @param Document|Serializable|array|stdClass $query Query object for reranking.
+     * @param BSONArray|PackedArray|array|string $path Field path or array of field paths to use for reranking.
+     * @param int $numDocsToRerank Maximum number of documents to send to Voyage AI for reranking. Value must be between 1 and 1000.
+     */
+    public static function rerank(
+        string $model,
+        Document|Serializable|stdClass|array $query,
+        PackedArray|BSONArray|array|string $path,
+        int $numDocsToRerank,
+    ): RerankStage {
+        return new RerankStage($model, $query, $path, $numDocsToRerank);
+    }
+
+    /**
      * Randomly selects the specified number of documents from its input.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/
@@ -573,14 +591,9 @@ trait FactoryTrait
      * New in MongoDB 8.0
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/
-     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
-     * - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
-     * - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
+     * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with score fusion.
      * @param bool $scoreDetails Set to true to include detailed scoring information.
-     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
-     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
-     * - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
-     * - combination.expression: This is the custom expression that is used when combination.method is set to expression.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the scores.
      */
     public static function scoreFusion(
         Document|Serializable|stdClass|array $input,

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -568,11 +568,9 @@ trait FluentFactoryTrait
      * New in MongoDB 8.1
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rankFusion/
-     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
-     * - input.pipelines: Map from name to ranked input pipeline. Each pipeline must operate on the same collection. Minimum of one pipeline.
+     * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with rank fusion.
      * @param bool $scoreDetails Set to true to include detailed scoring information.
-     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
-     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the ranked results.
      */
     public function rankFusion(
         Document|Serializable|stdClass|array $input,
@@ -626,6 +624,28 @@ trait FluentFactoryTrait
     }
 
     /**
+     * Reranks documents using a Voyage AI reranking model to improve relevance scoring.
+     *
+     * New in MongoDB 8.3
+     *
+     * @see https://www.mongodb.com/docs/vector-search/query/aggregation-stages/rerank/
+     * @param string $model Name of the Voyage AI reranking model to use (e.g. rerank-2.5, rerank-2.5-lite).
+     * @param Document|Serializable|array|stdClass $query Query object for reranking.
+     * @param BSONArray|PackedArray|array|string $path Field path or array of field paths to use for reranking.
+     * @param int $numDocsToRerank Maximum number of documents to send to Voyage AI for reranking. Value must be between 1 and 1000.
+     */
+    public function rerank(
+        string $model,
+        Document|Serializable|stdClass|array $query,
+        PackedArray|BSONArray|array|string $path,
+        int $numDocsToRerank,
+    ): static {
+        $this->pipeline[] = Stage::rerank($model, $query, $path, $numDocsToRerank);
+
+        return $this;
+    }
+
+    /**
      * Randomly selects the specified number of documents from its input.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/
@@ -644,14 +664,9 @@ trait FluentFactoryTrait
      * New in MongoDB 8.0
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/
-     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
-     * - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
-     * - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
+     * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with score fusion.
      * @param bool $scoreDetails Set to true to include detailed scoring information.
-     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
-     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
-     * - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
-     * - combination.expression: This is the custom expression that is used when combination.method is set to expression.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the scores.
      */
     public function scoreFusion(
         Document|Serializable|stdClass|array $input,

--- a/src/Builder/Stage/RankFusionStage.php
+++ b/src/Builder/Stage/RankFusionStage.php
@@ -30,27 +30,19 @@ final class RankFusionStage implements StageInterface, OperatorInterface
     public const NAME = '$rankFusion';
     public const PROPERTIES = ['input' => 'input', 'scoreDetails' => 'scoreDetails', 'combination' => 'combination'];
 
-    /**
-     * @var Document|Serializable|array|stdClass $input An object with the following required fields:
-     * - input.pipelines: Map from name to ranked input pipeline. Each pipeline must operate on the same collection. Minimum of one pipeline.
-     */
+    /** @var Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with rank fusion. */
     public readonly Document|Serializable|stdClass|array $input;
 
     /** @var bool $scoreDetails Set to true to include detailed scoring information. */
     public readonly bool $scoreDetails;
 
-    /**
-     * @var Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
-     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
-     */
+    /** @var Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the ranked results. */
     public readonly Optional|Document|Serializable|stdClass|array $combination;
 
     /**
-     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
-     * - input.pipelines: Map from name to ranked input pipeline. Each pipeline must operate on the same collection. Minimum of one pipeline.
+     * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with rank fusion.
      * @param bool $scoreDetails Set to true to include detailed scoring information.
-     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
-     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the ranked results.
      */
     public function __construct(
         Document|Serializable|stdClass|array $input,

--- a/src/Builder/Stage/RerankStage.php
+++ b/src/Builder/Stage/RerankStage.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Stage;
+
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
+use MongoDB\BSON\Serializable;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\StageInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+use stdClass;
+
+use function array_is_list;
+use function is_array;
+
+/**
+ * Reranks documents using a Voyage AI reranking model to improve relevance scoring.
+ *
+ * New in MongoDB 8.3
+ *
+ * @see https://www.mongodb.com/docs/vector-search/query/aggregation-stages/rerank/
+ * @internal
+ */
+final class RerankStage implements StageInterface, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$rerank';
+
+    public const PROPERTIES = [
+        'model' => 'model',
+        'query' => 'query',
+        'path' => 'path',
+        'numDocsToRerank' => 'numDocsToRerank',
+    ];
+
+    /** @var string $model Name of the Voyage AI reranking model to use (e.g. rerank-2.5, rerank-2.5-lite). */
+    public readonly string $model;
+
+    /** @var Document|Serializable|array|stdClass $query Query object for reranking. */
+    public readonly Document|Serializable|stdClass|array $query;
+
+    /** @var BSONArray|PackedArray|array|string $path Field path or array of field paths to use for reranking. */
+    public readonly PackedArray|BSONArray|array|string $path;
+
+    /** @var int $numDocsToRerank Maximum number of documents to send to Voyage AI for reranking. Value must be between 1 and 1000. */
+    public readonly int $numDocsToRerank;
+
+    /**
+     * @param string $model Name of the Voyage AI reranking model to use (e.g. rerank-2.5, rerank-2.5-lite).
+     * @param Document|Serializable|array|stdClass $query Query object for reranking.
+     * @param BSONArray|PackedArray|array|string $path Field path or array of field paths to use for reranking.
+     * @param int $numDocsToRerank Maximum number of documents to send to Voyage AI for reranking. Value must be between 1 and 1000.
+     */
+    public function __construct(
+        string $model,
+        Document|Serializable|stdClass|array $query,
+        PackedArray|BSONArray|array|string $path,
+        int $numDocsToRerank,
+    ) {
+        $this->model = $model;
+        $this->query = $query;
+        if (is_array($path) && ! array_is_list($path)) {
+            throw new InvalidArgumentException('Expected $path argument to be a list, got an associative array.');
+        }
+
+        $this->path = $path;
+        $this->numDocsToRerank = $numDocsToRerank;
+    }
+}

--- a/src/Builder/Stage/ScoreFusionStage.php
+++ b/src/Builder/Stage/ScoreFusionStage.php
@@ -30,33 +30,19 @@ final class ScoreFusionStage implements StageInterface, OperatorInterface
     public const NAME = '$scoreFusion';
     public const PROPERTIES = ['input' => 'input', 'scoreDetails' => 'scoreDetails', 'combination' => 'combination'];
 
-    /**
-     * @var Document|Serializable|array|stdClass $input An object with the following required fields:
-     * - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
-     * - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
-     */
+    /** @var Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with score fusion. */
     public readonly Document|Serializable|stdClass|array $input;
 
     /** @var bool $scoreDetails Set to true to include detailed scoring information. */
     public readonly bool $scoreDetails;
 
-    /**
-     * @var Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
-     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
-     * - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
-     * - combination.expression: This is the custom expression that is used when combination.method is set to expression.
-     */
+    /** @var Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the scores. */
     public readonly Optional|Document|Serializable|stdClass|array $combination;
 
     /**
-     * @param Document|Serializable|array|stdClass $input An object with the following required fields:
-     * - input.pipelines: Map from name to input pipeline. Each pipeline must be operating on the same collection. Minimum of one pipeline.
-     * - input.normalization: Normalizes the score to the range 0 to 1 before combining the results. Value can be none, sigmoid or minMaxScaler.
+     * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with score fusion.
      * @param bool $scoreDetails Set to true to include detailed scoring information.
-     * @param Optional|Document|Serializable|array|stdClass $combination An object with the following optional fields:
-     * - combination.weights: Map from pipeline name to numbers (non-negative). If unspecified, default weight is 1 for each pipeline.
-     * - combination.method: Specifies method for combining scores. Value can be avg or expression. Default is avg.
-     * - combination.expression: This is the custom expression that is used when combination.method is set to expression.
+     * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the scores.
      */
     public function __construct(
         Document|Serializable|stdClass|array $input,

--- a/tests/Builder/Stage/Pipelines.php
+++ b/tests/Builder/Stage/Pipelines.php
@@ -2598,6 +2598,76 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/vector-search/query/aggregation-stages/rerank/#examples
+     */
+    case RerankExample = <<<'JSON'
+    [
+        {
+            "$match": {
+                "plot": {
+                    "$exists": true,
+                    "$type": [
+                        "string"
+                    ]
+                }
+            }
+        },
+        {
+            "$sort": {
+                "released": {
+                    "$numberInt": "-1"
+                }
+            }
+        },
+        {
+            "$rerank": {
+                "model": "rerank-2.5",
+                "query": {
+                    "text": "a group of heroes band together to stop a powerful enemy and save the world"
+                },
+                "numDocsToRerank": {
+                    "$numberInt": "100"
+                },
+                "path": [
+                    "title",
+                    "plot"
+                ]
+            }
+        },
+        {
+            "$addFields": {
+                "rerankScore": {
+                    "$meta": "score"
+                }
+            }
+        },
+        {
+            "$limit": {
+                "$numberInt": "10"
+            }
+        },
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "title": {
+                    "$numberInt": "1"
+                },
+                "plot": {
+                    "$numberInt": "1"
+                },
+                "rerankScore": {
+                    "$numberInt": "1"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sample/#example
      */
     case SampleExample = <<<'JSON'

--- a/tests/Builder/Stage/RerankStageTest.php
+++ b/tests/Builder/Stage/RerankStageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Query;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $rerank stage
+ */
+class RerankStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::match(
+                Query::query(
+                    plot: [Query::exists(true), Query::type('string')],
+                ),
+            ),
+            Stage::sort(released: -1),
+            Stage::rerank(
+                model: 'rerank-2.5',
+                query: object(text: 'a group of heroes band together to stop a powerful enemy and save the world'),
+                path: ['title', 'plot'],
+                numDocsToRerank: 100,
+            ),
+            Stage::addFields(
+                rerankScore: Expression::meta('score'),
+            ),
+            Stage::limit(10),
+            Stage::project(
+                _id: 0,
+                title: 1,
+                plot: 1,
+                rerankScore: 1,
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::RerankExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Adds support for the `$rerank` aggregation stage, available on MongoDB Atlas 8.3+.

The stage reranks documents using a Voyage AI reranking model to improve relevance scoring.

mql-specifications PR: mongodb/mql-specifications#36

Jira: PHPLIB-1763 / DRIVERS-3301