### PR TITLE
Fix generated names in data providers

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -191,7 +191,13 @@ OUTPUT;
             foreach ($values as $key => $value) {
                 $dataKey = $option . '_' . $key;
                 if (is_int($key)) {
-                    $dataKey .= '_' . get_debug_type($value);
+                    $suffix = get_debug_type($value);
+
+                    if (is_object($value) && preg_match('#(.*)_[0-9a-f]{8}$#', $suffix, $matches)) {
+                        $dataKey .= '_' . $matches[1];
+                    } else {
+                        $dataKey .= '_' . $suffix;
+                    }
                 }
 
                 $data[$dataKey] = [[$option => $value]];


### PR DESCRIPTION
While looking at the flaky test analysis on codecov.io, I noticed that there is a high number of tests with a 100% flake rate, all matching the pattern `MongoDB.Tests.Collection.CollectionFunctionalTest::testConstructorOptionTypeChecks with data set "codec_6_MockObject_Codec_[0-9a-f]{8}"`. This is due to `createOptionDataProvider` using `get_debug_type` to append the type being tested to the data set name, but this one particular test passes a PHPUnit stub with an auto-generated name. To work around this, this PR trims off that auto-generated suffix. We can't use `get_parent_class` here as the stub is for an interface, not a class.