### PR TITLE
PHPLIB-1386 Add $out stage with object encoding, db/coll fields, and timeseries support

### DIFF
--- a/generator/src/FluentStageFactoryGenerator.php
+++ b/generator/src/FluentStageFactoryGenerator.php
@@ -16,12 +16,15 @@ use Nette\PhpGenerator\PhpNamespace;
 use Nette\PhpGenerator\TraitType;
 use ReflectionClass;
 use stdClass;
+use Throwable;
 
 use function array_key_last;
 use function array_map;
 use function assert;
+use function class_implements;
 use function file_get_contents;
 use function implode;
+use function in_array;
 use function sprintf;
 
 /**
@@ -127,6 +130,11 @@ class FluentStageFactoryGenerator extends OperatorGenerator
 
         foreach ($file->getNamespaces() as $ns) {
             foreach ($ns->getUses() as $use) {
+                // Skip classes used in the method body only.
+                if (in_array(Throwable::class, class_implements($use), true)) {
+                    continue;
+                }
+
                 $namespace->addUse($use);
             }
         }

--- a/src/Builder/Stage.php
+++ b/src/Builder/Stage.php
@@ -16,7 +16,6 @@ use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\QueryInterface;
 use stdClass;
 
-use function assert;
 use function get_debug_type;
 use function is_array;
 use function is_string;
@@ -48,7 +47,7 @@ final class Stage
      * Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
-     * @param Document|Serializable|array|stdClass|string   $coll       The output collection name.
+     * @param Document|Serializable|array|stdClass|string   $coll       The output collection name. Passing a non-string value is deprecated since 2.4.
      * @param Optional|string                               $db         The output database name. If omitted, defaults to the current database.
      * @param Optional|Document|Serializable|array|stdClass $timeseries Specifies the configuration to use when writing to a time series collection.
      * The timeField is required. All other fields are optional.
@@ -61,7 +60,7 @@ final class Stage
         Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
     ): OutStage {
         if (! is_string($coll)) {
-            trigger_error(sprintf('Since mongodb/mongodb 2.3: %s::%s() first argument must be the collection name. Passing "%s" is deprecated', self::class, __FUNCTION__, get_debug_type($coll)), E_USER_DEPRECATED);
+            trigger_error(sprintf('Since mongodb/mongodb 2.4: %s::%s() first argument must be the collection name. Passing "%s" is deprecated', self::class, __FUNCTION__, get_debug_type($coll)), E_USER_DEPRECATED);
 
             if ($db !== Optional::Undefined || $timeseries !== Optional::Undefined) {
                 throw new InvalidArgumentException('When passing a non-string first argument, the $db and $timeseries arguments must not be passed.');
@@ -73,13 +72,15 @@ final class Stage
                 $coll = (array) $coll;
             }
 
-            assert(is_array($coll));
+            if (! is_array($coll) || ! isset($coll['coll']) || ! is_string($coll['coll'])) {
+                throw new InvalidArgumentException('When passing a non-string first argument, it must be an array or object with a "coll" string field.');
+            }
 
             if (isset($coll['db'])) {
                 $db = (string) $coll['db'];
             }
 
-            $coll = (string) $coll['coll'];
+            $coll = $coll['coll'];
         }
 
         return new OutStage($coll, $db, $timeseries);

--- a/src/Builder/Stage.php
+++ b/src/Builder/Stage.php
@@ -5,11 +5,25 @@ declare(strict_types=1);
 namespace MongoDB\Builder;
 
 use DateTimeInterface;
+use InvalidArgumentException;
+use MongoDB\BSON\Document;
+use MongoDB\BSON\Serializable;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Stage\MatchStage;
+use MongoDB\Builder\Stage\OutStage;
 use MongoDB\Builder\Type\FieldQueryInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\QueryInterface;
 use stdClass;
+
+use function assert;
+use function get_debug_type;
+use function is_array;
+use function is_string;
+use function sprintf;
+use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 final class Stage
 {
@@ -28,6 +42,47 @@ final class Stage
     {
         // Override the generated method to allow variadic arguments
         return self::generatedMatch($queries);
+    }
+
+    /**
+     * Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
+     * @param Document|Serializable|array|stdClass|string   $coll       The output collection name.
+     * @param Optional|string                               $db         The output database name. If omitted, defaults to the current database.
+     * @param Optional|Document|Serializable|array|stdClass $timeseries Specifies the configuration to use when writing to a time series collection.
+     * The timeField is required. All other fields are optional.
+     *
+     * New in MongoDB 7.0.3
+     */
+    public static function out(
+        Document|Serializable|stdClass|array|string $coll,
+        Optional|string $db = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
+    ): OutStage {
+        if (! is_string($coll)) {
+            trigger_error(sprintf('Since mongodb/mongodb 2.3: %s::%s() first argument must be the collection name. Passing "%s" is deprecated', self::class, __FUNCTION__, get_debug_type($coll)), E_USER_DEPRECATED);
+
+            if ($db !== Optional::Undefined || $timeseries !== Optional::Undefined) {
+                throw new InvalidArgumentException('When passing a non-string first argument, the $db and $timeseries arguments must not be passed.');
+            }
+
+            if ($coll instanceof Serializable) {
+                $coll = (array) $coll->bsonSerialize();
+            } elseif ($coll instanceof stdClass) {
+                $coll = (array) $coll;
+            }
+
+            assert(is_array($coll));
+
+            if (isset($coll['db'])) {
+                $db = (string) $coll['db'];
+            }
+
+            $coll = (string) $coll['coll'];
+        }
+
+        return new OutStage($coll, $db, $timeseries);
     }
 
     private function __construct()

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -468,11 +468,19 @@ trait FactoryTrait
      * Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
