### PR TITLE
PHPLIB-1691 Add $similarityCosine, $similarityDotProduct, and $similarityEuclidean expression operators

### DIFF
--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -1789,11 +1789,11 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityCosine/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
      */
     public static function similarityCosine(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
-        bool $score = false,
+        Optional|bool $score = Optional::Undefined,
     ): SimilarityCosineOperator {
         return new SimilarityCosineOperator($vectors, $score);
     }
@@ -1807,11 +1807,11 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityDotProduct/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
      */
     public static function similarityDotProduct(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
-        bool $score = false,
+        Optional|bool $score = Optional::Undefined,
     ): SimilarityDotProductOperator {
         return new SimilarityDotProductOperator($vectors, $score);
     }
@@ -1825,11 +1825,11 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityEuclidean/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
      */
     public static function similarityEuclidean(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
-        bool $score = false,
+        Optional|bool $score = Optional::Undefined,
     ): SimilarityEuclideanOperator {
         return new SimilarityEuclideanOperator($vectors, $score);
     }

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -1789,7 +1789,7 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityCosine/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false.
      */
     public static function similarityCosine(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
@@ -1807,7 +1807,7 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityDotProduct/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false.
      */
     public static function similarityDotProduct(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
@@ -1825,7 +1825,7 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityEuclidean/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false.
      */
     public static function similarityEuclidean(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -1781,6 +1781,60 @@ trait FactoryTrait
     }
 
     /**
+     * Returns the cosine similarity between two vectors. If the score argument is true, the result
+     * is normalized to a value between 0 and 1 for use as a vector search score.
+     *
+     * New in MongoDB 8.3
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityCosine/
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     */
+    public static function similarityCosine(
+        PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
+        bool $score = false,
+    ): SimilarityCosineOperator {
+        return new SimilarityCosineOperator($vectors, $score);
+    }
+
+    /**
+     * Returns the dot product similarity between two vectors. If the score argument is true, the result
+     * is normalized to a value between 0 and 1 for use as a vector search score.
+     *
+     * New in MongoDB 8.3
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityDotProduct/
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     */
+    public static function similarityDotProduct(
+        PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
+        bool $score = false,
+    ): SimilarityDotProductOperator {
+        return new SimilarityDotProductOperator($vectors, $score);
+    }
+
+    /**
+     * Returns the Euclidean similarity between two vectors. If the score argument is true, the result
+     * is normalized to a value between 0 and 1 for use as a vector search score.
+     *
+     * New in MongoDB 8.3
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityEuclidean/
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     */
+    public static function similarityEuclidean(
+        PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
+        bool $score = false,
+    ): SimilarityEuclideanOperator {
+        return new SimilarityEuclideanOperator($vectors, $score);
+    }
+
+    /**
      * Returns the sine of a value that is measured in radians.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sin/

--- a/src/Builder/Expression/SimilarityCosineOperator.php
+++ b/src/Builder/Expression/SimilarityCosineOperator.php
@@ -11,6 +11,7 @@ namespace MongoDB\Builder\Expression;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 
@@ -40,16 +41,18 @@ final class SimilarityCosineOperator implements ResolvesToDouble, OperatorInterf
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
 
-    /** @var bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
-    public readonly bool $score;
+    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    public readonly Optional|bool $score;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
      */
-    public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $vectors, bool $score = false)
-    {
+    public function __construct(
+        PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
+        Optional|bool $score = Optional::Undefined,
+    ) {
         if (is_string($vectors) && ! str_starts_with($vectors, '$')) {
             throw new InvalidArgumentException('Argument $vectors can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
         }

--- a/src/Builder/Expression/SimilarityCosineOperator.php
+++ b/src/Builder/Expression/SimilarityCosineOperator.php
@@ -41,13 +41,13 @@ final class SimilarityCosineOperator implements ResolvesToDouble, OperatorInterf
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
 
-    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false. */
     public readonly Optional|bool $score;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false.
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,

--- a/src/Builder/Expression/SimilarityCosineOperator.php
+++ b/src/Builder/Expression/SimilarityCosineOperator.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use MongoDB\BSON\PackedArray;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+
+use function array_is_list;
+use function is_array;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Returns the cosine similarity between two vectors. If the score argument is true, the result
+ * is normalized to a value between 0 and 1 for use as a vector search score.
+ *
+ * New in MongoDB 8.3
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityCosine/
+ * @internal
+ */
+final class SimilarityCosineOperator implements ResolvesToDouble, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$similarityCosine';
+    public const PROPERTIES = ['vectors' => 'vectors', 'score' => 'score'];
+
+    /**
+     * @var BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     */
+    public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
+
+    /** @var bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    public readonly bool $score;
+
+    /**
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     */
+    public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $vectors, bool $score = false)
+    {
+        if (is_string($vectors) && ! str_starts_with($vectors, '$')) {
+            throw new InvalidArgumentException('Argument $vectors can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        if (is_array($vectors) && ! array_is_list($vectors)) {
+            throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
+        }
+
+        $this->vectors = $vectors;
+        $this->score = $score;
+    }
+}

--- a/src/Builder/Expression/SimilarityDotProductOperator.php
+++ b/src/Builder/Expression/SimilarityDotProductOperator.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use MongoDB\BSON\PackedArray;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+
+use function array_is_list;
+use function is_array;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Returns the dot product similarity between two vectors. If the score argument is true, the result
+ * is normalized to a value between 0 and 1 for use as a vector search score.
+ *
+ * New in MongoDB 8.3
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityDotProduct/
+ * @internal
+ */
+final class SimilarityDotProductOperator implements ResolvesToDouble, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$similarityDotProduct';
+    public const PROPERTIES = ['vectors' => 'vectors', 'score' => 'score'];
+
+    /**
+     * @var BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     */
+    public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
+
+    /** @var bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    public readonly bool $score;
+
+    /**
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     */
+    public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $vectors, bool $score = false)
+    {
+        if (is_string($vectors) && ! str_starts_with($vectors, '$')) {
+            throw new InvalidArgumentException('Argument $vectors can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        if (is_array($vectors) && ! array_is_list($vectors)) {
+            throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
+        }
+
+        $this->vectors = $vectors;
+        $this->score = $score;
+    }
+}

--- a/src/Builder/Expression/SimilarityDotProductOperator.php
+++ b/src/Builder/Expression/SimilarityDotProductOperator.php
@@ -41,13 +41,13 @@ final class SimilarityDotProductOperator implements ResolvesToDouble, OperatorIn
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
 
-    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false. */
     public readonly Optional|bool $score;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false.
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,

--- a/src/Builder/Expression/SimilarityDotProductOperator.php
+++ b/src/Builder/Expression/SimilarityDotProductOperator.php
@@ -11,6 +11,7 @@ namespace MongoDB\Builder\Expression;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 
@@ -40,16 +41,18 @@ final class SimilarityDotProductOperator implements ResolvesToDouble, OperatorIn
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
 
-    /** @var bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
-    public readonly bool $score;
+    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    public readonly Optional|bool $score;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
      */
-    public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $vectors, bool $score = false)
-    {
+    public function __construct(
+        PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
+        Optional|bool $score = Optional::Undefined,
+    ) {
         if (is_string($vectors) && ! str_starts_with($vectors, '$')) {
             throw new InvalidArgumentException('Argument $vectors can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
         }

--- a/src/Builder/Expression/SimilarityEuclideanOperator.php
+++ b/src/Builder/Expression/SimilarityEuclideanOperator.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use MongoDB\BSON\PackedArray;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+
+use function array_is_list;
+use function is_array;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Returns the Euclidean similarity between two vectors. If the score argument is true, the result
+ * is normalized to a value between 0 and 1 for use as a vector search score.
+ *
+ * New in MongoDB 8.3
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityEuclidean/
+ * @internal
+ */
+final class SimilarityEuclideanOperator implements ResolvesToDouble, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$similarityEuclidean';
+    public const PROPERTIES = ['vectors' => 'vectors', 'score' => 'score'];
+
+    /**
+     * @var BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     */
+    public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
+
+    /** @var bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    public readonly bool $score;
+
+    /**
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
+     * Both arrays must have the same length.
+     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     */
+    public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $vectors, bool $score = false)
+    {
+        if (is_string($vectors) && ! str_starts_with($vectors, '$')) {
+            throw new InvalidArgumentException('Argument $vectors can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        if (is_array($vectors) && ! array_is_list($vectors)) {
+            throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
+        }
+
+        $this->vectors = $vectors;
+        $this->score = $score;
+    }
+}

--- a/src/Builder/Expression/SimilarityEuclideanOperator.php
+++ b/src/Builder/Expression/SimilarityEuclideanOperator.php
@@ -11,6 +11,7 @@ namespace MongoDB\Builder\Expression;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 
@@ -40,16 +41,18 @@ final class SimilarityEuclideanOperator implements ResolvesToDouble, OperatorInt
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
 
-    /** @var bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
-    public readonly bool $score;
+    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    public readonly Optional|bool $score;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
      */
-    public function __construct(PackedArray|ResolvesToArray|BSONArray|array|string $vectors, bool $score = false)
-    {
+    public function __construct(
+        PackedArray|ResolvesToArray|BSONArray|array|string $vectors,
+        Optional|bool $score = Optional::Undefined,
+    ) {
         if (is_string($vectors) && ! str_starts_with($vectors, '$')) {
             throw new InvalidArgumentException('Argument $vectors can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
         }

--- a/src/Builder/Expression/SimilarityEuclideanOperator.php
+++ b/src/Builder/Expression/SimilarityEuclideanOperator.php
@@ -41,13 +41,13 @@ final class SimilarityEuclideanOperator implements ResolvesToDouble, OperatorInt
      */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $vectors;
 
-    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. */
+    /** @var Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false. */
     public readonly Optional|bool $score;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $vectors An array of exactly two expressions that each resolve to an array of numbers.
      * Both arrays must have the same length.
-     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score.
+     * @param Optional|bool $score If true, normalizes the result to a value between 0 and 1 for use as a vector search score. Defaults to false.
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $vectors,

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -4813,6 +4813,162 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityCosine/#example
+     */
+    case SimilarityCosineExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "raw": {
+                    "$similarityCosine": {
+                        "vectors": [
+                            "$a",
+                            "$b"
+                        ],
+                        "score": false
+                    }
+                },
+                "normalized": {
+                    "$similarityCosine": {
+                        "vectors": [
+                            "$a",
+                            "$b"
+                        ],
+                        "score": true
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Short Syntax
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityCosine/#example
+     */
+    case SimilarityCosineShortSyntax = <<<'JSON'
+    [
+        {
+            "$project": {
+                "raw": {
+                    "$similarityCosine": [
+                        "$a",
+                        "$b"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityDotProduct/#example
+     */
+    case SimilarityDotProductExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "raw": {
+                    "$similarityDotProduct": {
+                        "vectors": [
+                            "$a",
+                            "$b"
+                        ],
+                        "score": false
+                    }
+                },
+                "normalized": {
+                    "$similarityDotProduct": {
+                        "vectors": [
+                            "$a",
+                            "$b"
+                        ],
+                        "score": true
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Short Syntax
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityDotProduct/#example
+     */
+    case SimilarityDotProductShortSyntax = <<<'JSON'
+    [
+        {
+            "$project": {
+                "raw": {
+                    "$similarityDotProduct": [
+                        "$a",
+                        "$b"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityEuclidean/#example
+     */
+    case SimilarityEuclideanExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "raw": {
+                    "$similarityEuclidean": {
+                        "vectors": [
+                            "$a",
+                            "$b"
+                        ],
+                        "score": false
+                    }
+                },
+                "normalized": {
+                    "$similarityEuclidean": {
+                        "vectors": [
+                            "$a",
+                            "$b"
+                        ],
+                        "score": true
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Short Syntax
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityEuclidean/#example
+     */
+    case SimilarityEuclideanShortSyntax = <<<'JSON'
+    [
+        {
+            "$project": {
+                "raw": {
+                    "$similarityEuclidean": [
+                        "$a",
+                        "$b"
+                    ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/sin/#example
      */
     case SinExample = <<<'JSON'

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -4824,8 +4824,7 @@ enum Pipelines: string
                         "vectors": [
                             "$a",
                             "$b"
-                        ],
-                        "score": false
+                        ]
                     }
                 },
                 "normalized": {
@@ -4836,26 +4835,6 @@ enum Pipelines: string
                         ],
                         "score": true
                     }
-                }
-            }
-        }
-    ]
-    JSON;
-
-    /**
-     * Short Syntax
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityCosine/#example
-     */
-    case SimilarityCosineShortSyntax = <<<'JSON'
-    [
-        {
-            "$project": {
-                "raw": {
-                    "$similarityCosine": [
-                        "$a",
-                        "$b"
-                    ]
                 }
             }
         }
@@ -4876,8 +4855,7 @@ enum Pipelines: string
                         "vectors": [
                             "$a",
                             "$b"
-                        ],
-                        "score": false
+                        ]
                     }
                 },
                 "normalized": {
@@ -4888,26 +4866,6 @@ enum Pipelines: string
                         ],
                         "score": true
                     }
-                }
-            }
-        }
-    ]
-    JSON;
-
-    /**
-     * Short Syntax
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityDotProduct/#example
-     */
-    case SimilarityDotProductShortSyntax = <<<'JSON'
-    [
-        {
-            "$project": {
-                "raw": {
-                    "$similarityDotProduct": [
-                        "$a",
-                        "$b"
-                    ]
                 }
             }
         }
@@ -4928,8 +4886,7 @@ enum Pipelines: string
                         "vectors": [
                             "$a",
                             "$b"
-                        ],
-                        "score": false
+                        ]
                     }
                 },
                 "normalized": {
@@ -4940,26 +4897,6 @@ enum Pipelines: string
                         ],
                         "score": true
                     }
-                }
-            }
-        }
-    ]
-    JSON;
-
-    /**
-     * Short Syntax
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/similarityEuclidean/#example
-     */
-    case SimilarityEuclideanShortSyntax = <<<'JSON'
-    [
-        {
-            "$project": {
-                "raw": {
-                    "$similarityEuclidean": [
-                        "$a",
-                        "$b"
-                    ]
                 }
             }
         }

--- a/tests/Builder/Expression/SimilarityCosineOperatorTest.php
+++ b/tests/Builder/Expression/SimilarityCosineOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $similarityCosine expression
+ */
+class SimilarityCosineOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                raw: Expression::similarityCosine(['$a', '$b']),
+                normalized: Expression::similarityCosine(vectors: ['$a', '$b'], score: true),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SimilarityCosineExample, $pipeline);
+    }
+
+    public function testShortSyntax(): void
+    {
+        $this->markTestSkipped('The builder does not support the short syntax for $similarityCosine');
+    }
+}

--- a/tests/Builder/Expression/SimilarityCosineOperatorTest.php
+++ b/tests/Builder/Expression/SimilarityCosineOperatorTest.php
@@ -25,9 +25,4 @@ class SimilarityCosineOperatorTest extends PipelineTestCase
 
         $this->assertSamePipeline(Pipelines::SimilarityCosineExample, $pipeline);
     }
-
-    public function testShortSyntax(): void
-    {
-        $this->markTestSkipped('The builder does not support the short syntax for $similarityCosine');
-    }
 }

--- a/tests/Builder/Expression/SimilarityDotProductOperatorTest.php
+++ b/tests/Builder/Expression/SimilarityDotProductOperatorTest.php
@@ -25,9 +25,4 @@ class SimilarityDotProductOperatorTest extends PipelineTestCase
 
         $this->assertSamePipeline(Pipelines::SimilarityDotProductExample, $pipeline);
     }
