### PR TITLE
PHPLIB-1930 test server 9.0

### DIFF
--- a/.evergreen/config/generate-config.php
+++ b/.evergreen/config/generate-config.php
@@ -17,6 +17,7 @@ $lowestPhpVersion = min($supportedPhpVersions);
 $supportedMongoDBVersions = [
     'latest',
     'rapid',
+    '9.0',
     '8.0',
     '7.0',
     '6.0',

--- a/.evergreen/config/generated/test-variant/modern-php-full.yml
+++ b/.evergreen/config/generated/test-variant/modern-php-full.yml
@@ -33,10 +33,10 @@ buildvariants:
         name: "build-php-8.5"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
 
   # Test versions < 5.0
   - name: test-rhel80-php-8.5
@@ -52,10 +52,10 @@ buildvariants:
         name: "build-php-8.5"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"
   # Test MongoDB >= 7.0
@@ -91,10 +91,10 @@ buildvariants:
         name: "build-php-8.4"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
 
   # Test versions < 5.0
   - name: test-rhel80-php-8.4
@@ -110,10 +110,10 @@ buildvariants:
         name: "build-php-8.4"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"
   # Test MongoDB >= 7.0
@@ -149,10 +149,10 @@ buildvariants:
         name: "build-php-8.3"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
 
   # Test versions < 5.0
   - name: test-rhel80-php-8.3
@@ -168,10 +168,10 @@ buildvariants:
         name: "build-php-8.3"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"
   # Test MongoDB >= 7.0
@@ -207,10 +207,10 @@ buildvariants:
         name: "build-php-8.2"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
 
   # Test versions < 5.0
   - name: test-rhel80-php-8.2
@@ -226,10 +226,10 @@ buildvariants:
         name: "build-php-8.2"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"
   # Test MongoDB >= 7.0
@@ -265,10 +265,10 @@ buildvariants:
         name: "build-php-8.1"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
 
   # Test versions < 5.0
   - name: test-rhel80-php-8.1
@@ -284,9 +284,9 @@ buildvariants:
         name: "build-php-8.1"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"

--- a/.evergreen/config/generated/test/csfle.yml
+++ b/.evergreen/config/generated/test/csfle.yml
@@ -74,6 +74,43 @@ tasks:
         vars:
           SKIP_AWS_CREDS: "yes"
           TESTS: "csfle-without-aws-creds"
+  - name: "test-mongodb-9.0-crypt-shared"
+    tags: ["replicaset", "local", "9.0", "csfle", "tag"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "replica_set"
+          MONGODB_VERSION: "9.0"
+      - func: "start kms servers"
+      - func: "run tests"
+        vars:
+          TESTS: "csfle"
+
+  - name: "test-mongodb-9.0-mongocryptd"
+    tags: ["replicaset", "local", "9.0", "csfle", "pr", "tag"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "replica_set"
+          SKIP_CRYPT_SHARED: "yes"
+          MONGODB_VERSION: "9.0"
+      - func: "start kms servers"
+      - func: "run tests"
+        vars:
+          TESTS: "csfle"
+
+  - name: "test-mongodb-9.0-no-aws-creds"
+    tags: ["replicaset", "local", "9.0", "csfle", "tag"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "replica_set"
+          MONGODB_VERSION: "9.0"
+      - func: "start kms servers"
+      - func: "run tests"
+        vars:
+          SKIP_AWS_CREDS: "yes"
+          TESTS: "csfle-without-aws-creds"
   - name: "test-mongodb-8.0-crypt-shared"
     tags: ["replicaset", "local", "8.0", "csfle", "tag"]
     commands:

--- a/.evergreen/config/generated/test/load-balanced.yml
+++ b/.evergreen/config/generated/test/load-balanced.yml
@@ -30,6 +30,21 @@ tasks:
         vars:
           MONGODB_URI: "${SINGLE_MONGOS_LB_URI}"
           SSL: "yes"
+  - name: "test-mongodb-9.0-loadbalanced"
+    tags: ["loadbalanced", "local", "9.0", "tag"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "sharded_cluster"
+          MONGODB_VERSION: "9.0"
+          LOAD_BALANCER: "true"
+          SSL: "yes"
+      - func: "start load balancer"
+      - func: "start kms servers"
+      - func: "run tests"
+        vars:
+          MONGODB_URI: "${SINGLE_MONGOS_LB_URI}"
+          SSL: "yes"
   - name: "test-mongodb-8.0-loadbalanced"
     tags: ["loadbalanced", "local", "8.0", "tag"]
     commands:

--- a/.evergreen/config/generated/test/local.yml
+++ b/.evergreen/config/generated/test/local.yml
@@ -58,6 +58,35 @@ tasks:
           MONGODB_VERSION: "rapid"
       - func: "start kms servers"
       - func: "run tests"
+  - name: "test-mongodb-9.0-standalone-noauth-nossl"
+    tags: ["standalone", "local", "9.0", "tag"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "server"
+          MONGODB_VERSION: "9.0"
+      - func: "start kms servers"
+      - func: "run tests"
+
+  - name: "test-mongodb-9.0-replicaset-noauth-nossl"
+    tags: ["replicaset", "local", "9.0", "pr", "tag"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "replica_set"
+          MONGODB_VERSION: "9.0"
+      - func: "start kms servers"
+      - func: "run tests"
+
+  - name: "test-mongodb-9.0-sharded-noauth-nossl"
+    tags: ["sharded", "local", "9.0", "tag"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "sharded_cluster"
+          MONGODB_VERSION: "9.0"
+      - func: "start kms servers"
+      - func: "run tests"
   - name: "test-mongodb-8.0-standalone-noauth-nossl"
     tags: ["standalone", "local", "8.0", "tag"]
     commands:

--- a/.evergreen/config/generated/test/require-api-version.yml
+++ b/.evergreen/config/generated/test/require-api-version.yml
@@ -52,6 +52,32 @@ tasks:
       - func: "run tests"
         vars:
           TESTS: "versioned-api"
+  - name: "test-mongodb-9.0-requireApiVersion"
+    tags: ["standalone", "local", "9.0", "versioned_api", "pr", "tag"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "server"
+          AUTH: "auth"
+          REQUIRE_API_VERSION: "yes"
+          MONGODB_VERSION: "9.0"
+      - func: "start kms servers"
+      - func: "run tests"
+        vars:
+          API_VERSION: "1"
+
+  - name: "test-mongodb-9.0-acceptApiVersion2"
+    tags: ["standalone", "local", "9.0", "versioned_api"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          TOPOLOGY: "server"
+          ORCHESTRATION_FILE: "versioned-api-testing.json"
+          MONGODB_VERSION: "9.0"
+      - func: "start kms servers"
+      - func: "run tests"
+        vars:
+          TESTS: "versioned-api"
   - name: "test-mongodb-8.0-requireApiVersion"
     tags: ["standalone", "local", "8.0", "versioned_api", "pr", "tag"]
     commands:

--- a/.evergreen/config/templates/test-variant/modern-php-full.yml
+++ b/.evergreen/config/templates/test-variant/modern-php-full.yml
@@ -31,10 +31,10 @@
         name: "build-php-%phpVersion%"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.4.2 !.4.4 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
 
   # Test versions < 5.0
   - name: test-rhel80-php-%phpVersion%
@@ -50,9 +50,9 @@
         name: "build-php-%phpVersion%"
     tasks:
       # Remember to add new major versions here as they are released
-      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
-      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.rapid !.latest"
+      - ".standalone .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".replicaset .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".sharded .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
+      - ".loadbalanced .local !.csfle !.6.0 !.7.0 !.8.0 !.9.0 !.rapid !.latest"
       - "test_atlas_task_group"
       - ".csfle"


### PR DESCRIPTION
# Summary
- Add server 9.0 to test matrix.
- Bump drivers-evergreen-tools to include changes to test the 9.0 branch https://github.com/mongodb-labs/drivers-evergreen-tools/commit/890a93bdb88c595907813a9bfd0a56156d9f9f5b

# Motivation

This was an urgent ask to ensure 9.0 has test coverage.

Evergreen patch: https://spruce.corp.mongodb.com/version/6a7e0e3822cd030007b24174/. Failures of `testResumeAfterOption` ([example](https://spruce.corp.mongodb.com/task/mongo_php_library_2.x_test_debian12_php_8.2_local_test_mongodb_9.0_sharded_noauth_nossl_patch_171401c7075dfc326a045019b82e31a2404924b6_6a7e0e3822cd030007b24174_26_08_13_18_34_53/tests?execution=0&sorts=STATUS%3AASC)) are also failing against latest servers.