-     * @param Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to.
+     * @param string $coll The output collection name.
+     * @param Optional|string $db The output database name. If omitted, defaults to the current database.
+     * @param Optional|Document|Serializable|array|stdClass $timeseries Specifies the configuration to use when writing to a time series collection.
+     * The timeField is required. All other fields are optional.
+     *
+     * New in MongoDB 7.0.3
      */
-    public static function out(Document|Serializable|stdClass|array|string $coll): OutStage
-    {
-        return new OutStage($coll);
+    public static function out(
+        string $coll,
+        Optional|string $db = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
+    ): OutStage {
+        return new OutStage($coll, $db, $timeseries);
     }
 
     /**

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Stage;
 
 use DateTimeInterface;
+use InvalidArgumentException;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
@@ -53,6 +54,27 @@ trait FluentFactoryTrait
         DateTimeInterface|QueryInterface|FieldQueryInterface|Type|stdClass|array|string|int|float|bool|null ...$queries,
     ): static {
         $this->pipeline[] = Stage::match(...$queries);
+
+        return $this;
+    }
+
+    /**
+     * Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
+     * @param Document|Serializable|array|stdClass|string   $coll       The output collection name. Passing a non-string value is deprecated since 2.4.
+     * @param Optional|string                               $db         The output database name. If omitted, defaults to the current database.
+     * @param Optional|Document|Serializable|array|stdClass $timeseries Specifies the configuration to use when writing to a time series collection.
+     * The timeField is required. All other fields are optional.
+     *
+     * New in MongoDB 7.0.3
+     */
+    public function out(
+        Document|Serializable|stdClass|array|string $coll,
+        Optional|string $db = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
+    ): static {
+        $this->pipeline[] = Stage::out($coll, $db, $timeseries);
 
         return $this;
     }
@@ -517,27 +539,6 @@ trait FluentFactoryTrait
         Optional|string $whenNotMatched = Optional::Undefined,
     ): static {
         $this->pipeline[] = Stage::merge($into, $on, $let, $whenMatched, $whenNotMatched);
-
-        return $this;
-    }
-
-    /**
-     * Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
-     *
-     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
-     * @param string $coll The output collection name.
-     * @param Optional|string $db The output database name. If omitted, defaults to the current database.
-     * @param Optional|Document|Serializable|array|stdClass $timeseries Specifies the configuration to use when writing to a time series collection.
-     * The timeField is required. All other fields are optional.
-     *
-     * New in MongoDB 7.0.3
-     */
-    public function out(
-        string $coll,
-        Optional|string $db = Optional::Undefined,
-        Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
-    ): static {
-        $this->pipeline[] = Stage::out($coll, $db, $timeseries);
 
         return $this;
     }

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -525,11 +525,19 @@ trait FluentFactoryTrait
      * Writes the resulting documents of the aggregation pipeline to a collection. To use the $out stage, it must be the last stage in the pipeline.
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/
-     * @param Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to.
+     * @param string $coll The output collection name.
+     * @param Optional|string $db The output database name. If omitted, defaults to the current database.
+     * @param Optional|Document|Serializable|array|stdClass $timeseries Specifies the configuration to use when writing to a time series collection.
+     * The timeField is required. All other fields are optional.
+     *
+     * New in MongoDB 7.0.3
      */