-
-    public function testShortSyntax(): void
-    {
-        $this->markTestSkipped('The builder does not support the short syntax for $similarityDotProduct');
-    }
 }

--- a/tests/Builder/Expression/SimilarityDotProductOperatorTest.php
+++ b/tests/Builder/Expression/SimilarityDotProductOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $similarityDotProduct expression
+ */
+class SimilarityDotProductOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                raw: Expression::similarityDotProduct(['$a', '$b']),
+                normalized: Expression::similarityDotProduct(vectors: ['$a', '$b'], score: true),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SimilarityDotProductExample, $pipeline);
+    }
+
+    public function testShortSyntax(): void
+    {
+        $this->markTestSkipped('The builder does not support the short syntax for $similarityDotProduct');
+    }
+}

--- a/tests/Builder/Expression/SimilarityEuclideanOperatorTest.php
+++ b/tests/Builder/Expression/SimilarityEuclideanOperatorTest.php
@@ -25,9 +25,4 @@ class SimilarityEuclideanOperatorTest extends PipelineTestCase
 
         $this->assertSamePipeline(Pipelines::SimilarityEuclideanExample, $pipeline);
     }
-
-    public function testShortSyntax(): void
-    {
-        $this->markTestSkipped('The builder does not support the short syntax for $similarityEuclidean');
-    }
 }

