### PR TITLE
Dependabot/GitHub actions/alcaeus/automatic merge up action 1.1.0

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -30,4 +30,6 @@ jobs:
           branchNamePattern: 'v<major>.<minor>'
           devBranchNamePattern: 'v<major>.x'
           ignoredBranches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
+          labels: merge-up
           enableAutoMerge: true
+          assignApprover: true

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Create pull request
         id: create-pull-request
-        uses: alcaeus/automatic-merge-up-action@1.0.0
+        uses: alcaeus/automatic-merge-up-action@1.1.0
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'v<major>.<minor>'


### PR DESCRIPTION
Supersedes https://github.com/mongodb/mongo-php-library/pull/1956

Enable 2 new features when creating merge-up PR:
- Add "merge-up" label
- Assign the approver of the merged pull request