### PR TITLE
Add Atlas Stream Processing commands

### DIFF
--- a/examples/atlas_stream_processing.php
+++ b/examples/atlas_stream_processing.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This example demonstrates the full lifecycle of an Atlas Stream Processing
+ * (ASP) stream processor using MongoDB\StreamProcessingClient. It creates,
+ * starts, samples, stops, and drops a processor.
+ *
+ * Requirements:
+ *
+ *   - An Atlas Stream Processing workspace with a hostname matching the
+ *     pattern atlas-stream-<workspaceId>-<suffix>.<region>.a.query.mongodb.net
+ *   - A user with the `atlasAdmin` role
+ *   - Two connections registered in the workspace:
+ *       - `sample_stream_solar`  (built-in sample source)
+ *       - `__testLog`            (built-in test sink)
+ *
+ * Use the MONGODB_STREAM_PROCESSING_URI environment variable to specify the
+ * workspace connection string (including username/password). Example:
+ *
+ *   MONGODB_STREAM_PROCESSING_URI='mongodb://user:pass@atlas-stream-….a.query.mongodb.net/' \
+ *       php examples/atlas_stream_processing.php
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Examples;
+
+use MongoDB\Driver\Exception\Exception as DriverException;
+use MongoDB\StreamProcessingClient;
+use RuntimeException;
+use Throwable;
+
+use function count;
+use function getenv;
+use function sleep;
+use function time;
+use function uniqid;
+use function var_export;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$uri = getenv('MONGODB_STREAM_PROCESSING_URI');
+if (! $uri) {
+    echo "This example requires an Atlas Stream Processing workspace endpoint.\n";
+    echo "Set MONGODB_STREAM_PROCESSING_URI to the workspace connection string.\n";
+    exit(1);
+}
+
+if (! StreamProcessingClient::isWorkspaceUri($uri)) {
+    echo "MONGODB_STREAM_PROCESSING_URI does not look like a workspace endpoint.\n";
+    echo "Expected hostname pattern: atlas-stream-*.<region>.a.query.mongodb.net (or mongodb-stage.net for Atlas staging)\n";
+    exit(1);
+}
+
+$client = new StreamProcessingClient($uri);
+$processors = $client->streamProcessors();
+$name = 'phplib_demo_' . uniqid();
+
+$pipeline = [
+    ['$source' => ['connectionName' => 'sample_stream_solar']],
+    ['$emit' => ['connectionName' => '__testLog', 'topic' => 'phplib-demo']],
+];
+
+echo 'Workspace: ', $uri, "\n";
+echo 'Processor: ', $name, "\n\n";
+
+try {
+    /* --- create --- */
+    echo '[1/6] create(' . $name . ")\n";
+    $processors->create($name, $pipeline);
+    $processor = $processors->get($name);
+
+    $info = $processors->getInfo($name);
+    echo '      state=', $info->getState(), "\n\n";
+
+    /* --- start --- */
+    echo "[2/6] start()\n";
+    $processor->start();
+
+    // Wait for the processor to reach STARTED before requesting stats.
+    $deadline = time() + 30;
+    $state = $processors->getInfo($name)->getState();
+    while ($state !== 'STARTED' && time() < $deadline) {
+        sleep(1);
+        $state = $processors->getInfo($name)->getState();
+    }
+
+    echo '      state=', $state, "\n\n";
+    if ($state !== 'STARTED') {
+        throw new RuntimeException('Processor failed to reach STARTED within 30s; got ' . $state);
+    }
+
+    /* --- stats --- */
+    echo "[3/6] stats()\n";
+    $stats = $processor->stats();
+    echo '      ', var_export($stats['stats'] ?? $stats, true), "\n\n";
+
+    /* --- sample --- */
+    echo "[4/6] getStreamProcessorSamples()\n";
+    $samples = $processor->getStreamProcessorSamples(['limit' => 5]);
+    echo '      open  cursorId=', $samples->getCursorId(), ' docs=', count($samples->getDocuments()), "\n";
+
+    if (! $samples->isExhausted()) {
+        // Give the stream a moment to produce something.
+        sleep(2);
+        $samples = $processor->getStreamProcessorSamples([
+            'cursorId' => $samples->getCursorId(),
+            'batchSize' => 5,
+        ]);
+        echo '      batch cursorId=', $samples->getCursorId(), ' docs=', count($samples->getDocuments()), "\n";
+        foreach ($samples->getDocuments() as $i => $doc) {
+            echo '          [', $i, '] ', var_export($doc, true), "\n";
+        }
+    }
+
+    echo "\n";
+
+    /* --- stop --- */
+    echo "[5/6] stop()\n";
+    $processor->stop();
+    echo '      state=', $processors->getInfo($name)->getState(), "\n\n";
+
+    /* --- drop --- */
+    echo "[6/6] drop()\n";
+    $processor->drop();
+    echo "      dropped\n\n";
+
+    echo "OK.\n";
+    exit(0);
+} catch (Throwable $e) {
+    echo "\nFAILED: ", $e::class, ': ', $e->getMessage(), "\n";
+
+    // Best-effort cleanup so we don't leave processors behind.
+    try {
+        $processors->get($name)->drop();
+        echo '(cleaned up processor ' . $name . ")\n";
+    } catch (DriverException) {
+        // Processor may not exist, already be dropped, or be in a non-droppable state.
+    }
+
+    exit(1);
+}

--- a/examples/atlas_stream_processing.php
+++ b/examples/atlas_stream_processing.php
@@ -108,8 +108,9 @@ try {
             'batchSize' => 5,
         ]);
         echo '      batch cursorId=', $samples->getCursorId(), ' docs=', count($samples->getDocuments()), "\n";
+        /** @psalm-suppress MixedAssignment */
         foreach ($samples->getDocuments() as $i => $doc) {
-            echo '          [', $i, '] ', var_export($doc, true), "\n";
+            echo '          [', (int) $i, '] ', var_export($doc, true), "\n";
         }
     }
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -549,12 +549,6 @@
       <code><![CDATA[stdClass]]></code>
     </MoreSpecificReturnType>
   </file>
-  <file src="src/Model/StreamProcessorInfo.php">
-    <MixedAssignment>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-  </file>
   <file src="src/Operation/Aggregate.php">
     <MixedArgument>
       <code><![CDATA[$this->options['codec']]]></code>
@@ -862,28 +856,6 @@
       <code><![CDATA[$replacement]]></code>
     </PossiblyInvalidArgument>
   </file>
-  <file src="src/Operation/StreamProcessing/CreateStreamProcessor.php">
-    <MixedAssignment>
-      <code><![CDATA[$subOptions[$key]]]></code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Operation/StreamProcessing/GetMoreSampleStreamProcessor.php">
-    <MixedAssignment>
-      <code><![CDATA[$batch]]></code>
-      <code><![CDATA[$cmd['batchSize']]]></code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Operation/StreamProcessing/StartSampleStreamProcessor.php">
-    <MixedAssignment>
-      <code><![CDATA[$cmd['limit']]]></code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Operation/StreamProcessing/StartStreamProcessor.php">
-    <MixedAssignment>
-      <code><![CDATA[$cmd['workers']]]></code>
-      <code><![CDATA[$subOptions[$key]]]></code>
-    </MixedAssignment>
-  </file>
   <file src="src/Operation/Update.php">
     <MixedAssignment>
       <code><![CDATA[$cmd['bypassDocumentValidation']]]></code>
@@ -926,13 +898,6 @@
       <code><![CDATA[self::BACKOFF_INITIAL * (1.5 ** ($transactionAttempt - 1))]]></code>
       <code><![CDATA[self::MAX_TIME * 1e9]]></code>
     </InvalidOperand>
