### PR TITLE
Require ext-mongodb 2.4.0 for PHPLIB 2.4.0

### DIFF
--- a/.evergreen/compile-extension.sh
+++ b/.evergreen/compile-extension.sh
@@ -26,12 +26,18 @@ install_extension ()
       make install
 
       cd ${PROJECT_DIRECTORY}
-   elif [ "${EXTENSION_VERSION}" != "" ]; then
-      echo "Installing driver version ${EXTENSION_VERSION} from PECL"
-      MAKEFLAGS=-j20 pecl install -f mongodb-${EXTENSION_VERSION}
    else
-      echo "Installing latest driver version from PECL"
-      MAKEFLAGS=-j20 pecl install -f mongodb
+      # The base images ship a channel snapshot that predates recent releases,
+      # so PECL would silently resolve down to an older version.
+      pecl channel-update pecl.php.net
+
+      if [ "${EXTENSION_VERSION}" != "" ]; then
+         echo "Installing driver version ${EXTENSION_VERSION} from PECL"
+         MAKEFLAGS=-j20 pecl install -f mongodb-${EXTENSION_VERSION}
+      else
+         echo "Installing latest driver version from PECL"
+         MAKEFLAGS=-j20 pecl install -f mongodb
+      fi
    fi
 
    cp ${PROJECT_DIRECTORY}/.evergreen/config/php.ini ${PHP_PATH}/lib/php.ini

--- a/.evergreen/config/generated/build/build-extension.yml
+++ b/.evergreen/config/generated/build/build-extension.yml
@@ -16,7 +16,7 @@ tasks:
           PHP_VERSION: "8.5"
       - func: "compile extension"
         vars:
-          EXTENSION_VERSION: "2.3.0"
+          EXTENSION_VERSION: "2.4.0"
       - func: "upload extension"
   - name: "build-php-8.5-next-stable"
     tags: ["build", "php8.5", "next-stable", "pr", "tag"]
@@ -26,7 +26,7 @@ tasks:
           PHP_VERSION: "8.5"
       - func: "compile extension"
         vars:
-          EXTENSION_BRANCH: "v2.3"
+          EXTENSION_BRANCH: "v2.4"
       - func: "upload extension"
   - name: "build-php-8.5-next-minor"
     tags: ["build", "php8.5", "next-minor"]
@@ -54,7 +54,7 @@ tasks:
           PHP_VERSION: "8.4"
       - func: "compile extension"
         vars:
-          EXTENSION_VERSION: "2.3.0"
+          EXTENSION_VERSION: "2.4.0"
       - func: "upload extension"
   - name: "build-php-8.4-next-stable"
     tags: ["build", "php8.4", "next-stable", "pr", "tag"]
@@ -64,7 +64,7 @@ tasks:
           PHP_VERSION: "8.4"
       - func: "compile extension"
         vars:
-          EXTENSION_BRANCH: "v2.3"
+          EXTENSION_BRANCH: "v2.4"
       - func: "upload extension"
   - name: "build-php-8.4-next-minor"
     tags: ["build", "php8.4", "next-minor"]
@@ -92,7 +92,7 @@ tasks:
           PHP_VERSION: "8.3"
       - func: "compile extension"
         vars:
-          EXTENSION_VERSION: "2.3.0"
+          EXTENSION_VERSION: "2.4.0"
       - func: "upload extension"
   - name: "build-php-8.3-next-stable"
     tags: ["build", "php8.3", "next-stable", "pr", "tag"]
@@ -102,7 +102,7 @@ tasks:
           PHP_VERSION: "8.3"
       - func: "compile extension"
         vars:
-          EXTENSION_BRANCH: "v2.3"
+          EXTENSION_BRANCH: "v2.4"
       - func: "upload extension"
   - name: "build-php-8.3-next-minor"
     tags: ["build", "php8.3", "next-minor"]
@@ -130,7 +130,7 @@ tasks:
           PHP_VERSION: "8.2"
       - func: "compile extension"
         vars:
-          EXTENSION_VERSION: "2.3.0"
+          EXTENSION_VERSION: "2.4.0"
       - func: "upload extension"
   - name: "build-php-8.2-next-stable"
     tags: ["build", "php8.2", "next-stable", "pr", "tag"]
@@ -140,7 +140,7 @@ tasks:
           PHP_VERSION: "8.2"
       - func: "compile extension"
         vars:
-          EXTENSION_BRANCH: "v2.3"
+          EXTENSION_BRANCH: "v2.4"
       - func: "upload extension"
   - name: "build-php-8.2-next-minor"
     tags: ["build", "php8.2", "next-minor"]
@@ -168,7 +168,7 @@ tasks:
           PHP_VERSION: "8.1"
       - func: "compile extension"
         vars:
-          EXTENSION_VERSION: "2.3.0"
+          EXTENSION_VERSION: "2.4.0"
       - func: "upload extension"
   - name: "build-php-8.1-next-stable"
     tags: ["build", "php8.1", "next-stable", "pr", "tag"]
@@ -178,7 +178,7 @@ tasks:
           PHP_VERSION: "8.1"
       - func: "compile extension"
         vars:
-          EXTENSION_BRANCH: "v2.3"
+          EXTENSION_BRANCH: "v2.4"
       - func: "upload extension"
   - name: "build-php-8.1-next-minor"
     tags: ["build", "php8.1", "next-minor"]

--- a/.evergreen/config/templates/build/build-extension.yml
+++ b/.evergreen/config/templates/build/build-extension.yml
@@ -14,7 +14,7 @@
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
         vars:
-          EXTENSION_VERSION: "2.3.0"
+          EXTENSION_VERSION: "2.4.0"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-next-stable"
     tags: ["build", "php%phpVersion%", "next-stable", "pr", "tag"]
@@ -24,7 +24,7 @@
           PHP_VERSION: "%phpVersion%"
       - func: "compile extension"
         vars:
-          EXTENSION_BRANCH: "v2.3"
+          EXTENSION_BRANCH: "v2.4"
       - func: "upload extension"
   - name: "build-php-%phpVersion%-next-minor"
     tags: ["build", "php%phpVersion%", "next-minor"]

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,7 +28,7 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         extensions: "mongodb-${{ inputs.driver-version }}"
-        key: "extcache-${{ inputs.driver-version }}"
+        key: "extcache-${{ inputs.driver-version }}-${{ hashFiles('composer.json') }}"
 
     - name: Cache extensions
       uses: actions/cache@v4

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-mongodb": "^2.3",
+        "ext-mongodb": "^2.4",
         "composer-runtime-api": "^2.0",
         "psr/log": "^1.1.4|^2|^3",
         "symfony/polyfill-php85": "^1.33"


### PR DESCRIPTION
Bump the extension constraint and update the Evergreen build tasks: the "lowest" task now compiles the just-released 2.4.0, and "next-stable" tracks the new v2.4 branch.