### PR TITLE
Re-enable `createEntities` in unified spec tests

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,12 +4,12 @@ use PhpParser\Node\Expr\Cast\Bool_;
 use PhpParser\Node\Expr\Cast\Double;
 use PhpParser\Node\Expr\Cast\Int_;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector;
 use Rector\Renaming\Rector\Cast\RenameCastRector;
 use Rector\Renaming\ValueObject\RenameCast;
 
@@ -25,11 +25,6 @@ return RectorConfig::configure()
     ->withSkipPath(__DIR__ . '/tests/Builder/BuilderEncoderTest.php')
     ->withPhpSets(php80: true)
     ->withComposerBased(phpunit: true)
-    ->withRules([
-        ChangeSwitchToMatchRector::class,
-    ])
-    // All classes are public API by default, unless marked with @internal.
-    ->withConfiguredRule(RemoveAnnotationRector::class, ['api'])
     // Fix PHP 8.5 deprecations
     ->withConfiguredRule(
         RenameCastRector::class,
@@ -51,6 +46,7 @@ return RectorConfig::configure()
         StringableForToStringRector::class => [
             __DIR__ . '/src/Model/IndexInput.php',
         ],
+        AddDoesNotPerformAssertionToNonAssertingTestRector::class,
     ])
     // phpcs:enable
     ->withImportNames(importNames: false, removeUnusedImports: true);

--- a/tests/Operation/ExplainTest.php
+++ b/tests/Operation/ExplainTest.php
@@ -12,7 +12,7 @@ class ExplainTest extends TestCase
     #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
-        $explainable = $this->getMockBuilder(Explainable::class)->getMock();
+        $explainable = $this->createMock(Explainable::class);
         $this->expectException(InvalidArgumentException::class);
         new Explain($this->getDatabaseName(), $explainable, $options);
     }

--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -87,9 +87,7 @@ final class Operation
     private ?string $saveResultAsEntity = null;
 
     private static array $unsupportedOperations = [
-        self::OBJECT_TEST_RUNNER => [
-            'assertNumberConnectionsCheckedOut' => 'PHP does not implement CMAP',
-        ],
+        self::OBJECT_TEST_RUNNER => ['assertNumberConnectionsCheckedOut' => 'PHP does not implement CMAP'],
         Client::class => ['listDatabaseObjects' => 'listDatabaseObjects is not implemented'],
         Cursor::class => ['iterateOnce' => 'iterateOnce is not implemented (PHPC-1760)'],
         Database::class => [

--- a/tests/UnifiedSpecTests/Operation.php
+++ b/tests/UnifiedSpecTests/Operation.php
@@ -89,7 +89,6 @@ final class Operation
     private static array $unsupportedOperations = [
         self::OBJECT_TEST_RUNNER => [
             'assertNumberConnectionsCheckedOut' => 'PHP does not implement CMAP',
-            'createEntities' => 'createEntities is not implemented (PHPC-1760)',
         ],
         Client::class => ['listDatabaseObjects' => 'listDatabaseObjects is not implemented'],
         Cursor::class => ['iterateOnce' => 'iterateOnce is not implemented (PHPC-1760)'],

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -104,6 +104,7 @@ class UnifiedSpecTest extends FunctionalTestCase
         'valid-pass/entity-client-cmap-events: events are captured during an operation' => 'PHPC does not implement CMAP',
         'valid-pass/expectedEventsForClient-eventType: eventType can be set to command and cmap' => 'PHPC does not implement CMAP',
         'valid-pass/expectedEventsForClient-eventType: eventType defaults to command if unset' => 'PHPC does not implement CMAP',
+        'valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent: can assert on values of newDescription and previousDescription fields' => 'SDAM events are not observed by the unified test runner',
         // libmongoc always adds readConcern to aggregate command
         'index-management/search index operations ignore read and write concern: listSearchIndexes ignores read and write concern' => 'libmongoc appends readConcern to aggregate command',
         // Uses an invalid object name


### PR DESCRIPTION
I don't find the reason why `createEntities` was excluded in this commit: https://github.com/mongodb/mongo-php-library/commit/48a78c7a225b547d43e317914af5974bfdf2b951#diff-e1fc1998198af571cbeed186ed25b1c703850f87e91be5be15ebee8b674d29a0R89

So let's try to figure.