-  </file>
-  <file src="src/StreamProcessingClient.php">
-    <MixedAssignment>
-      <code><![CDATA[$uriOptions['authSource']]]></code>
-      <code><![CDATA[$uriOptions['tls']]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
   </file>
   <file src="src/UpdateResult.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -549,6 +549,12 @@
       <code><![CDATA[stdClass]]></code>
     </MoreSpecificReturnType>
   </file>
+  <file src="src/Model/StreamProcessorInfo.php">
+    <MixedAssignment>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+    </MixedAssignment>
+  </file>
   <file src="src/Operation/Aggregate.php">
     <MixedArgument>
       <code><![CDATA[$this->options['codec']]]></code>
@@ -856,6 +862,28 @@
       <code><![CDATA[$replacement]]></code>
     </PossiblyInvalidArgument>
   </file>
+  <file src="src/Operation/StreamProcessing/CreateStreamProcessor.php">
+    <MixedAssignment>
+      <code><![CDATA[$subOptions[$key]]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Operation/StreamProcessing/GetMoreSampleStreamProcessor.php">
+    <MixedAssignment>
+      <code><![CDATA[$batch]]></code>
+      <code><![CDATA[$cmd['batchSize']]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Operation/StreamProcessing/StartSampleStreamProcessor.php">
+    <MixedAssignment>
+      <code><![CDATA[$cmd['limit']]]></code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Operation/StreamProcessing/StartStreamProcessor.php">
+    <MixedAssignment>
+      <code><![CDATA[$cmd['workers']]]></code>
+      <code><![CDATA[$subOptions[$key]]]></code>
+    </MixedAssignment>
+  </file>
   <file src="src/Operation/Update.php">
     <MixedAssignment>
       <code><![CDATA[$cmd['bypassDocumentValidation']]]></code>
@@ -898,6 +926,13 @@
       <code><![CDATA[self::BACKOFF_INITIAL * (1.5 ** ($transactionAttempt - 1))]]></code>
       <code><![CDATA[self::MAX_TIME * 1e9]]></code>
     </InvalidOperand>
+  </file>
+  <file src="src/StreamProcessingClient.php">
+    <MixedAssignment>
+      <code><![CDATA[$uriOptions['authSource']]]></code>
+      <code><![CDATA[$uriOptions['tls']]]></code>
+      <code><![CDATA[$value]]></code>
+    </MixedAssignment>
   </file>
   <file src="src/UpdateResult.php">
     <MixedAssignment>

--- a/src/Model/StreamProcessorInfo.php
+++ b/src/Model/StreamProcessorInfo.php
@@ -1,0 +1,179 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Model;
+
+use ArrayAccess;
+use MongoDB\BSON\UTCDateTimeInterface;
+use MongoDB\Exception\BadMethodCallException;
+
+use function array_key_exists;
+
+/**
+ * Stream processor info model.
+ *
+ * Models the response of the getStreamProcessor command. Fields that the spec
+ * marks as Optional may be absent depending on server version; getters return
+ * null in that case.
+ *
+ * @template-implements ArrayAccess<string, mixed>
+ */
+final class StreamProcessorInfo implements ArrayAccess
+{
+    public function __construct(private array $info)
+    {
+    }
+
+    /** @see https://php.net/oop5.magic#language.oop5.magic.debuginfo */
+    public function __debugInfo(): array
+    {
+        return $this->info;
+    }
+
+    /**
+     * Processor id. Optional: not returned by all server versions.
+     */
+    public function getId(): ?string
+    {
+        return isset($this->info['id']) ? (string) $this->info['id'] : null;
+    }
+
+    public function getName(): string
+    {
+        return (string) $this->info['name'];
+    }
+
+    public function getState(): string
+    {
+        return (string) $this->info['state'];
+    }
+
+    public function getPipeline(): array
+    {
+        return (array) ($this->info['pipeline'] ?? []);
+    }
+
+    /**
+     * Pipeline version. Optional: not returned by all server versions.
+     */
+    public function getPipelineVersion(): ?int
+    {
+        return isset($this->info['pipelineVersion']) ? (int) $this->info['pipelineVersion'] : null;
+    }
+
+    public function getTier(): ?string
+    {
+        return isset($this->info['tier']) ? (string) $this->info['tier'] : null;
+    }
+
+    public function getDlq(): mixed
+    {
+        return $this->info['dlq'] ?? null;
+    }
+
+    public function getStreamMetaFieldName(): ?string
+    {
+        return isset($this->info['streamMetaFieldName']) ? (string) $this->info['streamMetaFieldName'] : null;
+    }
+
+    public function isAutoScalingEnabled(): bool
+    {
+        return (bool) ($this->info['enableAutoScaling'] ?? false);
+    }
+
+    public function isFailoverEnabled(): bool
+    {
+        return (bool) ($this->info['failoverEnabled'] ?? false);
+    }
+
+    public function getActiveRegion(): ?string
+    {
+        return isset($this->info['activeRegion']) ? (string) $this->info['activeRegion'] : null;
+    }
+
+    public function getWorkspaceDefaultRegion(): ?string
+    {
+        return isset($this->info['workspaceDefaultRegion']) ? (string) $this->info['workspaceDefaultRegion'] : null;
+    }
+
+    public function getLastStateChange(): ?UTCDateTimeInterface
+    {
+        $value = $this->info['lastStateChange'] ?? null;
+
+        return $value instanceof UTCDateTimeInterface ? $value : null;
+    }
+
+    public function getLastModifiedAt(): ?UTCDateTimeInterface
+    {
+        $value = $this->info['lastModifiedAt'] ?? null;
+
+        return $value instanceof UTCDateTimeInterface ? $value : null;
+    }
+
+    public function getModifiedBy(): ?string
+    {
+        return isset($this->info['modifiedBy']) ? (string) $this->info['modifiedBy'] : null;
+    }
+
+    public function hasStarted(): bool
+    {
+        return (bool) ($this->info['hasStarted'] ?? false);
+    }
+
+    /**
+     * Error message. Per spec this is always present; an empty string indicates
+     * no error has occurred.
+     */
+    public function getErrorMsg(): string
+    {
+        return (string) ($this->info['errorMsg'] ?? '');
+    }
+
+    public function isErrorRetryable(): bool
+    {
+        return (bool) ($this->info['errorRetryable'] ?? false);
+    }
+
+    public function getErrorCode(): ?int
+    {
+        return isset($this->info['errorCode']) ? (int) $this->info['errorCode'] : null;
+    }
+
+    /** @see https://php.net/arrayaccess.offsetexists */
+    public function offsetExists(mixed $offset): bool
+    {
+        return array_key_exists($offset, $this->info);
+    }
+
+    /** @see https://php.net/arrayaccess.offsetget */
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->info[$offset];
+    }
+
+    /** @see https://php.net/arrayaccess.offsetset */
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        throw BadMethodCallException::classIsImmutable(self::class);
+    }
+
+    /** @see https://php.net/arrayaccess.offsetunset */
+    public function offsetUnset(mixed $offset): void
+    {
+        throw BadMethodCallException::classIsImmutable(self::class);
+    }
+}

--- a/src/Model/StreamProcessorInfo.php
+++ b/src/Model/StreamProcessorInfo.php
@@ -112,6 +112,7 @@ final class StreamProcessorInfo implements ArrayAccess
 
     public function getLastStateChange(): ?UTCDateTimeInterface
     {
+        /** @psalm-suppress MixedAssignment */
         $value = $this->info['lastStateChange'] ?? null;
 
         return $value instanceof UTCDateTimeInterface ? $value : null;
@@ -119,6 +120,7 @@ final class StreamProcessorInfo implements ArrayAccess
 
     public function getLastModifiedAt(): ?UTCDateTimeInterface
     {
+        /** @psalm-suppress MixedAssignment */
         $value = $this->info['lastModifiedAt'] ?? null;
 
         return $value instanceof UTCDateTimeInterface ? $value : null;

--- a/src/Model/StreamProcessorInfo.php
+++ b/src/Model/StreamProcessorInfo.php
@@ -44,6 +44,30 @@ final class StreamProcessorInfo implements ArrayAccess
         return $this->info;
     }
 
+    public function getActiveRegion(): ?string
+    {
+        return isset($this->info['activeRegion']) ? (string) $this->info['activeRegion'] : null;
+    }
+
+    public function getDlq(): mixed
+    {
+        return $this->info['dlq'] ?? null;
+    }
+
+    public function getErrorCode(): ?int
+    {
+        return isset($this->info['errorCode']) ? (int) $this->info['errorCode'] : null;
+    }
+
+    /**
+     * Error message. Per spec this is always present; an empty string indicates
+     * no error has occurred.
+     */
+    public function getErrorMsg(): string
+    {
+        return (string) ($this->info['errorMsg'] ?? '');
+    }
+
     /**
      * Processor id. Optional: not returned by all server versions.
      */
@@ -52,14 +76,30 @@ final class StreamProcessorInfo implements ArrayAccess
         return isset($this->info['id']) ? (string) $this->info['id'] : null;
     }
 
+    public function getLastModifiedAt(): ?UTCDateTimeInterface
+    {
+        /** @psalm-suppress MixedAssignment */
+        $value = $this->info['lastModifiedAt'] ?? null;
+
+        return $value instanceof UTCDateTimeInterface ? $value : null;
+    }
+
+    public function getLastStateChange(): ?UTCDateTimeInterface
+    {
+        /** @psalm-suppress MixedAssignment */
+        $value = $this->info['lastStateChange'] ?? null;
+
+        return $value instanceof UTCDateTimeInterface ? $value : null;
+    }
+
+    public function getModifiedBy(): ?string
+    {
+        return isset($this->info['modifiedBy']) ? (string) $this->info['modifiedBy'] : null;
+    }
+
     public function getName(): string
     {
         return (string) $this->info['name'];
-    }
-
-    public function getState(): string
-    {
-        return (string) $this->info['state'];
     }
 
     public function getPipeline(): array
@@ -75,14 +115,9 @@ final class StreamProcessorInfo implements ArrayAccess
         return isset($this->info['pipelineVersion']) ? (int) $this->info['pipelineVersion'] : null;
     }
 
-    public function getTier(): ?string
+    public function getState(): string
     {
-        return isset($this->info['tier']) ? (string) $this->info['tier'] : null;
-    }
-
-    public function getDlq(): mixed
-    {
-        return $this->info['dlq'] ?? null;
+        return (string) $this->info['state'];
     }
 
     public function getStreamMetaFieldName(): ?string
@@ -90,19 +125,9 @@ final class StreamProcessorInfo implements ArrayAccess
         return isset($this->info['streamMetaFieldName']) ? (string) $this->info['streamMetaFieldName'] : null;
     }
 
-    public function isAutoScalingEnabled(): bool
+    public function getTier(): ?string
     {
-        return (bool) ($this->info['enableAutoScaling'] ?? false);
-    }
-
-    public function isFailoverEnabled(): bool
-    {
-        return (bool) ($this->info['failoverEnabled'] ?? false);
-    }
-
-    public function getActiveRegion(): ?string
-    {
-        return isset($this->info['activeRegion']) ? (string) $this->info['activeRegion'] : null;
+        return isset($this->info['tier']) ? (string) $this->info['tier'] : null;
     }
 
     public function getWorkspaceDefaultRegion(): ?string
@@ -110,39 +135,14 @@ final class StreamProcessorInfo implements ArrayAccess
         return isset($this->info['workspaceDefaultRegion']) ? (string) $this->info['workspaceDefaultRegion'] : null;
     }
 
-    public function getLastStateChange(): ?UTCDateTimeInterface
-    {
-        /** @psalm-suppress MixedAssignment */
-        $value = $this->info['lastStateChange'] ?? null;
-
-        return $value instanceof UTCDateTimeInterface ? $value : null;
-    }
-
-    public function getLastModifiedAt(): ?UTCDateTimeInterface
-    {
-        /** @psalm-suppress MixedAssignment */
-        $value = $this->info['lastModifiedAt'] ?? null;
-
-        return $value instanceof UTCDateTimeInterface ? $value : null;
-    }
-
-    public function getModifiedBy(): ?string
-    {
-        return isset($this->info['modifiedBy']) ? (string) $this->info['modifiedBy'] : null;
-    }
-
     public function hasStarted(): bool
     {
         return (bool) ($this->info['hasStarted'] ?? false);
     }
 
-    /**
-     * Error message. Per spec this is always present; an empty string indicates
-     * no error has occurred.
-     */
-    public function getErrorMsg(): string
+    public function isAutoScalingEnabled(): bool
     {
-        return (string) ($this->info['errorMsg'] ?? '');
+        return (bool) ($this->info['enableAutoScaling'] ?? false);
     }
 
     public function isErrorRetryable(): bool
@@ -150,9 +150,9 @@ final class StreamProcessorInfo implements ArrayAccess
         return (bool) ($this->info['errorRetryable'] ?? false);
     }
 
-    public function getErrorCode(): ?int
+    public function isFailoverEnabled(): bool
     {
-        return isset($this->info['errorCode']) ? (int) $this->info['errorCode'] : null;
+        return (bool) ($this->info['failoverEnabled'] ?? false);
     }
 
     /** @see https://php.net/arrayaccess.offsetexists */

--- a/src/Model/StreamProcessorSamples.php
+++ b/src/Model/StreamProcessorSamples.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Model;
+
+/**
+ * Result of a call to MongoDB\StreamProcessor::getStreamProcessorSamples().
+ *
+ * Callers MUST check the cursorId: a value of 0 indicates the cursor is
+ * exhausted and no further calls should be made.
+ */
+final class StreamProcessorSamples
+{
+    /**
+     * @param int   $cursorId  Cursor id to pass to the next call (0 when exhausted).
+     * @param array $documents Sampled documents returned by this call.
+     */
+    public function __construct(private int $cursorId, private array $documents)
+    {
+    }
+
+    public function getCursorId(): int
+    {
+        return $this->cursorId;
+    }
+
+    public function getDocuments(): array
+    {
+        return $this->documents;
+    }
+
+    public function isExhausted(): bool
+    {
+        return $this->cursorId === 0;
+    }
+}