-    public function out(Document|Serializable|stdClass|array|string $coll): static
-    {
-        $this->pipeline[] = Stage::out($coll);
+    public function out(
+        string $coll,
+        Optional|string $db = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
+    ): static {
+        $this->pipeline[] = Stage::out($coll, $db, $timeseries);
 
         return $this;
     }

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Stage;
 
 use DateTimeInterface;
-use InvalidArgumentException;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;

--- a/src/Builder/Stage/OutStage.php
+++ b/src/Builder/Stage/OutStage.php
@@ -12,6 +12,7 @@ use MongoDB\BSON\Document;
 use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Builder\Type\OutputStageInterface;
 use stdClass;
 
@@ -23,16 +24,39 @@ use stdClass;
  */
 final class OutStage implements OutputStageInterface, OperatorInterface
 {
-    public const ENCODE = Encode::Single;
+    public const ENCODE = Encode::Object;
     public const NAME = '$out';
-    public const PROPERTIES = ['coll' => 'coll'];
+    public const PROPERTIES = ['coll' => 'coll', 'db' => 'db', 'timeseries' => 'timeseries'];
 
-    /** @var Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to. */
-    public readonly Document|Serializable|stdClass|array|string $coll;
+    /** @var string $coll The output collection name. */
+    public readonly string $coll;
 
-    /** @param Document|Serializable|array|stdClass|string $coll Target database name to write documents from $out to. */
-    public function __construct(Document|Serializable|stdClass|array|string $coll)
-    {
+    /** @var Optional|string $db The output database name. If omitted, defaults to the current database. */
+    public readonly Optional|string $db;
+
+    /**
+     * @var Optional|Document|Serializable|array|stdClass $timeseries Specifies the configuration to use when writing to a time series collection.
+     * The timeField is required. All other fields are optional.
+     *
+     * New in MongoDB 7.0.3
+     */
+    public readonly Optional|Document|Serializable|stdClass|array $timeseries;
+
+    /**
+     * @param string $coll The output collection name.
+     * @param Optional|string $db The output database name. If omitted, defaults to the current database.
+     * @param Optional|Document|Serializable|array|stdClass $timeseries Specifies the configuration to use when writing to a time series collection.
+     * The timeField is required. All other fields are optional.
+     *
+     * New in MongoDB 7.0.3
+     */
+    public function __construct(
+        string $coll,
+        Optional|string $db = Optional::Undefined,
+        Optional|Document|Serializable|stdClass|array $timeseries = Optional::Undefined,
+    ) {
         $this->coll = $coll;
+        $this->db = $db;
+        $this->timeseries = $timeseries;
     }
 }

--- a/tests/Builder/Stage/OutStageLegacyTest.php
+++ b/tests/Builder/Stage/OutStageLegacyTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use InvalidArgumentException;
+use MongoDB\BSON\Serializable;
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+use stdClass;
+
+use function MongoDB\object;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
+
+/**
+ * Test $out stage with deprecated arguments
+ */
+class OutStageLegacyTest extends PipelineTestCase
+{
+    public function testDeprecatedOutputToSameDatabaseWithObject(): void
+    {
+        $pipeline = $this->assertDeprecated(
+            fn () => new Pipeline(
+                Stage::group(
+                    _id: Expression::stringFieldPath('author'),
+                    books: Accumulator::push(Expression::stringFieldPath('title')),
+                ),
+                Stage::out(object(coll: 'authors')),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToSameDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputToADifferentDatabaseWithObject(): void
+    {
+        $pipeline = $this->assertDeprecated(
+            fn () => new Pipeline(
+                Stage::group(
+                    _id: Expression::stringFieldPath('author'),
+                    books: Accumulator::push(Expression::stringFieldPath('title')),
+                ),
+                Stage::out(object(db: 'reporting', coll: 'authors')),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputToADifferentDatabaseWithSerializable(): void
+    {
+        $pipeline = $this->assertDeprecated(
+            fn () => new Pipeline(
+                Stage::group(
+                    _id: Expression::stringFieldPath('author'),
+                    books: Accumulator::push(Expression::stringFieldPath('title')),
+                ),
+                Stage::out(new class implements Serializable {
+                    public function bsonSerialize(): stdClass
+                    {
+                        return (object) ['db' => 'reporting', 'coll' => 'authors'];
+                    }
+                }),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputWithArray(): void
+    {
+        $pipeline = $this->assertDeprecated(
+            fn () => new Pipeline(
+                Stage::group(
+                    _id: Expression::stringFieldPath('author'),
+                    books: Accumulator::push(Expression::stringFieldPath('title')),
+                ),
+                Stage::out(['coll' => 'authors', 'db' => 'reporting']),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputThrowsWithExtraArguments(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$db and $timeseries arguments must not be passed');
+
+        $this->assertDeprecated(
+            fn () => Stage::out(object(coll: 'authors'), db: 'reporting'),
+        );
+    }
+
+    public function testDeprecatedOutputThrowsWithMissingCollField(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"coll" string field');
+
+        $this->assertDeprecated(
+            fn () => Stage::out(object(db: 'reporting')),
+        );
+    }
+
+    private function assertDeprecated(callable $callable): mixed
+    {
+        $messages = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$messages): bool {
+            $messages[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $result = $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertCount(1, $messages, 'Expected exactly one deprecation notice');
+
+        return $result;
+    }
+}

--- a/tests/Builder/Stage/OutStageTest.php
+++ b/tests/Builder/Stage/OutStageTest.php
@@ -26,15 +26,27 @@ class OutStageTest extends PipelineTestCase
                     Expression::stringFieldPath('title'),
                 ),
             ),
+            Stage::out(coll: 'authors', db: 'reporting'),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+    }
+
+    public function testOutputToATimeSeriesCollection(): void
+    {
+        $pipeline = new Pipeline(
             Stage::out(
-                object(
-                    db: 'reporting',
-                    coll: 'authors',
+                coll: 'sensorData',
+                db: 'reporting',
+                timeseries: object(
+                    timeField: 'timestamp',
+                    metaField: 'sensorId',
+                    granularity: 'hours',
                 ),
             ),
         );
 
-        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+        $this->assertSamePipeline(Pipelines::OutOutputToATimeSeriesCollection, $pipeline);
     }
 
     public function testOutputToSameDatabase(): void

--- a/tests/Builder/Stage/OutStageTest.php
+++ b/tests/Builder/Stage/OutStageTest.php
@@ -4,20 +4,13 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Stage;
 
-use InvalidArgumentException;
-use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
-use stdClass;
 
 use function MongoDB\object;
-use function restore_error_handler;
-use function set_error_handler;
-
-use const E_USER_DEPRECATED;
 
 /**
  * Test $out stage
@@ -69,100 +62,5 @@ class OutStageTest extends PipelineTestCase
         );
 
         $this->assertSamePipeline(Pipelines::OutOutputToSameDatabase, $pipeline);
-    }
-
-    public function testDeprecatedOutputToSameDatabaseWithObject(): void
-    {
-        $pipeline = $this->assertDeprecated(
-            fn () => new Pipeline(
-                Stage::group(
-                    _id: Expression::stringFieldPath('author'),
-                    books: Accumulator::push(Expression::stringFieldPath('title')),
-                ),
-                Stage::out(object(coll: 'authors')),
-            ),
-        );
-
-        $this->assertSamePipeline(Pipelines::OutOutputToSameDatabase, $pipeline);
-    }
-
-    public function testDeprecatedOutputToADifferentDatabaseWithObject(): void
-    {
-        $pipeline = $this->assertDeprecated(
-            fn () => new Pipeline(
-                Stage::group(
-                    _id: Expression::stringFieldPath('author'),
-                    books: Accumulator::push(Expression::stringFieldPath('title')),
-                ),
-                Stage::out(object(db: 'reporting', coll: 'authors')),
-            ),
-        );
-
-        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
-    }
-
-    public function testDeprecatedOutputToADifferentDatabaseWithSerializable(): void
-    {
-        $pipeline = $this->assertDeprecated(
-            fn () => new Pipeline(
-                Stage::group(
-                    _id: Expression::stringFieldPath('author'),
-                    books: Accumulator::push(Expression::stringFieldPath('title')),
-                ),
-                Stage::out(new class implements Serializable {
-                    public function bsonSerialize(): stdClass
-                    {
-                        return (object) ['db' => 'reporting', 'coll' => 'authors'];
-                    }
-                }),
-            ),
-        );
-
-        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
-    }
-
-    public function testDeprecatedOutputWithArray(): void
-    {
-        $pipeline = $this->assertDeprecated(
-            fn () => new Pipeline(
-                Stage::group(
-                    _id: Expression::stringFieldPath('author'),
-                    books: Accumulator::push(Expression::stringFieldPath('title')),
-                ),
-                Stage::out(['coll' => 'authors', 'db' => 'reporting']),
-            ),
-        );
-
-        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
-    }
-
-    public function testDeprecatedOutputThrowsWithExtraArguments(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('$db and $timeseries arguments must not be passed');
-
-        $this->assertDeprecated(
-            fn () => Stage::out(object(coll: 'authors'), db: 'reporting'),
-        );
-    }
-
-    private function assertDeprecated(callable $callable): mixed
-    {
-        $messages = [];
-        set_error_handler(static function (int $errno, string $errstr) use (&$messages): bool {
-            $messages[] = $errstr;
-
-            return true;
-        }, E_USER_DEPRECATED);
-
-        try {
-            $result = $callable();
-        } finally {
-            restore_error_handler();
-        }
-
-        self::assertCount(1, $messages, 'Expected exactly one deprecation notice');
-
-        return $result;
     }
 }

--- a/tests/Builder/Stage/OutStageTest.php
+++ b/tests/Builder/Stage/OutStageTest.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Stage;
 
+use InvalidArgumentException;
+use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Accumulator;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
 use MongoDB\Tests\Builder\PipelineTestCase;
+use stdClass;
 
 use function MongoDB\object;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_DEPRECATED;
 
 /**
  * Test $out stage
@@ -62,5 +69,100 @@ class OutStageTest extends PipelineTestCase
         );
 
         $this->assertSamePipeline(Pipelines::OutOutputToSameDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputToSameDatabaseWithObject(): void
+    {
+        $pipeline = $this->assertDeprecated(
+            fn () => new Pipeline(
+                Stage::group(
+                    _id: Expression::stringFieldPath('author'),
+                    books: Accumulator::push(Expression::stringFieldPath('title')),
+                ),
+                Stage::out(object(coll: 'authors')),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToSameDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputToADifferentDatabaseWithObject(): void
+    {
+        $pipeline = $this->assertDeprecated(
+            fn () => new Pipeline(
+                Stage::group(
+                    _id: Expression::stringFieldPath('author'),
+                    books: Accumulator::push(Expression::stringFieldPath('title')),
+                ),
+                Stage::out(object(db: 'reporting', coll: 'authors')),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputToADifferentDatabaseWithSerializable(): void
+    {
+        $pipeline = $this->assertDeprecated(
+            fn () => new Pipeline(
+                Stage::group(
+                    _id: Expression::stringFieldPath('author'),
+                    books: Accumulator::push(Expression::stringFieldPath('title')),
+                ),
+                Stage::out(new class implements Serializable {
+                    public function bsonSerialize(): stdClass
+                    {
+                        return (object) ['db' => 'reporting', 'coll' => 'authors'];
+                    }
+                }),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputWithArray(): void
+    {
+        $pipeline = $this->assertDeprecated(
+            fn () => new Pipeline(
+                Stage::group(
+                    _id: Expression::stringFieldPath('author'),
+                    books: Accumulator::push(Expression::stringFieldPath('title')),
+                ),
+                Stage::out(['coll' => 'authors', 'db' => 'reporting']),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::OutOutputToADifferentDatabase, $pipeline);
+    }
+
+    public function testDeprecatedOutputThrowsWithExtraArguments(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$db and $timeseries arguments must not be passed');
+
+        $this->assertDeprecated(
+            fn () => Stage::out(object(coll: 'authors'), db: 'reporting'),
+        );
+    }
+
+    private function assertDeprecated(callable $callable): mixed
+    {
+        $messages = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$messages): bool {
+            $messages[] = $errstr;
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $result = $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertCount(1, $messages, 'Expected exactly one deprecation notice');
+
+        return $result;
     }
 }

--- a/tests/Builder/Stage/Pipelines.php
+++ b/tests/Builder/Stage/Pipelines.php
@@ -1934,7 +1934,9 @@ enum Pipelines: string
             }
         },
         {
-            "$out": "authors"
+            "$out": {
+                "coll": "authors"
+            }
         }
     ]
     JSON;
@@ -1958,6 +1960,27 @@ enum Pipelines: string
             "$out": {
                 "db": "reporting",
                 "coll": "authors"
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Output to a Time Series Collection
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/out/#output-to-a-time-series-collection
+     */
+    case OutOutputToATimeSeriesCollection = <<<'JSON'
+    [
+        {
+            "$out": {
+                "db": "reporting",
+                "coll": "sensorData",
+                "timeseries": {
+                    "timeField": "timestamp",
+                    "metaField": "sensorId",
+                    "granularity": "hours"
+                }
             }
         }
     ]


### PR DESCRIPTION
## Summary

Rewrites the `$out` stage builder with:
- `encode: object` (was `encode: single` with an `outCollection` type accepting a string or object)
- Explicit `coll` (required) and `db` (optional) named parameters
- `timeseries` nested object argument (minVersion 7.0.3) with `timeField`, `metaField`, `granularity`, `bucketMaxSpanSeconds`, `bucketRoundingSeconds`

Generated from [mql-specifications PR #42](https://github.com/mongodb/mql-specifications/pull/42) (rebased on upstream main).

**Deprecation since 2.4**: Passing a non-string first argument to `Stage::out()` triggers `E_USER_DEPRECATED`. The old forms still work:
- `Stage::out('authors')` → no change, still works
- `Stage::out(object(coll: 'authors'))` → deprecated, use `Stage::out('authors')`
- `Stage::out(object(db: 'reporting', coll: 'authors'))` → deprecated, use `Stage::out(coll: 'authors', db: 'reporting')`

## Jira

https://jira.mongodb.org/browse/PHPLIB-1386