### PR TITLE
PHPLIB-1930 update GitHub actions from 8.0 to 9.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,18 +31,18 @@ jobs:
           - "8.4"
           - "8.5"
         mongodb-version:
-          - "8.0"
+          - "9.0"
         topology:
           - "replica_set"
         include:
-          # Test additional topologies for MongoDB 8.0
+          # Test additional topologies for MongoDB 9.0
           - os: "ubuntu-24.04"
             php-version: "8.4"
-            mongodb-version: "8.0"
+            mongodb-version: "9.0"
             topology: "server"
           - os: "ubuntu-24.04"
             php-version: "8.4"
-            mongodb-version: "8.0"
+            mongodb-version: "9.0"
             topology: "sharded_cluster"
           # Test lowest server/php versions
           - os: "ubuntu-22.04"


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-php-library/pull/1953 to update GitHub actions from testing 8.0 to 9.0.