### PR TITLE
PHPLIB-1846: Add Prose 27 - String Explicit Encryption tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -40,6 +40,10 @@ github_pr_aliases: &github_pr_aliases
   # Run PR tasks for all PR variants (only MongoDB 7.0)
   - variant_tags: ["pr"]
     task_tags: ["pr 7.0"]
+  # Run csfle tests against MongoDB latest on the next-minor extension so
+  # that QE string query tests (Prose 27) get PR coverage
+  - variant_tags: ["csfle-next-minor"]
+    task: "^test-mongodb-latest-crypt-shared$"
 
 commit_queue_aliases: *github_pr_aliases
 

--- a/.evergreen/config/generated/test-variant/phpc.yml
+++ b/.evergreen/config/generated/test-variant/phpc.yml
@@ -34,3 +34,6 @@ buildvariants:
       - ".replicaset .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
       - ".sharded .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
       - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
+      # Run csfle tests against MongoDB latest so that QE string query tests
+      # (Prose 27) get coverage on the upcoming extension version.
+      - "test-mongodb-latest-crypt-shared"

--- a/.evergreen/config/generated/test-variant/phpc.yml
+++ b/.evergreen/config/generated/test-variant/phpc.yml
@@ -19,7 +19,7 @@ buildvariants:
       - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
 
   - name: test-debian12-php-8.5-phpc-next-minor
-    tags: ["test", "debian", "x64", "php8.5"]
+    tags: ["test", "debian", "x64", "php8.5", "csfle-next-minor"]
     display_name: "Test: Debian 12, PHP 8.5, PHPC next-minor"
     run_on: debian12-small
     expansions:

--- a/.evergreen/config/templates/test-variant/phpc.yml
+++ b/.evergreen/config/templates/test-variant/phpc.yml
@@ -32,3 +32,6 @@
       - ".replicaset .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
       - ".sharded .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
       - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
+      # Run csfle tests against MongoDB latest so that QE string query tests
+      # (Prose 27) get coverage on the upcoming extension version.
+      - "test-mongodb-latest-crypt-shared"

--- a/.evergreen/config/templates/test-variant/phpc.yml
+++ b/.evergreen/config/templates/test-variant/phpc.yml
@@ -17,7 +17,7 @@
       - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.5.0 !.6.0"
 
   - name: test-debian12-php-%phpVersion%-phpc-next-minor
-    tags: ["test", "debian", "x64", "php%phpVersion%"]
+    tags: ["test", "debian", "x64", "php%phpVersion%", "csfle-next-minor"]
     display_name: "Test: Debian 12, PHP %phpVersion%, PHPC next-minor"
     run_on: debian12-small
     expansions:

--- a/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose22_RangeExplicitEncryptionTest.php
@@ -125,7 +125,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
         // TODO: skip DecimalNoPrecision test on mongos
         yield 'DecimalNoPrecision' => [
             'DecimalNoPrecision',
-            ['sparsity' => 1],
+            ['trimFactor' => 1, 'sparsity' => 1],
         ];
 
         yield 'DecimalPrecision' => [
@@ -133,6 +133,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
             [
                 'min' => new Decimal128('0'),
                 'max' => new Decimal128('200'),
+                'trimFactor' => 1,
                 'sparsity' => 1,
                 'precision' => 2,
             ],
@@ -140,7 +141,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
 
         yield 'DoubleNoPrecision' => [
             'DoubleNoPrecision',
-            ['sparsity' => 1],
+            ['trimFactor' => 1, 'sparsity' => 1],
         ];
 
         yield 'DoublePrecision' => [
@@ -148,6 +149,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
             [
                 'min' => 0.0,
                 'max' => 200.0,
+                'trimFactor' => 1,
                 'sparsity' => 1,
                 'precision' => 2,
             ],
@@ -158,6 +160,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
             [
                 'min' => new UTCDateTime(0),
                 'max' => new UTCDateTime(200),
+                'trimFactor' => 1,
                 'sparsity' => 1,
             ],
         ];
@@ -167,6 +170,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
             [
                 'min' => 0,
                 'max' => 200,
+                'trimFactor' => 1,
                 'sparsity' => 1,
             ],
         ];
@@ -176,6 +180,7 @@ class Prose22_RangeExplicitEncryptionTest extends FunctionalTestCase
             [
                 'min' => new Int64(0),
                 'max' => new Int64(200),
+                'trimFactor' => 1,
                 'sparsity' => 1,
             ],
         ];

