### PR TITLE
Update automatic merge up action and evergreen submodule

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -30,4 +30,6 @@ jobs:
           branchNamePattern: 'v<major>.<minor>'
           devBranchNamePattern: 'v<major>.x'
           ignoredBranches: ${{ vars.IGNORED_MERGE_UP_BRANCHES }}
+          labels: merge-up
           enableAutoMerge: true
+          assignApprover: true

--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Create pull request
         id: create-pull-request
-        uses: alcaeus/automatic-merge-up-action@1.0.0
+        uses: alcaeus/automatic-merge-up-action@1.1.0
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'v<major>.<minor>'

--- a/rector.php
+++ b/rector.php
@@ -4,10 +4,10 @@ use PhpParser\Node\Expr\Cast\Bool_;
 use PhpParser\Node\Expr\Cast\Double;
 use PhpParser\Node\Expr\Cast\Int_;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassLike\RemoveAnnotationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
+use Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector;
 use Rector\Renaming\Rector\Cast\RenameCastRector;
 use Rector\Renaming\ValueObject\RenameCast;
 
@@ -23,11 +23,6 @@ return RectorConfig::configure()
     // Error with StaticCallOnNonStaticToInstanceCallRector
     // https://github.com/rectorphp/rector/issues/9608
     ->withSkipPath(__DIR__ . '/tests/Builder/BuilderEncoderTest.php')
-    ->withRules([
-        ChangeSwitchToMatchRector::class,
-    ])
-    // All classes are public API by default, unless marked with @internal.
-    ->withConfiguredRule(RemoveAnnotationRector::class, ['api'])
     // Fix PHP 8.5 deprecations
     ->withConfiguredRule(
         RenameCastRector::class,
@@ -45,6 +40,7 @@ return RectorConfig::configure()
         ChangeSwitchToMatchRector::class => [
             __DIR__ . '/tests/SpecTests/Operation.php',
         ],
+        AddDoesNotPerformAssertionToNonAssertingTestRector::class,
     ])
     // phpcs:enable
     ->withImportNames(importNames: false, removeUnusedImports: true);

--- a/tests/Model/IndexInfoFunctionalTest.php
+++ b/tests/Model/IndexInfoFunctionalTest.php
@@ -29,8 +29,8 @@ class IndexInfoFunctionalTest extends FunctionalTestCase
         $this->assertEquals($indexName, $index->getName());
         $this->assertTrue($index->is2dSphere());
 
-        // MongoDB 3.2+ reports index version 3
-        $this->assertEquals(3, $index['2dsphereIndexVersion']);
+        // MongoDB 3.2+ reports index version 3, MongoDB 8.3+ reports version 4
+        $this->assertGreaterThanOrEqual(3, $index['2dsphereIndexVersion']);
     }
 
     #[Group('matrix-testing-exclude-server-5.0-driver-4.0')]

--- a/tests/Operation/ExplainTest.php
+++ b/tests/Operation/ExplainTest.php
@@ -12,7 +12,7 @@ class ExplainTest extends TestCase
     #[DataProvider('provideInvalidConstructorOptions')]
     public function testConstructorOptionTypeChecks(array $options): void
     {
-        $explainable = $this->getMockBuilder(Explainable::class)->getMock();
+        $explainable = $this->createMock(Explainable::class);
         $this->expectException(InvalidArgumentException::class);
         new Explain($this->getDatabaseName(), $explainable, $options);
     }


### PR DESCRIPTION
Supersedes https://github.com/mongodb/mongo-php-library/pull/1956

Enable 2 new features when creating merge-up PR:
- Add "merge-up" label
- Assign the approver of the merged pull request

Backport rector fixes and drivers-evergreen-tools update in order to make the CI pass