### PR TITLE
Reduce round trips in GridFS delete and chunk lookups

### DIFF
--- a/src/GridFS/Bucket.php
+++ b/src/GridFS/Bucket.php
@@ -210,10 +210,9 @@ class Bucket
      */
     public function delete(mixed $id): void
     {
-        $file = $this->collectionWrapper->findFileById($id);
-        $this->collectionWrapper->deleteFileAndChunksById($id);
+        $deletedCount = $this->collectionWrapper->deleteFileAndChunksById($id);
 
-        if ($file === null) {
+        if ($deletedCount === 0) {
             throw FileNotFoundException::byId($id, $this->getFilesNamespace());
         }
     }

--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -95,11 +95,16 @@ final class CollectionWrapper
 
     /**
      * Deletes a GridFS file and related chunks by ID.
+     *
+     * @return int|null Number of deleted files (i.e. 0 or 1), or null if the
+     *                   write was not acknowledged
      */
-    public function deleteFileAndChunksById(mixed $id): void
+    public function deleteFileAndChunksById(mixed $id): ?int
     {
-        $this->filesCollection->deleteOne(['_id' => $id]);
+        $result = $this->filesCollection->deleteOne(['_id' => $id]);
         $this->chunksCollection->deleteMany(['files_id' => $id]);
+
+        return $result->isAcknowledged() ? $result->getDeletedCount() : null;
     }
 
     /**
@@ -119,11 +124,14 @@ final class CollectionWrapper
      */
     public function findChunksByFileId(mixed $id, int $fromChunk = 0): CursorInterface
     {
+        $filter = ['files_id' => $id];
+
+        if ($fromChunk > 0) {
+            $filter['n'] = ['$gte' => $fromChunk];
+        }
+
         return $this->chunksCollection->find(
-            [
-                'files_id' => $id,
-                'n' => ['$gte' => $fromChunk],
-            ],
+            $filter,
             [
                 'sort' => ['n' => 1],
                 'typeMap' => ['root' => 'stdClass'],


### PR DESCRIPTION
`Bucket::delete()` issued a find command on the files collection only to check whether the file existed, before the delete commands on the `files` and `chunks` collections. This uses the deleted count reported by the files collection delete instead, removing that extra round trip.

`deleteFileAndChunksById()` now returns null when the write is unacknowledged, since a deleted count is not available in that case, and `delete()` only raises `FileNotFoundException` when the count is known to be `0`. This preserves the existing behavior for unacknowledged write concerns.

This also skips the `n >= 0` filter when reading chunks from the start of a file, since that clause never excludes any document and was sent on every read.