### PR TITLE
PHPLIB-1724 Batch MQL spec updates

### DIFF
--- a/generator/expressions.php
+++ b/generator/expressions.php
@@ -178,6 +178,9 @@ return $expressions + [
     'whenNotMatched' => [
         'acceptedTypes' => [...$bsonTypes['string']],
     ],
+    'scoreNormalization' => [
+        'acceptedTypes' => [...$bsonTypes['string']],
+    ],
 
     // @todo create specific model classes factories
     'outCollection' => [

--- a/src/Builder/Accumulator/FactoryTrait.php
+++ b/src/Builder/Accumulator/FactoryTrait.php
@@ -427,6 +427,28 @@ trait FactoryTrait
     }
 
     /**
+     * Normalizes a numeric expression within a window of values. By default, values can range
+     * between zero and one. The smallest value becomes zero, the largest value becomes one, and
+     * all other values scale proportionally in between. You can also specify a custom minimum
+     * and maximum value for the normalized output range.
+     * Available only in the $setWindowFields stage.
+     *
+     * New in MongoDB 8.2
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minMaxScaler/
+     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $input Numeric expression containing the value that you want to normalize.
+     * @param Optional|Decimal128|Int64|float|int $min Minimum value that you want in the output. If omitted, defaults to 0.
+     * @param Optional|Decimal128|Int64|float|int $max Maximum value that you want in the output. If omitted, defaults to 1.
+     */
+    public static function minMaxScaler(
+        Decimal128|Int64|ResolvesToNumber|float|int|string $input,
+        Optional|Decimal128|Int64|float|int $min = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $max = Optional::Undefined,
+    ): MinMaxScalerAccumulator {
+        return new MinMaxScalerAccumulator($input, $min, $max);
+    }
+
+    /**
      * Returns the n smallest values in an array. Distinct from the $minN accumulator.
      *
      * New in MongoDB 5.2

--- a/src/Builder/Accumulator/MinMaxScalerAccumulator.php
+++ b/src/Builder/Accumulator/MinMaxScalerAccumulator.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Accumulator;
+
+use MongoDB\BSON\Decimal128;
+use MongoDB\BSON\Int64;
+use MongoDB\Builder\Expression\ResolvesToNumber;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\WindowInterface;
+use MongoDB\Exception\InvalidArgumentException;
+
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Normalizes a numeric expression within a window of values. By default, values can range
+ * between zero and one. The smallest value becomes zero, the largest value becomes one, and
+ * all other values scale proportionally in between. You can also specify a custom minimum
+ * and maximum value for the normalized output range.
+ * Available only in the $setWindowFields stage.
+ *
+ * New in MongoDB 8.2
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minMaxScaler/
+ * @internal
+ */
+final class MinMaxScalerAccumulator implements WindowInterface, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$minMaxScaler';
+    public const PROPERTIES = ['input' => 'input', 'min' => 'min', 'max' => 'max'];
+
+    /** @var Decimal128|Int64|ResolvesToNumber|float|int|string $input Numeric expression containing the value that you want to normalize. */
+    public readonly Decimal128|Int64|ResolvesToNumber|float|int|string $input;
+
+    /** @var Optional|Decimal128|Int64|float|int $min Minimum value that you want in the output. If omitted, defaults to 0. */
+    public readonly Optional|Decimal128|Int64|float|int $min;
+
+    /** @var Optional|Decimal128|Int64|float|int $max Maximum value that you want in the output. If omitted, defaults to 1. */
+    public readonly Optional|Decimal128|Int64|float|int $max;
+
+    /**
+     * @param Decimal128|Int64|ResolvesToNumber|float|int|string $input Numeric expression containing the value that you want to normalize.
+     * @param Optional|Decimal128|Int64|float|int $min Minimum value that you want in the output. If omitted, defaults to 0.
+     * @param Optional|Decimal128|Int64|float|int $max Maximum value that you want in the output. If omitted, defaults to 1.
+     */
+    public function __construct(
+        Decimal128|Int64|ResolvesToNumber|float|int|string $input,
+        Optional|Decimal128|Int64|float|int $min = Optional::Undefined,
+        Optional|Decimal128|Int64|float|int $max = Optional::Undefined,
+    ) {
+        if (is_string($input) && ! str_starts_with($input, '$')) {
+            throw new InvalidArgumentException('Argument $input can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        $this->input = $input;
+        $this->min = $min;
+        $this->max = $max;
+    }
+}

--- a/src/Builder/Expression/ConvertOperator.php
+++ b/src/Builder/Expression/ConvertOperator.php
@@ -14,10 +14,18 @@ use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
 use MongoDB\Builder\Type\Optional;
+use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
+use function is_string;
+use function str_starts_with;
+
 /**
- * Converts a value to a specified type.
+ * Converts a value to a specified type. Any type can be converted to string.
+ * If the optional base argument is specified, $convert interprets the input string as a
+ * number in the given base and converts it to a decimal, or converts a numeric value to a
+ * string representation in that base. Supported bases are 2 (binary), 8 (octal), 10
+ * (decimal), and 16 (hexadecimal).
  *
  * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/
  * @internal
@@ -26,7 +34,14 @@ final class ConvertOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
     public const NAME = '$convert';
-    public const PROPERTIES = ['input' => 'input', 'to' => 'to', 'onError' => 'onError', 'onNull' => 'onNull'];
+
+    public const PROPERTIES = [
+        'input' => 'input',
+        'to' => 'to',
+        'onError' => 'onError',
+        'onNull' => 'onNull',
+        'base' => 'base',
+    ];
 
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input;
@@ -47,22 +62,50 @@ final class ConvertOperator implements ResolvesToAny, OperatorInterface
     public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull;
 
     /**
+     * @var Optional|ResolvesToInt|int|string $base The numeric base to use when converting between strings and integers. Must be one of
+     * 2 (binary), 8 (octal), 10 (decimal), or 16 (hexadecimal).
+     * When converting a string to a number, $convert interprets the string as a number in
+     * the given base and returns the decimal equivalent.
+     * When converting a number to a string, $convert returns the string representation of
+     * the number in the given base.
+     * If unspecified, $convert uses base 10.
+     *
+     * New in MongoDB 8.3
+     */
+    public readonly Optional|ResolvesToInt|int|string $base;
+
+    /**
      * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
      * @param ResolvesToInt|ResolvesToString|int|string $to
      * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onError The value to return on encountering an error during conversion, including unsupported type conversions. The arguments can be any valid expression.
      * If unspecified, the operation throws an error upon encountering an error and stops.
      * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the input is null or missing. The arguments can be any valid expression.
      * If unspecified, $convert returns null if the input is null or missing.
+     * @param Optional|ResolvesToInt|int|string $base The numeric base to use when converting between strings and integers. Must be one of
+     * 2 (binary), 8 (octal), 10 (decimal), or 16 (hexadecimal).
+     * When converting a string to a number, $convert interprets the string as a number in
+     * the given base and returns the decimal equivalent.
+     * When converting a number to a string, $convert returns the string representation of
+     * the number in the given base.
+     * If unspecified, $convert uses base 10.
+     *
+     * New in MongoDB 8.3
      */
     public function __construct(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
         ResolvesToInt|ResolvesToString|int|string $to,
         Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
         Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
+        Optional|ResolvesToInt|int|string $base = Optional::Undefined,
     ) {
         $this->input = $input;
         $this->to = $to;
         $this->onError = $onError;
         $this->onNull = $onNull;
+        if (is_string($base) && ! str_starts_with($base, '$')) {
+            throw new InvalidArgumentException('Argument $base can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        $this->base = $base;
     }
 }

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -1257,7 +1257,7 @@ trait FactoryTrait
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to an array.
      * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
-     * @param Optional|ResolvesToString|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
+     * @param Optional|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
      * @param Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
      * the input array. If specified, this variable is available within the in expression.
      *
@@ -1266,7 +1266,7 @@ trait FactoryTrait
     public static function map(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
-        Optional|ResolvesToString|string $as = Optional::Undefined,
+        Optional|string $as = Optional::Undefined,
         Optional|string $arrayIndexAs = Optional::Undefined,
     ): MapOperator {
         return new MapOperator($input, $in, $as, $arrayIndexAs);

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -430,7 +430,11 @@ trait FactoryTrait
     }
 
     /**
-     * Converts a value to a specified type.
+     * Converts a value to a specified type. Any type can be converted to string.
+     * If the optional base argument is specified, $convert interprets the input string as a
+     * number in the given base and converts it to a decimal, or converts a numeric value to a
+     * string representation in that base. Supported bases are 2 (binary), 8 (octal), 10
+     * (decimal), and 16 (hexadecimal).
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/
      * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $input
@@ -439,14 +443,24 @@ trait FactoryTrait
      * If unspecified, the operation throws an error upon encountering an error and stops.
      * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $onNull The value to return if the input is null or missing. The arguments can be any valid expression.
      * If unspecified, $convert returns null if the input is null or missing.
+     * @param Optional|ResolvesToInt|int|string $base The numeric base to use when converting between strings and integers. Must be one of
+     * 2 (binary), 8 (octal), 10 (decimal), or 16 (hexadecimal).
+     * When converting a string to a number, $convert interprets the string as a number in
+     * the given base and returns the decimal equivalent.
+     * When converting a number to a string, $convert returns the string representation of
+     * the number in the given base.
+     * If unspecified, $convert uses base 10.
+     *
+     * New in MongoDB 8.3
      */
     public static function convert(
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $input,
         ResolvesToInt|ResolvesToString|int|string $to,
         Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onError = Optional::Undefined,
         Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $onNull = Optional::Undefined,
+        Optional|ResolvesToInt|int|string $base = Optional::Undefined,
     ): ConvertOperator {
-        return new ConvertOperator($input, $to, $onError, $onNull);
+        return new ConvertOperator($input, $to, $onError, $onNull, $base);
     }
 
     /**
@@ -1244,13 +1258,18 @@ trait FactoryTrait
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to an array.
      * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
      * @param Optional|ResolvesToString|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
+     * @param Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the in expression.
+     *
+     * New in MongoDB 8.3
      */
     public static function map(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
         Optional|ResolvesToString|string $as = Optional::Undefined,
+        Optional|string $arrayIndexAs = Optional::Undefined,
     ): MapOperator {
-        return new MapOperator($input, $in, $as);
+        return new MapOperator($input, $in, $as, $arrayIndexAs);
     }
 
     /**
@@ -2100,6 +2119,20 @@ trait FactoryTrait
         DateTimeInterface|Decimal128|Int64|UTCDateTime|ResolvesToDate|ResolvesToNumber|float|int|string $expression2,
     ): SubtractOperator {
         return new SubtractOperator($expression1, $expression2);
+    }
+
+    /**
+     * Returns the subtype of a given value as an integer. In MongoDB 8.3, the only expression
+     * that contains a subtype is a BinData expression.
+     *
+     * New in MongoDB 8.3
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtype/
+     * @param Binary|ResolvesToBinData|string $expression An expression that resolves to a BinData value.
+     */
+    public static function subtype(Binary|ResolvesToBinData|string $expression): SubtypeOperator
+    {
+        return new SubtypeOperator($expression);
     }
 
     /**

--- a/src/Builder/Expression/MapOperator.php
+++ b/src/Builder/Expression/MapOperator.php
@@ -34,7 +34,7 @@ final class MapOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
     public const NAME = '$map';
-    public const PROPERTIES = ['input' => 'input', 'in' => 'in', 'as' => 'as'];
+    public const PROPERTIES = ['input' => 'input', 'in' => 'in', 'as' => 'as', 'arrayIndexAs' => 'arrayIndexAs'];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to an array. */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $input;
@@ -46,14 +46,27 @@ final class MapOperator implements ResolvesToArray, OperatorInterface
     public readonly Optional|ResolvesToString|string $as;
 
     /**
+     * @var Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the in expression.
+     *
+     * New in MongoDB 8.3
+     */
+    public readonly Optional|string $arrayIndexAs;
+
+    /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to an array.
      * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
      * @param Optional|ResolvesToString|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
+     * @param Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the in expression.
+     *
+     * New in MongoDB 8.3
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
         Optional|ResolvesToString|string $as = Optional::Undefined,
+        Optional|string $arrayIndexAs = Optional::Undefined,
     ) {
         if (is_string($input) && ! str_starts_with($input, '$')) {
             throw new InvalidArgumentException('Argument $input can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
@@ -66,5 +79,6 @@ final class MapOperator implements ResolvesToArray, OperatorInterface
         $this->input = $input;
         $this->in = $in;
         $this->as = $as;
+        $this->arrayIndexAs = $arrayIndexAs;
     }
 }

--- a/src/Builder/Expression/MapOperator.php
+++ b/src/Builder/Expression/MapOperator.php
@@ -42,8 +42,8 @@ final class MapOperator implements ResolvesToArray, OperatorInterface
     /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as. */
     public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in;
 
-    /** @var Optional|ResolvesToString|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this. */
-    public readonly Optional|ResolvesToString|string $as;
+    /** @var Optional|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this. */
+    public readonly Optional|string $as;
 
     /**
      * @var Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
@@ -56,7 +56,7 @@ final class MapOperator implements ResolvesToArray, OperatorInterface
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to an array.
      * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $in An expression that is applied to each element of the input array. The expression references each element individually with the variable name specified in as.
-     * @param Optional|ResolvesToString|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
+     * @param Optional|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
      * @param Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
      * the input array. If specified, this variable is available within the in expression.
      *
@@ -65,7 +65,7 @@ final class MapOperator implements ResolvesToArray, OperatorInterface
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
-        Optional|ResolvesToString|string $as = Optional::Undefined,
+        Optional|string $as = Optional::Undefined,
         Optional|string $arrayIndexAs = Optional::Undefined,
     ) {
         if (is_string($input) && ! str_starts_with($input, '$')) {

--- a/src/Builder/Expression/SubtypeOperator.php
+++ b/src/Builder/Expression/SubtypeOperator.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use MongoDB\BSON\Binary;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\OperatorInterface;
+
+/**
+ * Returns the subtype of a given value as an integer. In MongoDB 8.3, the only expression
+ * that contains a subtype is a BinData expression.
+ *
+ * New in MongoDB 8.3
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtype/
+ * @internal
+ */
+final class SubtypeOperator implements ResolvesToInt, OperatorInterface
+{
+    public const ENCODE = Encode::Single;
+    public const NAME = '$subtype';
+    public const PROPERTIES = ['expression' => 'expression'];
+
+    /** @var Binary|ResolvesToBinData|string $expression An expression that resolves to a BinData value. */
+    public readonly Binary|ResolvesToBinData|string $expression;
+
+    /** @param Binary|ResolvesToBinData|string $expression An expression that resolves to a BinData value. */
+    public function __construct(Binary|ResolvesToBinData|string $expression)
+    {
+        $this->expression = $expression;
+    }
+}

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -19,7 +19,6 @@ use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Expression\ArrayFieldPath;
 use MongoDB\Builder\Expression\ResolvesToArray;
-use MongoDB\Builder\Expression\ResolvesToBinData;
 use MongoDB\Builder\Expression\ResolvesToObject;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Type\AccumulatorInterface;
@@ -839,7 +838,7 @@ trait FactoryTrait
      * @param string $index Name of the Atlas Vector Search index to use.
      * @param int $limit Number of documents to return in the results. This value can't exceed the value of numCandidates if you specify numCandidates.
      * @param string $path Indexed vector type field to search.
-     * @param BSONArray|Binary|PackedArray|ResolvesToBinData|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
+     * @param BSONArray|Binary|PackedArray|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
      * must match the indexed field value type.
      * @param Optional|bool $exact This is required if numCandidates is omitted. false to run ANN search. true to run ENN search.
      * @param Optional|QueryInterface|array $filter Any match query that compares an indexed field with a boolean, date, objectId, number (not decimals), string, or UUID to use as a pre-filter.
@@ -851,7 +850,7 @@ trait FactoryTrait
         string $index,
         int $limit,
         string $path,
-        Binary|PackedArray|ResolvesToBinData|BSONArray|array|string $queryVector,
+        Binary|PackedArray|BSONArray|array|string $queryVector,
         Optional|bool $exact = Optional::Undefined,
         Optional|QueryInterface|array $filter = Optional::Undefined,
         Optional|int $numCandidates = Optional::Undefined,

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Stage;
 
 use DateTimeInterface;
+use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
@@ -18,6 +19,7 @@ use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Expression\ArrayFieldPath;
 use MongoDB\Builder\Expression\ResolvesToArray;
+use MongoDB\Builder\Expression\ResolvesToBinData;
 use MongoDB\Builder\Expression\ResolvesToObject;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Type\AccumulatorInterface;
@@ -519,7 +521,7 @@ trait FactoryTrait
      */
     public static function rankFusion(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails = false,
+        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
     ): RankFusionStage {
         return new RankFusionStage($input, $scoreDetails, $combination);
@@ -594,6 +596,32 @@ trait FactoryTrait
     }
 
     /**
+     * Computes and returns a new score as metadata. It also optionally normalizes the input
+     * scores, by default to a range between zero and one.
+     *
+     * New in MongoDB 8.2
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/score/
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $score Computes a new value from the input scores and stores the value in the $meta keyword
+     * score. Returns an error for non-numeric inputs.
+     * @param Optional|string $normalization Normalizes the score to the range of 0 to 1. Value can be:
+     * - none: Doesn't normalize. If omitted, defaults to none.
+     * - sigmoid: Applies the sigmoid expression: 1 / (1 + e^-x).
+     * - minMaxScaler: Applies the $minMaxScaler window function.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $weight Number to multiply the score expression by after normalization.
+     * @param Optional|bool $scoreDetails Specifies if $score computes and populates the $scoreDetails metadata field for each
+     * output document.
+     */
+    public static function score(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $score,
+        Optional|string $normalization = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $weight = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
+    ): ScoreStage {
+        return new ScoreStage($score, $normalization, $weight, $scoreDetails);
+    }
+
+    /**
      * Combines multiple pipelines using relative score fusion to create hybrid search results.
      *
      * New in MongoDB 8.0
@@ -605,7 +633,7 @@ trait FactoryTrait
      */
     public static function scoreFusion(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails = false,
+        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
     ): ScoreFusionStage {
         return new ScoreFusionStage($input, $scoreDetails, $combination);
@@ -811,7 +839,8 @@ trait FactoryTrait
      * @param string $index Name of the Atlas Vector Search index to use.
      * @param int $limit Number of documents to return in the results. This value can't exceed the value of numCandidates if you specify numCandidates.
      * @param string $path Indexed vector type field to search.
-     * @param BSONArray|PackedArray|array $queryVector Array of numbers that represent the query vector. The number type must match the indexed field value type.
+     * @param BSONArray|Binary|PackedArray|ResolvesToBinData|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
+     * must match the indexed field value type.
      * @param Optional|bool $exact This is required if numCandidates is omitted. false to run ANN search. true to run ENN search.
      * @param Optional|QueryInterface|array $filter Any match query that compares an indexed field with a boolean, date, objectId, number (not decimals), string, or UUID to use as a pre-filter.
      * @param Optional|int $numCandidates This field is required if exact is false or omitted.
@@ -822,7 +851,7 @@ trait FactoryTrait
         string $index,
         int $limit,
         string $path,
-        PackedArray|BSONArray|array $queryVector,
+        Binary|PackedArray|ResolvesToBinData|BSONArray|array|string $queryVector,
         Optional|bool $exact = Optional::Undefined,
         Optional|QueryInterface|array $filter = Optional::Undefined,
         Optional|int $numCandidates = Optional::Undefined,

--- a/src/Builder/Stage/FactoryTrait.php
+++ b/src/Builder/Stage/FactoryTrait.php
@@ -516,15 +516,15 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rankFusion/
      * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with rank fusion.
-     * @param bool $scoreDetails Set to true to include detailed scoring information.
      * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the ranked results.
+     * @param Optional|bool $scoreDetails Set to true to include detailed scoring information.
      */
     public static function rankFusion(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
     ): RankFusionStage {
-        return new RankFusionStage($input, $scoreDetails, $combination);
+        return new RankFusionStage($input, $combination, $scoreDetails);
     }
 
     /**
@@ -628,15 +628,15 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/
      * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with score fusion.
-     * @param bool $scoreDetails Set to true to include detailed scoring information.
      * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the scores.
+     * @param Optional|bool $scoreDetails Set to true to include detailed scoring information.
      */
     public static function scoreFusion(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
     ): ScoreFusionStage {
-        return new ScoreFusionStage($input, $scoreDetails, $combination);
+        return new ScoreFusionStage($input, $combination, $scoreDetails);
     }
 
     /**

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MongoDB\Builder\Stage;
 
 use DateTimeInterface;
+use MongoDB\BSON\Binary;
 use MongoDB\BSON\Decimal128;
 use MongoDB\BSON\Document;
 use MongoDB\BSON\Int64;
@@ -18,6 +19,7 @@ use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Expression\ArrayFieldPath;
 use MongoDB\Builder\Expression\ResolvesToArray;
+use MongoDB\Builder\Expression\ResolvesToBinData;
 use MongoDB\Builder\Expression\ResolvesToObject;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
@@ -582,7 +584,7 @@ trait FluentFactoryTrait
      */
     public function rankFusion(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails = false,
+        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
     ): static {
         $this->pipeline[] = Stage::rankFusion($input, $scoreDetails, $combination);
@@ -667,6 +669,34 @@ trait FluentFactoryTrait
     }
 
     /**
+     * Computes and returns a new score as metadata. It also optionally normalizes the input
+     * scores, by default to a range between zero and one.
+     *
+     * New in MongoDB 8.2
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/score/
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $score Computes a new value from the input scores and stores the value in the $meta keyword
+     * score. Returns an error for non-numeric inputs.
+     * @param Optional|string $normalization Normalizes the score to the range of 0 to 1. Value can be:
+     * - none: Doesn't normalize. If omitted, defaults to none.
+     * - sigmoid: Applies the sigmoid expression: 1 / (1 + e^-x).
+     * - minMaxScaler: Applies the $minMaxScaler window function.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $weight Number to multiply the score expression by after normalization.
+     * @param Optional|bool $scoreDetails Specifies if $score computes and populates the $scoreDetails metadata field for each
+     * output document.
+     */
+    public function score(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $score,
+        Optional|string $normalization = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|string|int|float|bool|null $weight = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
+    ): static {
+        $this->pipeline[] = Stage::score($score, $normalization, $weight, $scoreDetails);
+
+        return $this;
+    }
+
+    /**
      * Combines multiple pipelines using relative score fusion to create hybrid search results.
      *
      * New in MongoDB 8.0
@@ -678,7 +708,7 @@ trait FluentFactoryTrait
      */
     public function scoreFusion(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails = false,
+        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
     ): static {
         $this->pipeline[] = Stage::scoreFusion($input, $scoreDetails, $combination);
@@ -908,7 +938,8 @@ trait FluentFactoryTrait
      * @param string $index Name of the Atlas Vector Search index to use.
      * @param int $limit Number of documents to return in the results. This value can't exceed the value of numCandidates if you specify numCandidates.
      * @param string $path Indexed vector type field to search.
-     * @param BSONArray|PackedArray|array $queryVector Array of numbers that represent the query vector. The number type must match the indexed field value type.
+     * @param BSONArray|Binary|PackedArray|ResolvesToBinData|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
+     * must match the indexed field value type.
      * @param Optional|bool $exact This is required if numCandidates is omitted. false to run ANN search. true to run ENN search.
      * @param Optional|QueryInterface|array $filter Any match query that compares an indexed field with a boolean, date, objectId, number (not decimals), string, or UUID to use as a pre-filter.
      * @param Optional|int $numCandidates This field is required if exact is false or omitted.
@@ -919,7 +950,7 @@ trait FluentFactoryTrait
         string $index,
         int $limit,
         string $path,
-        PackedArray|BSONArray|array $queryVector,
+        Binary|PackedArray|ResolvesToBinData|BSONArray|array|string $queryVector,
         Optional|bool $exact = Optional::Undefined,
         Optional|QueryInterface|array $filter = Optional::Undefined,
         Optional|int $numCandidates = Optional::Undefined,

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -579,15 +579,15 @@ trait FluentFactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/rankFusion/
      * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with rank fusion.
-     * @param bool $scoreDetails Set to true to include detailed scoring information.
      * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the ranked results.
+     * @param Optional|bool $scoreDetails Set to true to include detailed scoring information.
      */
     public function rankFusion(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
     ): static {
-        $this->pipeline[] = Stage::rankFusion($input, $scoreDetails, $combination);
+        $this->pipeline[] = Stage::rankFusion($input, $combination, $scoreDetails);
 
         return $this;
     }
@@ -703,15 +703,15 @@ trait FluentFactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/
      * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with score fusion.
-     * @param bool $scoreDetails Set to true to include detailed scoring information.
      * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the scores.
+     * @param Optional|bool $scoreDetails Set to true to include detailed scoring information.
      */
     public function scoreFusion(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
     ): static {
-        $this->pipeline[] = Stage::scoreFusion($input, $scoreDetails, $combination);
+        $this->pipeline[] = Stage::scoreFusion($input, $combination, $scoreDetails);
 
         return $this;
     }

--- a/src/Builder/Stage/FluentFactoryTrait.php
+++ b/src/Builder/Stage/FluentFactoryTrait.php
@@ -19,7 +19,6 @@ use MongoDB\BSON\Timestamp;
 use MongoDB\BSON\Type;
 use MongoDB\Builder\Expression\ArrayFieldPath;
 use MongoDB\Builder\Expression\ResolvesToArray;
-use MongoDB\Builder\Expression\ResolvesToBinData;
 use MongoDB\Builder\Expression\ResolvesToObject;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
@@ -938,7 +937,7 @@ trait FluentFactoryTrait
      * @param string $index Name of the Atlas Vector Search index to use.
      * @param int $limit Number of documents to return in the results. This value can't exceed the value of numCandidates if you specify numCandidates.
      * @param string $path Indexed vector type field to search.
-     * @param BSONArray|Binary|PackedArray|ResolvesToBinData|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
+     * @param BSONArray|Binary|PackedArray|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
      * must match the indexed field value type.
      * @param Optional|bool $exact This is required if numCandidates is omitted. false to run ANN search. true to run ENN search.
      * @param Optional|QueryInterface|array $filter Any match query that compares an indexed field with a boolean, date, objectId, number (not decimals), string, or UUID to use as a pre-filter.
@@ -950,7 +949,7 @@ trait FluentFactoryTrait
         string $index,
         int $limit,
         string $path,
-        Binary|PackedArray|ResolvesToBinData|BSONArray|array|string $queryVector,
+        Binary|PackedArray|BSONArray|array|string $queryVector,
         Optional|bool $exact = Optional::Undefined,
         Optional|QueryInterface|array $filter = Optional::Undefined,
         Optional|int $numCandidates = Optional::Undefined,

--- a/src/Builder/Stage/RankFusionStage.php
+++ b/src/Builder/Stage/RankFusionStage.php
@@ -28,29 +28,29 @@ final class RankFusionStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
     public const NAME = '$rankFusion';
-    public const PROPERTIES = ['input' => 'input', 'scoreDetails' => 'scoreDetails', 'combination' => 'combination'];
+    public const PROPERTIES = ['input' => 'input', 'combination' => 'combination', 'scoreDetails' => 'scoreDetails'];
 
     /** @var Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with rank fusion. */
     public readonly Document|Serializable|stdClass|array $input;
 
-    /** @var bool $scoreDetails Set to true to include detailed scoring information. */
-    public readonly bool $scoreDetails;
-
     /** @var Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the ranked results. */
     public readonly Optional|Document|Serializable|stdClass|array $combination;
 
+    /** @var Optional|bool $scoreDetails Set to true to include detailed scoring information. */
+    public readonly Optional|bool $scoreDetails;
+
     /**
      * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with rank fusion.
-     * @param bool $scoreDetails Set to true to include detailed scoring information.
      * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the ranked results.
+     * @param Optional|bool $scoreDetails Set to true to include detailed scoring information.
      */
     public function __construct(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
     ) {
         $this->input = $input;
-        $this->scoreDetails = $scoreDetails;
         $this->combination = $combination;
+        $this->scoreDetails = $scoreDetails;
     }
 }

--- a/src/Builder/Stage/RankFusionStage.php
+++ b/src/Builder/Stage/RankFusionStage.php
@@ -46,7 +46,7 @@ final class RankFusionStage implements StageInterface, OperatorInterface
      */
     public function __construct(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails = false,
+        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
     ) {
         $this->input = $input;

--- a/src/Builder/Stage/ScoreFusionStage.php
+++ b/src/Builder/Stage/ScoreFusionStage.php
@@ -46,7 +46,7 @@ final class ScoreFusionStage implements StageInterface, OperatorInterface
      */
     public function __construct(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails = false,
+        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
     ) {
         $this->input = $input;

--- a/src/Builder/Stage/ScoreFusionStage.php
+++ b/src/Builder/Stage/ScoreFusionStage.php
@@ -28,29 +28,29 @@ final class ScoreFusionStage implements StageInterface, OperatorInterface
 {
     public const ENCODE = Encode::Object;
     public const NAME = '$scoreFusion';
-    public const PROPERTIES = ['input' => 'input', 'scoreDetails' => 'scoreDetails', 'combination' => 'combination'];
+    public const PROPERTIES = ['input' => 'input', 'combination' => 'combination', 'scoreDetails' => 'scoreDetails'];
 
     /** @var Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with score fusion. */
     public readonly Document|Serializable|stdClass|array $input;
 
-    /** @var bool $scoreDetails Set to true to include detailed scoring information. */
-    public readonly bool $scoreDetails;
-
     /** @var Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the scores. */
     public readonly Optional|Document|Serializable|stdClass|array $combination;
 
+    /** @var Optional|bool $scoreDetails Set to true to include detailed scoring information. */
+    public readonly Optional|bool $scoreDetails;
+
     /**
      * @param Document|Serializable|array|stdClass $input An object that specifies the pipelines to combine with score fusion.
-     * @param bool $scoreDetails Set to true to include detailed scoring information.
      * @param Optional|Document|Serializable|array|stdClass $combination An object that specifies how to combine the scores.
+     * @param Optional|bool $scoreDetails Set to true to include detailed scoring information.
      */
     public function __construct(
         Document|Serializable|stdClass|array $input,
-        bool $scoreDetails,
         Optional|Document|Serializable|stdClass|array $combination = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
     ) {
         $this->input = $input;
-        $this->scoreDetails = $scoreDetails;
         $this->combination = $combination;
+        $this->scoreDetails = $scoreDetails;
     }
 }

--- a/src/Builder/Stage/ScoreStage.php
+++ b/src/Builder/Stage/ScoreStage.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Stage;
+
+use DateTimeInterface;
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
+use MongoDB\Builder\Type\StageInterface;
+use stdClass;
+
+/**
+ * Computes and returns a new score as metadata. It also optionally normalizes the input
+ * scores, by default to a range between zero and one.
+ *
+ * New in MongoDB 8.2
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/score/
+ * @internal
+ */
+final class ScoreStage implements StageInterface, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$score';
+
+    public const PROPERTIES = [
+        'score' => 'score',
+        'normalization' => 'normalization',
+        'weight' => 'weight',
+        'scoreDetails' => 'scoreDetails',
+    ];
+
+    /**
+     * @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $score Computes a new value from the input scores and stores the value in the $meta keyword
+     * score. Returns an error for non-numeric inputs.
+     */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $score;
+
+    /**
+     * @var Optional|string $normalization Normalizes the score to the range of 0 to 1. Value can be:
+     * - none: Doesn't normalize. If omitted, defaults to none.
+     * - sigmoid: Applies the sigmoid expression: 1 / (1 + e^-x).
+     * - minMaxScaler: Applies the $minMaxScaler window function.
+     */
+    public readonly Optional|string $normalization;
+
+    /** @var Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $weight Number to multiply the score expression by after normalization. */
+    public readonly Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $weight;
+
+    /**
+     * @var Optional|bool $scoreDetails Specifies if $score computes and populates the $scoreDetails metadata field for each
+     * output document.
+     */
+    public readonly Optional|bool $scoreDetails;
+
+    /**
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $score Computes a new value from the input scores and stores the value in the $meta keyword
+     * score. Returns an error for non-numeric inputs.
+     * @param Optional|string $normalization Normalizes the score to the range of 0 to 1. Value can be:
+     * - none: Doesn't normalize. If omitted, defaults to none.
+     * - sigmoid: Applies the sigmoid expression: 1 / (1 + e^-x).
+     * - minMaxScaler: Applies the $minMaxScaler window function.
+     * @param Optional|DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $weight Number to multiply the score expression by after normalization.
+     * @param Optional|bool $scoreDetails Specifies if $score computes and populates the $scoreDetails metadata field for each
+     * output document.
+     */
+    public function __construct(
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $score,
+        Optional|string $normalization = Optional::Undefined,
+        Optional|DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $weight = Optional::Undefined,
+        Optional|bool $scoreDetails = Optional::Undefined,
+    ) {
+        $this->score = $score;
+        $this->normalization = $normalization;
+        $this->weight = $weight;
+        $this->scoreDetails = $scoreDetails;
+    }
+}

--- a/src/Builder/Stage/VectorSearchStage.php
+++ b/src/Builder/Stage/VectorSearchStage.php
@@ -10,7 +10,6 @@ namespace MongoDB\Builder\Stage;
 
 use MongoDB\BSON\Binary;
 use MongoDB\BSON\PackedArray;
-use MongoDB\Builder\Expression\ResolvesToBinData;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\InputStageInterface;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -57,10 +56,10 @@ final class VectorSearchStage implements InputStageInterface, OperatorInterface
     public readonly string $path;
 
     /**
-     * @var BSONArray|Binary|PackedArray|ResolvesToBinData|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
+     * @var BSONArray|Binary|PackedArray|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
      * must match the indexed field value type.
      */
-    public readonly Binary|PackedArray|ResolvesToBinData|BSONArray|array|string $queryVector;
+    public readonly Binary|PackedArray|BSONArray|array|string $queryVector;
 
     /** @var Optional|bool $exact This is required if numCandidates is omitted. false to run ANN search. true to run ENN search. */
     public readonly Optional|bool $exact;
@@ -81,7 +80,7 @@ final class VectorSearchStage implements InputStageInterface, OperatorInterface
      * @param string $index Name of the Atlas Vector Search index to use.
      * @param int $limit Number of documents to return in the results. This value can't exceed the value of numCandidates if you specify numCandidates.
      * @param string $path Indexed vector type field to search.
-     * @param BSONArray|Binary|PackedArray|ResolvesToBinData|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
+     * @param BSONArray|Binary|PackedArray|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
      * must match the indexed field value type.
      * @param Optional|bool $exact This is required if numCandidates is omitted. false to run ANN search. true to run ENN search.
      * @param Optional|QueryInterface|array $filter Any match query that compares an indexed field with a boolean, date, objectId, number (not decimals), string, or UUID to use as a pre-filter.
@@ -93,7 +92,7 @@ final class VectorSearchStage implements InputStageInterface, OperatorInterface
         string $index,
         int $limit,
         string $path,
-        Binary|PackedArray|ResolvesToBinData|BSONArray|array|string $queryVector,
+        Binary|PackedArray|BSONArray|array|string $queryVector,
         Optional|bool $exact = Optional::Undefined,
         Optional|QueryInterface|array $filter = Optional::Undefined,
         Optional|int $numCandidates = Optional::Undefined,

--- a/src/Builder/Stage/VectorSearchStage.php
+++ b/src/Builder/Stage/VectorSearchStage.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Stage;
 
+use MongoDB\BSON\Binary;
 use MongoDB\BSON\PackedArray;
+use MongoDB\Builder\Expression\ResolvesToBinData;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\InputStageInterface;
 use MongoDB\Builder\Type\OperatorInterface;
@@ -54,8 +56,11 @@ final class VectorSearchStage implements InputStageInterface, OperatorInterface
     /** @var string $path Indexed vector type field to search. */
     public readonly string $path;
 
-    /** @var BSONArray|PackedArray|array $queryVector Array of numbers that represent the query vector. The number type must match the indexed field value type. */
-    public readonly PackedArray|BSONArray|array $queryVector;
+    /**
+     * @var BSONArray|Binary|PackedArray|ResolvesToBinData|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
+     * must match the indexed field value type.
+     */
+    public readonly Binary|PackedArray|ResolvesToBinData|BSONArray|array|string $queryVector;
 
     /** @var Optional|bool $exact This is required if numCandidates is omitted. false to run ANN search. true to run ENN search. */
     public readonly Optional|bool $exact;
@@ -76,7 +81,8 @@ final class VectorSearchStage implements InputStageInterface, OperatorInterface
      * @param string $index Name of the Atlas Vector Search index to use.
      * @param int $limit Number of documents to return in the results. This value can't exceed the value of numCandidates if you specify numCandidates.
      * @param string $path Indexed vector type field to search.
-     * @param BSONArray|PackedArray|array $queryVector Array of numbers that represent the query vector. The number type must match the indexed field value type.
+     * @param BSONArray|Binary|PackedArray|ResolvesToBinData|array|string $queryVector Array of numbers or a BinData value that represent the query vector. The number type
+     * must match the indexed field value type.
      * @param Optional|bool $exact This is required if numCandidates is omitted. false to run ANN search. true to run ENN search.
      * @param Optional|QueryInterface|array $filter Any match query that compares an indexed field with a boolean, date, objectId, number (not decimals), string, or UUID to use as a pre-filter.
      * @param Optional|int $numCandidates This field is required if exact is false or omitted.
@@ -87,7 +93,7 @@ final class VectorSearchStage implements InputStageInterface, OperatorInterface
         string $index,
         int $limit,
         string $path,
-        PackedArray|BSONArray|array $queryVector,
+        Binary|PackedArray|ResolvesToBinData|BSONArray|array|string $queryVector,
         Optional|bool $exact = Optional::Undefined,
         Optional|QueryInterface|array $filter = Optional::Undefined,
         Optional|int $numCandidates = Optional::Undefined,

--- a/tests/Builder/Accumulator/MinMaxScalerAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MinMaxScalerAccumulatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Accumulator;
+
+use MongoDB\Builder\Accumulator;
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $minMaxScaler accumulator
+ */
+class MinMaxScalerAccumulatorTest extends PipelineTestCase
+{
+    public function testNormalizeValuesWithCustomRange(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::setWindowFields(
+                sortBy: object(a: 1),
+                output: object(
+                    scaled: Accumulator::minMaxScaler(
+                        input: Expression::fieldPath('a'),
+                    ),
+                    scaledTo100: Accumulator::minMaxScaler(
+                        input: Expression::fieldPath('a'),
+                        min: 0,
+                        max: 100,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MinMaxScalerNormalizeValuesWithCustomRange, $pipeline);
+    }
+}

--- a/tests/Builder/Accumulator/MinMaxScalerAccumulatorTest.php
+++ b/tests/Builder/Accumulator/MinMaxScalerAccumulatorTest.php
@@ -24,10 +24,10 @@ class MinMaxScalerAccumulatorTest extends PipelineTestCase
                 sortBy: object(a: 1),
                 output: object(
                     scaled: Accumulator::minMaxScaler(
-                        input: Expression::fieldPath('a'),
+                        input: Expression::numberFieldPath('a'),
                     ),
                     scaledTo100: Accumulator::minMaxScaler(
-                        input: Expression::fieldPath('a'),
+                        input: Expression::numberFieldPath('a'),
                         min: 0,
                         max: 100,
                     ),

--- a/tests/Builder/Accumulator/Pipelines.php
+++ b/tests/Builder/Accumulator/Pipelines.php
@@ -1537,6 +1537,43 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Normalize values with custom range
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minMaxScaler/#examples
+     */
+    case MinMaxScalerNormalizeValuesWithCustomRange = <<<'JSON'
+    [
+        {
+            "$setWindowFields": {
+                "sortBy": {
+                    "a": {
+                        "$numberInt": "1"
+                    }
+                },
+                "output": {
+                    "scaled": {
+                        "$minMaxScaler": {
+                            "input": "$a"
+                        }
+                    },
+                    "scaledTo100": {
+                        "$minMaxScaler": {
+                            "input": "$a",
+                            "min": {
+                                "$numberInt": "0"
+                            },
+                            "max": {
+                                "$numberInt": "100"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Find the Minimum Three Scores for a Single Game
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/minN/#find-the-minimum-three-scores-for-a-single-game

--- a/tests/Builder/Expression/ConvertOperatorTest.php
+++ b/tests/Builder/Expression/ConvertOperatorTest.php
@@ -35,7 +35,7 @@ class ConvertOperatorTest extends PipelineTestCase
         $pipeline = new Pipeline(
             Stage::project(
                 binaryString: Expression::convert(
-                    input: Expression::stringFieldPath('value'),
+                    input: Expression::intFieldPath('value'),
                     to: 'string',
                     base: 2,
                 ),

--- a/tests/Builder/Expression/ConvertOperatorTest.php
+++ b/tests/Builder/Expression/ConvertOperatorTest.php
@@ -15,6 +15,36 @@ use MongoDB\Tests\Builder\PipelineTestCase;
  */
 class ConvertOperatorTest extends PipelineTestCase
 {
+    public function testConvertHexadecimalStringToInteger(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                decimalValue: Expression::convert(
+                    input: Expression::stringFieldPath('hexString'),
+                    to: 'int',
+                    base: 16,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ConvertConvertHexadecimalStringToInteger, $pipeline);
+    }
+
+    public function testConvertIntegerToBinaryString(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                binaryString: Expression::convert(
+                    input: Expression::stringFieldPath('value'),
+                    to: 'string',
+                    base: 2,
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ConvertConvertIntegerToBinaryString, $pipeline);
+    }
+
     public function testExample(): void
     {
         $pipeline = new Pipeline(

--- a/tests/Builder/Expression/MapOperatorTest.php
+++ b/tests/Builder/Expression/MapOperatorTest.php
@@ -72,4 +72,23 @@ class MapOperatorTest extends PipelineTestCase
 
         $this->assertSamePipeline(Pipelines::MapTruncateEachArrayElement, $pipeline);
     }
+
+    public function testUseArrayIndex(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                result: Expression::map(
+                    input: Expression::arrayFieldPath('scores'),
+                    as: 'score',
+                    arrayIndexAs: 'idx',
+                    in: Expression::add(
+                        Expression::variable('score'),
+                        Expression::variable('idx'),
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::MapUseArrayIndex, $pipeline);
+    }
 }

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -3231,6 +3231,33 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Use Array Index
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/map/
+     */
+    case MapUseArrayIndex = <<<'JSON'
+    [
+        {
+            "$project": {
+                "result": {
+                    "$map": {
+                        "input": "$scores",
+                        "as": "score",
+                        "arrayIndexAs": "idx",
+                        "in": {
+                            "$add": [
+                                "$$score",
+                                "$$idx"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Use in $project Stage
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/#use-in--project-stage
@@ -5736,6 +5763,23 @@ enum Pipelines: string
                             "$numberInt": "300000"
                         }
                     ]
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/subtype/
+     */
+    case SubtypeExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "result": {
+                    "$subtype": "$myBinDataField"
                 }
             }
         }

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -927,6 +927,52 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Convert Hexadecimal String to Integer
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#base-conversion
+     */
+    case ConvertConvertHexadecimalStringToInteger = <<<'JSON'
+    [
+        {
+            "$project": {
+                "decimalValue": {
+                    "$convert": {
+                        "input": "$hexString",
+                        "to": "int",
+                        "base": {
+                            "$numberInt": "16"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Convert Integer to Binary String
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/convert/#base-conversion
+     */
+    case ConvertConvertIntegerToBinaryString = <<<'JSON'
+    [
+        {
+            "$project": {
+                "binaryString": {
+                    "$convert": {
+                        "input": "$value",
+                        "to": "string",
+                        "base": {
+                            "$numberInt": "2"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/cos/#example

--- a/tests/Builder/Expression/SubtypeOperatorTest.php
+++ b/tests/Builder/Expression/SubtypeOperatorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $subtype expression
+ */
+class SubtypeOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                result: Expression::subtype(
+                    Expression::binDataFieldPath('myBinDataField'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::SubtypeExample, $pipeline);
+    }
+}

--- a/tests/Builder/Stage/Pipelines.php
+++ b/tests/Builder/Stage/Pipelines.php
@@ -2708,6 +2708,23 @@ enum Pipelines: string
     /**
      * Example
      *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/score/
+     */
+    case ScoreExample = <<<'JSON'
+    [
+        {
+            "$score": {
+                "score": {
+                    "$meta": "vectorSearchScore"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/scoreFusion/#examples
      */
     case ScoreFusionExample = <<<'JSON'

--- a/tests/Builder/Stage/ScoreStageTest.php
+++ b/tests/Builder/Stage/ScoreStageTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Stage;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+/**
+ * Test $score stage
+ */
+class ScoreStageTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::score(
+                score: Expression::meta('vectorSearchScore'),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ScoreExample, $pipeline);
+    }
+}


### PR DESCRIPTION
## Summary

Bumps `generator/mql-specifications` to [PR #41](https://github.com/mongodb/mql-specifications/pull/41) and regenerates the builder classes.

### New operators

- **`$minMaxScaler`** (window accumulator, MongoDB 8.2) — PHPLIB-1849
- **`$score`** (stage, MongoDB 8.2) — PHPLIB-1850
- **`$subtype`** (expression, MongoDB 8.3) — PHPLIB-1774

### Updated operators

- **`$convert`** — new optional `base` argument (MongoDB 8.3) for base conversion — PHPLIB-1817
- **`$map`** — new optional `arrayIndexAs` argument (MongoDB 8.3) to expose the array index — PHPLIB-1771
- **`$vectorSearch`** — `queryVector` now also accepts `BinData` / `ResolvesToBinData` — PHPLIB-1603
- **`$rankFusion`** / **`$scoreFusion`** — `scoreDetails` is no longer marked optional by default

## Jira

https://jira.mongodb.org/browse/PHPLIB-1724