### PR TITLE
PHPLIB-1795: Support `flat` indexing method for vector search

### DIFF
--- a/tests/Type/SearchIndexShapes.php
+++ b/tests/Type/SearchIndexShapes.php
@@ -184,4 +184,46 @@ final class SearchIndexShapes
             ['name' => 'my_vector_index', 'type' => 'vectorSearch'],
         );
     }
+
+    /** @see https://www.mongodb.com/docs/vector-search/index/vector-search-type/#mongodb-vector-search-index-fields */
+    public function vectorSearchIndexWithHnswIndexingMethod(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'fields' => [
+                    [
+                        'type' => 'vector',
+                        'path' => 'plot_embedding',
+                        'numDimensions' => 1536,
+                        'similarity' => 'cosine',
+                        'indexingMethod' => 'hnsw',
+                        'hnswOptions' => [
+                            'maxEdges' => 32,
+                            'numEdgeCandidates' => 200,
+                        ],
+                    ],
+                ],
+            ],
+            ['name' => 'my_hnsw_index', 'type' => 'vectorSearch'],
+        );
+    }
+
+    /** @see https://www.mongodb.com/docs/vector-search/index/vector-search-type/#mongodb-vector-search-index-fields */
+    public function vectorSearchIndexWithFlatIndexingMethod(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'fields' => [
+                    [
+                        'type' => 'vector',
+                        'path' => 'plot_embedding',
+                        'numDimensions' => 1536,
+                        'similarity' => 'cosine',
+                        'indexingMethod' => 'flat',
+                    ],
+                ],
+            ],
+            ['name' => 'my_flat_index', 'type' => 'vectorSearch'],
+        );
+    }
 }


### PR DESCRIPTION
The `indexingMethod` key was already present in the `VectorSearchIndex` shape. The only thing missing was a type test, seeing as no prose tests have been defined as of yet. Correct me in case I'm wrong and there's more to do to support this new option.