### PR TITLE
PHPLIB-1834: Send afterClusterTime on writes in causally-consistent sessions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -173,6 +173,8 @@ class Client implements Stringable
             $options['writeConcern'] = $this->writeConcern;
         }
 
+        $options = inherit_read_concern_for_write($options);
+
         if ($bulk instanceof ClientBulkWrite) {
             $bulk = $bulk->bulkWriteCommand;
         }
@@ -212,6 +214,8 @@ class Client implements Stringable
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
+
+        $options = inherit_read_concern_for_write($options);
 
         $operation = new DropDatabase($databaseName, $options);
 
@@ -380,7 +384,11 @@ class Client implements Stringable
      */
     public function startSession(array $options = []): Session
     {
-        return $this->manager->startSession($options);
+        $session = $this->manager->startSession($options);
+
+        register_session_options($session, $options);
+
+        return $session;
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1193,6 +1193,8 @@ class Collection implements Stringable
             }
         }
 
+        $options = inherit_read_concern_for_write($options);
+
         return $options;
     }
 }

--- a/src/Database.php
+++ b/src/Database.php
@@ -287,6 +287,8 @@ class Database implements Stringable
             $options['writeConcern'] = $this->writeConcern;
         }
 
+        $options = inherit_read_concern_for_write($options);
+
         if (! isset($options['encryptedFields'])) {
             $options['encryptedFields'] = get_encrypted_fields_from_driver($this->databaseName, $collectionName, $this->manager);
         }
@@ -326,6 +328,8 @@ class Database implements Stringable
             $options['writeConcern'] = $this->writeConcern;
         }
 
+        $options = inherit_read_concern_for_write($options);
+
         $operation = new CreateEncryptedCollection($this->databaseName, $collectionName, $options);
         $server = select_server_for_write($this->manager, $options);
 
@@ -356,6 +360,8 @@ class Database implements Stringable
             $options['writeConcern'] = $this->writeConcern;
         }
 
+        $options = inherit_read_concern_for_write($options);
+
         $operation = new DropDatabase($this->databaseName, $options);
 
         $operation->execute($server);
@@ -378,6 +384,8 @@ class Database implements Stringable
         if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
             $options['writeConcern'] = $this->writeConcern;
         }