--- a/src/Operation/StreamProcessing/CreateStreamProcessor.php
+++ b/src/Operation/StreamProcessing/CreateStreamProcessor.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Operation\StreamProcessing;
+
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
+use MongoDB\Exception\InvalidArgumentException;
+
+use function is_bool;
+use function is_string;
+use function MongoDB\is_document;
+
+/**
+ * Operation for the createStreamProcessor command.
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-stream-processing/
+ */
+final class CreateStreamProcessor
+{
+    /**
+     * Constructs a createStreamProcessor command.
+     *
+     * Supported options:
+     *
+     *  * dlq (document): Dead letter queue configuration.
+     *
+     *  * streamMetaFieldName (string): Field name used for stream metadata.
+     *
+     *  * tier (string): Compute tier (e.g. "SP2", "SP5", "SP10", "SP30", "SP50").
+     *
+     *  * failover (bool): Whether failover is enabled.
+     *
+     * @param string $name     Stream processor name
+     * @param array  $pipeline Aggregation pipeline
+     * @param array  $options  Command options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     */
+    public function __construct(private string $name, private array $pipeline, private array $options = [])
+    {
+        if (isset($options['dlq']) && ! is_document($options['dlq'])) {
+            throw InvalidArgumentException::invalidType('"dlq" option', $options['dlq'], 'document');
+        }
+
+        if (isset($options['streamMetaFieldName']) && ! is_string($options['streamMetaFieldName'])) {
+            throw InvalidArgumentException::invalidType('"streamMetaFieldName" option', $options['streamMetaFieldName'], 'string');
+        }
+
+        if (isset($options['tier']) && ! is_string($options['tier'])) {
+            throw InvalidArgumentException::invalidType('"tier" option', $options['tier'], 'string');
+        }
+
+        if (isset($options['failover']) && ! is_bool($options['failover'])) {
+            throw InvalidArgumentException::invalidType('"failover" option', $options['failover'], 'bool');
+        }
+    }
+
+    /**
+     * Execute the operation.
+     *
+     * @throws DriverRuntimeException for driver errors (e.g. connection errors)
+     */
+    public function execute(Server $server): void
+    {
+        $server->executeCommand('admin', $this->createCommand());
+    }
+
+    private function createCommand(): Command
+    {
+        $cmd = [
+            'createStreamProcessor' => $this->name,
+            'pipeline' => $this->pipeline,
+        ];
+
+        $subOptions = [];
+
+        foreach (['dlq', 'streamMetaFieldName', 'tier', 'failover'] as $key) {
+            if (isset($this->options[$key])) {
+                $subOptions[$key] = $this->options[$key];
+            }
+        }
+
+        if ($subOptions !== []) {
+            $cmd['options'] = (object) $subOptions;
+        }
+
+        return new Command($cmd);
+    }
+}

--- a/src/Operation/StreamProcessing/CreateStreamProcessor.php
+++ b/src/Operation/StreamProcessing/CreateStreamProcessor.php
@@ -91,6 +91,7 @@ final class CreateStreamProcessor
 
         foreach (['dlq', 'streamMetaFieldName', 'tier', 'failover'] as $key) {
             if (isset($this->options[$key])) {
+                /** @psalm-suppress MixedAssignment */
                 $subOptions[$key] = $this->options[$key];
             }
         }

--- a/src/Operation/StreamProcessing/DropStreamProcessor.php
+++ b/src/Operation/StreamProcessing/DropStreamProcessor.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Operation\StreamProcessing;
+
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
+
+/**
+ * Operation for the dropStreamProcessor command. A dropped processor cannot be recovered.
+ */
+final class DropStreamProcessor
+{
+    public function __construct(private string $name)
+    {
+    }
+
+    /** @throws DriverRuntimeException for driver errors (e.g. connection errors) */
+    public function execute(Server $server): void
+    {
+        $server->executeCommand('admin', new Command(['dropStreamProcessor' => $this->name]));
+    }
+}

--- a/src/Operation/StreamProcessing/GetMoreSampleStreamProcessor.php
+++ b/src/Operation/StreamProcessing/GetMoreSampleStreamProcessor.php
@@ -70,9 +70,13 @@ final class GetMoreSampleStreamProcessor
             throw new UnexpectedValueException('getMoreSampleStreamProcessor command did not return a cursorId');
         }
 
-        /* Dev-server deviation: some server builds use "messages" instead of
+        /**
+         * Dev-server deviation: some server builds use "messages" instead of
          * "nextBatch". Prefer the spec-defined "nextBatch" but fall back to
-         * "messages" if present. */
+         * "messages" if present.
+         *
+         * @psalm-suppress MixedAssignment
+         */
         $batch = $response['nextBatch'] ?? $response['messages'] ?? [];
         if (! is_array($batch)) {
             $batch = [];
@@ -89,6 +93,7 @@ final class GetMoreSampleStreamProcessor
         ];
 
         if (isset($this->options['batchSize'])) {
+            /** @psalm-suppress MixedAssignment */
             $cmd['batchSize'] = $this->options['batchSize'];
         }
 

--- a/src/Operation/StreamProcessing/GetMoreSampleStreamProcessor.php
+++ b/src/Operation/StreamProcessing/GetMoreSampleStreamProcessor.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Operation\StreamProcessing;
+
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Model\StreamProcessorSamples;
+
+use function current;
+use function is_array;
+use function is_int;
+use function iterator_to_array;
+
+/**
+ * Operation for the getMoreSampleStreamProcessor command.
+ *
+ * This is the second phase of the custom two-phase sample cursor; it is NOT
+ * implemented using the standard MongoDB getMore command.
+ */
+final class GetMoreSampleStreamProcessor
+{
+    /**
+     * Supported options:
+     *
+     *  * batchSize (integer): Number of documents to return in the batch.
+     *
+     * @param string $name     Stream processor name
+     * @param int    $cursorId The cursorId returned by startSampleStreamProcessor or a prior getMore call.
+     * @param array  $options  Command options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     */
+    public function __construct(private string $name, private int $cursorId, private array $options = [])
+    {
+        if (isset($options['batchSize']) && ! is_int($options['batchSize'])) {
+            throw InvalidArgumentException::invalidType('"batchSize" option', $options['batchSize'], 'integer');
+        }
+    }
+
+    /**
+     * Execute the operation.
+     *
+     * @throws UnexpectedValueException if the response is malformed
+     * @throws DriverRuntimeException   for driver errors (e.g. connection errors)
+     */
+    public function execute(Server $server): StreamProcessorSamples
+    {
+        $cursor = $server->executeCommand('admin', $this->createCommand());
+        $cursor->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
+
+        $response = current(iterator_to_array($cursor));
+        if (! is_array($response) || ! isset($response['cursorId'])) {
+            throw new UnexpectedValueException('getMoreSampleStreamProcessor command did not return a cursorId');
+        }
+
+        /* Dev-server deviation: some server builds use "messages" instead of
+         * "nextBatch". Prefer the spec-defined "nextBatch" but fall back to
+         * "messages" if present. */
+        $batch = $response['nextBatch'] ?? $response['messages'] ?? [];
+        if (! is_array($batch)) {
+            $batch = [];
+        }
+
+        return new StreamProcessorSamples((int) $response['cursorId'], $batch);
+    }
+
+    private function createCommand(): Command
+    {
+        $cmd = [
+            'getMoreSampleStreamProcessor' => $this->name,
+            'cursorId' => $this->cursorId,
+        ];
+
+        if (isset($this->options['batchSize'])) {
+            $cmd['batchSize'] = $this->options['batchSize'];
+        }
+
+        return new Command($cmd);
+    }
+}

--- a/src/Operation/StreamProcessing/GetStreamProcessor.php
+++ b/src/Operation/StreamProcessing/GetStreamProcessor.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Operation\StreamProcessing;
+
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
+use MongoDB\Exception\UnexpectedValueException;
+use MongoDB\Model\StreamProcessorInfo;
+
+use function current;
+use function is_array;
+use function iterator_to_array;
+
+/**
+ * Operation for the getStreamProcessor command.
+ */
+final class GetStreamProcessor
+{
+    public function __construct(private string $name)
+    {
+    }
+
+    /**
+     * Execute the operation.
+     *
+     * @throws UnexpectedValueException if the server response is malformed
+     * @throws DriverRuntimeException   for driver errors (e.g. connection errors)
+     */
+    public function execute(Server $server): StreamProcessorInfo
+    {
+        $cursor = $server->executeReadCommand('admin', new Command(['getStreamProcessor' => $this->name]));
+        $cursor->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
+
+        $response = current(iterator_to_array($cursor));
+        if (! is_array($response)) {
+            throw new UnexpectedValueException('getStreamProcessor command returned no response');
+        }
+
+        /* Dev-server deviation: some server builds wrap the processor document in
+         * a top-level "result" key. Unwrap if present so the rest of the driver
+         * sees a flat document matching the spec. */
+        if (isset($response['result']) && is_array($response['result'])) {
+            $response = $response['result'] + $response;
+            unset($response['result']);
+        }
+
+        return new StreamProcessorInfo($response);
+    }
+}

--- a/src/Operation/StreamProcessing/GetStreamProcessorStats.php
+++ b/src/Operation/StreamProcessing/GetStreamProcessorStats.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Operation\StreamProcessing;
+
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnexpectedValueException;
+
+use function current;
+use function is_array;
+use function is_bool;
+use function iterator_to_array;
+
+/**
+ * Operation for the getStreamProcessorStats command.
+ */
+final class GetStreamProcessorStats
+{
+    /**
+     * Supported options:
+     *
+     *  * verbose (bool): If true, includes per-operator statistics.
+     *
+     * @param string $name    Stream processor name
+     * @param array  $options Command options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     */
+    public function __construct(private string $name, private array $options = [])
+    {
+        if (isset($options['verbose']) && ! is_bool($options['verbose'])) {
+            throw InvalidArgumentException::invalidType('"verbose" option', $options['verbose'], 'bool');
+        }
+    }
+
+    /**
+     * Execute the operation.
+     *
+     * @throws UnexpectedValueException if the server response is malformed
+     * @throws DriverRuntimeException   for driver errors (e.g. connection errors)
+     */
+    public function execute(Server $server): array
+    {
+        $cursor = $server->executeReadCommand('admin', $this->createCommand());
+        $cursor->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
+
+        $response = current(iterator_to_array($cursor));
+        if (! is_array($response)) {
+            throw new UnexpectedValueException('getStreamProcessorStats command returned no response');
+        }
+
+        return $response;
+    }
+
+    private function createCommand(): Command
+    {
+        $cmd = ['getStreamProcessorStats' => $this->name];
+
+        if (isset($this->options['verbose'])) {
+            $cmd['options'] = (object) ['verbose' => $this->options['verbose']];
+        }
+
+        return new Command($cmd);
+    }
+}

