### PR TITLE
PHPLIB-1789: Add autoEmbed type in VectorSearchIndexShape

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -109,6 +109,7 @@ use function strlen;
  * @psalm-type VectorSearchIndexShape = array{
  *     fields: list<
  *         array{type: 'vector', path: string, numDimensions: int, similarity: 'euclidean'|'cosine'|'dotProduct', quantization?: 'none'|'scalar'|'binary', indexingMethod?: 'flat'|'hnsw', hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int}} |
+ *         array{type: 'autoEmbed', modality: 'text', path: string, model: string, numDimensions?: int, quantization?: 'float'|'scalar'|'binary'|'binaryNoRescore', similarity?: 'euclidean'|'cosine'|'dotProduct', indexingMethod?: 'flat'|'hnsw', hnswOptions?: array{maxEdges?: int, numEdgeCandidates?: int}} |
  *         array{type: 'filter', path: string}
  *     >,
  *     storedSource?: bool|array{include: list<string>}|array{exclude: list<string>},

--- a/tests/Type/SearchIndexShapes.php
+++ b/tests/Type/SearchIndexShapes.php
@@ -226,4 +226,48 @@ final class SearchIndexShapes
             ['name' => 'my_flat_index', 'type' => 'vectorSearch'],
         );
     }
+
+    /** @see https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/ */
+    public function autoEmbedVectorSearchIndex(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'fields' => [
+                    [
+                        'type' => 'autoEmbed',
+                        'modality' => 'text',
+                        'path' => 'description',
+                        'model' => 'voyage-4',
+                    ],
+                ],
+            ],
+            ['name' => 'my_auto_embed_index', 'type' => 'vectorSearch'],
+        );
+    }
+
+    /** @see https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/ */
+    public function autoEmbedVectorSearchIndexWithOptions(Collection $collection): void
+    {
+        $collection->createSearchIndex(
+            [
+                'fields' => [
+                    [
+                        'type' => 'autoEmbed',
+                        'modality' => 'text',
+                        'path' => 'description',
+                        'model' => 'voyage-4-large',
+                        'numDimensions' => 1024,
+                        'quantization' => 'scalar',
+                        'similarity' => 'dotProduct',
+                        'indexingMethod' => 'hnsw',
+                        'hnswOptions' => [
+                            'maxEdges' => 32,
+                            'numEdgeCandidates' => 200,
+                        ],
+                    ],
+                ],
+            ],
+            ['name' => 'my_auto_embed_index', 'type' => 'vectorSearch'],
+        );
+    }
 }


### PR DESCRIPTION
Adds `type: 'autoEmbed'` to the `VectorSearchIndexShape` Psalm type in `Collection.php`, with the following fields:

- Required: `type`, `modality` (`'text'`), `path`, `model` (string)
- Optional: `numDimensions`, `quantization` (`'float'|'scalar'|'binary'|'binaryNoRescore'`), `similarity`, `indexingMethod`, `hnswOptions`

The `model` field is typed as `string` rather than a string enum to avoid having to update the type every time a new model is released.

Two Psalm type tests added in `SearchIndexShapes.php`.

Jira: https://jira.mongodb.org/browse/PHPLIB-1789