--- a/tests/Builder/Expression/SimilarityEuclideanOperatorTest.php
+++ b/tests/Builder/Expression/SimilarityEuclideanOperatorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $similarityEuclidean expression
+ */
+class SimilarityEuclideanOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                raw: Expression::similarityEuclidean(['$a', '$b']),
+                normalized: Expression::similarityEuclidean(vectors: ['$a', '$b'], score: true),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SimilarityEuclideanExample, $pipeline);
+    }
+
+    public function testShortSyntax(): void
+    {
+        $this->markTestSkipped('The builder does not support the short syntax for $similarityEuclidean');
+    }
+}

--- a/tests/Builder/Stage/OutStageTest.php
+++ b/tests/Builder/Stage/OutStageTest.php
@@ -10,8 +10,6 @@ use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
 
-use function MongoDB\object;
-
 /**
  * Test $out stage
  */
@@ -36,13 +34,13 @@ class OutStageTest extends PipelineTestCase
     {
         $pipeline = new Pipeline(
             Stage::out(
-                coll: 'sensorData',
                 db: 'reporting',
-                timeseries: object(
-                    timeField: 'timestamp',
-                    metaField: 'sensorId',
-                    granularity: 'hours',
-                ),
+                coll: 'sensorData',
+                timeseries: [
+                    'timeField' => 'timestamp',
+                    'metaField' => 'sensorId',
+                    'granularity' => 'hours',
+                ],
             ),
         );
 


### PR DESCRIPTION
## Summary

- Adds support for the three vector similarity expression operators introduced in MongoDB 8.3
- `$similarityCosine` — cosine similarity between two vectors
- `$similarityDotProduct` — dot product similarity between two vectors
- `$similarityEuclidean` — Euclidean similarity between two vectors

All three operators share the same structure: `vectors` (array of two expressions resolving to arrays of numbers) and `score` (boolean, default `false`, to normalize the result as a vector search score).

Classes are generated from [mql-specifications PR #43](https://github.com/mongodb/mql-specifications/pull/43), bumped to commit `2b22235` (rebased on top of upstream main to include `returnStoredSource` changes).

## Jira

https://jira.mongodb.org/browse/PHPLIB-1691