--- a/src/Operation/StreamProcessing/StartSampleStreamProcessor.php
+++ b/src/Operation/StreamProcessing/StartSampleStreamProcessor.php
@@ -78,6 +78,7 @@ final class StartSampleStreamProcessor
         $cmd = ['startSampleStreamProcessor' => $this->name];
 
         if (isset($this->options['limit'])) {
+            /** @psalm-suppress MixedAssignment */
             $cmd['limit'] = $this->options['limit'];
         }
 

--- a/src/Operation/StreamProcessing/StartSampleStreamProcessor.php
+++ b/src/Operation/StreamProcessing/StartSampleStreamProcessor.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Operation\StreamProcessing;
+
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Exception\UnexpectedValueException;
+
+use function current;
+use function is_array;
+use function is_int;
+use function iterator_to_array;
+
+/**
+ * Operation for the startSampleStreamProcessor command.
+ *
+ * Returns the int64 cursorId used by GetMoreSampleStreamProcessor to retrieve
+ * the first batch of sampled documents. The startSampleStreamProcessor command
+ * itself does not return any documents.
+ */
+final class StartSampleStreamProcessor
+{
+    /**
+     * Supported options:
+     *
+     *  * limit (integer): Maximum number of documents to sample.
+     *
+     * @param string $name    Stream processor name
+     * @param array  $options Command options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     */
+    public function __construct(private string $name, private array $options = [])
+    {
+        if (isset($options['limit']) && ! is_int($options['limit'])) {
+            throw InvalidArgumentException::invalidType('"limit" option', $options['limit'], 'integer');
+        }
+    }
+
+    /**
+     * Execute the operation.
+     *
+     * @return int The cursorId returned by the server.
+     * @throws UnexpectedValueException if the response is missing cursorId
+     * @throws DriverRuntimeException   for driver errors (e.g. connection errors)
+     */
+    public function execute(Server $server): int
+    {
+        $cursor = $server->executeCommand('admin', $this->createCommand());
+        $cursor->setTypeMap(['root' => 'array', 'document' => 'array', 'array' => 'array']);
+
+        $response = current(iterator_to_array($cursor));
+        if (! is_array($response) || ! isset($response['cursorId'])) {
+            throw new UnexpectedValueException('startSampleStreamProcessor command did not return a cursorId');
+        }
+
+        return (int) $response['cursorId'];
+    }
+
+    private function createCommand(): Command
+    {
+        $cmd = ['startSampleStreamProcessor' => $this->name];
+
+        if (isset($this->options['limit'])) {
+            $cmd['limit'] = $this->options['limit'];
+        }
+
+        return new Command($cmd);
+    }
+}

--- a/src/Operation/StreamProcessing/StartStreamProcessor.php
+++ b/src/Operation/StreamProcessing/StartStreamProcessor.php
@@ -1,0 +1,162 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Operation\StreamProcessing;
+
+use MongoDB\BSON\Timestamp;
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
+use MongoDB\Exception\InvalidArgumentException;
+
+use function implode;
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_int;
+use function is_string;
+use function sprintf;
+
+/**
+ * Operation for the startStreamProcessor command.
+ *
+ * @see https://www.mongodb.com/docs/atlas/atlas-stream-processing/
+ */
+final class StartStreamProcessor
+{
+    private const VALID_FAILOVER_MODES = ['GRACEFUL', 'FORCED'];
+
+    /**
+     * Constructs a startStreamProcessor command.
+     *
+     * Supported options:
+     *
+     *  * workers (integer): Number of workers.
+     *
+     *  * clearCheckpoints (bool): Clear checkpoints before starting.
+     *
+     *  * startAtOperationTime (MongoDB\BSON\Timestamp): Resume from a specific
+     *    operation time.
+     *
+     *  * tier (string): Compute tier. One of "SP2", "SP5", "SP10", "SP30", "SP50".
+     *
+     *  * enableAutoScaling (bool): Enable auto-scaling.
+     *
+     *  * failover (array): Failover configuration. The "region" key is required.
+     *    Optional "mode" must be "GRACEFUL" (default) or "FORCED". Optional
+     *    "dryRun" validates without executing.
+     *
+     * Note: the spec's "startAfter" option is RESERVED for future use and is not
+     * yet accepted by the server; this driver MUST NOT send it.
+     *
+     * @param string $name    Stream processor name
+     * @param array  $options Command options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     */
+    public function __construct(private string $name, private array $options = [])
+    {
+        if (isset($options['workers']) && ! is_int($options['workers'])) {
+            throw InvalidArgumentException::invalidType('"workers" option', $options['workers'], 'integer');
+        }
+
+        if (isset($options['clearCheckpoints']) && ! is_bool($options['clearCheckpoints'])) {
+            throw InvalidArgumentException::invalidType('"clearCheckpoints" option', $options['clearCheckpoints'], 'bool');
+        }
+
+        if (isset($options['startAtOperationTime']) && ! $options['startAtOperationTime'] instanceof Timestamp) {
+            throw InvalidArgumentException::invalidType('"startAtOperationTime" option', $options['startAtOperationTime'], Timestamp::class);
+        }
+
+        if (isset($options['tier']) && ! is_string($options['tier'])) {
+            throw InvalidArgumentException::invalidType('"tier" option', $options['tier'], 'string');
+        }
+
+        if (isset($options['enableAutoScaling']) && ! is_bool($options['enableAutoScaling'])) {
+            throw InvalidArgumentException::invalidType('"enableAutoScaling" option', $options['enableAutoScaling'], 'bool');
+        }
+
+        if (isset($options['failover'])) {
+            self::validateFailover($options['failover']);
+        }
+    }
+
+    /**
+     * Execute the operation.
+     *
+     * @throws DriverRuntimeException for driver errors (e.g. connection errors)
+     */
+    public function execute(Server $server): void
+    {
+        $server->executeCommand('admin', $this->createCommand());
+    }
+
+    private function createCommand(): Command
+    {
+        $cmd = ['startStreamProcessor' => $this->name];
+
+        if (isset($this->options['workers'])) {
+            $cmd['workers'] = $this->options['workers'];
+        }
+
+        $subOptions = [];
+
+        foreach (['clearCheckpoints', 'startAtOperationTime', 'tier', 'enableAutoScaling'] as $key) {
+            if (isset($this->options[$key])) {
+                $subOptions[$key] = $this->options[$key];
+            }
+        }
+
+        if ($subOptions !== []) {
+            $cmd['options'] = (object) $subOptions;
+        }
+
+        if (isset($this->options['failover'])) {
+            $cmd['failover'] = (object) $this->options['failover'];
+        }
+
+        return new Command($cmd);
+    }
+
+    private static function validateFailover(mixed $failover): void
+    {
+        if (! is_array($failover)) {
+            throw InvalidArgumentException::invalidType('"failover" option', $failover, 'array');
+        }
+
+        if (! isset($failover['region']) || ! is_string($failover['region'])) {
+            throw new InvalidArgumentException('"failover" option requires a "region" string');
+        }
+
+        if (isset($failover['mode'])) {
+            if (! is_string($failover['mode'])) {
+                throw InvalidArgumentException::invalidType('"failover.mode" option', $failover['mode'], 'string');
+            }
+
+            if (! in_array($failover['mode'], self::VALID_FAILOVER_MODES, true)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid "failover.mode" value "%s"; expected one of: %s',
+                    $failover['mode'],
+                    implode(', ', self::VALID_FAILOVER_MODES),
+                ));
+            }
+        }
+
+        if (isset($failover['dryRun']) && ! is_bool($failover['dryRun'])) {
+            throw InvalidArgumentException::invalidType('"failover.dryRun" option', $failover['dryRun'], 'bool');
+        }
+    }
+}

--- a/src/Operation/StreamProcessing/StartStreamProcessor.php
+++ b/src/Operation/StreamProcessing/StartStreamProcessor.php
@@ -109,6 +109,7 @@ final class StartStreamProcessor
         $cmd = ['startStreamProcessor' => $this->name];
 
         if (isset($this->options['workers'])) {
+            /** @psalm-suppress MixedAssignment */
             $cmd['workers'] = $this->options['workers'];
         }
 
@@ -116,6 +117,7 @@ final class StartStreamProcessor
 
         foreach (['clearCheckpoints', 'startAtOperationTime', 'tier', 'enableAutoScaling'] as $key) {
             if (isset($this->options[$key])) {
+                /** @psalm-suppress MixedAssignment */
                 $subOptions[$key] = $this->options[$key];
             }
         }

--- a/src/Operation/StreamProcessing/StopStreamProcessor.php
+++ b/src/Operation/StreamProcessing/StopStreamProcessor.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Operation\StreamProcessing;
+
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use MongoDB\Driver\Server;
+
+/**
+ * Operation for the stopStreamProcessor command.
+ */
+final class StopStreamProcessor
+{
+    public function __construct(private string $name)
+    {
+    }
+
+    /** @throws DriverRuntimeException for driver errors (e.g. connection errors) */
+    public function execute(Server $server): void
+    {
+        $server->executeCommand('admin', new Command(['stopStreamProcessor' => $this->name]));
+    }
+}

