### PR TITLE
PHPLIB-1859 Add Psalm array shapes for search and vector search index definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,8 +161,12 @@ $ vendor/bin/phpcbf
 
 The library uses [psalm](https://psalm.dev) to run static analysis on the code
 and ensure an additional level of type safety. New code is expected to adhere
-to level 1, with a baseline covering existing issues. To run static analysis
-checks, run the `psalm` binary:
+to level 1, with a baseline covering existing issues.
+
+Psalm array shape types defined with `@psalm-type` must be suffixed with `Shape`
+(e.g. `SearchIndexShape`, `OperationShape`).
+
+To run static analysis checks, run the `psalm` binary:
 
 ```console
 $ vendor/bin/psalm

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -14,6 +14,7 @@
     <projectFiles>
         <directory name="src" />
         <directory name="examples" />
+        <directory name="tests/Type" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -168,7 +168,7 @@ use function strlen;
  *     storedSource?: SearchIndexStoredSourceShape,
  * }
  * @psalm-type SearchIndexShape = array{
- *     definition: SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape,
+ *     definition: SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape|object,
  *     name?: string,
  *     type?: string,
  * }
@@ -1104,9 +1104,9 @@ class Collection implements Stringable
      * Update a single Atlas Search index in the collection.
      * Only available when used against a 7.0+ Atlas cluster.
      *
-     * @param string                                                                   $name       Search index name
-     * @param SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape|array|object $definition Atlas Search index definition
-     * @param array{comment?: mixed}                                                   $options    Command options
+     * @param string                                                             $name       Search index name
+     * @param SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape|object $definition Atlas Search index definition
+     * @param array{comment?: mixed}                                             $options    Command options
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -147,7 +147,7 @@ use function strlen;
  *     analyzer?: string,
  *     analyzers?: list<SearchIndexAnalyzerShape>,
  *     searchAnalyzer?: string,
- *     mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, SearchIndexFieldShape|list<SearchIndexFieldShape>>},
+ *     mappings: array{dynamic?: bool, fields?: array<string, SearchIndexFieldShape|list<SearchIndexFieldShape>>},
  *     storedSource?: SearchIndexStoredSourceShape,
  *     synonyms?: list<SearchIndexSynonymShape>,
  * }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -81,97 +81,39 @@ use function strlen;
 
 /**
  * @psalm-import-type OperationShape from BulkWrite
- * @psalm-type SearchIndexFieldShape = array{
- *     type: 'boolean'|'date'|'dateFacet'|'objectId'|'stringFacet'|'uuid',
- * } | array{
- *     type: 'autocomplete',
- *     analyzer?: string,
- *     maxGrams?: int,
- *     minGrams?: int,
- *     tokenization?: 'edgeGram'|'rightEdgeGram'|'nGram',
- *     foldDiacritics?: bool,
- *     similarity?: array{type: 'bm25'|'boolean'|'stableTfl'},
- * } | array{
- *     type: 'document'|'embeddedDocuments',
- *     dynamic?: bool,
- *     fields: array<string, array<mixed>>,
- * } | array{
- *     type: 'geo',
- *     indexShapes?: bool,
- * } | array{
- *     type: 'number'|'numberFacet',
- *     representation?: 'int64'|'double',
- *     indexIntegers?: bool,
- *     indexDoubles?: bool,
- * } | array{
- *     type: 'token',
- *     normalizer?: 'lowercase'|'none',
- * } | array{
- *     type: 'string',
- *     analyzer?: string,
- *     searchAnalyzer?: string,
- *     indexOptions?: 'docs'|'freqs'|'positions'|'offsets',
- *     store?: bool,
- *     ignoreAbove?: int,
- *     multi?: array<string, array<string, mixed>>,
- *     norms?: 'include'|'omit',
- *     similarity?: array{type: 'bm25'|'boolean'|'stableTfl'},
- * }
- * @psalm-type SearchIndexCharFilterShape = array{
- *     type: 'icuNormalize'|'persian',
- * } | array{
- *     type: 'htmlStrip',
- *     ignoredTags?: list<string>,
- * } | array{
- *     type: 'mapping',
- *     mappings?: array<string, string>,
- * }
- * @psalm-type SearchIndexTokenFilterShape = array{type: string, ...}
- * @psalm-type SearchIndexAnalyzerShape = array{
- *     name: string,
- *     charFilters?: list<SearchIndexCharFilterShape>,
- *     tokenizer: array{type: string},
- *     tokenFilters?: list<SearchIndexTokenFilterShape>,
- * }
- * @psalm-type SearchIndexStoredSourceShape = bool | array{
- *     include: list<string>,
- * } | array{
- *     exclude: list<string>,
- * }
- * @psalm-type SearchIndexSynonymShape = array{
- *     analyzer: string,
- *     name: string,
- *     source?: array{collection: string},
- * }
- * @psalm-type SearchIndexDefinitionShape = array{
- *     analyzer?: string,
- *     analyzers?: list<SearchIndexAnalyzerShape>,
- *     searchAnalyzer?: string,
- *     mappings: array{dynamic?: bool, fields?: array<string, SearchIndexFieldShape|list<SearchIndexFieldShape>>},
- *     storedSource?: SearchIndexStoredSourceShape,
- *     synonyms?: list<SearchIndexSynonymShape>,
- * }
- * @psalm-type VectorSearchIndexFieldShape = array{
- *     type: 'vector',
- *     path: string,
- *     numDimensions: int,
- *     similarity: 'euclidean'|'cosine'|'dotProduct',
- *     quantization?: 'none'|'scalar'|'binary',
- *     indexingMethod?: 'flat'|'hnsw',
- *     hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int},
- * } | array{
- *     type: 'filter',
- *     path: string,
- * }
- * @psalm-type VectorSearchIndexDefinitionShape = array{
- *     fields: list<VectorSearchIndexFieldShape>,
- *     storedSource?: SearchIndexStoredSourceShape,
- * }
  * @psalm-type SearchIndexShape = array{
- *     definition: SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape|object,
- *     name?: string,
- *     type?: string,
+ *     analyzer?: string,
+ *     analyzers?: list<array{
+ *         name: string,
+ *         charFilters?: list<array{type: 'icuNormalize'|'persian'}|array{type: 'htmlStrip', ignoredTags?: list<string>}|array{type: 'mapping', mappings?: array<string, string>}>,
+ *         tokenizer: array{type: string},
+ *         tokenFilters?: list<array{type: string, ...}>,
+ *     }>,
+ *     searchAnalyzer?: string,
+ *     mappings: array{
+ *         dynamic?: bool,
+ *         fields?: array<string,
+ *             array{type: 'boolean'|'date'|'dateFacet'|'objectId'|'stringFacet'|'uuid'} |
+ *             array{type: 'autocomplete', analyzer?: string, maxGrams?: int, minGrams?: int, tokenization?: 'edgeGram'|'rightEdgeGram'|'nGram', foldDiacritics?: bool, similarity?: array{type: 'bm25'|'boolean'|'stableTfl'}} |
+ *             array{type: 'document'|'embeddedDocuments', dynamic?: bool, fields: array<string, array<mixed>>} |
+ *             array{type: 'geo', indexShapes?: bool} |
+ *             array{type: 'number'|'numberFacet', representation?: 'int64'|'double', indexIntegers?: bool, indexDoubles?: bool} |
+ *             array{type: 'token', normalizer?: 'lowercase'|'none'} |
+ *             array{type: 'string', analyzer?: string, searchAnalyzer?: string, indexOptions?: 'docs'|'freqs'|'positions'|'offsets', store?: bool, ignoreAbove?: int, multi?: array<string, array<string, mixed>>, norms?: 'include'|'omit', similarity?: array{type: 'bm25'|'boolean'|'stableTfl'}} |
+ *             list<array{type: string, ...}>
+ *         >,
+ *     },
+ *     storedSource?: bool|array{include: list<string>}|array{exclude: list<string>},
+ *     synonyms?: list<array{analyzer: string, name: string, source?: array{collection: string}}>,
  * }
+ * @psalm-type VectorSearchIndexShape = array{
+ *     fields: list<
+ *         array{type: 'vector', path: string, numDimensions: int, similarity: 'euclidean'|'cosine'|'dotProduct', quantization?: 'none'|'scalar'|'binary', indexingMethod?: 'flat'|'hnsw', hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int}} |
+ *         array{type: 'filter', path: string}
+ *     >,
+ *     storedSource?: bool|array{include: list<string>}|array{exclude: list<string>},
+ * }
+ * @psalm-type SearchIndexSpecShape = array{definition: SearchIndexShape|VectorSearchIndexShape|object, name?: string, type?: string}
  */
 class Collection implements Stringable
 {
@@ -474,8 +416,8 @@ class Collection implements Stringable
      *
      * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/
      * @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/
-     * @param SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape|object $definition Atlas Search index mapping definition
-     * @param array{comment?: mixed, name?: string, type?: string}               $options    Index and command options
+     * @param SearchIndexShape|VectorSearchIndexShape|object       $definition Atlas Search index mapping definition
+     * @param array{comment?: mixed, name?: string, type?: string} $options    Index and command options
      * @return string The name of the created search index
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
@@ -489,7 +431,7 @@ class Collection implements Stringable
         /** @psalm-var array{comment?: mixed} */
         $operationOptions = array_diff_key($options, $indexOptionKeys);
 
-        /** @psalm-var list<SearchIndexShape> */
+        /** @psalm-var list<SearchIndexSpecShape> */
         $indexes = [['definition' => $definition] + $indexOptions];
         $names = $this->createSearchIndexes($indexes, $operationOptions);
 
@@ -513,8 +455,8 @@ class Collection implements Stringable
      *
      * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/
      * @see https://mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/
-     * @param list<SearchIndexShape> $indexes List of search index specifications
-     * @param array{comment?: mixed} $options Command options
+     * @param list<SearchIndexSpecShape> $indexes List of search index specifications
+     * @param array{comment?: mixed}     $options Command options
      * @return string[] The names of the created search indexes
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
@@ -1104,9 +1046,9 @@ class Collection implements Stringable
      * Update a single Atlas Search index in the collection.
      * Only available when used against a 7.0+ Atlas cluster.
      *
-     * @param string                                                             $name       Search index name
-     * @param SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape|object $definition Atlas Search index definition
-     * @param array{comment?: mixed}                                             $options    Command options
+     * @param string                                         $name       Search index name
+     * @param SearchIndexShape|VectorSearchIndexShape|object $definition Atlas Search index definition
+     * @param array{comment?: mixed}                         $options    Command options
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -79,7 +79,100 @@ use function is_array;
 use function is_bool;
 use function strlen;
 
-/** @phpstan-import-type OperationType from BulkWrite */
+/**
+ * @psalm-import-type OperationShape from BulkWrite
+ * @psalm-type SearchIndexFieldShape = array{
+ *     type: 'boolean'|'date'|'dateFacet'|'objectId'|'stringFacet'|'uuid',
+ * } | array{
+ *     type: 'autocomplete',
+ *     analyzer?: string,
+ *     maxGrams?: int,
+ *     minGrams?: int,
+ *     tokenization?: 'edgeGram'|'rightEdgeGram'|'nGram',
+ *     foldDiacritics?: bool,
+ *     similarity?: array{type: 'bm25'|'boolean'|'stableTfl'},
+ * } | array{
+ *     type: 'document'|'embeddedDocuments',
+ *     dynamic?: bool,
+ *     fields: array<string, array<mixed>>,
+ * } | array{
+ *     type: 'geo',
+ *     indexShapes?: bool,
+ * } | array{
+ *     type: 'number'|'numberFacet',
+ *     representation?: 'int64'|'double',
+ *     indexIntegers?: bool,
+ *     indexDoubles?: bool,
+ * } | array{
+ *     type: 'token',
+ *     normalizer?: 'lowercase'|'none',
+ * } | array{
+ *     type: 'string',
+ *     analyzer?: string,
+ *     searchAnalyzer?: string,
+ *     indexOptions?: 'docs'|'freqs'|'positions'|'offsets',
+ *     store?: bool,
+ *     ignoreAbove?: int,
+ *     multi?: array<string, array<string, mixed>>,
+ *     norms?: 'include'|'omit',
+ *     similarity?: array{type: 'bm25'|'boolean'|'stableTfl'},
+ * }
+ * @psalm-type SearchIndexCharFilterShape = array{
+ *     type: 'icuNormalize'|'persian',
+ * } | array{
+ *     type: 'htmlStrip',
+ *     ignoredTags?: list<string>,
+ * } | array{
+ *     type: 'mapping',
+ *     mappings?: array<string, string>,
+ * }
+ * @psalm-type SearchIndexTokenFilterShape = array{type: string, ...}
+ * @psalm-type SearchIndexAnalyzerShape = array{
+ *     name: string,
+ *     charFilters?: list<SearchIndexCharFilterShape>,
+ *     tokenizer: array{type: string},
+ *     tokenFilters?: list<SearchIndexTokenFilterShape>,
+ * }
+ * @psalm-type SearchIndexStoredSourceShape = bool | array{
+ *     include: list<string>,
+ * } | array{
+ *     exclude: list<string>,
+ * }
+ * @psalm-type SearchIndexSynonymShape = array{
+ *     analyzer: string,
+ *     name: string,
+ *     source?: array{collection: string},
+ * }
+ * @psalm-type SearchIndexDefinitionShape = array{
+ *     analyzer?: string,
+ *     analyzers?: list<SearchIndexAnalyzerShape>,
+ *     searchAnalyzer?: string,
+ *     mappings: array{dynamic: true} | array{dynamic?: bool, fields: array<string, SearchIndexFieldShape|list<SearchIndexFieldShape>>},
+ *     storedSource?: SearchIndexStoredSourceShape,
+ *     synonyms?: list<SearchIndexSynonymShape>,
+ * }
+ * @psalm-type VectorSearchIndexFieldShape = array{
+ *     type: 'vector',
+ *     path: string,
+ *     numDimensions: int,
+ *     similarity: 'euclidean'|'cosine'|'dotProduct',
+ *     quantization?: 'none'|'scalar'|'binary',
+ *     indexingMethod?: 'flat'|'hnsw',
+ *     hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int},
+ * } | array{
+ *     type: 'filter',
+ *     path: string,
+ * }
+ * @psalm-type VectorSearchIndexDefinitionShape = array{
+ *     fields: list<VectorSearchIndexFieldShape>,
+ *     storedSource?: SearchIndexStoredSourceShape,
+ * }
+ * @psalm-type SearchIndexShape = array{
+ *     definition: SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape,
+ *     name?: string,
+ *     type?: string,
+ * }
+ */
 class Collection implements Stringable
 {
     private const DEFAULT_TYPE_MAP = [
@@ -255,7 +348,7 @@ class Collection implements Stringable
      * Executes multiple write operations.
      *
      * @param list<array{deleteMany: list<array|object>}|array{deleteOne: list<array|object>}|array{insertOne: list<array|object>}|array{replaceOne: list<array|object>}|array{updateMany: list<array|object>}|array{updateOne: list<array|object>}> $operations List of write operations
-     * @psalm-param list<OperationType> $operations List of write operations
+     * @psalm-param list<OperationShape> $operations List of write operations
      * @param array                                                                                                                                                                                                                                  $options    Command options
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
@@ -380,9 +473,9 @@ class Collection implements Stringable
      * Only available when used against a 7.0+ Atlas cluster.
      *
      * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/
-     * @see https://mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/
-     * @param array|object                                         $definition Atlas Search index mapping definition
-     * @param array{comment?: mixed, name?: string, type?: string} $options    Index and command options
+     * @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/
+     * @param SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape|object $definition Atlas Search index mapping definition
+     * @param array{comment?: mixed, name?: string, type?: string}               $options    Index and command options
      * @return string The name of the created search index
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
@@ -396,7 +489,9 @@ class Collection implements Stringable
         /** @psalm-var array{comment?: mixed} */
         $operationOptions = array_diff_key($options, $indexOptionKeys);
 
-        $names = $this->createSearchIndexes([['definition' => $definition] + $indexOptions], $operationOptions);
+        /** @psalm-var list<SearchIndexShape> */
+        $indexes = [['definition' => $definition] + $indexOptions];
+        $names = $this->createSearchIndexes($indexes, $operationOptions);
 
         return current($names);
     }
@@ -418,8 +513,8 @@ class Collection implements Stringable
      *
      * @see https://www.mongodb.com/docs/manual/reference/command/createSearchIndexes/
      * @see https://mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/
-     * @param list<array{definition: array|object, name?: string, type?: string}> $indexes List of search index specifications
-     * @param array{comment?: mixed}                                              $options Command options
+     * @param list<SearchIndexShape> $indexes List of search index specifications
+     * @param array{comment?: mixed} $options Command options
      * @return string[] The names of the created search indexes
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter/option parsing errors
@@ -1009,9 +1104,9 @@ class Collection implements Stringable
      * Update a single Atlas Search index in the collection.
      * Only available when used against a 7.0+ Atlas cluster.
      *
-     * @param string                 $name       Search index name
-     * @param array|object           $definition Atlas Search index definition
-     * @param array{comment?: mixed} $options    Command options
+     * @param string                                                                   $name       Search index name
+     * @param SearchIndexDefinitionShape|VectorSearchIndexDefinitionShape|array|object $definition Atlas Search index definition
+     * @param array{comment?: mixed}                                                   $options    Command options
      * @throws UnsupportedException if options are not supported by the selected server
      * @throws InvalidArgumentException for parameter parsing errors
      * @throws DriverRuntimeException for other driver errors (e.g. connection errors)

--- a/src/Model/SearchIndexInput.php
+++ b/src/Model/SearchIndexInput.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Model;
 
 use MongoDB\BSON\Serializable;
+use MongoDB\Collection;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
@@ -33,11 +34,12 @@ use function MongoDB\is_document;
  * @see \MongoDB\Collection::createSearchIndexes()
  * @see https://github.com/mongodb/specifications/blob/master/source/index-management/index-management.md#search-indexes
  * @see https://mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/
+ * @psalm-import-type SearchIndexShape from Collection
  */
 final class SearchIndexInput implements Serializable
 {
     /**
-     * @param array{definition: array|object, name?: string, type?: string} $index Search index specification
+     * @param SearchIndexShape $index Search index specification
      * @throws InvalidArgumentException
      */
     public function __construct(private array $index)

--- a/src/Model/SearchIndexInput.php
+++ b/src/Model/SearchIndexInput.php
@@ -34,12 +34,12 @@ use function MongoDB\is_document;
  * @see \MongoDB\Collection::createSearchIndexes()
  * @see https://github.com/mongodb/specifications/blob/master/source/index-management/index-management.md#search-indexes
  * @see https://mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/
- * @psalm-import-type SearchIndexShape from Collection
+ * @psalm-import-type SearchIndexSpecShape from Collection
  */
 final class SearchIndexInput implements Serializable
 {
     /**
-     * @param SearchIndexShape $index Search index specification
+     * @param SearchIndexSpecShape $index Search index specification
      * @throws InvalidArgumentException
      */
     public function __construct(private array $index)

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -47,7 +47,7 @@ use function sprintf;
  * @see \MongoDB\Collection::bulkWrite()
  *
  * @psalm-type Document = object|array
- * @psalm-type OperationType = array{deleteMany: array{0: Document, 1?: array}}|array{deleteOne: array{0: Document, 1?: array}}|array{insertOne: array{0: Document}}|array{replaceOne: array{0: Document, 1: Document, 2?: array}}|array{updateMany: array{0: Document, 1: Document, 2?: array}}|array{updateOne: array{0: Document, 1: Document, 2?: array}}
+ * @psalm-type OperationShape = array{deleteMany: array{0: Document, 1?: array}}|array{deleteOne: array{0: Document, 1?: array}}|array{insertOne: array{0: Document}}|array{replaceOne: array{0: Document, 1: Document, 2?: array}}|array{updateMany: array{0: Document, 1: Document, 2?: array}}|array{updateOne: array{0: Document, 1: Document, 2?: array}}
  */
 final class BulkWrite
 {
@@ -58,7 +58,7 @@ final class BulkWrite
     public const UPDATE_MANY = 'updateMany';
     public const UPDATE_ONE  = 'updateOne';
 
-    /** @psalm-var list<OperationType> */
+    /** @psalm-var list<OperationShape> */
     private array $operations;
 
     private array $options;
@@ -138,7 +138,7 @@ final class BulkWrite
      * @param string $databaseName   Database name
      * @param string $collectionName Collection name
      * @param array  $operations     List of write operations
-     * @psalm-param list<OperationType> $operations
+     * @psalm-param list<OperationShape> $operations
      * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
@@ -280,8 +280,8 @@ final class BulkWrite
     }
 
     /**
-     * @psalm-param list<OperationType> $operations
-     * @psalm-return list<OperationType>
+     * @psalm-param list<OperationShape> $operations
+     * @psalm-return list<OperationShape>
      */
     private function validateOperations(array $operations, ?DocumentCodec $codec, Encoder $builderEncoder): array
     {

--- a/tests/Type/BulkWriteShapes.php
+++ b/tests/Type/BulkWriteShapes.php
@@ -18,15 +18,12 @@
 namespace MongoDB\Tests\Type;
 
 use MongoDB\Collection;
-use MongoDB\Operation\BulkWrite;
 
 /**
  * Psalm type tests for bulk write operation shapes.
  *
  * This file is not executed by PHPUnit; it is only checked by Psalm to verify
  * that the OperationShape defined in BulkWrite is accepted by Collection::bulkWrite.
- *
- * @psalm-import-type OperationShape from BulkWrite
  */
 final class BulkWriteShapes
 {

--- a/tests/Type/BulkWriteShapes.php
+++ b/tests/Type/BulkWriteShapes.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright 2015-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Tests\Type;
+
+use MongoDB\Collection;
+
+/**
+ * Psalm type tests for bulk write operation shapes.
+ *
+ * This file is not executed by PHPUnit; it is only checked by Psalm to verify
+ * that the OperationShape defined in BulkWrite is accepted by Collection::bulkWrite.
+ *
+ * @psalm-import-type OperationShape from \MongoDB\Operation\BulkWrite
+ */
+final class BulkWriteShapes
+{
+    /** @see https://www.mongodb.com/docs/php-library/current/write/bulk-write/ */
+    public function bulkWrite(Collection $collection): void
+    {
+        $collection->bulkWrite([
+            ['insertOne' => [['x' => 1]]],
+            ['updateOne' => [['x' => 1], ['$set' => ['y' => 1]]]],
+            ['updateMany' => [['x' => ['$gt' => 1]], ['$inc' => ['x' => 1]]]],
+            ['replaceOne' => [['x' => 1], ['y' => 1]]],
+            ['deleteOne' => [['x' => 1]]],
+            ['deleteMany' => [['x' => ['$gt' => 5]]]],
+        ]);
+    }
+}

--- a/tests/Type/BulkWriteShapes.php
+++ b/tests/Type/BulkWriteShapes.php
@@ -18,6 +18,7 @@
 namespace MongoDB\Tests\Type;
 
 use MongoDB\Collection;
+use MongoDB\Operation\BulkWrite;
 
 /**
  * Psalm type tests for bulk write operation shapes.
@@ -25,7 +26,7 @@ use MongoDB\Collection;
  * This file is not executed by PHPUnit; it is only checked by Psalm to verify
  * that the OperationShape defined in BulkWrite is accepted by Collection::bulkWrite.
  *
- * @psalm-import-type OperationShape from \MongoDB\Operation\BulkWrite
+ * @psalm-import-type OperationShape from BulkWrite
  */
 final class BulkWriteShapes
 {

--- a/tests/Type/SearchIndexShapes.php
+++ b/tests/Type/SearchIndexShapes.php
@@ -24,10 +24,6 @@ use MongoDB\Collection;
  *
  * This file is not executed by PHPUnit; it is only checked by Psalm to verify
  * that the array shapes defined in Collection are accepted by its methods.
- *
- * @psalm-import-type SearchIndexDefinitionShape from Collection
- * @psalm-import-type VectorSearchIndexDefinitionShape from Collection
- * @psalm-import-type SearchIndexShape from Collection
  */
 final class SearchIndexShapes
 {

--- a/tests/Type/SearchIndexShapes.php
+++ b/tests/Type/SearchIndexShapes.php
@@ -75,6 +75,13 @@ final class SearchIndexShapes
         ]);
     }
 
+    public function createSearchIndexWithDynamicFalse(Collection $collection): void
+    {
+        $collection->createSearchIndex([
+            'mappings' => ['dynamic' => false],
+        ]);
+    }
+
     /** @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/#create-a-vector-search-index */
     public function createVectorSearchIndex(Collection $collection): void
     {

--- a/tests/Type/SearchIndexShapes.php
+++ b/tests/Type/SearchIndexShapes.php
@@ -1,0 +1,184 @@
+<?php
+/*
+ * Copyright 2015-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace MongoDB\Tests\Type;
+
+use MongoDB\Collection;
+
+/**
+ * Psalm type tests for search index shapes.
+ *
+ * This file is not executed by PHPUnit; it is only checked by Psalm to verify
+ * that the array shapes defined in Collection are accepted by its methods.
+ *
+ * @psalm-import-type SearchIndexDefinitionShape from Collection
+ * @psalm-import-type VectorSearchIndexDefinitionShape from Collection
+ * @psalm-import-type SearchIndexShape from Collection
+ */
+final class SearchIndexShapes
+{
+    /** @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/#create-a-search-index-on-all-fields */
+    public function createSearchIndexOnAllFields(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            ['mappings' => ['dynamic' => true]],
+            ['name' => 'searchIndex01'],
+        );
+    }
+
+    /** @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/#create-a-search-index-with-a-language-analyzer */
+    public function createSearchIndexWithLanguageAnalyzer(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'mappings' => [
+                    'fields' => [
+                        'subject' => [
+                            'fields' => [
+                                'fr' => [
+                                    'analyzer' => 'lucene.french',
+                                    'type' => 'string',
+                                ],
+                            ],
+                            'type' => 'document',
+                        ],
+                    ],
+                ],
+            ],
+            ['name' => 'frenchIndex01'],
+        );
+    }
+
+    /** @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/#create-a-search-index-with-the-default-name */
+    public function createSearchIndexWithDefaultName(Collection $collection): void
+    {
+        $collection->createSearchIndex([
+            'mappings' => [
+                'fields' => [
+                    'title' => ['type' => 'string'],
+                ],
+            ],
+        ]);
+    }
+
+    /** @see https://www.mongodb.com/docs/manual/reference/method/db.collection.createSearchIndex/#create-a-vector-search-index */
+    public function createVectorSearchIndex(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'fields' => [
+                    [
+                        'type' => 'vector',
+                        'numDimensions' => 1,
+                        'path' => 'genre',
+                        'similarity' => 'cosine',
+                    ],
+                ],
+            ],
+            ['name' => 'vectorSearchIndex01', 'type' => 'vectorSearch'],
+        );
+    }
+
+    /** @see https://www.mongodb.com/docs/manual/reference/method/db.collection.updateSearchIndex/#example */
+    public function updateSearchIndexWithStoredSourceExclude(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'mappings' => ['dynamic' => true],
+                'storedSource' => ['exclude' => ['imdb.rating']],
+            ],
+            ['name' => 'searchIndex01'],
+        );
+
+        $collection->updateSearchIndex(
+            'searchIndex01',
+            [
+                'mappings' => ['dynamic' => true],
+                'storedSource' => ['exclude' => ['movies']],
+            ],
+        );
+    }
+
+    /** @see https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/ */
+    public function searchIndexStoredSourceTrue(Collection $collection): void
+    {
+        $collection->createSearchIndex([
+            'mappings' => ['dynamic' => true],
+            'storedSource' => true,
+        ]);
+    }
+
+    /** @see https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/ */
+    public function searchIndexStoredSourceInclude(Collection $collection): void
+    {
+        $collection->createSearchIndex([
+            'mappings' => ['dynamic' => true],
+            'storedSource' => ['include' => ['title', 'awards.wins']],
+        ]);
+    }
+
+    /** @see https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/ */
+    public function searchIndexStoredSourceExclude(Collection $collection): void
+    {
+        $collection->createSearchIndex([
+            'mappings' => ['dynamic' => true],
+            'storedSource' => ['exclude' => ['directors', 'imdb.rating']],
+        ]);
+    }
+
+    /** @see https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/ */
+    public function vectorSearchIndexStoredSourceTrue(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'fields' => [
+                    [
+                        'type' => 'vector',
+                        'path' => 'plot_embedding',
+                        'numDimensions' => 1536,
+                        'similarity' => 'euclidean',
+                    ],
+                ],
+                'storedSource' => true,
+            ],
+            ['name' => 'my_vector_index', 'type' => 'vectorSearch'],
+        );
+    }
+
+    /** @see https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/ */
+    public function vectorSearchIndexStoredSourceInclude(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'fields' => [
+                    [
+                        'type' => 'vector',
+                        'path' => 'plot_embedding',
+                        'numDimensions' => 1536,
+                        'similarity' => 'euclidean',
+                    ],
+                    [
+                        'type' => 'filter',
+                        'path' => 'genres',
+                    ],
+                ],
+                'storedSource' => ['include' => ['title', 'plot_embedding']],
+            ],
+            ['name' => 'my_vector_index', 'type' => 'vectorSearch'],
+        );
+    }
+}


### PR DESCRIPTION
Adds typed `@psalm-type` shapes to `Collection` for all search and vector search index structures, including `storedSource` support in `VectorSearchIndexDefinitionShape` (PHPLIB-1859) and `SearchIndexDefinitionShape`.

The shapes are adapted from [laravel-mongodb](https://github.com/mongodb/laravel-mongodb/blob/5.x/src/Schema/Blueprint.php), which defines equivalent PHPStan types.

- Renames `OperationType` → `OperationShape` in `BulkWrite` for naming consistency
- Defines shapes: `SearchIndexFieldShape`, `SearchIndexCharFilterShape`, `SearchIndexTokenFilterShape`, `SearchIndexAnalyzerShape`, `SearchIndexStoredSourceShape`, `SearchIndexSynonymShape`, `SearchIndexDefinitionShape`, `VectorSearchIndexFieldShape`, `VectorSearchIndexDefinitionShape`, `SearchIndexShape`
- Updates `@param` on `createSearchIndex`, `createSearchIndexes`, `updateSearchIndex`
- `SearchIndexInput` imports `SearchIndexShape` from `Collection` via `@psalm-import-type`
- Adds `tests/Type/SearchIndexShapes.php` and `tests/Type/BulkWriteShapes.php` with Psalm type tests based on documentation examples
- Adds `tests/Type/` to `psalm.xml.dist`