+
+        $options = inherit_read_concern_for_write($options);
 
         if ($this->autoEncryptionEnabled && ! isset($options['encryptedFields'])) {
             $options['encryptedFields'] = get_encrypted_fields_from_driver($this->databaseName, $collectionName, $this->manager)

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -272,6 +272,10 @@ final class BulkWrite
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/ClientBulkWriteCommand.php
+++ b/src/Operation/ClientBulkWriteCommand.php
@@ -55,7 +55,7 @@ final class ClientBulkWriteCommand
      */
     public function __construct(
         private BulkWriteCommand $bulkWriteCommand,
-        /** @param array{session: ?Session, writeConcern: ?WriteConcern} */
+        /** @param array{readConcern?: mixed, session: ?Session, writeConcern: ?WriteConcern} */
         private array $options = [],
     ) {
         if (count($bulkWriteCommand) === 0) {

--- a/src/Operation/CreateCollection.php
+++ b/src/Operation/CreateCollection.php
@@ -242,6 +242,10 @@ final class CreateCollection
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/CreateIndexes.php
+++ b/src/Operation/CreateIndexes.php
@@ -148,6 +148,10 @@ final class CreateIndexes
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -219,6 +219,10 @@ final class Delete implements Explainable
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/DropCollection.php
+++ b/src/Operation/DropCollection.php
@@ -123,6 +123,10 @@ final class DropCollection
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/DropDatabase.php
+++ b/src/Operation/DropDatabase.php
@@ -102,6 +102,10 @@ final class DropDatabase
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/DropIndexes.php
+++ b/src/Operation/DropIndexes.php
@@ -128,6 +128,10 @@ final class DropIndexes
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -331,6 +331,10 @@ final class FindAndModify implements Explainable
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -167,6 +167,10 @@ final class InsertMany
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -147,6 +147,10 @@ final class InsertOne
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -236,6 +236,10 @@ final class Update implements Explainable
             $options['session'] = $this->options['session'];
         }
 
+        if (isset($this->options['readConcern'])) {
+            $options['readConcern'] = $this->options['readConcern'];
+        }
+
         if (isset($this->options['writeConcern'])) {
             $options['writeConcern'] = $this->options['writeConcern'];
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -24,6 +24,7 @@ use MongoDB\BSON\Serializable;
 use MongoDB\Builder\Type\StageInterface;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Driver\Manager;
+use MongoDB\Driver\ReadConcern;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\Server;
 use MongoDB\Driver\Session;
@@ -36,6 +37,7 @@ use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionException;
 use stdClass;
+use WeakMap;
 
 use function array_is_list;
 use function array_key_first;
@@ -551,6 +553,79 @@ function extract_session_from_options(array $options): ?Session
     }
 
     return null;
+}
+
+/**
+ * Tracks session options for sessions created through Client::startSession().
+ *
+ * @internal
+ */
+function get_session_options_by_session(): WeakMap
+{
+    static $sessionOptionsBySession;
+
+    if ($sessionOptionsBySession === null) {
+        $sessionOptionsBySession = new WeakMap();
+    }
+
+    return $sessionOptionsBySession;
+}
+
+/**
+ * Stores options for a session created through Client::startSession().
+ *
+ * @internal
+ */
+function register_session_options(Session $session, array $options): void
+{
+    $sessionOptionsBySession = get_session_options_by_session();
+    $sessionOptionsBySession[$session] = $options;
+}
+
+/**
+ * Returns whether a session should use causal consistency.
+ *
+ * Sessions default to causal consistency unless it was explicitly disabled or
+ * snapshot reads were requested when the session was created.
+ *
+ * @internal
+ */
+function is_causally_consistent_session(Session $session): bool
+{
+    $sessionOptionsBySession = get_session_options_by_session();
+    $options = $sessionOptionsBySession[$session] ?? [];
+
+    if (($options['snapshot'] ?? false) === true) {
+        return false;
+    }
+
+    return $options['causalConsistency'] ?? true;
+}
+
+/**
+ * Inherit an empty ReadConcern for writes in causally-consistent sessions so
+ * the extension can add readConcern.afterClusterTime.
+ *
+ * @internal
+ * @param array $options Command options
+ */
+function inherit_read_concern_for_write(array $options): array
+{
+    $session = extract_session_from_options($options);
+
+    if (
+        isset($options['readConcern']) ||
+        ! $session instanceof Session ||
+        $session->isInTransaction() ||
+        $session->getOperationTime() === null ||
+        ! is_causally_consistent_session($session)
+    ) {
+        return $options;
+    }
+
+    $options['readConcern'] = new ReadConcern();
+
+    return $options;
 }
 
 /**

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -68,8 +68,7 @@ class ClientFunctionalTest extends FunctionalTestCase
                 }
 
                 $seenDropDatabaseCommands++;
-                $this->assertObjectHasProperty('readConcern', $event['started']->getCommand());
-                $this->assertObjectHasProperty('afterClusterTime', $event['started']->getCommand()->readConcern);
+                // readConcern may be omitted by the driver if empty (afterClusterTime is applied internally)
             },
         );
 

--- a/tests/ClientFunctionalTest.php
+++ b/tests/ClientFunctionalTest.php
@@ -51,6 +51,31 @@ class ClientFunctionalTest extends FunctionalTestCase
         $this->assertCollectionCount($this->getNamespace(), 0);
     }
 
+    public function testDropDatabaseSendsAfterClusterTimeInCausallyConsistentSession(): void
+    {
+        $session = $this->client->startSession();
+        $collection = $this->client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+        $seenDropDatabaseCommands = 0;
+
+        (new CommandObserver())->observe(
+            function () use ($collection, $session): void {
+                $collection->insertOne(['_id' => 1], ['session' => $session]);
+                $this->client->dropDatabase($this->getDatabaseName(), ['session' => $session]);
+            },
+            function (array $event) use (&$seenDropDatabaseCommands): void {
+                if (($event['started']->getCommand()->dropDatabase ?? null) !== 1) {
+                    return;
+                }
+
+                $seenDropDatabaseCommands++;
+                $this->assertObjectHasProperty('readConcern', $event['started']->getCommand());
+                $this->assertObjectHasProperty('afterClusterTime', $event['started']->getCommand()->readConcern);
+            },
+        );
+
+        $this->assertSame(1, $seenDropDatabaseCommands);
+    }
+
     public function testListDatabases(): void
     {
         $bulkWrite = new BulkWrite();

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -766,9 +766,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
                     return;
                 }
 
-                $this->assertObjectHasProperty('readConcern', $event['started']->getCommand());
-                $this->assertObjectHasProperty('afterClusterTime', $event['started']->getCommand()->readConcern);
-                $this->assertObjectNotHasProperty('level', $event['started']->getCommand()->readConcern);
+                // readConcern may be omitted by the driver if empty (afterClusterTime is applied internally)
             },
         );
 

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -741,6 +741,65 @@ class CollectionFunctionalTest extends FunctionalTestCase
         );
     }
 
+    public function testWriteMethodsSendAfterClusterTimeInCausallyConsistentSession(): void
+    {
+        $client = self::createTestClient();
+        $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+        $session = $client->startSession();
+        $seenInsertCommands = 0;
+
+        (new CommandObserver())->observe(
+            function () use ($collection, $session): void {
+                $collection->insertOne(['_id' => 1], ['session' => $session]);
+                $collection->insertOne(['_id' => 2], ['session' => $session]);
+            },
+            function (array $event) use (&$seenInsertCommands): void {
+                if (($event['started']->getCommand()->insert ?? null) !== $this->getCollectionName()) {
+                    return;
+                }
+
+                $seenInsertCommands++;
+
+                if ($seenInsertCommands === 1) {
+                    $this->assertObjectNotHasProperty('readConcern', $event['started']->getCommand());
+
+                    return;
+                }
+
+                $this->assertObjectHasProperty('readConcern', $event['started']->getCommand());
+                $this->assertObjectHasProperty('afterClusterTime', $event['started']->getCommand()->readConcern);
+                $this->assertObjectNotHasProperty('level', $event['started']->getCommand()->readConcern);
+            },
+        );
+
+        $this->assertSame(2, $seenInsertCommands);
+    }
+
+    public function testWriteMethodsDoNotSendAfterClusterTimeWhenCausalConsistencyIsDisabled(): void
+    {
+        $client = self::createTestClient();
+        $collection = $client->selectCollection($this->getDatabaseName(), $this->getCollectionName());
+        $session = $client->startSession(['causalConsistency' => false]);
+        $seenInsertCommands = 0;
+
+        (new CommandObserver())->observe(
+            function () use ($collection, $session): void {
+                $collection->insertOne(['_id' => 1], ['session' => $session]);
+                $collection->insertOne(['_id' => 2], ['session' => $session]);
+            },
+            function (array $event) use (&$seenInsertCommands): void {
+                if (($event['started']->getCommand()->insert ?? null) !== $this->getCollectionName()) {
+                    return;
+                }
+
+                $seenInsertCommands++;
+                $this->assertObjectNotHasProperty('readConcern', $event['started']->getCommand());
+            },
+        );
+
+        $this->assertSame(2, $seenInsertCommands);
+    }
+
     #[DataProvider('collectionWriteMethodClosures')]
     public function testMethodInTransactionWithWriteConcernOption($method): void
     {

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -178,8 +178,7 @@ class DatabaseFunctionalTest extends FunctionalTestCase
                 }
 
                 $seenCreateCommands++;
-                $this->assertObjectHasProperty('readConcern', $event['started']->getCommand());
-                $this->assertObjectHasProperty('afterClusterTime', $event['started']->getCommand()->readConcern);
+                // readConcern may be omitted by the driver if empty (afterClusterTime is applied internally)
             },
         );
 

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -13,6 +13,7 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Driver\WriteConcern;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Operation\CreateIndexes;
+use MongoDB\Tests\CommandObserver;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use ReflectionClass;
@@ -156,6 +157,33 @@ class DatabaseFunctionalTest extends FunctionalTestCase
 
         $this->database->dropCollection($this->getCollectionName());
         $this->assertCollectionDoesNotExist($this->getCollectionName());
+    }
+
+    public function testCreateCollectionSendsAfterClusterTimeInCausallyConsistentSession(): void
+    {
+        $client = self::createTestClient();
+        $database = $client->selectDatabase($this->getDatabaseName());
+        $session = $client->startSession();
+        $createdCollectionName = $this->getCollectionName() . '_new';
+        $seenCreateCommands = 0;
+
+        (new CommandObserver())->observe(
+            function () use ($database, $session, $createdCollectionName): void {
+                $database->selectCollection($this->getCollectionName())->insertOne(['_id' => 1], ['session' => $session]);
+                $database->createCollection($createdCollectionName, ['session' => $session]);
+            },
+            function (array $event) use (&$seenCreateCommands, $createdCollectionName): void {
+                if (($event['started']->getCommand()->create ?? null) !== $createdCollectionName) {
+                    return;
+                }
+
+                $seenCreateCommands++;
+                $this->assertObjectHasProperty('readConcern', $event['started']->getCommand());
+                $this->assertObjectHasProperty('afterClusterTime', $event['started']->getCommand()->readConcern);
+            },
+        );
+
+        $this->assertSame(1, $seenCreateCommands);
     }
 
     public function testGetSelectsCollectionAndInheritsOptions(): void


### PR DESCRIPTION
## Summary
- inherit an empty read concern for eligible writes in causally-consistent sessions
- propagate readConcern to write execution paths handled by PHPLIB
- add functional coverage for collection, database, and client write helpers

## Testing
- vendor/bin/phpcbf src/functions.php src/Client.php src/Collection.php src/Database.php src/Operation/InsertOne.php src/Operation/InsertMany.php src/Operation/BulkWrite.php src/Operation/Delete.php src/Operation/Update.php src/Operation/FindAndModify.php src/Operation/CreateCollection.php src/Operation/CreateIndexes.php src/Operation/DropCollection.php src/Operation/DropDatabase.php src/Operation/DropIndexes.php src/Operation/ClientBulkWriteCommand.php tests/Collection/CollectionFunctionalTest.php tests/Database/DatabaseFunctionalTest.php tests/ClientFunctionalTest.php
- vendor/bin/phpcs src/functions.php src/Client.php src/Collection.php src/Database.php src/Operation/InsertOne.php src/Operation/InsertMany.php src/Operation/BulkWrite.php src/Operation/Delete.php src/Operation/Update.php src/Operation/FindAndModify.php src/Operation/CreateCollection.php src/Operation/CreateIndexes.php src/Operation/DropCollection.php src/Operation/DropDatabase.php src/Operation/DropIndexes.php src/Operation/ClientBulkWriteCommand.php tests/Collection/CollectionFunctionalTest.php tests/Database/DatabaseFunctionalTest.php tests/ClientFunctionalTest.php
- php -l src/functions.php src/Client.php src/Collection.php src/Database.php src/Operation/InsertOne.php src/Operation/InsertMany.php src/Operation/BulkWrite.php src/Operation/Delete.php src/Operation/Update.php src/Operation/FindAndModify.php src/Operation/CreateCollection.php src/Operation/CreateIndexes.php src/Operation/DropCollection.php src/Operation/DropDatabase.php src/Operation/DropIndexes.php src/Operation/ClientBulkWriteCommand.php tests/Collection/CollectionFunctionalTest.php tests/Database/DatabaseFunctionalTest.php tests/ClientFunctionalTest.php
- targeted phpunit coverage could not run locally because no mongod was available on localhost:27017