--- a/src/StreamProcessingClient.php
+++ b/src/StreamProcessingClient.php
@@ -1,0 +1,142 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB;
+
+use MongoDB\Driver\Exception\InvalidArgumentException as DriverInvalidArgumentException;
+use MongoDB\Driver\Manager;
+use MongoDB\Exception\InvalidArgumentException;
+use Stringable;
+
+use function preg_match;
+use function strtolower;
+
+/**
+ * Client for an Atlas Stream Processing workspace.
+ *
+ * Workspace endpoints share the mongodb:// URI scheme with standard MongoDB
+ * clusters but follow a distinct hostname pattern:
+ *
+ *     mongodb://atlas-stream-<workspaceId>-<suffix>.<region>.a.query.mongodb.net/
+ *
+ * Per the ASP spec, TLS is required and authSource defaults to "admin".
+ */
+final class StreamProcessingClient implements Stringable
+{
+    /**
+     * Pattern used to detect a workspace endpoint hostname.
+     *
+     * Matches hosts that start with "atlas-stream-" and end with
+     * ".a.query.mongodb.net" (case-insensitive). Either marker is sufficient
+     * for detection but both together provide a strong signal.
+     */
+    private const WORKSPACE_HOSTNAME_PATTERN = '#^mongodb://[^/?]*atlas-stream-[^/?]*\.a\.query\.mongodb\.net(?::\d+)?(/|$|\?)#i';
+
+    private Manager $manager;
+
+    /**
+     * @param string $uri           Workspace connection string
+     * @param array  $uriOptions    Additional connection string options
+     * @param array  $driverOptions Driver-specific options
+     * @throws InvalidArgumentException       if TLS is disabled or the URI is not a workspace endpoint
+     * @throws DriverInvalidArgumentException for parameter/option parsing errors in the driver
+     */
+    public function __construct(private string $uri, array $uriOptions = [], array $driverOptions = [])
+    {
+        if (! self::isWorkspaceUri($uri)) {
+            throw new InvalidArgumentException(
+                'StreamProcessingClient requires a workspace endpoint URI (atlas-stream-*.a.query.mongodb.net). '
+                . 'For standard MongoDB clusters use MongoDB\\Client instead.',
+            );
+        }
+
+        // mongodb+srv:// is not applicable for workspace endpoints
+        if (preg_match('#^mongodb\+srv://#i', $uri)) {
+            throw new InvalidArgumentException('mongodb+srv:// is not supported for workspace endpoints; use mongodb://');
+        }
+
+        $uriOptions = self::applyWorkspaceDefaults($uriOptions);
+
+        $this->manager = new Manager($uri, $uriOptions, $driverOptions);
+    }
+
+    /**
+     * Return the workspace URI.
+     */
+    public function __toString(): string
+    {
+        return $this->uri;
+    }
+
+    public function __debugInfo(): array
+    {
+        return [
+            'manager' => $this->manager,
+            'uri' => $this->uri,
+        ];
+    }
+
+    /**
+     * Return the underlying Manager for advanced uses (e.g. runCommand).
+     */
+    public function getManager(): Manager
+    {
+        return $this->manager;
+    }
+
+    /**
+     * Return a handle for managing stream processors in this workspace.
+     */
+    public function streamProcessors(): StreamProcessors
+    {
+        return new StreamProcessors($this->manager);
+    }
+
+    /**
+     * Return true if the supplied URI targets an Atlas Stream Processing workspace endpoint.
+     */
+    public static function isWorkspaceUri(string $uri): bool
+    {
+        return (bool) preg_match(self::WORKSPACE_HOSTNAME_PATTERN, $uri);
+    }
+
+    /**
+     * Apply workspace defaults to user-supplied URI options.
+     *
+     * Per spec, TLS is required and MUST NOT be disabled. authSource defaults
+     * to "admin" but MAY be overridden by the caller.
+     *
+     * @throws InvalidArgumentException if the caller has explicitly disabled TLS
+     */
+    private static function applyWorkspaceDefaults(array $uriOptions): array
+    {
+        foreach ($uriOptions as $key => $value) {
+            if (strtolower((string) $key) === 'tls' && $value === false) {
+                throw new InvalidArgumentException('TLS cannot be disabled for an Atlas Stream Processing workspace connection');
+            }
+
+            if (strtolower((string) $key) === 'ssl' && $value === false) {
+                throw new InvalidArgumentException('TLS cannot be disabled for an Atlas Stream Processing workspace connection');
+            }
+        }
+
+        $uriOptions['tls'] ??= true;
+        $uriOptions['authSource'] ??= 'admin';
+
+        return $uriOptions;
+    }
+}

--- a/src/StreamProcessingClient.php
+++ b/src/StreamProcessingClient.php
@@ -74,20 +74,20 @@ final class StreamProcessingClient implements Stringable
         $this->manager = new Manager($uri, $uriOptions, $driverOptions);
     }
 
-    /**
-     * Return the workspace URI.
-     */
-    public function __toString(): string
-    {
-        return $this->uri;
-    }
-
     public function __debugInfo(): array
     {
         return [
             'manager' => $this->manager,
             'uri' => $this->uri,
         ];
+    }
+
+    /**
+     * Return the workspace URI.
+     */
+    public function __toString(): string
+    {
+        return $this->uri;
     }
 
     /**
@@ -99,19 +99,19 @@ final class StreamProcessingClient implements Stringable
     }
 
     /**
-     * Return a handle for managing stream processors in this workspace.
-     */
-    public function streamProcessors(): StreamProcessors
-    {
-        return new StreamProcessors($this->manager);
-    }
-
-    /**
      * Return true if the supplied URI targets an Atlas Stream Processing workspace endpoint.
      */
     public static function isWorkspaceUri(string $uri): bool
     {
         return (bool) preg_match(self::WORKSPACE_HOSTNAME_PATTERN, $uri);
+    }
+
+    /**
+     * Return a handle for managing stream processors in this workspace.
+     */
+    public function streamProcessors(): StreamProcessors
+    {
+        return new StreamProcessors($this->manager);
     }
 
     /**

--- a/src/StreamProcessingClient.php
+++ b/src/StreamProcessingClient.php
@@ -121,6 +121,7 @@ final class StreamProcessingClient implements Stringable
      * to "admin" but MAY be overridden by the caller.
      *
      * @throws InvalidArgumentException if the caller has explicitly disabled TLS
+     * @psalm-suppress MixedAssignment
      */
     private static function applyWorkspaceDefaults(array $uriOptions): array
     {

--- a/src/StreamProcessingClient.php
+++ b/src/StreamProcessingClient.php
@@ -33,6 +33,9 @@ use function strtolower;
  *
  *     mongodb://atlas-stream-<workspaceId>-<suffix>.<region>.a.query.mongodb.net/
  *
+ * Atlas staging endpoints use `.a.query.mongodb-stage.net` instead; both are
+ * accepted.
+ *
  * Per the ASP spec, TLS is required and authSource defaults to "admin".
  */
 final class StreamProcessingClient implements Stringable
@@ -41,10 +44,10 @@ final class StreamProcessingClient implements Stringable
      * Pattern used to detect a workspace endpoint hostname.
      *
      * Matches hosts that start with "atlas-stream-" and end with
-     * ".a.query.mongodb.net" (case-insensitive). Either marker is sufficient
-     * for detection but both together provide a strong signal.
+     * ".a.query.mongodb.net" (production) or ".a.query.mongodb-<env>.net"
+     * (e.g. mongodb-stage.net for Atlas staging). Case-insensitive.
      */
-    private const WORKSPACE_HOSTNAME_PATTERN = '#^mongodb://[^/?]*atlas-stream-[^/?]*\.a\.query\.mongodb\.net(?::\d+)?(/|$|\?)#i';
+    private const WORKSPACE_HOSTNAME_PATTERN = '#^mongodb://[^/?]*atlas-stream-[^/?]*\.a\.query\.mongodb(?:-[a-z0-9]+)?\.net(?::\d+)?(/|$|\?)#i';
 
     private Manager $manager;
 

--- a/src/StreamProcessor.php
+++ b/src/StreamProcessor.php
@@ -49,33 +49,6 @@ final class StreamProcessor
         }
     }
 
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    /**
-     * Start the processor.
-     *
-     * @see StartStreamProcessor::__construct() for supported options
-     */
-    public function start(array $options = []): void
-    {
-        $operation = new StartStreamProcessor($this->name, $options);
-        $server = select_server_for_write($this->manager, []);
-        $operation->execute($server);
-    }
-
-    /**
-     * Stop the processor. The processor remains in STOPPED state and can be restarted.
-     */
-    public function stop(): void
-    {
-        $operation = new StopStreamProcessor($this->name);
-        $server = select_server_for_write($this->manager, []);
-        $operation->execute($server);
-    }
-
     /**
      * Drop the processor permanently. A dropped processor cannot be recovered.
      */
@@ -86,17 +59,9 @@ final class StreamProcessor
         $operation->execute($server);
     }
 
-    /**
-     * Return runtime statistics for the processor.
-     *
-     * @see GetStreamProcessorStats::__construct() for supported options
-     */
-    public function stats(array $options = []): array
+    public function getName(): string
     {
-        $operation = new GetStreamProcessorStats($this->name, $options);
-        $server = select_server_for_write($this->manager, []);
-
-        return $operation->execute($server);
+        return $this->name;
     }
 
     /**
@@ -135,5 +100,40 @@ final class StreamProcessor
         $operation = new GetMoreSampleStreamProcessor($this->name, $cursorId, $getMoreOptions);
 
         return $operation->execute($server);
+    }
+
+    /**
+     * Start the processor.
+     *
+     * @see StartStreamProcessor::__construct() for supported options
+     */
+    public function start(array $options = []): void
+    {
+        $operation = new StartStreamProcessor($this->name, $options);
+        $server = select_server_for_write($this->manager, []);
+        $operation->execute($server);
+    }
+
+    /**
+     * Return runtime statistics for the processor.
+     *
+     * @see GetStreamProcessorStats::__construct() for supported options
+     */
+    public function stats(array $options = []): array
+    {
+        $operation = new GetStreamProcessorStats($this->name, $options);
+        $server = select_server_for_write($this->manager, []);
+
+        return $operation->execute($server);
+    }
+
+    /**
+     * Stop the processor. The processor remains in STOPPED state and can be restarted.
+     */
+    public function stop(): void
+    {
+        $operation = new StopStreamProcessor($this->name);
+        $server = select_server_for_write($this->manager, []);
+        $operation->execute($server);
     }
 }

