### PR TITLE
PHPLIB-1818: Support regex in $replaceOne find argument

### DIFF
--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -1670,13 +1670,13 @@ trait FactoryTrait
      * New in MongoDB 4.4
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceOne/
-     * @param ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceAll returns null.
-     * @param ResolvesToNull|ResolvesToString|null|string $find The string to search for within the given input. Can be any valid expression that resolves to a string or a null. If find refers to a field that is missing, $replaceAll returns null.
-     * @param ResolvesToNull|ResolvesToString|null|string $replacement The string to use to replace all matched instances of find in input. Can be any valid expression that resolves to a string or a null.
+     * @param ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceOne returns null.
+     * @param Regex|ResolvesToNull|ResolvesToRegex|ResolvesToString|null|string $find The string or regex to search for within the given input. Can be any valid expression that resolves to a string, a regex, or a null. If find refers to a field that is missing, $replaceOne returns null.
+     * @param ResolvesToNull|ResolvesToString|null|string $replacement The string to use to replace the first matched instance of find in input. Can be any valid expression that resolves to a string or a null.
      */
     public static function replaceOne(
         ResolvesToNull|ResolvesToString|null|string $input,
-        ResolvesToNull|ResolvesToString|null|string $find,
+        Regex|ResolvesToNull|ResolvesToRegex|ResolvesToString|null|string $find,
         ResolvesToNull|ResolvesToString|null|string $replacement,
     ): ReplaceOneOperator {
         return new ReplaceOneOperator($input, $find, $replacement);

--- a/src/Builder/Expression/ReplaceOneOperator.php
+++ b/src/Builder/Expression/ReplaceOneOperator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Builder\Expression;
 
+use MongoDB\BSON\Regex;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\OperatorInterface;
 
@@ -25,23 +26,23 @@ final class ReplaceOneOperator implements ResolvesToString, OperatorInterface
     public const NAME = '$replaceOne';
     public const PROPERTIES = ['input' => 'input', 'find' => 'find', 'replacement' => 'replacement'];
 
-    /** @var ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceAll returns null. */
+    /** @var ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceOne returns null. */
     public readonly ResolvesToNull|ResolvesToString|null|string $input;
 
-    /** @var ResolvesToNull|ResolvesToString|null|string $find The string to search for within the given input. Can be any valid expression that resolves to a string or a null. If find refers to a field that is missing, $replaceAll returns null. */
-    public readonly ResolvesToNull|ResolvesToString|null|string $find;
+    /** @var Regex|ResolvesToNull|ResolvesToRegex|ResolvesToString|null|string $find The string or regex to search for within the given input. Can be any valid expression that resolves to a string, a regex, or a null. If find refers to a field that is missing, $replaceOne returns null. */
+    public readonly Regex|ResolvesToNull|ResolvesToRegex|ResolvesToString|null|string $find;
 
-    /** @var ResolvesToNull|ResolvesToString|null|string $replacement The string to use to replace all matched instances of find in input. Can be any valid expression that resolves to a string or a null. */
+    /** @var ResolvesToNull|ResolvesToString|null|string $replacement The string to use to replace the first matched instance of find in input. Can be any valid expression that resolves to a string or a null. */
     public readonly ResolvesToNull|ResolvesToString|null|string $replacement;
 
     /**
-     * @param ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceAll returns null.
-     * @param ResolvesToNull|ResolvesToString|null|string $find The string to search for within the given input. Can be any valid expression that resolves to a string or a null. If find refers to a field that is missing, $replaceAll returns null.
-     * @param ResolvesToNull|ResolvesToString|null|string $replacement The string to use to replace all matched instances of find in input. Can be any valid expression that resolves to a string or a null.
+     * @param ResolvesToNull|ResolvesToString|null|string $input The string on which you wish to apply the find. Can be any valid expression that resolves to a string or a null. If input refers to a field that is missing, $replaceOne returns null.
+     * @param Regex|ResolvesToNull|ResolvesToRegex|ResolvesToString|null|string $find The string or regex to search for within the given input. Can be any valid expression that resolves to a string, a regex, or a null. If find refers to a field that is missing, $replaceOne returns null.
+     * @param ResolvesToNull|ResolvesToString|null|string $replacement The string to use to replace the first matched instance of find in input. Can be any valid expression that resolves to a string or a null.
      */
     public function __construct(
         ResolvesToNull|ResolvesToString|null|string $input,
-        ResolvesToNull|ResolvesToString|null|string $find,
+        Regex|ResolvesToNull|ResolvesToRegex|ResolvesToString|null|string $find,
         ResolvesToNull|ResolvesToString|null|string $replacement,
     ) {
         $this->input = $input;

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -4521,6 +4521,32 @@ enum Pipelines: string
     JSON;
 
     /**
+     * Replace Using Regex
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceOne/#replace-using-regex
+     */
+    case ReplaceOneReplaceUsingRegex = <<<'JSON'
+    [
+        {
+            "$project": {
+                "item": {
+                    "$replaceOne": {
+                        "input": "$item",
+                        "find": {
+                            "$regularExpression": {
+                                "pattern": "\\bblue paint\\b",
+                                "options": ""
+                            }
+                        },
+                        "replacement": "red paint"
+                    }
+                }
+            }
+        }
+    ]
+    JSON;
+
+    /**
      * Example
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reverseArray/#example

--- a/tests/Builder/Expression/ReplaceOneOperatorTest.php
+++ b/tests/Builder/Expression/ReplaceOneOperatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MongoDB\Tests\Builder\Expression;
 
+use MongoDB\BSON\Regex;
 use MongoDB\Builder\Expression;
 use MongoDB\Builder\Pipeline;
 use MongoDB\Builder\Stage;
@@ -27,5 +28,20 @@ class ReplaceOneOperatorTest extends PipelineTestCase
         );
 
         $this->assertSamePipeline(Pipelines::ReplaceOneExample, $pipeline);
+    }
+
+    public function testReplaceUsingRegex(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                item: Expression::replaceOne(
+                    input: Expression::stringFieldPath('item'),
+                    find: new Regex('\bblue paint\b'),
+                    replacement: 'red paint',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReplaceOneReplaceUsingRegex, $pipeline);
     }
 }


### PR DESCRIPTION
- Adds `resolvesToRegex` to the `find` argument of `$replaceOne`, mirroring the existing support in `$replaceAll`
- Updates the mql-specifications submodule to mongodb/mql-specifications#49

Jira: https://jira.mongodb.org/browse/PHPLIB-1818