### PR TITLE
Grant the merge-up app token pull-requests write access

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -15,18 +15,28 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Create app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.PR_APP_ID }}
+          private-key: ${{ secrets.PR_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout
         id: checkout
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
+        uses: actions/checkout@v6
         with:
-          app_id: ${{ vars.PR_APP_ID }}
-          private_key: ${{ secrets.PR_APP_PRIVATE_KEY }}
+          token: ${{ steps.app-token.outputs.token }}
           submodules: true
           fetch-depth: 0
 
       - name: Create pull request
         id: create-pull-request
         uses: alcaeus/automatic-merge-up-action@1.1.0
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           ref: ${{ github.ref_name }}
           branchNamePattern: 'v<major>.<minor>'


### PR DESCRIPTION
A recent change in drivers-github-tools [added](https://github.com/mongodb-labs/drivers-github-tools/pull/110/changes#diff-c19011a32d4cf4f04a0089ef86511e3ce1c2493d4c25697e1625f27c7abf8a13R31) `permission-contents: write` to `secure-checkout`. I expect that reduced the permissions of the created token. `secure-checkout` persists the created token, which is later used by the `automatic-merge-up-action`. I expect this is the cause of a [permission error in `merge-up`](https://github.com/mongodb/mongo-php-library/actions/runs/32268117090/job/96119508722). 