--- a/src/StreamProcessor.php
+++ b/src/StreamProcessor.php
@@ -1,0 +1,139 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB;
+
+use MongoDB\Driver\Manager;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\StreamProcessorSamples;
+use MongoDB\Operation\StreamProcessing\DropStreamProcessor;
+use MongoDB\Operation\StreamProcessing\GetMoreSampleStreamProcessor;
+use MongoDB\Operation\StreamProcessing\GetStreamProcessorStats;
+use MongoDB\Operation\StreamProcessing\StartSampleStreamProcessor;
+use MongoDB\Operation\StreamProcessing\StartStreamProcessor;
+use MongoDB\Operation\StreamProcessing\StopStreamProcessor;
+
+use function array_diff_key;
+use function strlen;
+
+/**
+ * Handle for a specific named stream processor.
+ *
+ * Holding a handle does not imply the processor currently exists on the server.
+ */
+final class StreamProcessor
+{
+    /**
+     * @param Manager $manager Driver manager bound to a workspace endpoint
+     * @param string  $name    Stream processor name
+     * @throws InvalidArgumentException if the name is empty
+     */
+    public function __construct(private Manager $manager, private string $name)
+    {
+        if (strlen($name) < 1) {
+            throw new InvalidArgumentException('$name is invalid: ' . $name);
+        }
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Start the processor.
+     *
+     * @see StartStreamProcessor::__construct() for supported options
+     */
+    public function start(array $options = []): void
+    {
+        $operation = new StartStreamProcessor($this->name, $options);
+        $server = select_server_for_write($this->manager, []);
+        $operation->execute($server);
+    }
+
+    /**
+     * Stop the processor. The processor remains in STOPPED state and can be restarted.
+     */
+    public function stop(): void
+    {
+        $operation = new StopStreamProcessor($this->name);
+        $server = select_server_for_write($this->manager, []);
+        $operation->execute($server);
+    }
+
+    /**
+     * Drop the processor permanently. A dropped processor cannot be recovered.
+     */
+    public function drop(): void
+    {
+        $operation = new DropStreamProcessor($this->name);
+        $server = select_server_for_write($this->manager, []);
+        $operation->execute($server);
+    }
+
+    /**
+     * Return runtime statistics for the processor.
+     *
+     * @see GetStreamProcessorStats::__construct() for supported options
+     */
+    public function stats(array $options = []): array
+    {
+        $operation = new GetStreamProcessorStats($this->name, $options);
+        $server = select_server_for_write($this->manager, []);
+
+        return $operation->execute($server);
+    }
+
+    /**
+     * Retrieve a batch of sampled documents.
+     *
+     * Routes to startSampleStreamProcessor when no cursorId is supplied (or
+     * cursorId is 0); otherwise routes to getMoreSampleStreamProcessor with the
+     * supplied cursorId. The caller MUST stop iterating when the returned
+     * cursorId is 0.
+     *
+     * Supported options:
+     *
+     *  * cursorId (integer): The cursor id from a prior call. Absent or 0 opens
+     *    a new sample cursor.
+     *
+     *  * limit (integer): Maximum documents to sample. Only sent on the initial
+     *    call; ignored on subsequent calls.
+     *
+     *  * batchSize (integer): Batch size. Only sent on subsequent calls;
+     *    ignored on the initial call.
+     */
+    public function getStreamProcessorSamples(array $options = []): StreamProcessorSamples
+    {
+        $cursorId = isset($options['cursorId']) ? (int) $options['cursorId'] : 0;
+        $server = select_server_for_write($this->manager, []);
+
+        if ($cursorId === 0) {
+            $startOptions = array_diff_key($options, ['cursorId' => 1, 'batchSize' => 1]);
+            $operation = new StartSampleStreamProcessor($this->name, $startOptions);
+            $newCursorId = $operation->execute($server);
+
+            return new StreamProcessorSamples($newCursorId, []);
+        }
+
+        $getMoreOptions = array_diff_key($options, ['cursorId' => 1, 'limit' => 1]);
+        $operation = new GetMoreSampleStreamProcessor($this->name, $cursorId, $getMoreOptions);
+
+        return $operation->execute($server);
+    }
+}

--- a/src/StreamProcessors.php
+++ b/src/StreamProcessors.php
@@ -1,0 +1,82 @@
+<?php
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB;
+
+use MongoDB\Driver\Manager;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\StreamProcessorInfo;
+use MongoDB\Operation\StreamProcessing\CreateStreamProcessor;
+use MongoDB\Operation\StreamProcessing\GetStreamProcessor;
+
+use function strlen;
+
+/**
+ * Handle for managing stream processors in a workspace.
+ *
+ * Obtained via {@see StreamProcessingClient::streamProcessors()}.
+ */
+final class StreamProcessors
+{
+    public function __construct(private Manager $manager)
+    {
+    }
+
+    /**
+     * Create a new stream processor.
+     *
+     * @see CreateStreamProcessor::__construct() for supported options
+     * @throws InvalidArgumentException for parameter/option parsing errors
+     */
+    public function create(string $name, array $pipeline, array $options = []): void
+    {
+        if (strlen($name) < 1) {
+            throw new InvalidArgumentException('$name is invalid: ' . $name);
+        }
+
+        $operation = new CreateStreamProcessor($name, $pipeline, $options);
+        $server = select_server_for_write($this->manager, []);
+        $operation->execute($server);
+    }
+
+    /**
+     * Return a handle for the named stream processor.
+     *
+     * Does not imply that the processor currently exists on the server.
+     */
+    public function get(string $name): StreamProcessor
+    {
+        return new StreamProcessor($this->manager, $name);
+    }
+
+    /**
+     * Return information about a single stream processor.
+     *
+     * Sends the `getStreamProcessor` command.
+     */
+    public function getInfo(string $name): StreamProcessorInfo
+    {
+        if (strlen($name) < 1) {
+            throw new InvalidArgumentException('$name is invalid: ' . $name);
+        }
+
+        $operation = new GetStreamProcessor($name);
+        $server = select_server_for_write($this->manager, []);
+
+        return $operation->execute($server);
+    }
+}

--- a/tests/StreamProcessing/Operation/CreateStreamProcessorTest.php
+++ b/tests/StreamProcessing/Operation/CreateStreamProcessorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing\Operation;
+
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Operation\StreamProcessing\CreateStreamProcessor;
+use MongoDB\Tests\Operation\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class CreateStreamProcessorTest extends TestCase
+{
+    #[DataProvider('provideInvalidConstructorOptions')]
+    public function testConstructorOptionTypeChecks(array $options): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new CreateStreamProcessor('proc', [], $options);
+    }
+
+    public static function provideInvalidConstructorOptions(): array
+    {
+        return self::createOptionDataProvider([
+            'dlq' => self::getInvalidDocumentValues(),
+            'streamMetaFieldName' => self::getInvalidStringValues(),
+            'tier' => self::getInvalidStringValues(),
+            'failover' => self::getInvalidBooleanValues(),
+        ]);
+    }
+}

--- a/tests/StreamProcessing/Operation/GetMoreSampleStreamProcessorTest.php
+++ b/tests/StreamProcessing/Operation/GetMoreSampleStreamProcessorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing\Operation;
+
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Operation\StreamProcessing\GetMoreSampleStreamProcessor;
+use MongoDB\Tests\Operation\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class GetMoreSampleStreamProcessorTest extends TestCase
+{
+    #[DataProvider('provideInvalidConstructorOptions')]
+    public function testConstructorOptionTypeChecks(array $options): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new GetMoreSampleStreamProcessor('proc', 123, $options);
+    }
+
+    public static function provideInvalidConstructorOptions(): array
+    {
+        return self::createOptionDataProvider([
+            'batchSize' => self::getInvalidIntegerValues(),
+        ]);
+    }
+}

--- a/tests/StreamProcessing/Operation/GetStreamProcessorStatsTest.php
+++ b/tests/StreamProcessing/Operation/GetStreamProcessorStatsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing\Operation;
+
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Operation\StreamProcessing\GetStreamProcessorStats;
+use MongoDB\Tests\Operation\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class GetStreamProcessorStatsTest extends TestCase
+{
+    #[DataProvider('provideInvalidConstructorOptions')]
+    public function testConstructorOptionTypeChecks(array $options): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new GetStreamProcessorStats('proc', $options);
+    }
+
+    public static function provideInvalidConstructorOptions(): array
+    {
+        return self::createOptionDataProvider([
+            'verbose' => self::getInvalidBooleanValues(),
+        ]);
+    }
+}

--- a/tests/StreamProcessing/Operation/StartSampleStreamProcessorTest.php
+++ b/tests/StreamProcessing/Operation/StartSampleStreamProcessorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing\Operation;
+
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Operation\StreamProcessing\StartSampleStreamProcessor;
+use MongoDB\Tests\Operation\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class StartSampleStreamProcessorTest extends TestCase
+{
+    #[DataProvider('provideInvalidConstructorOptions')]
+    public function testConstructorOptionTypeChecks(array $options): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new StartSampleStreamProcessor('proc', $options);
+    }
+
+    public static function provideInvalidConstructorOptions(): array
+    {
+        return self::createOptionDataProvider([
+            'limit' => self::getInvalidIntegerValues(),
+        ]);
+    }
+}

--- a/tests/StreamProcessing/Operation/StartStreamProcessorTest.php
+++ b/tests/StreamProcessing/Operation/StartStreamProcessorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing\Operation;
+
+use MongoDB\BSON\Timestamp;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Operation\StreamProcessing\StartStreamProcessor;
+use MongoDB\Tests\Operation\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class StartStreamProcessorTest extends TestCase
+{
+    #[DataProvider('provideInvalidConstructorOptions')]
+    public function testConstructorOptionTypeChecks(array $options): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new StartStreamProcessor('proc', $options);
+    }
+
+    public static function provideInvalidConstructorOptions(): array
+    {
+        return self::createOptionDataProvider([
+            'workers' => self::getInvalidIntegerValues(),
+            'clearCheckpoints' => self::getInvalidBooleanValues(),
+            'startAtOperationTime' => [123, 3.14, 'foo', true, []],
+            'tier' => self::getInvalidStringValues(),
+            'enableAutoScaling' => self::getInvalidBooleanValues(),
+        ]);
+    }
+
+    public function testStartAtOperationTimeAcceptsTimestamp(): void
+    {
+        $op = new StartStreamProcessor('proc', ['startAtOperationTime' => new Timestamp(0, 0)]);
+        $this->assertInstanceOf(StartStreamProcessor::class, $op);
+    }
+
+    public function testFailoverRequiresRegion(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"failover" option requires a "region" string');
+        new StartStreamProcessor('proc', ['failover' => ['mode' => 'GRACEFUL']]);
+    }
+
+    public function testFailoverRejectsInvalidMode(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "failover.mode" value');
+        new StartStreamProcessor('proc', ['failover' => ['region' => 'us-east-1', 'mode' => 'INVALID']]);
+    }
+
+    public function testFailoverAcceptsValidConfiguration(): void
+    {
+        $op = new StartStreamProcessor('proc', [
+            'failover' => ['region' => 'us-east-1', 'mode' => 'FORCED', 'dryRun' => true],
+        ]);
+        $this->assertInstanceOf(StartStreamProcessor::class, $op);
+    }
+}

--- a/tests/StreamProcessing/StreamProcessingClientTest.php
+++ b/tests/StreamProcessing/StreamProcessingClientTest.php
@@ -21,6 +21,12 @@ class StreamProcessingClientTest extends TestCase
         $this->assertTrue(StreamProcessingClient::isWorkspaceUri($uri));
     }
 