--- a/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
@@ -1,0 +1,513 @@
+<?php
+
+namespace MongoDB\Tests\SpecTests\ClientSideEncryption;
+
+use Generator;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\Document;
+use MongoDB\Client;
+use MongoDB\Database;
+use MongoDB\Driver\ClientEncryption;
+use MongoDB\Driver\Exception\EncryptionException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+use function base64_decode;
+use function file_get_contents;
+use function version_compare;
+
+/**
+ * Prose test 27: String Explicit Encryption
+ *
+ * @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#27-string-explicit-encryption
+ */
+#[Group('csfle')]
+class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
+{
+    private ?ClientEncryption $clientEncryption = null;
+    private ?Client $explicitEncryptedClient = null;
+    private ?Client $autoEncryptedClient = null;
+    private mixed $key1Id = null;
+    private bool $serverAtLeast9 = false;
+    private bool $prefixPreviewSupported = false;
+
+    private static string $specDir = __DIR__ . '/../../specifications/source/client-side-encryption';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->isStandalone()) {
+            $this->markTestSkipped('String explicit encryption tests require replica sets');
+        }
+
+        $this->skipIfServerVersion('<', '8.2.0', 'String explicit encryption tests require MongoDB 8.2 or later');
+
+        $this->serverAtLeast9 = version_compare($this->getServerVersion(), '9.0.0', '>=');
+        $libmongocryptVersion = static::getModuleInfo('libmongocrypt bundled version') ?? '0';
+        $this->prefixPreviewSupported = ! $this->serverAtLeast9
+            && version_compare($libmongocryptVersion, '1.19.1', '>=');
+
+        $client = static::createTestClient();
+        $key1Document = $this->decodeJson(file_get_contents(self::$specDir . '/etc/data/keys/key1-document.json'));
+        $this->key1Id = $key1Document->_id;
+        self::insertKeyVaultData($client, [$key1Document]);
+
+        $this->clientEncryption = $client->createClientEncryption([
+            'keyVaultNamespace' => 'keyvault.datakeys',
+            'kmsProviders' => ['local' => ['key' => new Binary(base64_decode(self::LOCAL_MASTERKEY))]],
+        ]);
+
+        $this->explicitEncryptedClient = self::createTestClient(null, [], [
+            'autoEncryption' => [
+                'keyVaultNamespace' => 'keyvault.datakeys',
+                'kmsProviders' => ['local' => ['key' => new Binary(base64_decode(self::LOCAL_MASTERKEY))]],
+                'bypassQueryAnalysis' => true,
+            ],
+            /* libmongocrypt caches results from listCollections. Use a new
+             * client in each test to ensure its encryptedFields is applied. */
+            'disableClientPersistence' => true,
+        ]);
+
+        $this->autoEncryptedClient = self::createTestClient(null, [], [
+            'autoEncryption' => [
+                'keyVaultNamespace' => 'keyvault.datakeys',
+                'kmsProviders' => ['local' => ['key' => new Binary(base64_decode(self::LOCAL_MASTERKEY))]],
+            ],
+            'disableClientPersistence' => true,
+        ]);
+
+        $database = $this->explicitEncryptedClient->getDatabase($this->getDatabaseName());
+        $this->setUpCollections($database);
+        $this->insertInitialDocuments($database);
+    }
+
+    public function tearDown(): void
+    {
+        $this->clientEncryption = null;
+        $this->explicitEncryptedClient = null;
+        $this->autoEncryptedClient = null;
+    }
+
+    public static function providePrefixQueryTypeAndCollection(): Generator
+    {
+        yield 'prefix' => ['prefix', 'prefix-suffix'];
+        yield 'prefixPreview' => ['prefixPreview', 'prefix-suffix-preview'];
+    }
+
+    public static function provideSuffixQueryTypeAndCollection(): Generator
+    {
+        yield 'suffix' => ['suffix', 'prefix-suffix'];
+        yield 'suffixPreview' => ['suffixPreview', 'prefix-suffix-preview'];
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-1-can-find-a-document-by-prefix */
+    #[DataProvider('providePrefixQueryTypeAndCollection')]
+    public function testCase1_CanFindADocumentByPrefix(string $queryType, string $collectionName): void
+    {
+        $this->skipByQueryTypeAndServerVersion($queryType);
+
+        $encryptedFoo = $this->clientEncryption->encrypt('foo', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => $queryType,
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'prefix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($this->getDatabaseName())
+            ->getCollection($collectionName)
+            ->findOne(['$expr' => ['$encStrStartsWith' => ['input' => '$encryptedText', 'prefix' => $encryptedFoo]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['_id' => 0, 'encryptedText' => 'foobarbaz'], $result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-2-can-find-a-document-by-suffix */
+    #[DataProvider('provideSuffixQueryTypeAndCollection')]
+    public function testCase2_CanFindADocumentBySuffix(string $queryType, string $collectionName): void
+    {
+        $this->skipByQueryTypeAndServerVersion($queryType);
+
+        $encryptedBaz = $this->clientEncryption->encrypt('baz', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => $queryType,
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'suffix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($this->getDatabaseName())
+            ->getCollection($collectionName)
+            ->findOne(['$expr' => ['$encStrEndsWith' => ['input' => '$encryptedText', 'suffix' => $encryptedBaz]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['_id' => 0, 'encryptedText' => 'foobarbaz'], $result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-3-assert-no-document-found-by-prefix */
+    #[DataProvider('providePrefixQueryTypeAndCollection')]
+    public function testCase3_AssertNoDocumentFoundByPrefix(string $queryType, string $collectionName): void
+    {
+        $this->skipByQueryTypeAndServerVersion($queryType);
+
+        $encryptedBaz = $this->clientEncryption->encrypt('baz', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => $queryType,
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'prefix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($this->getDatabaseName())
+            ->getCollection($collectionName)
+            ->findOne(['$expr' => ['$encStrStartsWith' => ['input' => '$encryptedText', 'prefix' => $encryptedBaz]]]);
+
+        $this->assertNull($result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-4-assert-no-document-found-by-suffix */
+    #[DataProvider('provideSuffixQueryTypeAndCollection')]
+    public function testCase4_AssertNoDocumentFoundBySuffix(string $queryType, string $collectionName): void
+    {
+        $this->skipByQueryTypeAndServerVersion($queryType);
+
+        $encryptedFoo = $this->clientEncryption->encrypt('foo', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => $queryType,
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'suffix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($this->getDatabaseName())
+            ->getCollection($collectionName)
+            ->findOne(['$expr' => ['$encStrEndsWith' => ['input' => '$encryptedText', 'suffix' => $encryptedFoo]]]);
+
+        $this->assertNull($result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-5-can-find-a-document-by-substring */
+    public function testCase5_CanFindADocumentBySubstring(): void
+    {
+        $encryptedBar = $this->clientEncryption->encrypt('bar', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'substringPreview',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($this->getDatabaseName())
+            ->getCollection('substring')
+            ->findOne(['$expr' => ['$encStrContains' => ['input' => '$encryptedText', 'substring' => $encryptedBar]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['_id' => 0, 'encryptedText' => 'foobarbaz'], $result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-6-assert-no-document-found-by-substring */
+    public function testCase6_AssertNoDocumentFoundBySubstring(): void
+    {
+        $encryptedQux = $this->clientEncryption->encrypt('qux', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'substringPreview',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($this->getDatabaseName())
+            ->getCollection('substring')
+            ->findOne(['$expr' => ['$encStrContains' => ['input' => '$encryptedText', 'substring' => $encryptedQux]]]);
+
+        $this->assertNull($result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-7-assert-contentionfactor-is-required */
+    public function testCase7_AssertContentionFactorIsRequired(): void
+    {
+        $this->skipIfServerVersion('<', '9.0.0', 'Case 7 requires MongoDB 9.0.0+');
+
+        $this->expectException(EncryptionException::class);
+        $this->expectExceptionMessageMatches('/contention factor is required for string algorithm/');
+
+        $this->clientEncryption->encrypt('foo', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'prefix',
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'prefix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-8-can-find-an-auto-encrypted-case-insensitively-indexed-document-by-prefix-and-suffix */
+    public function testCase8_CanFindAutoEncryptedCaseInsensitiveDocumentByPrefixAndSuffix(): void
+    {
+        $this->skipIfServerVersion('<', '9.0.0', 'Case 8 requires MongoDB 9.0.0+');
+
+        $database = $this->getDatabaseName();
+
+        $this->autoEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('prefix-suffix-ci-di')
+            ->insertOne(['encryptedText' => 'BingQiLin']);
+
+        $encryptedBing = $this->clientEncryption->encrypt('bing', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'prefix',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => false,
+                'diacriticSensitive' => false,
+                'prefix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('prefix-suffix-ci-di')
+            ->findOne(['$expr' => ['$encStrStartsWith' => ['input' => '$encryptedText', 'prefix' => $encryptedBing]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['encryptedText' => 'BingQiLin'], $result);
+
+        $encryptedLin = $this->clientEncryption->encrypt('lin', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'suffix',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => false,
+                'diacriticSensitive' => false,
+                'suffix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('prefix-suffix-ci-di')
+            ->findOne(['$expr' => ['$encStrEndsWith' => ['input' => '$encryptedText', 'suffix' => $encryptedLin]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['encryptedText' => 'BingQiLin'], $result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-9-can-find-an-auto-encrypted-diacritic-insensitively-indexed-document-by-prefix-and-suffix */
+    public function testCase9_CanFindAutoEncryptedDiacriticInsensitiveDocumentByPrefixAndSuffix(): void
+    {
+        $this->skipIfServerVersion('<', '9.0.0', 'Case 9 requires MongoDB 9.0.0+');
+
+        $database = $this->getDatabaseName();
+
+        $this->autoEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('prefix-suffix-ci-di')
+            ->insertOne(['encryptedText' => 'cafébarbäz']);
+
+        $encryptedCafe = $this->clientEncryption->encrypt('cafe', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'prefix',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => false,
+                'diacriticSensitive' => false,
+                'prefix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('prefix-suffix-ci-di')
+            ->findOne(['$expr' => ['$encStrStartsWith' => ['input' => '$encryptedText', 'prefix' => $encryptedCafe]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['encryptedText' => 'cafébarbäz'], $result);
+
+        $encryptedBaz = $this->clientEncryption->encrypt('baz', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'suffix',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => false,
+                'diacriticSensitive' => false,
+                'suffix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('prefix-suffix-ci-di')
+            ->findOne(['$expr' => ['$encStrEndsWith' => ['input' => '$encryptedText', 'suffix' => $encryptedBaz]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['encryptedText' => 'cafébarbäz'], $result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-10-can-find-an-auto-encrypted-case-insensitively-indexed-document-by-substring */
+    public function testCase10_CanFindAutoEncryptedCaseInsensitiveDocumentBySubstring(): void
+    {
+        $database = $this->getDatabaseName();
+
+        $this->autoEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('substring-ci-di')
+            ->insertOne(['encryptedText' => 'FooBarBaz']);
+
+        $encryptedBar = $this->clientEncryption->encrypt('bar', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'substringPreview',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => false,
+                'diacriticSensitive' => false,
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('substring-ci-di')
+            ->findOne(['$expr' => ['$encStrContains' => ['input' => '$encryptedText', 'substring' => $encryptedBar]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['encryptedText' => 'FooBarBaz'], $result);
+    }
+
+    /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-11-can-find-an-auto-encrypted-diacritic-insensitively-indexed-document-by-substring */
+    public function testCase11_CanFindAutoEncryptedDiacriticInsensitiveDocumentBySubstring(): void
+    {
+        $database = $this->getDatabaseName();
+
+        $this->autoEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('substring-ci-di')
+            ->insertOne(['encryptedText' => 'foocafébaz']);
+
+        $encryptedCafe = $this->clientEncryption->encrypt('cafe', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'queryType' => 'substringPreview',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => false,
+                'diacriticSensitive' => false,
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $result = $this->explicitEncryptedClient
+            ->getDatabase($database)
+            ->getCollection('substring-ci-di')
+            ->findOne(['$expr' => ['$encStrContains' => ['input' => '$encryptedText', 'substring' => $encryptedCafe]]]);
+
+        $this->assertNotNull($result);
+        $this->assertDocumentsMatch(['encryptedText' => 'foocafébaz'], $result);
+    }
+
+    private function setUpCollections(Database $database): void
+    {
+        if ($this->serverAtLeast9) {
+            foreach (['prefix-suffix', 'prefix-suffix-ci-di'] as $name) {
+                $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-' . $name . '.json'));
+                $database->dropCollection($name, ['encryptedFields' => $encryptedFields]);
+                $database->createCollection($name, ['encryptedFields' => $encryptedFields]);
+            }
+        } elseif ($this->prefixPreviewSupported) {
+            $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-prefix-suffix-preview.json'));
+            $database->dropCollection('prefix-suffix-preview', ['encryptedFields' => $encryptedFields]);
+            $database->createCollection('prefix-suffix-preview', ['encryptedFields' => $encryptedFields]);
+        }
+
+        foreach (['substring', 'substring-ci-di'] as $name) {
+            $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-' . $name . '.json'));
+            $database->dropCollection($name, ['encryptedFields' => $encryptedFields]);
+            $database->createCollection($name, ['encryptedFields' => $encryptedFields]);
+        }
+    }
+
+    private function insertInitialDocuments(Database $database): void
+    {
+        if ($this->serverAtLeast9 || $this->prefixPreviewSupported) {
+            $collectionNameForPrefixSuffix = $this->serverAtLeast9 ? 'prefix-suffix' : 'prefix-suffix-preview';
+
+            $encryptedFoobarBazForPrefixSuffix = $this->clientEncryption->encrypt('foobarbaz', [
+                'keyId' => $this->key1Id,
+                'algorithm' => 'String',
+                'contentionFactor' => 0,
+                'stringOpts' => [
+                    'caseSensitive' => true,
+                    'diacriticSensitive' => true,
+                    'prefix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+                    'suffix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+                ],
+            ]);
+
+            $database->getCollection($collectionNameForPrefixSuffix)
+                ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBazForPrefixSuffix]);
+        }
+
+        $encryptedFoobarBazForSubstring = $this->clientEncryption->encrypt('foobarbaz', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+
+        $database->getCollection('substring')
+            ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBazForSubstring]);
+    }
+
+    private function skipByQueryTypeAndServerVersion(string $queryType): void
+    {
+        if ($queryType === 'prefix' || $queryType === 'suffix') {
+            $this->skipIfServerVersion('<', '9.0.0', $queryType . ' query type requires MongoDB 9.0.0+');
+        } else {
+            $this->skipIfServerVersion('>=', '9.0.0', $queryType . ' query type requires MongoDB pre-9.0.0');
+            if (! $this->prefixPreviewSupported) {
+                $this->markTestSkipped($queryType . ' query type requires libmongocrypt 1.19.1+');
+            }
+        }
+    }
+}

--- a/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
@@ -24,12 +24,12 @@ use function version_compare;
 #[Group('csfle')]
 class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
 {
-    private ?ClientEncryption $clientEncryption = null;
-    private ?Client $explicitEncryptedClient = null;
-    private ?Client $autoEncryptedClient = null;
-    private mixed $key1Id = null;
-    private bool $serverAtLeast9 = false;
-    private bool $prefixPreviewSupported = false;
+    private ClientEncryption $clientEncryption;
+    private Client $explicitEncryptedClient;
+    private Client $autoEncryptedClient;
+    private mixed $key1Id;
+    private bool $serverAtLeast9;
+    private bool $prefixPreviewSupported;
 
     private static string $specDir = __DIR__ . '/../../specifications/source/client-side-encryption';
 
@@ -84,9 +84,9 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
 
     public function tearDown(): void
     {
-        $this->clientEncryption = null;
-        $this->explicitEncryptedClient = null;
-        $this->autoEncryptedClient = null;
+        unset($this->clientEncryption);
+        unset($this->explicitEncryptedClient);
+        unset($this->autoEncryptedClient);
     }
 
     public static function providePrefixQueryTypeAndCollection(): Generator

--- a/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
 
 use function base64_decode;
 use function file_get_contents;
+use function in_array;
 use function phpversion;
 use function version_compare;
 
@@ -31,9 +32,6 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     private Client $autoEncryptedClient;
     private mixed $key1Id;
     private bool $serverAtLeast9;
-    private string $libmongocryptVersion;
-    private bool $prefixPreviewSupported;
-    private bool $substringPreviewSupported;
     private WriteConcern $majorityWriteConcern;
 
     private static string $specDir = __DIR__ . '/../../specifications/source/client-side-encryption';
@@ -52,14 +50,12 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
 
         $this->skipIfServerVersion('<', '8.2.0', 'String explicit encryption tests require MongoDB 8.2 or later');
 
-        /* The spec also requires libmongocrypt 1.18.1+; the extension always
-         * bundles a version well above that, so no top-level guard is added. */
+        /* Per-case libmongocrypt version requirements (baseline 1.18.1,
+         * prefix/suffix 1.19.0, prefixPreview/suffixPreview 1.19.1,
+         * substring 1.20.0, substringPreview 1.18.1) are all satisfied by
+         * ext-mongodb 2.4.0+, which bundles libmongocrypt 1.20.0+, so no
+         * runtime libmongocrypt guard is added. */
         $this->serverAtLeast9 = version_compare($this->getServerVersion(), '9.0.0', '>=');
-        $this->libmongocryptVersion = static::getModuleInfo('libmongocrypt bundled version') ?? '0';
-        $this->prefixPreviewSupported = ! $this->serverAtLeast9
-            && version_compare($this->libmongocryptVersion, '1.19.1', '>=');
-        $this->substringPreviewSupported = ! $this->serverAtLeast9
-            && version_compare($this->libmongocryptVersion, '1.18.1', '>=');
         $this->majorityWriteConcern = new WriteConcern(WriteConcern::MAJORITY);
 
         $client = static::createTestClient();
@@ -284,7 +280,6 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase7_AssertContentionFactorIsRequired(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 7 requires MongoDB 9.0.0+');
-        $this->skipIfLibmongocryptVersion('<', '1.19.0', 'Case 7 requires libmongocrypt 1.19.0+');
 
         $this->expectException(EncryptionException::class);
         $this->expectExceptionMessageMatches('/contention factor is required for string algorithm/');
@@ -305,7 +300,6 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase8_CanFindAutoEncryptedCaseInsensitiveDocumentByPrefixAndSuffix(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 8 requires MongoDB 9.0.0+');
-        $this->skipIfLibmongocryptVersion('<', '1.19.0', 'Case 8 requires libmongocrypt 1.19.0+');
 
         $database = $this->getDatabaseName();
 
@@ -359,7 +353,6 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase9_CanFindAutoEncryptedDiacriticInsensitiveDocumentByPrefixAndSuffix(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 9 requires MongoDB 9.0.0+');
-        $this->skipIfLibmongocryptVersion('<', '1.19.0', 'Case 9 requires libmongocrypt 1.19.0+');
 
         $database = $this->getDatabaseName();
 
@@ -413,7 +406,6 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase10_CanFindAutoEncryptedCaseInsensitiveDocumentBySubstring(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 10 requires MongoDB 9.0.0+');
-        $this->skipIfLibmongocryptVersion('<', '1.20.0', 'Case 10 requires libmongocrypt 1.20.0+');
 
         $database = $this->getDatabaseName();
 
@@ -447,7 +439,6 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase11_CanFindAutoEncryptedDiacriticInsensitiveDocumentBySubstring(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 11 requires MongoDB 9.0.0+');
-        $this->skipIfLibmongocryptVersion('<', '1.20.0', 'Case 11 requires libmongocrypt 1.20.0+');
 
         $database = $this->getDatabaseName();
 
@@ -479,100 +470,57 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
 
     private function setUpCollections(Database $database): void
     {
-        if ($this->serverAtLeast9) {
-            foreach (['prefix-suffix', 'prefix-suffix-ci-di', 'substring', 'substring-ci-di'] as $name) {
-                $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-' . $name . '.json'));
-                $database->dropCollection($name, ['encryptedFields' => $encryptedFields]);
-                $database->createCollection($name, ['encryptedFields' => $encryptedFields]);
-            }
+        $names = $this->serverAtLeast9
+            ? ['prefix-suffix', 'prefix-suffix-ci-di', 'substring', 'substring-ci-di']
+            : ['prefix-suffix-preview', 'substring-preview'];
 
-            return;
-        }
-
-        if ($this->prefixPreviewSupported) {
-            $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-prefix-suffix-preview.json'));
-            $database->dropCollection('prefix-suffix-preview', ['encryptedFields' => $encryptedFields]);
-            $database->createCollection('prefix-suffix-preview', ['encryptedFields' => $encryptedFields]);
-        }
-
-        if ($this->substringPreviewSupported) {
-            $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-substring-preview.json'));
-            $database->dropCollection('substring-preview', ['encryptedFields' => $encryptedFields]);
-            $database->createCollection('substring-preview', ['encryptedFields' => $encryptedFields]);
+        foreach ($names as $name) {
+            $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-' . $name . '.json'));
+            $database->dropCollection($name, ['encryptedFields' => $encryptedFields]);
+            $database->createCollection($name, ['encryptedFields' => $encryptedFields]);
         }
     }
 
     private function insertInitialDocuments(Database $database): void
     {
-        if ($this->serverAtLeast9 || $this->prefixPreviewSupported) {
-            $collectionName = $this->serverAtLeast9 ? 'prefix-suffix' : 'prefix-suffix-preview';
+        $prefixSuffixCollection = $this->serverAtLeast9 ? 'prefix-suffix' : 'prefix-suffix-preview';
+        $encryptedFoobarBaz = $this->clientEncryption->encrypt('foobarbaz', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'prefix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+                'suffix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+            ],
+        ]);
+        $database->getCollection($prefixSuffixCollection)
+            ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBaz]);
 
-            $encryptedFoobarBaz = $this->clientEncryption->encrypt('foobarbaz', [
-                'keyId' => $this->key1Id,
-                'algorithm' => 'String',
-                'contentionFactor' => 0,
-                'stringOpts' => [
-                    'caseSensitive' => true,
-                    'diacriticSensitive' => true,
-                    'prefix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
-                    'suffix' => ['strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
-                ],
-            ]);
-
-            $database->getCollection($collectionName)
-                ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBaz]);
-        }
-
-        if ($this->serverAtLeast9 || $this->substringPreviewSupported) {
-            $collectionName = $this->serverAtLeast9 ? 'substring' : 'substring-preview';
-
-            $encryptedFoobarBaz = $this->clientEncryption->encrypt('foobarbaz', [
-                'keyId' => $this->key1Id,
-                'algorithm' => 'String',
-                'contentionFactor' => 0,
-                'stringOpts' => [
-                    'caseSensitive' => true,
-                    'diacriticSensitive' => true,
-                    'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 6, 'strMinQueryLength' => 2],
-                ],
-            ]);
-
-            $database->getCollection($collectionName)
-                ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBaz]);
-        }
+        $substringCollection = $this->serverAtLeast9 ? 'substring' : 'substring-preview';
+        $encryptedFoobarBaz = $this->clientEncryption->encrypt('foobarbaz', [
+            'keyId' => $this->key1Id,
+            'algorithm' => 'String',
+            'contentionFactor' => 0,
+            'stringOpts' => [
+                'caseSensitive' => true,
+                'diacriticSensitive' => true,
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 6, 'strMinQueryLength' => 2],
+            ],
+        ]);
+        $database->getCollection($substringCollection)
+            ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBaz]);
     }
 
     private function skipByQueryTypeAndServerVersion(string $queryType): void
     {
-        if ($queryType === 'prefix' || $queryType === 'suffix') {
+        if (in_array($queryType, ['prefix', 'suffix', 'substring'], true)) {
             $this->skipIfServerVersion('<', '9.0.0', $queryType . ' query type requires MongoDB 9.0.0+');
-            $this->skipIfLibmongocryptVersion('<', '1.19.0', $queryType . ' query type requires libmongocrypt 1.19.0+');
-
-            return;
-        }
-
-        if ($queryType === 'substring') {
-            $this->skipIfServerVersion('<', '9.0.0', $queryType . ' query type requires MongoDB 9.0.0+');
-            $this->skipIfLibmongocryptVersion('<', '1.20.0', $queryType . ' query type requires libmongocrypt 1.20.0+');
 
             return;
         }
 
         $this->skipIfServerVersion('>=', '9.0.0', $queryType . ' query type requires MongoDB pre-9.0.0');
-
-        if ($queryType === 'substringPreview' && ! $this->substringPreviewSupported) {
-            $this->markTestSkipped('substringPreview query type requires libmongocrypt 1.18.1+');
-        }
-
-        if (($queryType === 'prefixPreview' || $queryType === 'suffixPreview') && ! $this->prefixPreviewSupported) {
-            $this->markTestSkipped($queryType . ' query type requires libmongocrypt 1.19.1+');
-        }
-    }
-
-    private function skipIfLibmongocryptVersion(string $operator, string $version, string $message): void
-    {
-        if (version_compare($this->libmongocryptVersion, $version, $operator)) {
-            $this->markTestSkipped($message);
-        }
     }
 }

--- a/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
@@ -9,6 +9,7 @@ use MongoDB\Client;
 use MongoDB\Database;
 use MongoDB\Driver\ClientEncryption;
 use MongoDB\Driver\Exception\EncryptionException;
+use MongoDB\Driver\WriteConcern;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -29,8 +30,10 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     private Client $autoEncryptedClient;
     private mixed $key1Id;
     private bool $serverAtLeast9;
+    private string $libmongocryptVersion;
     private bool $prefixPreviewSupported;
     private bool $substringPreviewSupported;
+    private WriteConcern $majorityWriteConcern;
 
     private static string $specDir = __DIR__ . '/../../specifications/source/client-side-encryption';
 
@@ -44,12 +47,15 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
 
         $this->skipIfServerVersion('<', '8.2.0', 'String explicit encryption tests require MongoDB 8.2 or later');
 
+        /* The spec also requires libmongocrypt 1.18.1+; the extension always
+         * bundles a version well above that, so no top-level guard is added. */
         $this->serverAtLeast9 = version_compare($this->getServerVersion(), '9.0.0', '>=');
-        $libmongocryptVersion = static::getModuleInfo('libmongocrypt bundled version') ?? '0';
+        $this->libmongocryptVersion = static::getModuleInfo('libmongocrypt bundled version') ?? '0';
         $this->prefixPreviewSupported = ! $this->serverAtLeast9
-            && version_compare($libmongocryptVersion, '1.19.1', '>=');
+            && version_compare($this->libmongocryptVersion, '1.19.1', '>=');
         $this->substringPreviewSupported = ! $this->serverAtLeast9
-            && version_compare($libmongocryptVersion, '1.18.1', '>=');
+            && version_compare($this->libmongocryptVersion, '1.18.1', '>=');
+        $this->majorityWriteConcern = new WriteConcern(WriteConcern::MAJORITY);
 
         $client = static::createTestClient();
         $key1Document = $this->decodeJson(file_get_contents(self::$specDir . '/etc/data/keys/key1-document.json'));
@@ -80,7 +86,7 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
             'disableClientPersistence' => true,
         ]);
 
-        $database = $this->explicitEncryptedClient->getDatabase($this->getDatabaseName());
+        $database = $this->explicitEncryptedClient->getDatabase($this->getDatabaseName(), ['writeConcern' => $this->majorityWriteConcern]);
         $this->setUpCollections($database);
         $this->insertInitialDocuments($database);
     }
@@ -273,6 +279,7 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase7_AssertContentionFactorIsRequired(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 7 requires MongoDB 9.0.0+');
+        $this->skipIfLibmongocryptVersion('<', '1.19.0', 'Case 7 requires libmongocrypt 1.19.0+');
 
         $this->expectException(EncryptionException::class);
         $this->expectExceptionMessageMatches('/contention factor is required for string algorithm/');
@@ -293,12 +300,13 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase8_CanFindAutoEncryptedCaseInsensitiveDocumentByPrefixAndSuffix(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 8 requires MongoDB 9.0.0+');
+        $this->skipIfLibmongocryptVersion('<', '1.19.0', 'Case 8 requires libmongocrypt 1.19.0+');
 
         $database = $this->getDatabaseName();
 
         $this->autoEncryptedClient
             ->getDatabase($database)
-            ->getCollection('prefix-suffix-ci-di')
+            ->getCollection('prefix-suffix-ci-di', ['writeConcern' => $this->majorityWriteConcern])
             ->insertOne(['encryptedText' => 'BingQiLin']);
 
         $encryptedBing = $this->clientEncryption->encrypt('bing', [
@@ -346,12 +354,13 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase9_CanFindAutoEncryptedDiacriticInsensitiveDocumentByPrefixAndSuffix(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 9 requires MongoDB 9.0.0+');
+        $this->skipIfLibmongocryptVersion('<', '1.19.0', 'Case 9 requires libmongocrypt 1.19.0+');
 
         $database = $this->getDatabaseName();
 
         $this->autoEncryptedClient
             ->getDatabase($database)
-            ->getCollection('prefix-suffix-ci-di')
+            ->getCollection('prefix-suffix-ci-di', ['writeConcern' => $this->majorityWriteConcern])
             ->insertOne(['encryptedText' => 'cafébarbäz']);
 
         $encryptedCafe = $this->clientEncryption->encrypt('cafe', [
@@ -399,12 +408,13 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase10_CanFindAutoEncryptedCaseInsensitiveDocumentBySubstring(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 10 requires MongoDB 9.0.0+');
+        $this->skipIfLibmongocryptVersion('<', '1.20.0', 'Case 10 requires libmongocrypt 1.20.0+');
 
         $database = $this->getDatabaseName();
 
         $this->autoEncryptedClient
             ->getDatabase($database)
-            ->getCollection('substring-ci-di')
+            ->getCollection('substring-ci-di', ['writeConcern' => $this->majorityWriteConcern])
             ->insertOne(['encryptedText' => 'FooBarBaz']);
 
         $encryptedBar = $this->clientEncryption->encrypt('bar', [
@@ -432,12 +442,13 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     public function testCase11_CanFindAutoEncryptedDiacriticInsensitiveDocumentBySubstring(): void
     {
         $this->skipIfServerVersion('<', '9.0.0', 'Case 11 requires MongoDB 9.0.0+');
+        $this->skipIfLibmongocryptVersion('<', '1.20.0', 'Case 11 requires libmongocrypt 1.20.0+');
 
         $database = $this->getDatabaseName();
 
         $this->autoEncryptedClient
             ->getDatabase($database)
-            ->getCollection('substring-ci-di')
+            ->getCollection('substring-ci-di', ['writeConcern' => $this->majorityWriteConcern])
             ->insertOne(['encryptedText' => 'foocafébaz']);
 
         $encryptedCafe = $this->clientEncryption->encrypt('cafe', [
@@ -528,8 +539,16 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
 
     private function skipByQueryTypeAndServerVersion(string $queryType): void
     {
-        if ($queryType === 'prefix' || $queryType === 'suffix' || $queryType === 'substring') {
+        if ($queryType === 'prefix' || $queryType === 'suffix') {
             $this->skipIfServerVersion('<', '9.0.0', $queryType . ' query type requires MongoDB 9.0.0+');
+            $this->skipIfLibmongocryptVersion('<', '1.19.0', $queryType . ' query type requires libmongocrypt 1.19.0+');
+
+            return;
+        }
+
+        if ($queryType === 'substring') {
+            $this->skipIfServerVersion('<', '9.0.0', $queryType . ' query type requires MongoDB 9.0.0+');
+            $this->skipIfLibmongocryptVersion('<', '1.20.0', $queryType . ' query type requires libmongocrypt 1.20.0+');
 
             return;
         }
@@ -542,6 +561,13 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
 
         if (($queryType === 'prefixPreview' || $queryType === 'suffixPreview') && ! $this->prefixPreviewSupported) {
             $this->markTestSkipped($queryType . ' query type requires libmongocrypt 1.19.1+');
+        }
+    }
+
+    private function skipIfLibmongocryptVersion(string $operator, string $version, string $message): void
+    {
+        if (version_compare($this->libmongocryptVersion, $version, $operator)) {
+            $this->markTestSkipped($message);
         }
     }
 }

--- a/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
@@ -30,6 +30,7 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     private mixed $key1Id;
     private bool $serverAtLeast9;
     private bool $prefixPreviewSupported;
+    private bool $substringPreviewSupported;
 
     private static string $specDir = __DIR__ . '/../../specifications/source/client-side-encryption';
 
@@ -47,6 +48,8 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
         $libmongocryptVersion = static::getModuleInfo('libmongocrypt bundled version') ?? '0';
         $this->prefixPreviewSupported = ! $this->serverAtLeast9
             && version_compare($libmongocryptVersion, '1.19.1', '>=');
+        $this->substringPreviewSupported = ! $this->serverAtLeast9
+            && version_compare($libmongocryptVersion, '1.18.1', '>=');
 
         $client = static::createTestClient();
         $key1Document = $this->decodeJson(file_get_contents(self::$specDir . '/etc/data/keys/key1-document.json'));
@@ -99,6 +102,12 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     {
         yield 'suffix' => ['suffix', 'prefix-suffix'];
         yield 'suffixPreview' => ['suffixPreview', 'prefix-suffix-preview'];
+    }
+
+    public static function provideSubstringQueryTypeAndCollection(): Generator
+    {
+        yield 'substring' => ['substring', 'substring'];
+        yield 'substringPreview' => ['substringPreview', 'substring-preview'];
     }
 
     /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-1-can-find-a-document-by-prefix */
@@ -208,23 +217,26 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     }
 
     /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-5-can-find-a-document-by-substring */
-    public function testCase5_CanFindADocumentBySubstring(): void
+    #[DataProvider('provideSubstringQueryTypeAndCollection')]
+    public function testCase5_CanFindADocumentBySubstring(string $queryType, string $collectionName): void
     {
+        $this->skipByQueryTypeAndServerVersion($queryType);
+
         $encryptedBar = $this->clientEncryption->encrypt('bar', [
             'keyId' => $this->key1Id,
             'algorithm' => 'String',
-            'queryType' => 'substringPreview',
+            'queryType' => $queryType,
             'contentionFactor' => 0,
             'stringOpts' => [
                 'caseSensitive' => true,
                 'diacriticSensitive' => true,
-                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 6, 'strMinQueryLength' => 2],
             ],
         ]);
 
         $result = $this->explicitEncryptedClient
             ->getDatabase($this->getDatabaseName())
-            ->getCollection('substring')
+            ->getCollection($collectionName)
             ->findOne(['$expr' => ['$encStrContains' => ['input' => '$encryptedText', 'substring' => $encryptedBar]]]);
 
         $this->assertNotNull($result);
@@ -232,23 +244,26 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     }
 
     /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-6-assert-no-document-found-by-substring */
-    public function testCase6_AssertNoDocumentFoundBySubstring(): void
+    #[DataProvider('provideSubstringQueryTypeAndCollection')]
+    public function testCase6_AssertNoDocumentFoundBySubstring(string $queryType, string $collectionName): void
     {
+        $this->skipByQueryTypeAndServerVersion($queryType);
+
         $encryptedQux = $this->clientEncryption->encrypt('qux', [
             'keyId' => $this->key1Id,
             'algorithm' => 'String',
-            'queryType' => 'substringPreview',
+            'queryType' => $queryType,
             'contentionFactor' => 0,
             'stringOpts' => [
                 'caseSensitive' => true,
                 'diacriticSensitive' => true,
-                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 6, 'strMinQueryLength' => 2],
             ],
         ]);
 
         $result = $this->explicitEncryptedClient
             ->getDatabase($this->getDatabaseName())
-            ->getCollection('substring')
+            ->getCollection($collectionName)
             ->findOne(['$expr' => ['$encStrContains' => ['input' => '$encryptedText', 'substring' => $encryptedQux]]]);
 
         $this->assertNull($result);
@@ -383,6 +398,8 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-10-can-find-an-auto-encrypted-case-insensitively-indexed-document-by-substring */
     public function testCase10_CanFindAutoEncryptedCaseInsensitiveDocumentBySubstring(): void
     {
+        $this->skipIfServerVersion('<', '9.0.0', 'Case 10 requires MongoDB 9.0.0+');
+
         $database = $this->getDatabaseName();
 
         $this->autoEncryptedClient
@@ -393,12 +410,12 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
         $encryptedBar = $this->clientEncryption->encrypt('bar', [
             'keyId' => $this->key1Id,
             'algorithm' => 'String',
-            'queryType' => 'substringPreview',
+            'queryType' => 'substring',
             'contentionFactor' => 0,
             'stringOpts' => [
                 'caseSensitive' => false,
                 'diacriticSensitive' => false,
-                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 6, 'strMinQueryLength' => 2],
             ],
         ]);
 
@@ -414,6 +431,8 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     /** @see https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#case-11-can-find-an-auto-encrypted-diacritic-insensitively-indexed-document-by-substring */
     public function testCase11_CanFindAutoEncryptedDiacriticInsensitiveDocumentBySubstring(): void
     {
+        $this->skipIfServerVersion('<', '9.0.0', 'Case 11 requires MongoDB 9.0.0+');
+
         $database = $this->getDatabaseName();
 
         $this->autoEncryptedClient
@@ -424,12 +443,12 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
         $encryptedCafe = $this->clientEncryption->encrypt('cafe', [
             'keyId' => $this->key1Id,
             'algorithm' => 'String',
-            'queryType' => 'substringPreview',
+            'queryType' => 'substring',
             'contentionFactor' => 0,
             'stringOpts' => [
                 'caseSensitive' => false,
                 'diacriticSensitive' => false,
-                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
+                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 6, 'strMinQueryLength' => 2],
             ],
         ]);
 
@@ -445,30 +464,34 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
     private function setUpCollections(Database $database): void
     {
         if ($this->serverAtLeast9) {
-            foreach (['prefix-suffix', 'prefix-suffix-ci-di'] as $name) {
+            foreach (['prefix-suffix', 'prefix-suffix-ci-di', 'substring', 'substring-ci-di'] as $name) {
                 $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-' . $name . '.json'));
                 $database->dropCollection($name, ['encryptedFields' => $encryptedFields]);
                 $database->createCollection($name, ['encryptedFields' => $encryptedFields]);
             }
-        } elseif ($this->prefixPreviewSupported) {
+
+            return;
+        }
+
+        if ($this->prefixPreviewSupported) {
             $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-prefix-suffix-preview.json'));
             $database->dropCollection('prefix-suffix-preview', ['encryptedFields' => $encryptedFields]);
             $database->createCollection('prefix-suffix-preview', ['encryptedFields' => $encryptedFields]);
         }
 
-        foreach (['substring', 'substring-ci-di'] as $name) {
-            $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-' . $name . '.json'));
-            $database->dropCollection($name, ['encryptedFields' => $encryptedFields]);
-            $database->createCollection($name, ['encryptedFields' => $encryptedFields]);
+        if ($this->substringPreviewSupported) {
+            $encryptedFields = Document::fromJSON(file_get_contents(self::$specDir . '/etc/data/encryptedFields-substring-preview.json'));
+            $database->dropCollection('substring-preview', ['encryptedFields' => $encryptedFields]);
+            $database->createCollection('substring-preview', ['encryptedFields' => $encryptedFields]);
         }
     }
 
     private function insertInitialDocuments(Database $database): void
     {
         if ($this->serverAtLeast9 || $this->prefixPreviewSupported) {
-            $collectionNameForPrefixSuffix = $this->serverAtLeast9 ? 'prefix-suffix' : 'prefix-suffix-preview';
+            $collectionName = $this->serverAtLeast9 ? 'prefix-suffix' : 'prefix-suffix-preview';
 
-            $encryptedFoobarBazForPrefixSuffix = $this->clientEncryption->encrypt('foobarbaz', [
+            $encryptedFoobarBaz = $this->clientEncryption->encrypt('foobarbaz', [
                 'keyId' => $this->key1Id,
                 'algorithm' => 'String',
                 'contentionFactor' => 0,
@@ -480,34 +503,45 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
                 ],
             ]);
 
-            $database->getCollection($collectionNameForPrefixSuffix)
-                ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBazForPrefixSuffix]);
+            $database->getCollection($collectionName)
+                ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBaz]);
         }
 
-        $encryptedFoobarBazForSubstring = $this->clientEncryption->encrypt('foobarbaz', [
-            'keyId' => $this->key1Id,
-            'algorithm' => 'String',
-            'contentionFactor' => 0,
-            'stringOpts' => [
-                'caseSensitive' => true,
-                'diacriticSensitive' => true,
-                'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 10, 'strMinQueryLength' => 2],
-            ],
-        ]);
+        if ($this->serverAtLeast9 || $this->substringPreviewSupported) {
+            $collectionName = $this->serverAtLeast9 ? 'substring' : 'substring-preview';
 
-        $database->getCollection('substring')
-            ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBazForSubstring]);
+            $encryptedFoobarBaz = $this->clientEncryption->encrypt('foobarbaz', [
+                'keyId' => $this->key1Id,
+                'algorithm' => 'String',
+                'contentionFactor' => 0,
+                'stringOpts' => [
+                    'caseSensitive' => true,
+                    'diacriticSensitive' => true,
+                    'substring' => ['strMaxLength' => 10, 'strMaxQueryLength' => 6, 'strMinQueryLength' => 2],
+                ],
+            ]);
+
+            $database->getCollection($collectionName)
+                ->insertOne(['_id' => 0, 'encryptedText' => $encryptedFoobarBaz]);
+        }
     }
 
     private function skipByQueryTypeAndServerVersion(string $queryType): void
     {
-        if ($queryType === 'prefix' || $queryType === 'suffix') {
+        if ($queryType === 'prefix' || $queryType === 'suffix' || $queryType === 'substring') {
             $this->skipIfServerVersion('<', '9.0.0', $queryType . ' query type requires MongoDB 9.0.0+');
-        } else {
-            $this->skipIfServerVersion('>=', '9.0.0', $queryType . ' query type requires MongoDB pre-9.0.0');
-            if (! $this->prefixPreviewSupported) {
-                $this->markTestSkipped($queryType . ' query type requires libmongocrypt 1.19.1+');
-            }
+
+            return;
+        }
+
+        $this->skipIfServerVersion('>=', '9.0.0', $queryType . ' query type requires MongoDB pre-9.0.0');
+
+        if ($queryType === 'substringPreview' && ! $this->substringPreviewSupported) {
+            $this->markTestSkipped('substringPreview query type requires libmongocrypt 1.18.1+');
+        }
+
+        if (($queryType === 'prefixPreview' || $queryType === 'suffixPreview') && ! $this->prefixPreviewSupported) {
+            $this->markTestSkipped($queryType . ' query type requires libmongocrypt 1.19.1+');
         }
     }
 }

--- a/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
+++ b/tests/SpecTests/ClientSideEncryption/Prose27_StringExplicitEncryptionTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\Group;
 
 use function base64_decode;
 use function file_get_contents;
+use function phpversion;
 use function version_compare;
 
 /**
@@ -43,6 +44,10 @@ class Prose27_StringExplicitEncryptionTest extends FunctionalTestCase
 
         if ($this->isStandalone()) {
             $this->markTestSkipped('String explicit encryption tests require replica sets');
+        }
+
+        if (version_compare(phpversion('mongodb'), '2.4.0dev', '<')) {
+            $this->markTestSkipped('String explicit encryption tests require ext-mongodb 2.4.0+ (stringOpts support)');
         }
 
         $this->skipIfServerVersion('<', '8.2.0', 'String explicit encryption tests require MongoDB 8.2 or later');

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -34,7 +34,6 @@ use UnexpectedValueException;
 
 use function base64_decode;
 use function basename;
-use function count;
 use function file_get_contents;
 use function getenv;
 use function glob;
@@ -1329,6 +1328,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         // Test setup
         $encryptedFields = $this->decodeJson(file_get_contents(self::$specDir . '/etc/data/encryptedFields.json'));
+        $encryptedFieldsC10 = $this->decodeJson(file_get_contents(self::$specDir . '/etc/data/encryptedFields-c10.json'));
         $key1Document = $this->decodeJson(file_get_contents(self::$specDir . '/etc/data/keys/key1-document.json'));
         $key1Id = $key1Document->_id;
 
@@ -1337,6 +1337,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $database = $client->selectDatabase('db');
         $database->dropCollection('explicit_encryption', ['encryptedFields' => $encryptedFields]);
         $database->createCollection('explicit_encryption', ['encryptedFields' => $encryptedFields]);
+        $database->dropCollection('explicit_encryption_c10', ['encryptedFields' => $encryptedFieldsC10]);
+        $database->createCollection('explicit_encryption_c10', ['encryptedFields' => $encryptedFieldsC10]);
 
         $database = $client->selectDatabase('keyvault');
         $database->dropCollection('datakeys');
@@ -1398,7 +1400,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             static function (self $test, ClientEncryption $clientEncryption, Client $encryptedClient, Client $keyVaultClient, Binary $key1Id): void {
                 $value = 'encrypted indexed value';
 
-                $collection = $encryptedClient->selectCollection('db', 'explicit_encryption');
+                $collection = $encryptedClient->selectCollection('db', 'explicit_encryption_c10');
 
                 for ($i = 0; $i < 10; $i++) {
                     $insertPayload = $clientEncryption->encrypt($value, [
@@ -1414,25 +1416,10 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                     'keyId' => $key1Id,
                     'algorithm' => ClientEncryption::ALGORITHM_INDEXED,
                     'queryType' => ClientEncryption::QUERY_TYPE_EQUALITY,
-                    'contentionFactor' => 0,
-                ]);
-
-                $results = $collection->find(['encryptedIndexed' => $findPayload])->toArray();
-
-                $test->assertLessThan(10, count($results));
-
-                foreach ($results as $result) {
-                    $test->assertSame($value, $result['encryptedIndexed']);
-                }
-
-                $findPayload2 = $clientEncryption->encrypt($value, [
-                    'keyId' => $key1Id,
-                    'algorithm' => ClientEncryption::ALGORITHM_INDEXED,
-                    'queryType' => ClientEncryption::QUERY_TYPE_EQUALITY,
                     'contentionFactor' => 10,
                 ]);
 
-                $results = $collection->find(['encryptedIndexed' => $findPayload2])->toArray();
+                $results = $collection->find(['encryptedIndexed' => $findPayload])->toArray();
 
                 $test->assertCount(10, $results);
 

--- a/tests/SpecTests/ClientSideEncryptionSpecTest.php
+++ b/tests/SpecTests/ClientSideEncryptionSpecTest.php
@@ -270,7 +270,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     public function testDataKeyAndDoubleEncryption(string $providerName, $masterKey): void
     {
         $client = static::createTestClient();
-        $client->selectCollection('db', 'coll')->drop();
+        $client->getCollection('db', 'coll')->drop();
 
         // Ensure that the key vault is dropped with a majority write concern
         self::insertKeyVaultData($client, []);
@@ -339,7 +339,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $this->assertObjectHasProperty('w', $insertCommand->writeConcern);
         $this->assertSame(WriteConcern::MAJORITY, $insertCommand->writeConcern->w);
 
-        $keys = $client->selectCollection('keyvault', 'datakeys')->find(['_id' => $dataKeyId]);
+        $keys = $client->getCollection('keyvault', 'datakeys')->find(['_id' => $dataKeyId]);
         $keys = iterator_to_array($keys);
         $this->assertCount(1, $keys);
 
@@ -351,8 +351,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $this->assertInstanceOf(Binary::class, $encrypted);
         $this->assertSame(Binary::TYPE_ENCRYPTED, $encrypted->getType());
 
-        $clientEncrypted->selectCollection('db', 'coll')->insertOne(['_id' => 'local', 'value' => $encrypted]);
-        $hello = $clientEncrypted->selectCollection('db', 'coll')->findOne(['_id' => 'local']);
+        $clientEncrypted->getCollection('db', 'coll')->insertOne(['_id' => 'local', 'value' => $encrypted]);
+        $hello = $clientEncrypted->getCollection('db', 'coll')->findOne(['_id' => 'local']);
         $this->assertNotNull($hello);
         $this->assertSame('hello ' . $providerName, $hello['value']);
 
@@ -360,7 +360,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $this->assertEquals($encrypted, $encryptedAltName);
 
         $this->expectException(BulkWriteException::class);
-        $clientEncrypted->selectCollection('db', 'coll')->insertOne(['encrypted_placeholder' => $encrypted]);
+        $clientEncrypted->getCollection('db', 'coll')->insertOne(['encrypted_placeholder' => $encrypted]);
     }
 
     public static function dataKeyProvider()
@@ -410,7 +410,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     public function testExternalKeyVault($withExternalKeyVault): void
     {
         $client = static::createTestClient();
-        $client->selectCollection('db', 'coll')->drop();
+        $client->getCollection('db', 'coll')->drop();
 
         self::insertKeyVaultData($client, [
             $this->decodeJson(file_get_contents(self::$specDir . '/external/external-key.json')),
@@ -437,7 +437,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $clientEncryption = $clientEncrypted->createClientEncryption($encryptionOpts);
 
         try {
-            $result = $clientEncrypted->selectCollection('db', 'coll')->insertOne(['encrypted' => 'test']);
+            $result = $clientEncrypted->getCollection('db', 'coll')->insertOne(['encrypted' => 'test']);
 
             if ($withExternalKeyVault) {
                 $this->fail('Expected exception to be thrown');
@@ -558,8 +558,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     {
         $client = static::createTestClient();
 
-        $client->selectCollection('db', 'coll')->drop();
-        $client->selectDatabase('db')->createCollection('coll', ['validator' => ['$jsonSchema' => $this->decodeJson(file_get_contents(self::$specDir . '/limits/limits-schema.json'))]]);
+        $client->getCollection('db', 'coll')->drop();
+        $client->getDatabase('db')->createCollection('coll', ['validator' => ['$jsonSchema' => $this->decodeJson(file_get_contents(self::$specDir . '/limits/limits-schema.json'))]]);
 
         self::insertKeyVaultData($client, [
             $this->decodeJson(file_get_contents(self::$specDir . '/limits/limits-key.json')),
@@ -575,7 +575,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         $clientEncrypted = static::createTestClient(null, [], ['autoEncryption' => $autoEncryptionOpts]);
 
-        $collection = $clientEncrypted->selectCollection('db', 'coll');
+        $collection = $clientEncrypted->getCollection('db', 'coll');
 
         $document = json_decode(file_get_contents(self::$specDir . '/limits/limits-doc.json'), true, 512, JSON_THROW_ON_ERROR);
 
@@ -591,8 +591,8 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     {
         $client = static::createTestClient();
 
-        $client->selectCollection('db', 'view')->drop();
-        $client->selectDatabase('db')->command(['create' => 'view', 'viewOn' => 'coll']);
+        $client->getCollection('db', 'view')->drop();
+        $client->getDatabase('db')->command(['create' => 'view', 'viewOn' => 'coll']);
 
         $autoEncryptionOpts = [
             'keyVaultNamespace' => 'keyvault.datakeys',
@@ -604,7 +604,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $clientEncrypted = static::createTestClient(null, [], ['autoEncryption' => $autoEncryptionOpts]);
 
         try {
-            $clientEncrypted->selectCollection('db', 'view')->insertOne(['foo' => 'bar']);
+            $clientEncrypted->getCollection('db', 'view')->insertOne(['foo' => 'bar']);
             $this->fail('Expected exception to be thrown');
         } catch (BulkWriteException $e) {
             $previous = $e->getPrevious();
@@ -624,12 +624,12 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     public function testCorpus($schemaMap = true): void
     {
         $client = static::createTestClient();
-        $client->selectDatabase('db')->dropCollection('coll');
+        $client->getDatabase('db')->dropCollection('coll');
 
         $schema = $this->decodeJson(file_get_contents(self::$specDir . '/corpus/corpus-schema.json'));
 
         if (! $schemaMap) {
-            $client->selectDatabase('db')->createCollection('coll', ['validator' => ['$jsonSchema' => $schema]]);
+            $client->getDatabase('db')->createCollection('coll', ['validator' => ['$jsonSchema' => $schema]]);
         }
 
         self::insertKeyVaultData($client, [
@@ -668,7 +668,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $clientEncrypted = static::createTestClient(null, [], ['autoEncryption' => $autoEncryptionOpts]);
         $clientEncryption = $clientEncrypted->createClientEncryption($encryptionOpts);
 
-        $collection = $clientEncrypted->selectCollection('db', 'coll');
+        $collection = $clientEncrypted->getCollection('db', 'coll');
 
         $unpreparedFieldNames = [
             '_id',
@@ -694,7 +694,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $this->assertDocumentsMatch($corpus, $corpusDecrypted);
 
         $corpusEncryptedExpected = (array) $this->decodeJson(file_get_contents(self::$specDir . '/corpus/corpus-encrypted.json'));
-        $corpusEncryptedActual = $client->selectCollection('db', 'coll')->findOne(['_id' => 'client_side_encryption_corpus'], ['typeMap' => ['root' => 'array', 'document' => stdClass::class, 'array' => 'array']]);
+        $corpusEncryptedActual = $client->getCollection('db', 'coll')->findOne(['_id' => 'client_side_encryption_corpus'], ['typeMap' => ['root' => 'array', 'document' => stdClass::class, 'array' => 'array']]);
 
         foreach ($corpusEncryptedExpected as $fieldName => $expectedData) {
             if (in_array($fieldName, $unpreparedFieldNames, true)) {
@@ -917,7 +917,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         $clientEncrypted = static::createTestClient(null, [], ['autoEncryption' => $autoEncryptionOpts]);
 
-        $clientEncrypted->selectCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
+        $clientEncrypted->getCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
 
         $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
@@ -960,7 +960,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         $clientEncrypted = static::createTestClient(null, [], ['autoEncryption' => $autoEncryptionOpts]);
 
         try {
-            $clientEncrypted->selectCollection('db', 'coll')->insertOne(['encrypted' => 'test']);
+            $clientEncrypted->getCollection('db', 'coll')->insertOne(['encrypted' => 'test']);
             $this->fail('Expected exception to be thrown');
         } catch (BulkWriteException $e) {
             $previous = $e->getPrevious();
@@ -995,7 +995,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         // Disable adding cryptSharedLibPath, as it may interfere with this test
         $clientEncrypted = static::createTestClient(null, [], ['autoEncryption' => $autoEncryptionOpts]);
 
-        $clientEncrypted->selectCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
+        $clientEncrypted->getCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
 
         $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
@@ -1029,7 +1029,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         // Disable adding cryptSharedLibPath, as it may interfere with this test
         $clientEncrypted = static::createTestClient(null, [], ['autoEncryption' => $autoEncryptionOpts]);
 
-        $clientEncrypted->selectCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
+        $clientEncrypted->getCollection('db', 'coll')->insertOne(['unencrypted' => 'test']);
 
         $clientMongocryptd = static::createTestClient('mongodb://localhost:27021/?serverSelectionTimeoutMS=1000');
 
@@ -1334,17 +1334,17 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
         $client = static::createTestClient();
 
-        $database = $client->selectDatabase('db');
+        $database = $client->getDatabase('db');
         $database->dropCollection('explicit_encryption', ['encryptedFields' => $encryptedFields]);
         $database->createCollection('explicit_encryption', ['encryptedFields' => $encryptedFields]);
         $database->dropCollection('explicit_encryption_c10', ['encryptedFields' => $encryptedFieldsC10]);
         $database->createCollection('explicit_encryption_c10', ['encryptedFields' => $encryptedFieldsC10]);
 
-        $database = $client->selectDatabase('keyvault');
+        $database = $client->getDatabase('keyvault');
         $database->dropCollection('datakeys');
         $database->createCollection('datakeys');
 
-        $client->selectCollection('keyvault', 'datakeys')->insertOne($key1Document, ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]);
+        $client->getCollection('keyvault', 'datakeys')->insertOne($key1Document, ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]);
 
         $keyVaultClient = static::createTestClient();
 
@@ -1378,7 +1378,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                     'contentionFactor' => 0,
                 ]);
 
-                $collection = $encryptedClient->selectCollection('db', 'explicit_encryption');
+                $collection = $encryptedClient->getCollection('db', 'explicit_encryption');
                 $collection->insertOne(['encryptedIndexed' => $insertPayload]);
 
                 $findPayload = $clientEncryption->encrypt($value, [
@@ -1400,7 +1400,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
             static function (self $test, ClientEncryption $clientEncryption, Client $encryptedClient, Client $keyVaultClient, Binary $key1Id): void {
                 $value = 'encrypted indexed value';
 
-                $collection = $encryptedClient->selectCollection('db', 'explicit_encryption_c10');
+                $collection = $encryptedClient->getCollection('db', 'explicit_encryption_c10');
 
                 for ($i = 0; $i < 10; $i++) {
                     $insertPayload = $clientEncryption->encrypt($value, [
@@ -1439,7 +1439,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                     'algorithm' => ClientEncryption::ALGORITHM_UNINDEXED,
                 ]);
 
-                $collection = $encryptedClient->selectCollection('db', 'explicit_encryption');
+                $collection = $encryptedClient->getCollection('db', 'explicit_encryption');
                 $collection->insertOne(['_id' => 1, 'encryptedUnindexed' => $insertPayload]);
 
                 $results = $collection->find(['_id' => 1])->toArray();
@@ -1493,7 +1493,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         // Ensure that the key vault is dropped with a majority write concern
         self::insertKeyVaultData($client, []);
 
-        $client->selectCollection('keyvault', 'datakeys')->createIndex(
+        $client->getCollection('keyvault', 'datakeys')->createIndex(
             ['keyAltNames' => 1],
             [
                 'unique' => true,
@@ -1576,7 +1576,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
     {
         // Test setup
         $setupClient = static::createTestClient();
-        $setupClient->selectCollection('db', 'decryption_events')->drop();
+        $setupClient->getCollection('db', 'decryption_events')->drop();
 
         // Ensure that the key vault is dropped with a majority write concern
         self::insertKeyVaultData($setupClient, []);
@@ -1639,7 +1639,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         // See: https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-1-command-error
         yield 'Case 1: Command Error' => [
             static function (self $test, Client $setupClient, ClientEncryption $clientEncryption, Client $encryptedClient, CommandSubscriber $subscriber, Binary $cipherText, Binary $malformedCipherText): void {
-                $setupClient->selectDatabase('admin')->command([
+                $setupClient->getDatabase('admin')->command([
                     'configureFailPoint' => 'failCommand',
                     'mode' => ['times' => 1],
                     'data' => [
@@ -1649,7 +1649,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                 ]);
 
                 try {
-                    $encryptedClient->selectCollection('db', 'decryption_events')->aggregate([]);
+                    $encryptedClient->getCollection('db', 'decryption_events')->aggregate([]);
                     $test->fail('Expected exception to be thrown');
                 } catch (CommandException $e) {
                     $test->assertSame(123, $e->getCode());
@@ -1662,7 +1662,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         // See: https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-2-network-error
         yield 'Case 2: Network Error' => [
             static function (self $test, Client $setupClient, ClientEncryption $clientEncryption, Client $encryptedClient, CommandSubscriber $subscriber, Binary $cipherText, Binary $malformedCipherText): void {
-                $setupClient->selectDatabase('admin')->command([
+                $setupClient->getDatabase('admin')->command([
                     'configureFailPoint' => 'failCommand',
                     'mode' => ['times' => 1],
                     'data' => [
@@ -1672,7 +1672,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
                 ]);
 
                 try {
-                    $encryptedClient->selectCollection('db', 'decryption_events')->aggregate([]);
+                    $encryptedClient->getCollection('db', 'decryption_events')->aggregate([]);
                     $test->fail('Expected exception to be thrown');
                 } catch (ConnectionTimeoutException) {
                     $test->addToAssertionCount(1);
@@ -1685,7 +1685,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         // See: https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-3-decrypt-error
         yield 'Case 3: Decrypt Error' => [
             static function (self $test, Client $setupClient, ClientEncryption $clientEncryption, Client $encryptedClient, CommandSubscriber $subscriber, Binary $cipherText, Binary $malformedCipherText): void {
-                $collection = $encryptedClient->selectCollection('db', 'decryption_events');
+                $collection = $encryptedClient->getCollection('db', 'decryption_events');
 
                 $collection->insertOne(['encrypted' => $malformedCipherText]);
 
@@ -1704,7 +1704,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
         // See: https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/tests#case-4-decrypt-success
         yield 'Case 4: Decrypt Success' => [
             static function (self $test, Client $setupClient, ClientEncryption $clientEncryption, Client $encryptedClient, CommandSubscriber $subscriber, Binary $cipherText, Binary $malformedCipherText): void {
-                $collection = $encryptedClient->selectCollection('db', 'decryption_events');
+                $collection = $encryptedClient->getCollection('db', 'decryption_events');
 
                 $collection->insertOne(['encrypted' => $cipherText]);
                 $collection->aggregate([]);
@@ -1937,7 +1937,7 @@ class ClientSideEncryptionSpecTest extends FunctionalTestCase
 
     private static function insertKeyVaultData(Client $client, ?array $keyVaultData = null): void
     {
-        $collection = $client->selectCollection('keyvault', 'datakeys', ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]);
+        $collection = $client->getCollection('keyvault', 'datakeys', ['writeConcern' => new WriteConcern(WriteConcern::MAJORITY)]);
         $collection->drop();
 
         if (empty($keyVaultData)) {


### PR DESCRIPTION
Implements all 11 test cases for the [String Explicit Encryption spec](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/tests/README.md#27-string-explicit-encryption), covering prefix/suffix/substring query types with case and diacritic sensitivity options.

Requires `stringOpts` support in the PHP driver extension: [PHPC-2728](https://jira.mongodb.org/browse/PHPC-2728) / https://github.com/mongodb/mongo-php-driver/pull/2033

Also enables the `test-mongodb-latest-crypt-shared` csfle task on the `phpc-next-minor` Evergreen variant so that the QE string query tests run on MongoDB 9.0+ with the upcoming extension on every PR, and fixes two pre-existing spec-compliance bugs that surfaced on that job:

- Prose 22 `RangeOpts` did not declare `trimFactor: 1`, causing a payload/collection mismatch on MongoDB 9.0+ (SERVER-127899 enforcement).
- Prose 12 "Case 2" wrote to `db.explicit_encryption` (contention=0) with `contentionFactor=10` payloads instead of the spec's `db.explicit_encryption_c10` collection.

### Tickets resolved

- [PHPLIB-1846](https://jira.mongodb.org/browse/PHPLIB-1846) - QE - Case and diacritic sensitivity not honoured for explicit encryption (this PR's target)
- [PHPLIB-1827](https://jira.mongodb.org/browse/PHPLIB-1827) - Add QE prefix+suffix GA and rename API to string (library-side test coverage; the `stringOpts`/algorithm rename lives in ext-mongodb)
- [PHPLIB-1878](https://jira.mongodb.org/browse/PHPLIB-1878) - Explicit Encryption prose test "Case 2" fails on latest server: payload contentionFactor exceeds collection's configured contention
- [PHPLIB-1908](https://jira.mongodb.org/browse/PHPLIB-1908) - Add "substring" to QE GA (covered by Prose 27 cases 5, 6, 10, 11 using the `substring` queryType and `substring`/`substring-ci-di` collections on server 9.0+)
- [PHPLIB-1909](https://jira.mongodb.org/browse/PHPLIB-1909) - Skip "substringPreview" on server 9.0+ (already Closed; now actually implemented by `skipByQueryTypeAndServerVersion()`)