### PR TITLE
PHPLIB-1771: Add `arrayIndexAs` support for `$filter` and `$reduce` operators

### DIFF
--- a/generator/src/OperatorTestGenerator.php
+++ b/generator/src/OperatorTestGenerator.php
@@ -116,8 +116,8 @@ class OperatorTestGenerator extends OperatorGenerator
         $class->setComment('Test ' . $operator->name . ' ' . basename($definition->configFiles));
 
         foreach ($operator->tests as $test) {
-            $testName = 'test' . str_replace([' ', '-'], '', ucwords(str_replace('$', '', $test->name)));
-            $caseName = str_replace([' ', '-'], '', ucwords(str_replace('$', '', $operator->name . ' ' . $test->name)));
+            $testName = 'test' . str_replace([' ', '-', ','], '', ucwords(str_replace('$', '', $test->name)));
+            $caseName = str_replace([' ', '-', ','], '', ucwords(str_replace('$', '', $operator->name . ' ' . $test->name)));
 
             // Handle update tests (filter + update)
             if ($test->filter !== null && $test->update !== null) {

--- a/src/Builder/Expression/FactoryTrait.php
+++ b/src/Builder/Expression/FactoryTrait.php
@@ -800,18 +800,25 @@ trait FactoryTrait
      *
      * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input
-     * @param ResolvesToBool|bool|string $cond An expression that resolves to a boolean value used to determine if an element should be included in the output array. The expression references each element of the input array individually with the variable name specified in as.
+     * @param ResolvesToBool|bool|string $cond An expression that resolves to a boolean value used to determine if an element should be included in the output array. The expression references each element of the input array individually with the variable name specified in as, and the element index with the variable name specified in arrayIndexAs (MongoDB 8.3+).
      * @param Optional|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
+     * @param Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the cond expression.
+     *
+     * New in MongoDB 8.3
      * @param Optional|ResolvesToInt|int|string $limit A number expression that restricts the number of matching array elements that $filter returns. You cannot specify a limit less than 1. The matching array elements are returned in the order they appear in the input array.
      * If the specified limit is greater than the number of matching array elements, $filter returns all matching array elements. If the limit is null, $filter returns all matching array elements.
+     *
+     * New in MongoDB 8.3
      */
     public static function filter(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
         ResolvesToBool|bool|string $cond,
         Optional|string $as = Optional::Undefined,
+        Optional|string $arrayIndexAs = Optional::Undefined,
         Optional|ResolvesToInt|int|string $limit = Optional::Undefined,
     ): FilterOperator {
-        return new FilterOperator($input, $cond, $as, $limit);
+        return new FilterOperator($input, $cond, $as, $arrayIndexAs, $limit);
     }
 
     /**
@@ -1606,15 +1613,30 @@ trait FactoryTrait
      * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $initialValue The initial cumulative value set before in is applied to the first element of the input array.
      * @param DateTimeInterface|Document|ExpressionInterface|Serializable|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      * During evaluation of the in expression, two variables will be available:
-     * - value is the variable that represents the cumulative value of the expression.
-     * - this is the variable that refers to the element being processed.
+     * - value is the variable that represents the cumulative value of the expression. Use valueAs (MongoDB 8.3+) to specify a custom name.
+     * - this is the variable that refers to the element being processed. Use as (MongoDB 8.3+) to specify a custom name.
+     * @param Optional|string $as A name for the variable that represents each individual element of the input array.
+     * If no name is specified, the variable name defaults to this.
+     *
+     * New in MongoDB 8.3
+     * @param Optional|string $valueAs A name for the variable that represents the cumulative value of the expression.
+     * If no name is specified, the variable name defaults to value.
+     *
+     * New in MongoDB 8.3
+     * @param Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the in expression.
+     *
+     * New in MongoDB 8.3
      */
     public static function reduce(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $initialValue,
         DateTimeInterface|Document|Serializable|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
+        Optional|string $as = Optional::Undefined,
+        Optional|string $valueAs = Optional::Undefined,
+        Optional|string $arrayIndexAs = Optional::Undefined,
     ): ReduceOperator {
-        return new ReduceOperator($input, $initialValue, $in);
+        return new ReduceOperator($input, $initialValue, $in, $as, $valueAs, $arrayIndexAs);
     }
 
     /**

--- a/src/Builder/Expression/FilterOperator.php
+++ b/src/Builder/Expression/FilterOperator.php
@@ -30,34 +30,58 @@ final class FilterOperator implements ResolvesToArray, OperatorInterface
 {
     public const ENCODE = Encode::Object;
     public const NAME = '$filter';
-    public const PROPERTIES = ['input' => 'input', 'cond' => 'cond', 'as' => 'as', 'limit' => 'limit'];
+
+    public const PROPERTIES = [
+        'input' => 'input',
+        'cond' => 'cond',
+        'as' => 'as',
+        'arrayIndexAs' => 'arrayIndexAs',
+        'limit' => 'limit',
+    ];
 
     /** @var BSONArray|PackedArray|ResolvesToArray|array|string $input */
     public readonly PackedArray|ResolvesToArray|BSONArray|array|string $input;
 
-    /** @var ResolvesToBool|bool|string $cond An expression that resolves to a boolean value used to determine if an element should be included in the output array. The expression references each element of the input array individually with the variable name specified in as. */
+    /** @var ResolvesToBool|bool|string $cond An expression that resolves to a boolean value used to determine if an element should be included in the output array. The expression references each element of the input array individually with the variable name specified in as, and the element index with the variable name specified in arrayIndexAs (MongoDB 8.3+). */
     public readonly ResolvesToBool|bool|string $cond;
 
     /** @var Optional|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this. */
     public readonly Optional|string $as;
 
     /**
+     * @var Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the cond expression.
+     *
+     * New in MongoDB 8.3
+     */
+    public readonly Optional|string $arrayIndexAs;
+
+    /**
      * @var Optional|ResolvesToInt|int|string $limit A number expression that restricts the number of matching array elements that $filter returns. You cannot specify a limit less than 1. The matching array elements are returned in the order they appear in the input array.
      * If the specified limit is greater than the number of matching array elements, $filter returns all matching array elements. If the limit is null, $filter returns all matching array elements.
+     *
+     * New in MongoDB 8.3
      */
     public readonly Optional|ResolvesToInt|int|string $limit;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input
-     * @param ResolvesToBool|bool|string $cond An expression that resolves to a boolean value used to determine if an element should be included in the output array. The expression references each element of the input array individually with the variable name specified in as.
+     * @param ResolvesToBool|bool|string $cond An expression that resolves to a boolean value used to determine if an element should be included in the output array. The expression references each element of the input array individually with the variable name specified in as, and the element index with the variable name specified in arrayIndexAs (MongoDB 8.3+).
      * @param Optional|string $as A name for the variable that represents each individual element of the input array. If no name is specified, the variable name defaults to this.
+     * @param Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the cond expression.
+     *
+     * New in MongoDB 8.3
      * @param Optional|ResolvesToInt|int|string $limit A number expression that restricts the number of matching array elements that $filter returns. You cannot specify a limit less than 1. The matching array elements are returned in the order they appear in the input array.
      * If the specified limit is greater than the number of matching array elements, $filter returns all matching array elements. If the limit is null, $filter returns all matching array elements.
+     *
+     * New in MongoDB 8.3
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
         ResolvesToBool|bool|string $cond,
         Optional|string $as = Optional::Undefined,
+        Optional|string $arrayIndexAs = Optional::Undefined,
         Optional|ResolvesToInt|int|string $limit = Optional::Undefined,
     ) {
         if (is_string($input) && ! str_starts_with($input, '$')) {
@@ -75,6 +99,7 @@ final class FilterOperator implements ResolvesToArray, OperatorInterface
 
         $this->cond = $cond;
         $this->as = $as;
+        $this->arrayIndexAs = $arrayIndexAs;
         if (is_string($limit) && ! str_starts_with($limit, '$')) {
             throw new InvalidArgumentException('Argument $limit can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
         }

--- a/src/Builder/Expression/ReduceOperator.php
+++ b/src/Builder/Expression/ReduceOperator.php
@@ -16,6 +16,7 @@ use MongoDB\BSON\Type;
 use MongoDB\Builder\Type\Encode;
 use MongoDB\Builder\Type\ExpressionInterface;
 use MongoDB\Builder\Type\OperatorInterface;
+use MongoDB\Builder\Type\Optional;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Model\BSONArray;
 use stdClass;
@@ -35,7 +36,15 @@ final class ReduceOperator implements ResolvesToAny, OperatorInterface
 {
     public const ENCODE = Encode::Object;
     public const NAME = '$reduce';
-    public const PROPERTIES = ['input' => 'input', 'initialValue' => 'initialValue', 'in' => 'in'];
+
+    public const PROPERTIES = [
+        'input' => 'input',
+        'initialValue' => 'initialValue',
+        'in' => 'in',
+        'as' => 'as',
+        'valueAs' => 'valueAs',
+        'arrayIndexAs' => 'arrayIndexAs',
+    ];
 
     /**
      * @var BSONArray|PackedArray|ResolvesToArray|array|string $input Can be any valid expression that resolves to an array.
@@ -50,10 +59,34 @@ final class ReduceOperator implements ResolvesToAny, OperatorInterface
     /**
      * @var DateTimeInterface|Document|ExpressionInterface|Serializable|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      * During evaluation of the in expression, two variables will be available:
-     * - value is the variable that represents the cumulative value of the expression.
-     * - this is the variable that refers to the element being processed.
+     * - value is the variable that represents the cumulative value of the expression. Use valueAs (MongoDB 8.3+) to specify a custom name.
+     * - this is the variable that refers to the element being processed. Use as (MongoDB 8.3+) to specify a custom name.
      */
     public readonly DateTimeInterface|Document|Serializable|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in;
+
+    /**
+     * @var Optional|string $as A name for the variable that represents each individual element of the input array.
+     * If no name is specified, the variable name defaults to this.
+     *
+     * New in MongoDB 8.3
+     */
+    public readonly Optional|string $as;
+
+    /**
+     * @var Optional|string $valueAs A name for the variable that represents the cumulative value of the expression.
+     * If no name is specified, the variable name defaults to value.
+     *
+     * New in MongoDB 8.3
+     */
+    public readonly Optional|string $valueAs;
+
+    /**
+     * @var Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the in expression.
+     *
+     * New in MongoDB 8.3
+     */
+    public readonly Optional|string $arrayIndexAs;
 
     /**
      * @param BSONArray|PackedArray|ResolvesToArray|array|string $input Can be any valid expression that resolves to an array.
@@ -62,13 +95,28 @@ final class ReduceOperator implements ResolvesToAny, OperatorInterface
      * @param DateTimeInterface|ExpressionInterface|Type|array|bool|float|int|null|stdClass|string $initialValue The initial cumulative value set before in is applied to the first element of the input array.
      * @param DateTimeInterface|Document|ExpressionInterface|Serializable|Type|array|bool|float|int|null|stdClass|string $in A valid expression that $reduce applies to each element in the input array in left-to-right order. Wrap the input value with $reverseArray to yield the equivalent of applying the combining expression from right-to-left.
      * During evaluation of the in expression, two variables will be available:
-     * - value is the variable that represents the cumulative value of the expression.
-     * - this is the variable that refers to the element being processed.
+     * - value is the variable that represents the cumulative value of the expression. Use valueAs (MongoDB 8.3+) to specify a custom name.
+     * - this is the variable that refers to the element being processed. Use as (MongoDB 8.3+) to specify a custom name.
+     * @param Optional|string $as A name for the variable that represents each individual element of the input array.
+     * If no name is specified, the variable name defaults to this.
+     *
+     * New in MongoDB 8.3
+     * @param Optional|string $valueAs A name for the variable that represents the cumulative value of the expression.
+     * If no name is specified, the variable name defaults to value.
+     *
+     * New in MongoDB 8.3
+     * @param Optional|string $arrayIndexAs A name for the variable that represents the index of the current element in
+     * the input array. If specified, this variable is available within the in expression.
+     *
+     * New in MongoDB 8.3
      */
     public function __construct(
         PackedArray|ResolvesToArray|BSONArray|array|string $input,
         DateTimeInterface|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $initialValue,
         DateTimeInterface|Document|Serializable|Type|ExpressionInterface|stdClass|array|bool|float|int|null|string $in,
+        Optional|string $as = Optional::Undefined,
+        Optional|string $valueAs = Optional::Undefined,
+        Optional|string $arrayIndexAs = Optional::Undefined,
     ) {
         if (is_string($input) && ! str_starts_with($input, '$')) {
             throw new InvalidArgumentException('Argument $input can be an expression, field paths and variable names must be prefixed by "$" or "$$".');
@@ -81,5 +129,8 @@ final class ReduceOperator implements ResolvesToAny, OperatorInterface
         $this->input = $input;
         $this->initialValue = $initialValue;
         $this->in = $in;
+        $this->as = $as;
+        $this->valueAs = $valueAs;
+        $this->arrayIndexAs = $arrayIndexAs;
     }
 }

--- a/tests/Builder/Expression/FilterOperatorTest.php
+++ b/tests/Builder/Expression/FilterOperatorTest.php
@@ -51,6 +51,29 @@ class FilterOperatorTest extends PipelineTestCase
         $this->assertSamePipeline(Pipelines::FilterLimitGreaterThanPossibleMatches, $pipeline);
     }
 
+    public function testUseTheArrayIndexAsField(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                name: 1,
+                secondaryHobbies: Expression::filter(
+                    input: Expression::arrayFieldPath('hobbies'),
+                    arrayIndexAs: 'myIndex',
+                    cond: Expression::eq(
+                        Expression::mod(
+                            Expression::variable('myIndex'),
+                            2,
+                        ),
+                        0,
+                    ),
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::FilterUseTheArrayIndexAsField, $pipeline);
+    }
+
     public function testUsingTheLimitField(): void
     {
         $pipeline = new Pipeline(

--- a/tests/Builder/Expression/Pipelines.php
+++ b/tests/Builder/Expression/Pipelines.php
@@ -2180,6 +2180,47 @@ enum Pipelines: string
     ]
     EXTENDED_JSON;
 
+    /**
+     * Use the arrayIndexAs Field
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/filter/#use-the-arrayindexas-field
+     */
+    case FilterUseTheArrayIndexAsField = <<<'EXTENDED_JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "name": {
+                    "$numberInt": "1"
+                },
+                "secondaryHobbies": {
+                    "$filter": {
+                        "input": "$hobbies",
+                        "arrayIndexAs": "myIndex",
+                        "cond": {
+                            "$eq": [
+                                {
+                                    "$mod": [
+                                        "$$myIndex",
+                                        {
+                                            "$numberInt": "2"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "$numberInt": "0"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+    EXTENDED_JSON;
+
     /** Use in $addFields Stage */
     case FirstUseInAddFieldsStage = <<<'EXTENDED_JSON'
     [
@@ -4207,6 +4248,53 @@ enum Pipelines: string
                                 "$$this"
                             ]
                         }
+                    }
+                }
+            }
+        }
+    ]
+    EXTENDED_JSON;
+
+    /**
+     * Use as, valueAs, and arrayIndexAs
+     *
+     * @see https://www.mongodb.com/docs/manual/reference/operator/aggregation/reduce/#use-as--valueas--and-arrayindexas
+     */
+    case ReduceUseAsValueAsAndArrayIndexAs = <<<'EXTENDED_JSON'
+    [
+        {
+            "$project": {
+                "_id": {
+                    "$numberInt": "0"
+                },
+                "name": {
+                    "$numberInt": "1"
+                },
+                "text": {
+                    "$reduce": {
+                        "input": "$hobbies",
+                        "initialValue": "My hobbies include:",
+                        "in": {
+                            "$concat": [
+                                "$$accumulatedText",
+                                " ",
+                                {
+                                    "$toString": {
+                                        "$add": [
+                                            "$$myIndex",
+                                            {
+                                                "$numberInt": "1"
+                                            }
+                                        ]
+                                    }
+                                },
+                                ") ",
+                                "$$hobby"
+                            ]
+                        },
+                        "as": "hobby",
+                        "valueAs": "accumulatedText",
+                        "arrayIndexAs": "myIndex"
                     }
                 }
             }

--- a/tests/Builder/Expression/ReduceOperatorTest.php
+++ b/tests/Builder/Expression/ReduceOperatorTest.php
@@ -138,4 +138,35 @@ class ReduceOperatorTest extends PipelineTestCase
 
         $this->assertSamePipeline(Pipelines::ReduceStringConcatenation, $pipeline);
     }
+
+    public function testUseAsValueAsAndArrayIndexAs(): void
+    {
+        $pipeline = new Pipeline(
+            Stage::project(
+                _id: 0,
+                name: 1,
+                text: Expression::reduce(
+                    input: Expression::arrayFieldPath('hobbies'),
+                    initialValue: 'My hobbies include:',
+                    in: Expression::concat(
+                        Expression::variable('accumulatedText'),
+                        ' ',
+                        Expression::toString(
+                            Expression::add(
+                                Expression::variable('myIndex'),
+                                1,
+                            ),
+                        ),
+                        ') ',
+                        Expression::variable('hobby'),
+                    ),
+                    as: 'hobby',
+                    valueAs: 'accumulatedText',
+                    arrayIndexAs: 'myIndex',
+                ),
+            ),
+        );
+
+        $this->assertSamePipeline(Pipelines::ReduceUseAsValueAsAndArrayIndexAs, $pipeline);
+    }
 }


### PR DESCRIPTION
Implements the new MongoDB 8.3 parameters added in [mongodb/mql-specifications#54](https://github.com/mongodb/mql-specifications/pull/54), completing the work started in PHPLIB-1771:

- `$filter`: adds `arrayIndexAs` parameter to expose the current element's index in the `cond` expression
- `$reduce`: adds `as`, `valueAs`, and `arrayIndexAs` parameters to customize variable names and expose the element index in the `in` expression

Also fixes the test name generator to strip commas from test case names (needed for the new spec test names).