+    public function testIsWorkspaceUriDetectsStagingEndpoint(): void
+    {
+        $uri = 'mongodb://user:pass@atlas-stream-699c842ef433fe6001480b17-etif1.virginia-usa.a.query.mongodb-stage.net';
+        $this->assertTrue(StreamProcessingClient::isWorkspaceUri($uri));
+    }
+
     #[DataProvider('provideNonWorkspaceUris')]
     public function testIsWorkspaceUriRejectsOtherEndpoints(string $uri): void
     {

--- a/tests/StreamProcessing/StreamProcessingClientTest.php
+++ b/tests/StreamProcessing/StreamProcessingClientTest.php
@@ -2,8 +2,10 @@
 
 namespace MongoDB\Tests\StreamProcessing;
 
+use MongoDB\Driver\Manager;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\StreamProcessingClient;
+use MongoDB\StreamProcessors;
 use MongoDB\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -66,5 +68,37 @@ class StreamProcessingClientTest extends TestCase
             'mongodb://atlas-stream-x.us-east-1.a.query.mongodb.net/',
             ['tls' => false],
         );
+    }
+
+    public function testConstructorRejectsSslDisabled(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('TLS cannot be disabled');
+        new StreamProcessingClient(
+            'mongodb://atlas-stream-x.us-east-1.a.query.mongodb.net/',
+            ['ssl' => false],
+        );
+    }
+
+    public function testConstructorAcceptsWorkspaceUri(): void
+    {
+        $uri = 'mongodb://atlas-stream-x.us-east-1.a.query.mongodb.net/';
+        $client = new StreamProcessingClient($uri);
+
+        $this->assertSame($uri, (string) $client);
+        $this->assertInstanceOf(Manager::class, $client->getManager());
+        $this->assertInstanceOf(StreamProcessors::class, $client->streamProcessors());
+    }
+
+    public function testDebugInfoReturnsManagerAndUri(): void
+    {
+        $uri = 'mongodb://atlas-stream-x.us-east-1.a.query.mongodb.net/';
+        $client = new StreamProcessingClient($uri);
+
+        $debug = $client->__debugInfo();
+        $this->assertArrayHasKey('manager', $debug);
+        $this->assertArrayHasKey('uri', $debug);
+        $this->assertSame($uri, $debug['uri']);
+        $this->assertInstanceOf(Manager::class, $debug['manager']);
     }
 }

--- a/tests/StreamProcessing/StreamProcessingClientTest.php
+++ b/tests/StreamProcessing/StreamProcessingClientTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing;
+
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\StreamProcessingClient;
+use MongoDB\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class StreamProcessingClientTest extends TestCase
+{
+    public function testIsWorkspaceUriDetectsValidEndpoint(): void
+    {
+        $uri = 'mongodb://atlas-stream-699c842ef433fe6001480b17-etif1.virginia-usa.a.query.mongodb.net/';
+        $this->assertTrue(StreamProcessingClient::isWorkspaceUri($uri));
+    }
+
+    public function testIsWorkspaceUriDetectsValidEndpointWithCredentialsAndPort(): void
+    {
+        $uri = 'mongodb://user:pass@atlas-stream-xyz.us-east-1.a.query.mongodb.net:27017/?retryWrites=true';
+        $this->assertTrue(StreamProcessingClient::isWorkspaceUri($uri));
+    }
+
+    #[DataProvider('provideNonWorkspaceUris')]
+    public function testIsWorkspaceUriRejectsOtherEndpoints(string $uri): void
+    {
+        $this->assertFalse(StreamProcessingClient::isWorkspaceUri($uri));
+    }
+
+    public static function provideNonWorkspaceUris(): array
+    {
+        return [
+            'standard cluster' => ['mongodb://localhost:27017/'],
+            'srv standard'     => ['mongodb+srv://cluster0.example.mongodb.net/'],
+            'similar hostname' => ['mongodb://atlas-stream-x.example.com/'],
+            'missing prefix'   => ['mongodb://abc.virginia-usa.a.query.mongodb.net/'],
+        ];
+    }
+
+    public function testConstructorRejectsNonWorkspaceUri(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('StreamProcessingClient requires a workspace endpoint URI');
+        new StreamProcessingClient('mongodb://localhost:27017/');
+    }
+
+    public function testConstructorRejectsSrvScheme(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new StreamProcessingClient('mongodb+srv://atlas-stream-x.us-east-1.a.query.mongodb.net/');
+    }
+
+    public function testConstructorRejectsTlsDisabled(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('TLS cannot be disabled');
+        // The Manager would also reject if it tried to connect, but we expect
+        // our validation to short-circuit before reaching libmongoc.
+        new StreamProcessingClient(
+            'mongodb://atlas-stream-x.us-east-1.a.query.mongodb.net/',
+            ['tls' => false],
+        );
+    }
+}

