### PR TITLE
PHPLIB-1691 Validate that vectors argument has exactly 2 items

### DIFF
--- a/generator/src/Definition/ArgumentDefinition.php
+++ b/generator/src/Definition/ArgumentDefinition.php
@@ -33,6 +33,8 @@ final class ArgumentDefinition
         public mixed $default = null,
         public bool $mergeObject = false,
         public string|null $minVersion = null,
+        public int|null $minItems = null,
+        public int|null $maxItems = null,
         mixed ...$ignoredOtherArgs,
     ) {
         assert($this->optional === false || $this->default === null, 'Optional arguments cannot have a default value');

--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -162,14 +162,13 @@ class OperatorClassGenerator extends OperatorGenerator
 
                 if ($argument->minItems !== null || $argument->maxItems !== null) {
                     $namespace->addUseFunction('count');
-                    $namespace->addUseFunction('is_array');
+                    $namespace->addUseFunction('is_countable');
                     $namespace->addUseFunction('sprintf');
                     $namespace->addUse(InvalidArgumentException::class);
-                    $namespace->addUse('Countable');
                     if ($argument->minItems !== null && $argument->minItems === $argument->maxItems) {
                         $constructor->addBody(<<<PHP
                         /** @psalm-suppress RedundantCondition */
-                        if ((is_array(\${$argument->propertyName}) || \${$argument->propertyName} instanceof Countable) && count(\${$argument->propertyName}) !== {$argument->minItems}) {
+                        if (is_countable(\${$argument->propertyName}) && count(\${$argument->propertyName}) !== {$argument->minItems}) {
                             throw new InvalidArgumentException(sprintf('Expected exactly %d items for \${$argument->propertyName}, got %d.', {$argument->minItems}, count(\${$argument->propertyName})));
                         }
 
@@ -178,7 +177,7 @@ class OperatorClassGenerator extends OperatorGenerator
                         if ($argument->minItems !== null) {
                             $constructor->addBody(<<<PHP
                             /** @psalm-suppress RedundantCondition */
-                            if ((is_array(\${$argument->propertyName}) || \${$argument->propertyName} instanceof Countable) && count(\${$argument->propertyName}) < {$argument->minItems}) {
+                            if (is_countable(\${$argument->propertyName}) && count(\${$argument->propertyName}) < {$argument->minItems}) {
                                 throw new InvalidArgumentException(sprintf('Expected at least %d items for \${$argument->propertyName}, got %d.', {$argument->minItems}, count(\${$argument->propertyName})));
                             }
 
@@ -188,7 +187,7 @@ class OperatorClassGenerator extends OperatorGenerator
                         if ($argument->maxItems !== null) {
                             $constructor->addBody(<<<PHP
                             /** @psalm-suppress RedundantCondition */
-                            if ((is_array(\${$argument->propertyName}) || \${$argument->propertyName} instanceof Countable) && count(\${$argument->propertyName}) > {$argument->maxItems}) {
+                            if (is_countable(\${$argument->propertyName}) && count(\${$argument->propertyName}) > {$argument->maxItems}) {
                                 throw new InvalidArgumentException(sprintf('Expected at most %d items for \${$argument->propertyName}, got %d.', {$argument->maxItems}, count(\${$argument->propertyName})));
                             }
 

--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -160,6 +160,42 @@ class OperatorClassGenerator extends OperatorGenerator
                     PHP);
                 }
 
+                if ($argument->minItems !== null || $argument->maxItems !== null) {
+                    $namespace->addUseFunction('count');
+                    $namespace->addUseFunction('is_array');
+                    $namespace->addUseFunction('sprintf');
+                    $namespace->addUse(InvalidArgumentException::class);
+                    if ($argument->minItems !== null && $argument->minItems === $argument->maxItems) {
+                        $constructor->addBody(<<<PHP
+                        /** @psalm-suppress RedundantCondition \${$argument->propertyName} can also be ResolvesToArray, BSONArray, PackedArray */
+                        if (is_array(\${$argument->propertyName}) && count(\${$argument->propertyName}) !== {$argument->minItems}) {
+                            throw new InvalidArgumentException(sprintf('Expected exactly %d items for \${$argument->propertyName}, got %d.', {$argument->minItems}, count(\${$argument->propertyName})));
+                        }
+
+                        PHP);
+                    } else {
+                        if ($argument->minItems !== null) {
+                            $constructor->addBody(<<<PHP
+                            /** @psalm-suppress RedundantCondition \${$argument->propertyName} can also be ResolvesToArray, BSONArray, PackedArray */
+                            if (is_array(\${$argument->propertyName}) && count(\${$argument->propertyName}) < {$argument->minItems}) {
+                                throw new InvalidArgumentException(sprintf('Expected at least %d items for \${$argument->propertyName}, got %d.', {$argument->minItems}, count(\${$argument->propertyName})));
+                            }
+
+                            PHP);
+                        }
+
+                        if ($argument->maxItems !== null) {
+                            $constructor->addBody(<<<PHP
+                            /** @psalm-suppress RedundantCondition \${$argument->propertyName} can also be ResolvesToArray, BSONArray, PackedArray */
+                            if (is_array(\${$argument->propertyName}) && count(\${$argument->propertyName}) > {$argument->maxItems}) {
+                                throw new InvalidArgumentException(sprintf('Expected at most %d items for \${$argument->propertyName}, got %d.', {$argument->maxItems}, count(\${$argument->propertyName})));
+                            }
+
+                            PHP);
+                        }
+                    }
+                }
+
                 if ($type->query) {
                     $namespace->addUseFunction('is_array');
                     $namespace->addUse(QueryObject::class);

--- a/generator/src/OperatorClassGenerator.php
+++ b/generator/src/OperatorClassGenerator.php
@@ -165,10 +165,11 @@ class OperatorClassGenerator extends OperatorGenerator
                     $namespace->addUseFunction('is_array');
                     $namespace->addUseFunction('sprintf');
                     $namespace->addUse(InvalidArgumentException::class);
+                    $namespace->addUse('Countable');
                     if ($argument->minItems !== null && $argument->minItems === $argument->maxItems) {
                         $constructor->addBody(<<<PHP
-                        /** @psalm-suppress RedundantCondition \${$argument->propertyName} can also be ResolvesToArray, BSONArray, PackedArray */
-                        if (is_array(\${$argument->propertyName}) && count(\${$argument->propertyName}) !== {$argument->minItems}) {
+                        /** @psalm-suppress RedundantCondition */
+                        if ((is_array(\${$argument->propertyName}) || \${$argument->propertyName} instanceof Countable) && count(\${$argument->propertyName}) !== {$argument->minItems}) {
                             throw new InvalidArgumentException(sprintf('Expected exactly %d items for \${$argument->propertyName}, got %d.', {$argument->minItems}, count(\${$argument->propertyName})));
                         }
 
@@ -176,8 +177,8 @@ class OperatorClassGenerator extends OperatorGenerator
                     } else {
                         if ($argument->minItems !== null) {
                             $constructor->addBody(<<<PHP
-                            /** @psalm-suppress RedundantCondition \${$argument->propertyName} can also be ResolvesToArray, BSONArray, PackedArray */
-                            if (is_array(\${$argument->propertyName}) && count(\${$argument->propertyName}) < {$argument->minItems}) {
+                            /** @psalm-suppress RedundantCondition */
+                            if ((is_array(\${$argument->propertyName}) || \${$argument->propertyName} instanceof Countable) && count(\${$argument->propertyName}) < {$argument->minItems}) {
                                 throw new InvalidArgumentException(sprintf('Expected at least %d items for \${$argument->propertyName}, got %d.', {$argument->minItems}, count(\${$argument->propertyName})));
                             }
 
@@ -186,8 +187,8 @@ class OperatorClassGenerator extends OperatorGenerator
 
                         if ($argument->maxItems !== null) {
                             $constructor->addBody(<<<PHP
-                            /** @psalm-suppress RedundantCondition \${$argument->propertyName} can also be ResolvesToArray, BSONArray, PackedArray */
-                            if (is_array(\${$argument->propertyName}) && count(\${$argument->propertyName}) > {$argument->maxItems}) {
+                            /** @psalm-suppress RedundantCondition */
+                            if ((is_array(\${$argument->propertyName}) || \${$argument->propertyName} instanceof Countable) && count(\${$argument->propertyName}) > {$argument->maxItems}) {
                                 throw new InvalidArgumentException(sprintf('Expected at most %d items for \${$argument->propertyName}, got %d.', {$argument->maxItems}, count(\${$argument->propertyName})));
                             }
 

--- a/src/Builder/Expression/SimilarityCosineOperator.php
+++ b/src/Builder/Expression/SimilarityCosineOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use Countable;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -63,8 +64,8 @@ final class SimilarityCosineOperator implements ResolvesToDouble, OperatorInterf
             throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
         }
 
-        /** @psalm-suppress RedundantCondition $vectors can also be ResolvesToArray, BSONArray, PackedArray */
-        if (is_array($vectors) && count($vectors) !== 2) {
+        /** @psalm-suppress RedundantCondition */
+        if ((is_array($vectors) || $vectors instanceof Countable) && count($vectors) !== 2) {
             throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 

--- a/src/Builder/Expression/SimilarityCosineOperator.php
+++ b/src/Builder/Expression/SimilarityCosineOperator.php
@@ -16,8 +16,10 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 
 use function array_is_list;
+use function count;
 use function is_array;
 use function is_string;
+use function sprintf;
 use function str_starts_with;
 
 /**
@@ -59,6 +61,11 @@ final class SimilarityCosineOperator implements ResolvesToDouble, OperatorInterf
 
         if (is_array($vectors) && ! array_is_list($vectors)) {
             throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
+        }
+
+        /** @psalm-suppress RedundantCondition $vectors can also be ResolvesToArray, BSONArray, PackedArray */
+        if (is_array($vectors) && count($vectors) !== 2) {
+            throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 
         $this->vectors = $vectors;

--- a/src/Builder/Expression/SimilarityCosineOperator.php
+++ b/src/Builder/Expression/SimilarityCosineOperator.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
-use Countable;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -19,6 +18,7 @@ use MongoDB\Model\BSONArray;
 use function array_is_list;
 use function count;
 use function is_array;
+use function is_countable;
 use function is_string;
 use function sprintf;
 use function str_starts_with;
@@ -65,7 +65,7 @@ final class SimilarityCosineOperator implements ResolvesToDouble, OperatorInterf
         }
 
         /** @psalm-suppress RedundantCondition */
-        if ((is_array($vectors) || $vectors instanceof Countable) && count($vectors) !== 2) {
+        if (is_countable($vectors) && count($vectors) !== 2) {
             throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 

--- a/src/Builder/Expression/SimilarityDotProductOperator.php
+++ b/src/Builder/Expression/SimilarityDotProductOperator.php
@@ -16,8 +16,10 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 
 use function array_is_list;
+use function count;
 use function is_array;
 use function is_string;
+use function sprintf;
 use function str_starts_with;
 
 /**
@@ -59,6 +61,11 @@ final class SimilarityDotProductOperator implements ResolvesToDouble, OperatorIn
 
         if (is_array($vectors) && ! array_is_list($vectors)) {
             throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
+        }
+
+        /** @psalm-suppress RedundantCondition $vectors can also be ResolvesToArray, BSONArray, PackedArray */
+        if (is_array($vectors) && count($vectors) !== 2) {
+            throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 
         $this->vectors = $vectors;

--- a/src/Builder/Expression/SimilarityDotProductOperator.php
+++ b/src/Builder/Expression/SimilarityDotProductOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use Countable;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -63,8 +64,8 @@ final class SimilarityDotProductOperator implements ResolvesToDouble, OperatorIn
             throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
         }
 
-        /** @psalm-suppress RedundantCondition $vectors can also be ResolvesToArray, BSONArray, PackedArray */
-        if (is_array($vectors) && count($vectors) !== 2) {
+        /** @psalm-suppress RedundantCondition */
+        if ((is_array($vectors) || $vectors instanceof Countable) && count($vectors) !== 2) {
             throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 

--- a/src/Builder/Expression/SimilarityDotProductOperator.php
+++ b/src/Builder/Expression/SimilarityDotProductOperator.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
-use Countable;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -19,6 +18,7 @@ use MongoDB\Model\BSONArray;
 use function array_is_list;
 use function count;
 use function is_array;
+use function is_countable;
 use function is_string;
 use function sprintf;
 use function str_starts_with;
@@ -65,7 +65,7 @@ final class SimilarityDotProductOperator implements ResolvesToDouble, OperatorIn
         }
 
         /** @psalm-suppress RedundantCondition */
-        if ((is_array($vectors) || $vectors instanceof Countable) && count($vectors) !== 2) {
+        if (is_countable($vectors) && count($vectors) !== 2) {
             throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 

--- a/src/Builder/Expression/SimilarityEuclideanOperator.php
+++ b/src/Builder/Expression/SimilarityEuclideanOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use Countable;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -63,8 +64,8 @@ final class SimilarityEuclideanOperator implements ResolvesToDouble, OperatorInt
             throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
         }
 
-        /** @psalm-suppress RedundantCondition $vectors can also be ResolvesToArray, BSONArray, PackedArray */
-        if (is_array($vectors) && count($vectors) !== 2) {
+        /** @psalm-suppress RedundantCondition */
+        if ((is_array($vectors) || $vectors instanceof Countable) && count($vectors) !== 2) {
             throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 

--- a/src/Builder/Expression/SimilarityEuclideanOperator.php
+++ b/src/Builder/Expression/SimilarityEuclideanOperator.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
-use Countable;
 use MongoDB\BSON\PackedArray;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -19,6 +18,7 @@ use MongoDB\Model\BSONArray;
 use function array_is_list;
 use function count;
 use function is_array;
+use function is_countable;
 use function is_string;
 use function sprintf;
 use function str_starts_with;
@@ -65,7 +65,7 @@ final class SimilarityEuclideanOperator implements ResolvesToDouble, OperatorInt
         }
 
         /** @psalm-suppress RedundantCondition */
-        if ((is_array($vectors) || $vectors instanceof Countable) && count($vectors) !== 2) {
+        if (is_countable($vectors) && count($vectors) !== 2) {
             throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 

--- a/src/Builder/Expression/SimilarityEuclideanOperator.php
+++ b/src/Builder/Expression/SimilarityEuclideanOperator.php
@@ -16,8 +16,10 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 
 use function array_is_list;
+use function count;
 use function is_array;
 use function is_string;
+use function sprintf;
 use function str_starts_with;
 
 /**
@@ -59,6 +61,11 @@ final class SimilarityEuclideanOperator implements ResolvesToDouble, OperatorInt
 
         if (is_array($vectors) && ! array_is_list($vectors)) {
             throw new InvalidArgumentException('Expected $vectors argument to be a list, got an associative array.');
+        }
+
+        /** @psalm-suppress RedundantCondition $vectors can also be ResolvesToArray, BSONArray, PackedArray */
+        if (is_array($vectors) && count($vectors) !== 2) {
+            throw new InvalidArgumentException(sprintf('Expected exactly %d items for $vectors, got %d.', 2, count($vectors)));
         }
 
         $this->vectors = $vectors;

--- a/tests/Builder/Expression/SimilarityValidationTest.php
+++ b/tests/Builder/Expression/SimilarityValidationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that the generated minItems/maxItems validation works correctly
+ * for the $similarityCosine, $similarityDotProduct, and $similarityEuclidean operators.
+ */
+class SimilarityValidationTest extends TestCase
+{
+    public static function provideWrongItemCount(): iterable
+    {
+        yield 'empty array' => [[]];
+        yield 'one item' => [['$a']];
+        yield 'three items' => [['$a', '$b', '$c']];
+        yield 'BSONArray with one item' => [new BSONArray(['$a'])];
+        yield 'BSONArray with three items' => [new BSONArray(['$a', '$b', '$c'])];
+    }
+
+    #[DataProvider('provideWrongItemCount')]
+    public function testSimilarityCosineRejectsWrongVectorCount(array|BSONArray $vectors): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Expected exactly 2 items for \$vectors/');
+
+        Expression::similarityCosine($vectors);
+    }
+
+    #[DataProvider('provideWrongItemCount')]
+    public function testSimilarityDotProductRejectsWrongVectorCount(array|BSONArray $vectors): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Expected exactly 2 items for \$vectors/');
+
+        Expression::similarityDotProduct($vectors);
+    }
+
+    #[DataProvider('provideWrongItemCount')]
+    public function testSimilarityEuclideanRejectsWrongVectorCount(array|BSONArray $vectors): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Expected exactly 2 items for \$vectors/');
+
+        Expression::similarityEuclidean($vectors);
+    }
+
+    public function testSimilarityCosineAcceptsExactlyTwoItems(): void
+    {
+        $operator = Expression::similarityCosine(['$a', '$b']);
+        $this->assertSame(['$a', '$b'], $operator->vectors);
+    }
+
+    public function testSimilarityCosineAcceptsBSONArrayWithTwoItems(): void
+    {
+        $vectors = new BSONArray(['$a', '$b']);
+        $operator = Expression::similarityCosine($vectors);
+        $this->assertSame($vectors, $operator->vectors);
+    }
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-1691
https://github.com/mongodb/mql-specifications/pull/44

Adds `minItems` and `maxItems` properties to `ArgumentDefinition` to support array length constraints in the code generator. Generates an `InvalidArgumentException` when a countable value (plain PHP array, `BSONArray`, `PackedArray`) is passed with the wrong number of items. Expression types like `ResolvesToArray` are not validated.

Bumps `generator/mql-specifications` to [PR #44](https://github.com/mongodb/mql-specifications/pull/44) which adds `minItems: 2` / `maxItems: 2` to the `vectors` argument of `$similarityCosine`, `$similarityDotProduct`, and `$similarityEuclidean`.