### PR TITLE
PHPLIB-1761 Add builder support for $top, $bottom, $topN, $bottomN expression operators

### DIFF
--- a/src/Builder/Expression/BottomNOperator.php
+++ b/src/Builder/Expression/BottomNOperator.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use DateTimeInterface;
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
+use MongoDB\BSON\Serializable;
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+use stdClass;
+
+use function array_is_list;
+use function is_array;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Returns an aggregation of the bottom n elements within an array, according to the specified sort order.
+ * If the array contains fewer than n elements, $bottomN returns all elements in the array.
+ *
+ * New in MongoDB 7.0
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN-array-operator/
+ * @internal
+ */
+final class BottomNOperator implements ResolvesToArray, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$bottomN';
+    public const PROPERTIES = ['n' => 'n', 'sortBy' => 'sortBy', 'output' => 'output', 'input' => 'input'];
+
+    /** @var ResolvesToInt|int|string $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $bottomN returns. */
+    public readonly ResolvesToInt|int|string $n;
+
+    /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
+    public readonly Document|Serializable|stdClass|array $sortBy;
+
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+
+    /** @var BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the bottom n elements. */
+    public readonly PackedArray|ResolvesToArray|BSONArray|array|string $input;
+
+    /**
+     * @param ResolvesToInt|int|string $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $bottomN returns.
+     * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression.
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the bottom n elements.
+     */
+    public function __construct(
+        ResolvesToInt|int|string $n,
+        Document|Serializable|stdClass|array $sortBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        PackedArray|ResolvesToArray|BSONArray|array|string $input,
+    ) {
+        if (is_string($n) && ! str_starts_with($n, '$')) {
+            throw new InvalidArgumentException('Argument $n can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        $this->n = $n;
+        $this->sortBy = $sortBy;
+        $this->output = $output;
+        if (is_string($input) && ! str_starts_with($input, '$')) {
+            throw new InvalidArgumentException('Argument $input can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        if (is_array($input) && ! array_is_list($input)) {
+            throw new InvalidArgumentException('Expected $input argument to be a list, got an associative array.');
+        }
+
+        $this->input = $input;
+    }
+}

--- a/src/Builder/Expression/BottomOperator.php
+++ b/src/Builder/Expression/BottomOperator.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use DateTimeInterface;
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
+use MongoDB\BSON\Serializable;
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+use stdClass;
+
+use function array_is_list;
+use function is_array;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Returns the bottom element within an array according to the specified sort order.
+ *
+ * New in MongoDB 7.0
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom-array-operator/
+ * @internal
+ */
+final class BottomOperator implements ResolvesToAny, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$bottom';
+    public const PROPERTIES = ['sortBy' => 'sortBy', 'output' => 'output', 'input' => 'input'];
+
+    /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
+    public readonly Document|Serializable|stdClass|array $sortBy;
+
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+
+    /** @var BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the bottom element. */
+    public readonly PackedArray|ResolvesToArray|BSONArray|array|string $input;
+
+    /**
+     * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression.
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the bottom element.
+     */
+    public function __construct(
+        Document|Serializable|stdClass|array $sortBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        PackedArray|ResolvesToArray|BSONArray|array|string $input,
+    ) {
+        $this->sortBy = $sortBy;
+        $this->output = $output;
+        if (is_string($input) && ! str_starts_with($input, '$')) {
+            throw new InvalidArgumentException('Argument $input can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        if (is_array($input) && ! array_is_list($input)) {
+            throw new InvalidArgumentException('Expected $input argument to be a list, got an associative array.');
+        }
+
+        $this->input = $input;
+    }
+}

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -297,6 +297,45 @@ trait FactoryTrait
     }
 
     /**
+     * Returns the bottom element within an array according to the specified sort order.
+     *
+     * New in MongoDB 7.0
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom-array-operator/
+     * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression.
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the bottom element.
+     */
+    public static function bottom(
+        Document|Serializable|stdClass|array $sortBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        PackedArray|ResolvesToArray|BSONArray|array|string $input,
+    ): BottomOperator {
+        return new BottomOperator($sortBy, $output, $input);
+    }
+
+    /**
+     * Returns an aggregation of the bottom n elements within an array, according to the specified sort order.
+     * If the array contains fewer than n elements, $bottomN returns all elements in the array.
+     *
+     * New in MongoDB 7.0
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN-array-operator/
+     * @param ResolvesToInt|int|string $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $bottomN returns.
+     * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression.
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the bottom n elements.
+     */
+    public static function bottomN(
+        ResolvesToInt|int|string $n,
+        Document|Serializable|stdClass|array $sortBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        PackedArray|ResolvesToArray|BSONArray|array|string $input,
+    ): BottomNOperator {
+        return new BottomNOperator($n, $sortBy, $output, $input);
+    }
+
+    /**
      * Returns the size in bytes of a given document (i.e. BSON type Object) when encoded as BSON.
      *
      * New in MongoDB 4.4
@@ -2226,6 +2265,45 @@ trait FactoryTrait
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $expression,
     ): ToObjectIdOperator {
         return new ToObjectIdOperator($expression);
+    }
+
+    /**
+     * Returns the top element within an array according to the specified sort order.
+     *
+     * New in MongoDB 7.0
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/top-array-operator/
+     * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression.
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the top element.
+     */
+    public static function top(
+        Document|Serializable|stdClass|array $sortBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        PackedArray|ResolvesToArray|BSONArray|array|string $input,
+    ): TopOperator {
+        return new TopOperator($sortBy, $output, $input);
+    }
+
+    /**
+     * Returns an aggregation of the top n elements within an array, according to the specified sort order.
+     * If the array contains fewer than n elements, $topN returns all elements in the array.
+     *
+     * New in MongoDB 7.0
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN-array-operator/
+     * @param ResolvesToInt|int|string $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $topN returns.
+     * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression.
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the top n elements.
+     */
+    public static function topN(
+        ResolvesToInt|int|string $n,
+        Document|Serializable|stdClass|array $sortBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        PackedArray|ResolvesToArray|BSONArray|array|string $input,
+    ): TopNOperator {
+        return new TopNOperator($n, $sortBy, $output, $input);
     }
 
     /**

--- a/src/Builder/Expression/TopNOperator.php
+++ b/src/Builder/Expression/TopNOperator.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use DateTimeInterface;
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
+use MongoDB\BSON\Serializable;
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+use stdClass;
+
+use function array_is_list;
+use function is_array;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Returns an aggregation of the top n elements within an array, according to the specified sort order.
+ * If the array contains fewer than n elements, $topN returns all elements in the array.
+ *
+ * New in MongoDB 7.0
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN-array-operator/
+ * @internal
+ */
+final class TopNOperator implements ResolvesToArray, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$topN';
+    public const PROPERTIES = ['n' => 'n', 'sortBy' => 'sortBy', 'output' => 'output', 'input' => 'input'];
+
+    /** @var ResolvesToInt|int|string $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $topN returns. */
+    public readonly ResolvesToInt|int|string $n;
+
+    /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
+    public readonly Document|Serializable|stdClass|array $sortBy;
+
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+
+    /** @var BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the top n elements. */
+    public readonly PackedArray|ResolvesToArray|BSONArray|array|string $input;
+
+    /**
+     * @param ResolvesToInt|int|string $n An expression that resolves to a positive integer. The integer specifies the number of array elements that $topN returns.
+     * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression.
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the top n elements.
+     */
+    public function __construct(
+        ResolvesToInt|int|string $n,
+        Document|Serializable|stdClass|array $sortBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        PackedArray|ResolvesToArray|BSONArray|array|string $input,
+    ) {
+        if (is_string($n) && ! str_starts_with($n, '$')) {
+            throw new InvalidArgumentException('Argument $n can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        $this->n = $n;
+        $this->sortBy = $sortBy;
+        $this->output = $output;
+        if (is_string($input) && ! str_starts_with($input, '$')) {
+            throw new InvalidArgumentException('Argument $input can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        if (is_array($input) && ! array_is_list($input)) {
+            throw new InvalidArgumentException('Expected $input argument to be a list, got an associative array.');
+        }
+
+        $this->input = $input;
+    }
+}

--- a/src/Builder/Expression/TopOperator.php
+++ b/src/Builder/Expression/TopOperator.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * THIS FILE IS AUTO-GENERATED. ANY CHANGES WILL BE LOST!
+ */
+
+declare(strict_types=1);
+
+namespace MongoDB\Builder\Expression;
+
+use DateTimeInterface;
+use MongoDB\BSON\Document;
+use MongoDB\BSON\PackedArray;
+use MongoDB\BSON\Serializable;
+use MongoDB\BSON\Type;
+use MongoDB\Builder\Type\Encode;
+use MongoDB\Builder\Type\ExpressionInterface;
+use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Model\BSONArray;
+use stdClass;
+
+use function array_is_list;
+use function is_array;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Returns the top element within an array according to the specified sort order.
+ *
+ * New in MongoDB 7.0
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/top-array-operator/
+ * @internal
+ */
+final class TopOperator implements ResolvesToAny, OperatorInterface
+{
+    public const ENCODE = Encode::Object;
+    public const NAME = '$top';
+    public const PROPERTIES = ['sortBy' => 'sortBy', 'output' => 'output', 'input' => 'input'];
+
+    /** @var Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort. */
+    public readonly Document|Serializable|stdClass|array $sortBy;
+
+    /** @var DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression. */
+    public readonly DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output;
+
+    /** @var BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the top element. */
+    public readonly PackedArray|ResolvesToArray|BSONArray|array|string $input;
+
+    /**
+     * @param Document|Serializable|array|stdClass $sortBy Specifies the order of results, with syntax similar to $sort.
+     * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $output Represents the output for each element in the input array and can be any expression.
+     * @param BSONArray|PackedArray|ResolvesToArray|array|string $input An expression that resolves to the array from which to return the top element.
+     */
+    public function __construct(
+        Document|Serializable|stdClass|array $sortBy,
+        DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $output,
+        PackedArray|ResolvesToArray|BSONArray|array|string $input,
+    ) {
+        $this->sortBy = $sortBy;
+        $this->output = $output;
+        if (is_string($input) && ! str_starts_with($input, '$')) {
+            throw new InvalidArgumentException('Argument $input can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
+        }
+
+        if (is_array($input) && ! array_is_list($input)) {
+            throw new InvalidArgumentException('Expected $input argument to be a list, got an associative array.');
+        }
+
+        $this->input = $input;
+    }
+}

--- a/tests/Builder/Expression/BottomNOperatorTest.php
+++ b/tests/Builder/Expression/BottomNOperatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $bottomN expression
+ */
+class BottomNOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                bottomScores: Expression::bottomN(
+                    n: 3,
+                    sortBy: object(score: -1),
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    input: Expression::arrayFieldPath('results'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BottomNExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/BottomOperatorTest.php
+++ b/tests/Builder/Expression/BottomOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $bottom expression
+ */
+class BottomOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                bottomScore: Expression::bottom(
+                    sortBy: object(score: -1),
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    input: Expression::arrayFieldPath('results'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::BottomExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -591,6 +591,65 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottom-array-operator/#example
+     */
+    case BottomExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "bottomScore": {
+                    "$bottom": {
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        },
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "input": "$results"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bottomN-array-operator/#example
+     */
+    case BottomNExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "bottomScores": {
+                    "$bottomN": {
+                        "n": {
+                            "$numberInt": "3"
+                        },
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        },
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "input": "$results"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Return Sizes of Documents
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/bsonSize/#return-sizes-of-documents
@@ -6056,6 +6115,65 @@ enum Pipelines: string
                 },
                 "description": {
                     "$toUpper": "$description"
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/top-array-operator/#example
+     */
+    case TopExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "topScore": {
+                    "$top": {
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        },
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "input": "$results"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
+     * Example
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/topN-array-operator/#example
+     */
+    case TopNExample = <<<'JSON'
+    [
+        {
+            "$project": {
+                "topScores": {
+                    "$topN": {
+                        "n": {
+                            "$numberInt": "3"
+                        },
+                        "sortBy": {
+                            "score": {
+                                "$numberInt": "-1"
+                            }
+                        },
+                        "output": [
+                            "$playerId",
+                            "$score"
+                        ],
+                        "input": "$results"
+                    }
                 }
             }
         }

--- a/tests/Builder/Expression/TopNOperatorTest.php
+++ b/tests/Builder/Expression/TopNOperatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $topN expression
+ */
+class TopNOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                topScores: Expression::topN(
+                    n: 3,
+                    sortBy: object(score: -1),
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    input: Expression::arrayFieldPath('results'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TopNExample, $pipeline);
+    }
+}

--- a/tests/Builder/Expression/TopOperatorTest.php
+++ b/tests/Builder/Expression/TopOperatorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoDB\Tests\Builder\Expression;
+
+use MongoDB\Builder\Expression;
+use MongoDB\Builder\Pipeline;
+use MongoDB\Builder\Stage;
+use MongoDB\Tests\Builder\PipelineTestCase;
+
+use function MongoDB\object;
+
+/**
+ * Test $top expression
+ */
+class TopOperatorTest extends PipelineTestCase
+{
+    public function testExample(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                topScore: Expression::top(
+                    sortBy: object(score: -1),
+                    output: [
+                        Expression::fieldPath('playerId'),
+                        Expression::fieldPath('score'),
+                    ],
+                    input: Expression::arrayFieldPath('results'),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::TopExample, $pipeline);
+    }
+}


### PR DESCRIPTION
Fix PHPLIB-1761
- https://github.com/mongodb/mql-specifications/pull/46