--- a/tests/StreamProcessing/StreamProcessingFunctionalTest.php
+++ b/tests/StreamProcessing/StreamProcessingFunctionalTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing;
+
+use MongoDB\Driver\Exception\Exception;
+use MongoDB\Model\StreamProcessorInfo;
+use MongoDB\StreamProcessingClient;
+use MongoDB\StreamProcessor;
+use MongoDB\Tests\TestCase;
+use Throwable;
+
+use function getenv;
+use function uniqid;
+
+/**
+ * Functional lifecycle smoke test for Atlas Stream Processing.
+ *
+ * Skipped unless MONGODB_STREAM_PROCESSING_URI is set to a workspace endpoint
+ * (atlas-stream-*.a.query.mongodb.net) with valid credentials.
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class StreamProcessingFunctionalTest extends TestCase
+{
+    private StreamProcessingClient $client;
+
+    private string $processorName;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $uri = getenv('MONGODB_STREAM_PROCESSING_URI');
+        if ($uri === false || $uri === '') {
+            $this->markTestSkipped('MONGODB_STREAM_PROCESSING_URI is not configured');
+        }
+
+        if (! StreamProcessingClient::isWorkspaceUri($uri)) {
+            $this->markTestSkipped('MONGODB_STREAM_PROCESSING_URI is not a workspace endpoint');
+        }
+
+        $this->client = new StreamProcessingClient($uri);
+        $this->processorName = 'phplib_test_' . uniqid();
+    }
+
+    public function tearDown(): void
+    {
+        try {
+            $this->client->streamProcessors()->get($this->processorName)->drop();
+        } catch (Throwable) {
+            // Best-effort cleanup; processor may not exist or already be dropped.
+        }
+
+        parent::tearDown();
+    }
+
+    public function testLifecycle(): void
+    {
+        $sps = $this->client->streamProcessors();
+
+        $pipeline = [
+            ['$source' => ['connectionName' => 'sample_stream_solar']],
+            ['$emit' => ['connectionName' => '__testLog', 'topic' => 'phplib-output']],
+        ];
+
+        $sps->create($this->processorName, $pipeline);
+
+        $info = $sps->getInfo($this->processorName);
+        $this->assertInstanceOf(StreamProcessorInfo::class, $info);
+        $this->assertSame($this->processorName, $info->getName());
+        $this->assertContains($info->getState(), ['CREATED', 'VALIDATING', 'CREATING']);
+
+        $processor = $sps->get($this->processorName);
+        $this->assertInstanceOf(StreamProcessor::class, $processor);
+        $processor->start();
+
+        // Allow processor to reach STARTED before requesting stats.
+        $this->assertNotEmpty($processor->stats());
+
+        // First sample call opens the cursor (no documents yet).
+        $samples = $processor->getStreamProcessorSamples(['limit' => 5]);
+        $this->assertGreaterThan(0, $samples->getCursorId());
+        $this->assertSame([], $samples->getDocuments());
+
+        // Subsequent call(s) fetch batches via getMore.
+        $batch = $processor->getStreamProcessorSamples([
+            'cursorId' => $samples->getCursorId(),
+            'batchSize' => 5,
+        ]);
+        // We can't assert non-empty (stream may have nothing yet) but exhaustion
+        // detection MUST work either way.
+        if ($batch->isExhausted()) {
+            $this->assertSame(0, $batch->getCursorId());
+        } else {
+            $this->assertGreaterThan(0, $batch->getCursorId());
+        }
+
+        $processor->stop();
+        $processor->drop();
+    }
+
+    public function testGetInfoOnMissingProcessorThrows(): void
+    {
+        $this->expectException(Exception::class);
+        $this->client->streamProcessors()->getInfo('does_not_exist_' . uniqid());
+    }
+}

--- a/tests/StreamProcessing/StreamProcessorInfoTest.php
+++ b/tests/StreamProcessing/StreamProcessorInfoTest.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests\StreamProcessing;
 
 use MongoDB\BSON\UTCDateTime;
+use MongoDB\Exception\BadMethodCallException;
 use MongoDB\Model\StreamProcessorInfo;
 use MongoDB\Tests\TestCase;
 
@@ -60,11 +61,98 @@ class StreamProcessorInfoTest extends TestCase
         $this->assertSame('', $info->getErrorMsg());
     }
 
+    public function testGettersReturnDefaultsWhenFieldsAreMissing(): void
+    {
+        $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED']);
+
+        $this->assertNull($info->getActiveRegion());
+        $this->assertNull($info->getDlq());
+        $this->assertNull($info->getErrorCode());
+        $this->assertSame('', $info->getErrorMsg());
+        $this->assertNull($info->getId());
+        $this->assertNull($info->getLastModifiedAt());
+        $this->assertNull($info->getLastStateChange());
+        $this->assertNull($info->getModifiedBy());
+        $this->assertSame([], $info->getPipeline());
+        $this->assertNull($info->getPipelineVersion());
+        $this->assertNull($info->getStreamMetaFieldName());
+        $this->assertNull($info->getTier());
+        $this->assertNull($info->getWorkspaceDefaultRegion());
+        $this->assertFalse($info->hasStarted());
+        $this->assertFalse($info->isAutoScalingEnabled());
+        $this->assertFalse($info->isErrorRetryable());
+        $this->assertFalse($info->isFailoverEnabled());
+    }
+
+    public function testGetDlqReturnsRawValue(): void
+    {
+        $dlq = ['connectionName' => 'errors', 'db' => 'd', 'coll' => 'c'];
+        $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED', 'dlq' => $dlq]);
+        $this->assertSame($dlq, $info->getDlq());
+    }
+
+    public function testGetPipelineReturnsArray(): void
+    {
+        $pipeline = [['$source' => ['connectionName' => 's']], ['$emit' => ['connectionName' => 'e']]];
+        $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED', 'pipeline' => $pipeline]);
+        $this->assertSame($pipeline, $info->getPipeline());
+    }
+
+    public function testErrorFieldsAreExposedWhenSet(): void
+    {
+        $info = new StreamProcessorInfo([
+            'name' => 'p',
+            'state' => 'FAILED',
+            'errorMsg' => 'something went wrong',
+            'errorRetryable' => true,
+            'errorCode' => 125,
+        ]);
+
+        $this->assertSame('something went wrong', $info->getErrorMsg());
+        $this->assertTrue($info->isErrorRetryable());
+        $this->assertSame(125, $info->getErrorCode());
+    }
+
+    public function testLastModifiedAtIsExposed(): void
+    {
+        $date = new UTCDateTime();
+        $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED', 'lastModifiedAt' => $date]);
+        $this->assertSame($date, $info->getLastModifiedAt());
+    }
+
+    public function testWorkspaceDefaultRegionIsExposed(): void
+    {
+        $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED', 'workspaceDefaultRegion' => 'us-west-2']);
+        $this->assertSame('us-west-2', $info->getWorkspaceDefaultRegion());
+    }
+
+    public function testDebugInfoReturnsUnderlyingArray(): void
+    {
+        $data = ['name' => 'p', 'state' => 'CREATED'];
+        $info = new StreamProcessorInfo($data);
+        $this->assertSame($data, $info->__debugInfo());
+    }
+
     public function testArrayAccessIsReadOnly(): void
     {
         $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED']);
         $this->assertSame('p', $info['name']);
+        $this->assertSame('CREATED', $info['state']);
         $this->assertTrue(isset($info['state']));
         $this->assertFalse(isset($info['nope']));
+    }
+
+    public function testOffsetSetThrows(): void
+    {
+        $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED']);
+        $this->expectException(BadMethodCallException::class);
+        $info['name'] = 'q';
+    }
+
+    public function testOffsetUnsetThrows(): void
+    {
+        $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED']);
+        $this->expectException(BadMethodCallException::class);
+        unset($info['name']);
     }
 }

--- a/tests/StreamProcessing/StreamProcessorInfoTest.php
+++ b/tests/StreamProcessing/StreamProcessorInfoTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing;
+
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Model\StreamProcessorInfo;
+use MongoDB\Tests\TestCase;
+
+class StreamProcessorInfoTest extends TestCase
+{
+    public function testGettersExposeKnownFields(): void
+    {
+        $info = new StreamProcessorInfo([
+            'id' => 'proc-1',
+            'name' => 'smokeTestProcessor',
+            'state' => 'CREATED',
+            'pipeline' => [['$source' => ['connectionName' => 'sample_stream_solar']]],
+            'pipelineVersion' => 2,
+            'tier' => 'SP2',
+            'streamMetaFieldName' => '_stream_meta',
+            'enableAutoScaling' => true,
+            'failoverEnabled' => false,
+            'activeRegion' => 'us-east-1',
+            'workspaceDefaultRegion' => 'us-east-1',
+            'lastStateChange' => new UTCDateTime(),
+            'modifiedBy' => 'user-1',
+            'hasStarted' => false,
+            'errorMsg' => '',
+            'errorRetryable' => false,
+        ]);
+
+        $this->assertSame('proc-1', $info->getId());
+        $this->assertSame('smokeTestProcessor', $info->getName());
+        $this->assertSame('CREATED', $info->getState());
+        $this->assertSame(2, $info->getPipelineVersion());
+        $this->assertSame('SP2', $info->getTier());
+        $this->assertSame('_stream_meta', $info->getStreamMetaFieldName());
+        $this->assertTrue($info->isAutoScalingEnabled());
+        $this->assertFalse($info->isFailoverEnabled());
+        $this->assertSame('us-east-1', $info->getActiveRegion());
+        $this->assertSame('user-1', $info->getModifiedBy());
+        $this->assertFalse($info->hasStarted());
+        $this->assertSame('', $info->getErrorMsg());
+        $this->assertFalse($info->isErrorRetryable());
+        $this->assertNull($info->getErrorCode());
+        $this->assertInstanceOf(UTCDateTime::class, $info->getLastStateChange());
+    }
+
+    public function testIdAndPipelineVersionAreOptional(): void
+    {
+        $info = new StreamProcessorInfo([
+            'name' => 'p',
+            'state' => 'CREATED',
+            'pipeline' => [],
+            'errorMsg' => '',
+        ]);
+
+        $this->assertNull($info->getId());
+        $this->assertNull($info->getPipelineVersion());
+        $this->assertSame('', $info->getErrorMsg());
+    }
+
+    public function testArrayAccessIsReadOnly(): void
+    {
+        $info = new StreamProcessorInfo(['name' => 'p', 'state' => 'CREATED']);
+        $this->assertSame('p', $info['name']);
+        $this->assertTrue(isset($info['state']));
+        $this->assertFalse(isset($info['nope']));
+    }
+}

--- a/tests/StreamProcessing/StreamProcessorSamplesTest.php
+++ b/tests/StreamProcessing/StreamProcessorSamplesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing;
+
+use MongoDB\Model\StreamProcessorSamples;
+use MongoDB\Tests\TestCase;
+
+class StreamProcessorSamplesTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $samples = new StreamProcessorSamples(42, [['x' => 1], ['x' => 2]]);
+        $this->assertSame(42, $samples->getCursorId());
+        $this->assertSame([['x' => 1], ['x' => 2]], $samples->getDocuments());
+        $this->assertFalse($samples->isExhausted());
+    }
+
+    public function testIsExhaustedWhenCursorIdIsZero(): void
+    {
+        $samples = new StreamProcessorSamples(0, []);
+        $this->assertTrue($samples->isExhausted());
+    }
+}

--- a/tests/StreamProcessing/StreamProcessorsTest.php
+++ b/tests/StreamProcessing/StreamProcessorsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MongoDB\Tests\StreamProcessing;
+
+use MongoDB\Driver\Manager;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\StreamProcessor;
+use MongoDB\StreamProcessors;
+use MongoDB\Tests\TestCase;
+
+class StreamProcessorsTest extends TestCase
+{
+    private function makeManager(): Manager
+    {
+        return new Manager('mongodb://localhost:27017/');
+    }
+
+    public function testGetReturnsStreamProcessorHandle(): void
+    {
+        $sp = new StreamProcessors($this->makeManager());
+        $handle = $sp->get('proc');
+        $this->assertInstanceOf(StreamProcessor::class, $handle);
+        $this->assertSame('proc', $handle->getName());
+    }
+
+    public function testCreateRejectsEmptyName(): void
+    {
+        $sp = new StreamProcessors($this->makeManager());
+        $this->expectException(InvalidArgumentException::class);
+        $sp->create('', []);
+    }
+
+    public function testGetInfoRejectsEmptyName(): void
+    {
+        $sp = new StreamProcessors($this->makeManager());
+        $this->expectException(InvalidArgumentException::class);
+        $sp->getInfo('');
+    }
+
+    public function testStreamProcessorConstructorRejectsEmptyName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new StreamProcessor($this->makeManager(), '');
+    }
+}


### PR DESCRIPTION
## Summary

  Adds first-class driver support for Atlas Stream Processing (ASP), implementing the [ASP driver spec](https://docs.google.com/document/d/1ORSCgQCwB0wo54egVPUwvuY6egcvjaJpYf965IywKjs/edit). Users currently have to drop down to
  `Manager::executeCommand` against a workspace endpoint; this PR adds a dedicated client/handles/operations layer matching the patterns used by `Client` / `Database` / `Collection`.

  ## What's new

  **Public API** (`src/`)
  - `MongoDB\StreamProcessingClient` — workspace-scoped client distinct from `MongoDB\Client`. Validates the workspace URI (`atlas-stream-*.a.query.mongodb.net`), enforces TLS, defaults `authSource=admin`, and rejects
  `mongodb+srv://`.
  - `MongoDB\StreamProcessors` — `create()` / `get()` / `getInfo()` for managing processors in a workspace.
  - `MongoDB\StreamProcessor` — `start()` / `stop()` / `drop()` / `stats()` / `getStreamProcessorSamples()` for a named processor.
  - `MongoDB\Model\StreamProcessorInfo` — typed accessor over the `getStreamProcessor` response. Fields the spec marks `Optional` (e.g. `id`, `pipelineVersion`) return `null` when the server omits them.
  - `MongoDB\Model\StreamProcessorSamples` — result of `getStreamProcessorSamples()`, exposes `cursorId`, `documents`, `isExhausted()`.

  **Operation layer** (`src/Operation/StreamProcessing/`)
  One Operation class per wire command: `createStreamProcessor`, `startStreamProcessor`, `stopStreamProcessor`, `dropStreamProcessor`, `getStreamProcessor`, `getStreamProcessorStats`, `startSampleStreamProcessor`,
  `getMoreSampleStreamProcessor`. Retryable reads (`getStreamProcessor`, `getStreamProcessorStats`) use `executeReadCommand`; everything else uses `executeCommand` per the spec's retryability matrix. All commands target the
  `admin` database.

  ## Notable spec / server alignment

  - **`startAfter` (in `StartStreamProcessorOptions`) is intentionally NOT serialized** — the spec marks it RESERVED for future use and explicitly forbids drivers from sending it.
  - **Dev-server response shape deviations are accommodated**, matching the workarounds in the Python POC:
    - `GetStreamProcessor` unwraps `{ok: 1, result: {…}}` when the server wraps the response.
    - `GetMoreSampleStreamProcessor` accepts both `nextBatch` (spec) and `messages` (current dev server).
    - `StreamProcessorInfo::getId()` / `getPipelineVersion()` return `null` when the server omits the field.
  - **`getStreamProcessorSamples()` is a single-command dispatch:** absent/zero `cursorId` → `startSampleStreamProcessor`; non-zero `cursorId` → `getMoreSampleStreamProcessor`. Callers stop when the returned `cursorId === 0`.
  - Internal-only fields like `tenantID` / `projectId` are not surfaced in the user-facing API.

  ## Test plan

  - [x] `composer check:cs` — clean
  - [x] `composer check:rector` — clean (0 rule violations on new files)
  - [x] `composer check:psalm` — clean against updated baseline. The 11 new baseline entries are all `MixedAssignment` from reading untyped `array $options` / `array $info`, matching the pattern already established for every
  other Operation class.
  - [x] Unit tests under `tests/StreamProcessing/` cover constructor-option type validation for every Operation, URI/TLS validation for the client, and model getters. Run with `vendor/bin/phpunit --filter StreamProcessing`.
  - [ ] Functional smoke test `StreamProcessingFunctionalTest` exercises the full `create → start → stats → sample → stop → drop` lifecycle. Self-skips unless `MONGODB_STREAM_PROCESSING_URI` is set to a real workspace endpoint —
  needs an Evergreen variant or a workspace-aware tester to actually exercise.

  ## Out of scope (per spec)

  Deferred to a follow-up: `modifyStreamProcessor`, `listStreamProcessors`, `listStreamConnections`, `processStreamProcessor`, `listWorkspaceDefaults`. Users who need these today can still send them via `Manager::executeCommand`.