### PR TITLE
PHPLIB-1927: Reject "." and NUL bytes in database and collection names

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -77,6 +77,7 @@ use function array_key_exists;
 use function current;
 use function is_array;
 use function is_bool;
+use function str_contains;
 use function strlen;
 
 /**
@@ -174,11 +175,11 @@ class Collection implements Stringable
      */
     public function __construct(private Manager $manager, private string $databaseName, private string $collectionName, array $options = [])
     {
-        if (strlen($databaseName) < 1) {
+        if (strlen($databaseName) < 1 || str_contains($databaseName, '.') || str_contains($databaseName, "\0")) {
             throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
         }
 
-        if (strlen($collectionName) < 1) {
+        if (strlen($collectionName) < 1 || str_contains($collectionName, "\0")) {
             throw new InvalidArgumentException('$collectionName is invalid: ' . $collectionName);
         }
 

--- a/src/Database.php
+++ b/src/Database.php
@@ -56,6 +56,7 @@ use Throwable;
 
 use function is_array;
 use function is_bool;
+use function str_contains;
 use function strlen;
 
 /** @psalm-no-seal-properties */
@@ -112,7 +113,7 @@ class Database implements Stringable
      */
     public function __construct(private Manager $manager, private string $databaseName, array $options = [])
     {
-        if (strlen($databaseName) < 1) {
+        if (strlen($databaseName) < 1 || str_contains($databaseName, '.') || str_contains($databaseName, "\0")) {
             throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
         }
 

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -36,6 +36,7 @@ use function current;
 use function is_array;
 use function is_bool;
 use function key;
+use function MongoDB\create_namespace;
 use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
@@ -62,6 +63,8 @@ final class BulkWrite
     private array $operations;
 
     private array $options;
+
+    private string $namespace;
 
     /**
      * Constructs a bulk write operation.
@@ -142,8 +145,10 @@ final class BulkWrite
      * @param array  $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(private string $databaseName, private string $collectionName, array $operations, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $operations, array $options = [])
     {
+        $this->namespace = create_namespace($databaseName, $collectionName);
+
         if (empty($operations)) {
             throw new InvalidArgumentException('$operations is empty');
         }
@@ -232,7 +237,7 @@ final class BulkWrite
             }
         }
 
-        $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $this->createExecuteOptions());
+        $writeResult = $server->executeBulkWrite($this->namespace, $bulk, $this->createExecuteOptions());
 
         return new BulkWriteResult($writeResult, $insertedIds);
     }

--- a/src/Operation/Delete.php
+++ b/src/Operation/Delete.php
@@ -27,6 +27,7 @@ use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
 
 use function is_string;
+use function MongoDB\create_namespace;
 use function MongoDB\is_document;
 use function MongoDB\is_write_concern_acknowledged;
 use function MongoDB\server_supports_feature;
@@ -43,6 +44,8 @@ use function MongoDB\server_supports_feature;
 final class Delete implements Explainable
 {
     private const WIRE_VERSION_FOR_HINT = 9;
+
+    private string $namespace;
 
     /**
      * Constructs a delete command.
@@ -80,8 +83,10 @@ final class Delete implements Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(private string $databaseName, private string $collectionName, private array|object $filter, private int $limit, private array $options = [])
+    public function __construct(string $databaseName, private string $collectionName, private array|object $filter, private int $limit, private array $options = [])
     {
+        $this->namespace = create_namespace($databaseName, $collectionName);
+
         if (! is_document($filter)) {
             throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
@@ -140,7 +145,7 @@ final class Delete implements Explainable
         $bulk = new Bulk($this->createBulkWriteOptions());
         $bulk->delete($this->filter, $this->createDeleteOptions());
 
-        $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $this->createExecuteOptions());
+        $writeResult = $server->executeBulkWrite($this->namespace, $bulk, $this->createExecuteOptions());
 
         return new DeleteResult($writeResult);
     }

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -34,6 +34,7 @@ use function is_array;
 use function is_bool;
 use function is_integer;
 use function is_string;
+use function MongoDB\create_namespace;
 use function MongoDB\is_document;
 
 /**
@@ -48,6 +49,8 @@ final class Find implements Explainable
     public const NON_TAILABLE = 1;
     public const TAILABLE = 2;
     public const TAILABLE_AWAIT = 3;
+
+    private string $namespace;
 
     /**
      * Constructs a find command.
@@ -130,8 +133,10 @@ final class Find implements Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(private string $databaseName, private string $collectionName, private array|object $filter, private array $options = [])
+    public function __construct(string $databaseName, private string $collectionName, private array|object $filter, private array $options = [])
     {
+        $this->namespace = create_namespace($databaseName, $collectionName);
+
         if (! is_document($filter)) {
             throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
@@ -260,7 +265,7 @@ final class Find implements Explainable
             throw UnsupportedException::readConcernNotSupportedInTransaction();
         }
 
-        $cursor = $server->executeQuery($this->databaseName . '.' . $this->collectionName, new Query($this->filter, $this->createQueryOptions()), $this->createExecuteOptions());
+        $cursor = $server->executeQuery($this->namespace, new Query($this->filter, $this->createQueryOptions()), $this->createExecuteOptions());
 
         if (isset($this->options['codec'])) {
             return CodecCursor::fromCursor($cursor, $this->options['codec']);

--- a/src/Operation/InsertMany.php
+++ b/src/Operation/InsertMany.php
@@ -29,6 +29,7 @@ use MongoDB\InsertManyResult;
 
 use function array_is_list;
 use function is_bool;
+use function MongoDB\create_namespace;
 use function MongoDB\is_document;
 use function sprintf;
 
@@ -44,6 +45,8 @@ final class InsertMany
     private array $documents;
 
     private array $options;
+
+    private string $namespace;
 
     /**
      * Constructs an insert command.
@@ -75,8 +78,10 @@ final class InsertMany
      * @param array              $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(private string $databaseName, private string $collectionName, array $documents, array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array $documents, array $options = [])
     {
+        $this->namespace = create_namespace($databaseName, $collectionName);
+
         $options += ['ordered' => true];
 
         if (isset($options['bypassDocumentValidation']) && ! is_bool($options['bypassDocumentValidation'])) {
@@ -131,7 +136,7 @@ final class InsertMany
             $insertedIds[$i] = $bulk->insert($document);
         }
 
-        $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $this->createExecuteOptions());
+        $writeResult = $server->executeBulkWrite($this->namespace, $bulk, $this->createExecuteOptions());
 
         return new InsertManyResult($writeResult, $insertedIds);
     }

--- a/src/Operation/InsertOne.php
+++ b/src/Operation/InsertOne.php
@@ -28,6 +28,7 @@ use MongoDB\Exception\UnsupportedException;
 use MongoDB\InsertOneResult;
 
 use function is_bool;
+use function MongoDB\create_namespace;
 use function MongoDB\is_document;
 
 /**
@@ -39,6 +40,8 @@ use function MongoDB\is_document;
 final class InsertOne
 {
     private array|object $document;
+
+    private string $namespace;
 
     /**
      * Constructs an insert command.
@@ -65,8 +68,10 @@ final class InsertOne
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(private string $databaseName, private string $collectionName, array|object $document, private array $options = [])
+    public function __construct(string $databaseName, string $collectionName, array|object $document, private array $options = [])
     {
+        $this->namespace = create_namespace($databaseName, $collectionName);
+
         if (isset($this->options['bypassDocumentValidation']) && ! is_bool($this->options['bypassDocumentValidation'])) {
             throw InvalidArgumentException::invalidType('"bypassDocumentValidation" option', $this->options['bypassDocumentValidation'], 'boolean');
         }
@@ -111,7 +116,7 @@ final class InsertOne
 
         $insertedId = $bulk->insert($this->document);
 
-        $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $this->createExecuteOptions());
+        $writeResult = $server->executeBulkWrite($this->namespace, $bulk, $this->createExecuteOptions());
 
         return new InsertOneResult($writeResult, $insertedId);
     }

--- a/src/Operation/RenameCollection.php
+++ b/src/Operation/RenameCollection.php
@@ -27,6 +27,8 @@ use MongoDB\Exception\UnsupportedException;
 
 use function is_bool;
 
+use function MongoDB\create_namespace;
+
 /**
  * Operation for the renameCollection command.
  *
@@ -81,8 +83,8 @@ final class RenameCollection
             throw InvalidArgumentException::invalidType('"dropTarget" option', $this->options['dropTarget'], 'boolean');
         }
 
-        $this->fromNamespace = $fromDatabaseName . '.' . $fromCollectionName;
-        $this->toNamespace = $toDatabaseName . '.' . $toCollectionName;
+        $this->fromNamespace = create_namespace($fromDatabaseName, $fromCollectionName);
+        $this->toNamespace = create_namespace($toDatabaseName, $toCollectionName);
     }
 
     /**

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -29,6 +29,7 @@ use MongoDB\UpdateResult;
 use function is_array;
 use function is_bool;
 use function is_string;
+use function MongoDB\create_namespace;
 use function MongoDB\is_document;
 use function MongoDB\is_first_key_operator;
 use function MongoDB\is_pipeline;
@@ -45,6 +46,8 @@ use function MongoDB\is_pipeline;
 final class Update implements Explainable
 {
     private array $options;
+
+    private string $namespace;
 
     /**
      * Constructs a update command.
@@ -94,8 +97,10 @@ final class Update implements Explainable
      * @param array        $options        Command options
      * @throws InvalidArgumentException for parameter/option parsing errors
      */
-    public function __construct(private string $databaseName, private string $collectionName, private array|object $filter, private array|object $update, array $options = [])
+    public function __construct(string $databaseName, private string $collectionName, private array|object $filter, private array|object $update, array $options = [])
     {
+        $this->namespace = create_namespace($databaseName, $collectionName);
+
         if (! is_document($filter)) {
             throw InvalidArgumentException::expectedDocumentType('$filter', $filter);
         }
@@ -180,7 +185,7 @@ final class Update implements Explainable
         $bulk = new Bulk($this->createBulkWriteOptions());
         $bulk->update($this->filter, $this->update, $this->createUpdateOptions());
 
-        $writeResult = $server->executeBulkWrite($this->databaseName . '.' . $this->collectionName, $bulk, $this->createExecuteOptions());
+        $writeResult = $server->executeBulkWrite($this->namespace, $bulk, $this->createExecuteOptions());
 
         return new UpdateResult($writeResult);
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -45,6 +45,7 @@ use function get_object_vars;
 use function is_array;
 use function is_object;
 use function is_string;
+use function str_contains;
 use function str_ends_with;
 use function substr;
 
@@ -433,6 +434,30 @@ function is_string_array(mixed $input): bool
     }
 
     return true;
+}
+
+/**
+ * Validates a database and collection name and returns the namespace formed
+ * by concatenating them.
+ *
+ * A "." or NUL byte in the database name, or a NUL byte in the collection
+ * name, would shift the namespace split performed by the server and cause
+ * the operation to silently target a different database or collection.
+ *
+ * @internal
+ * @throws InvalidArgumentException if either name is invalid
+ */
+function create_namespace(string $databaseName, string $collectionName): string
+{
+    if ($databaseName === '' || str_contains($databaseName, '.') || str_contains($databaseName, "\0")) {
+        throw new InvalidArgumentException('$databaseName is invalid: ' . $databaseName);
+    }
+
+    if ($collectionName === '' || str_contains($collectionName, "\0")) {
+        throw new InvalidArgumentException('$collectionName is invalid: ' . $collectionName);
+    }
+
+    return $databaseName . '.' . $collectionName;
 }
 
 /**

--- a/tests/Collection/CollectionFunctionalTest.php
+++ b/tests/Collection/CollectionFunctionalTest.php
@@ -35,7 +35,7 @@ use const JSON_THROW_ON_ERROR;
  */
 class CollectionFunctionalTest extends FunctionalTestCase
 {
-    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
+    #[DataProvider('provideInvalidDatabaseNames')]
     public function testConstructorDatabaseNameArgument($databaseName, string $expectedExceptionClass): void
     {
         $this->expectException($expectedExceptionClass);
@@ -43,7 +43,7 @@ class CollectionFunctionalTest extends FunctionalTestCase
         new Collection($this->manager, $databaseName, $this->getCollectionName());
     }
 
-    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
+    #[DataProvider('provideInvalidCollectionNames')]
     public function testConstructorCollectionNameArgument($collectionName, string $expectedExceptionClass): void
     {
         $this->expectException($expectedExceptionClass);
@@ -51,11 +51,29 @@ class CollectionFunctionalTest extends FunctionalTestCase
         new Collection($this->manager, $this->getDatabaseName(), $collectionName);
     }
 
-    public static function provideInvalidDatabaseAndCollectionNames()
+    public function testConstructorAllowsDotInCollectionName(): void
+    {
+        $collection = new Collection($this->manager, $this->getDatabaseName(), 'foo.bar');
+
+        $this->assertSame('foo.bar', $collection->getCollectionName());
+    }
+
+    public static function provideInvalidDatabaseNames()
     {
         return [
             [null, TypeError::class],
             ['', InvalidArgumentException::class],
+            ['foo.bar', InvalidArgumentException::class],
+            ["foo\0bar", InvalidArgumentException::class],
+        ];
+    }
+
+    public static function provideInvalidCollectionNames()
+    {
+        return [
+            [null, TypeError::class],
+            ['', InvalidArgumentException::class],
+            ["foo\0bar", InvalidArgumentException::class],
         ];
     }
 

--- a/tests/Database/DatabaseFunctionalTest.php
+++ b/tests/Database/DatabaseFunctionalTest.php
@@ -39,6 +39,8 @@ class DatabaseFunctionalTest extends FunctionalTestCase
         return [
             [null, TypeError::class],
             ['', InvalidArgumentException::class],
+            ['foo.bar', InvalidArgumentException::class],
+            ["foo\0bar", InvalidArgumentException::class],
         ];
     }
 

--- a/tests/Operation/BulkWriteTest.php
+++ b/tests/Operation/BulkWriteTest.php
@@ -13,6 +13,15 @@ use TypeError;
 
 class BulkWriteTest extends TestCase
 {
+    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
+    public function testConstructorDatabaseAndCollectionNameChecks(string $databaseName, string $collectionName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new BulkWrite($databaseName, $collectionName, [
+            [BulkWrite::INSERT_ONE => [['x' => 1]]],
+        ]);
+    }
+
     public function testOperationsMustNotBeEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/DeleteTest.php
+++ b/tests/Operation/DeleteTest.php
@@ -16,6 +16,13 @@ use TypeError;
 
 class DeleteTest extends TestCase
 {
+    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
+    public function testConstructorDatabaseAndCollectionNameChecks(string $databaseName, string $collectionName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Delete($databaseName, $collectionName, ['x' => 1], 1);
+    }
+
     #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {

--- a/tests/Operation/FindTest.php
+++ b/tests/Operation/FindTest.php
@@ -12,6 +12,13 @@ use TypeError;
 
 class FindTest extends TestCase
 {
+    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
+    public function testConstructorDatabaseAndCollectionNameChecks(string $databaseName, string $collectionName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Find($databaseName, $collectionName, ['x' => 1]);
+    }
+
     #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {

--- a/tests/Operation/InsertManyTest.php
+++ b/tests/Operation/InsertManyTest.php
@@ -10,6 +10,13 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class InsertManyTest extends TestCase
 {
+    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
+    public function testConstructorDatabaseAndCollectionNameChecks(string $databaseName, string $collectionName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new InsertMany($databaseName, $collectionName, [['x' => 1]]);
+    }
+
     public function testConstructorDocumentsMustNotBeEmpty(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Operation/InsertOneTest.php
+++ b/tests/Operation/InsertOneTest.php
@@ -12,6 +12,13 @@ use TypeError;
 
 class InsertOneTest extends TestCase
 {
+    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
+    public function testConstructorDatabaseAndCollectionNameChecks(string $databaseName, string $collectionName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new InsertOne($databaseName, $collectionName, ['x' => 1]);
+    }
+
     #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorDocumentArgumentTypeCheck($document): void
     {

--- a/tests/Operation/RenameCollectionTest.php
+++ b/tests/Operation/RenameCollectionTest.php
@@ -29,4 +29,23 @@ class RenameCollectionTest extends TestCase
             'writeConcern' => self::getInvalidWriteConcernValues(),
         ]);
     }
+
+    #[DataProvider('provideInvalidRenameDatabaseAndCollectionNames')]
+    public function testConstructorDatabaseAndCollectionNameChecks(string $fromDatabaseName, string $fromCollectionName, string $toDatabaseName, string $toCollectionName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new RenameCollection($fromDatabaseName, $fromCollectionName, $toDatabaseName, $toCollectionName);
+    }
+
+    public static function provideInvalidRenameDatabaseAndCollectionNames(): array
+    {
+        return [
+            'dot in fromDatabaseName' => ['foo.bar', 'coll', 'db', 'coll'],
+            'NUL byte in fromDatabaseName' => ["foo\0bar", 'coll', 'db', 'coll'],
+            'NUL byte in fromCollectionName' => ['db', "foo\0bar", 'db', 'coll'],
+            'dot in toDatabaseName' => ['db', 'coll', 'foo.bar', 'coll'],
+            'NUL byte in toDatabaseName' => ['db', 'coll', "foo\0bar", 'coll'],
+            'NUL byte in toCollectionName' => ['db', 'coll', 'db', "foo\0bar"],
+        ];
+    }
 }

--- a/tests/Operation/UpdateTest.php
+++ b/tests/Operation/UpdateTest.php
@@ -11,6 +11,13 @@ use TypeError;
 
 class UpdateTest extends TestCase
 {
+    #[DataProvider('provideInvalidDatabaseAndCollectionNames')]
+    public function testConstructorDatabaseAndCollectionNameChecks(string $databaseName, string $collectionName): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Update($databaseName, $collectionName, ['x' => 1], ['$set' => ['x' => 1]]);
+    }
+
     #[DataProvider('provideInvalidDocumentValues')]
     public function testConstructorFilterArgumentTypeCheck($filter): void
     {

--- a/tests/SpecTests/Crud/Prose17_DatabaseAndCollectionNameValidationTest.php
+++ b/tests/SpecTests/Crud/Prose17_DatabaseAndCollectionNameValidationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace MongoDB\Tests\SpecTests\Crud;
+
+use MongoDB\ClientBulkWrite;
+use MongoDB\Exception\InvalidArgumentException;
+use MongoDB\Tests\SpecTests\FunctionalTestCase;
+
+/**
+ * Prose test 17: Ensure database and collection names are validated
+ *
+ * @see https://github.com/mongodb/specifications/tree/master/source/crud/tests#17-ensure-database-and-collection-names-are-validated
+ */
+class Prose17_DatabaseAndCollectionNameValidationTest extends FunctionalTestCase
+{
+    public function testDotInDatabaseNameViaGetDatabase(): void
+    {
+        $client = self::createTestClient();
+
+        $this->expectException(InvalidArgumentException::class);
+        $client->getDatabase('foo.bar')->getCollection('coll')->insertOne([]);
+    }
+
+    public function testDotInDatabaseNameViaGetCollection(): void
+    {
+        $client = self::createTestClient();
+
+        $this->expectException(InvalidArgumentException::class);
+        $client->getCollection('foo.bar', 'coll')->insertOne([]);
+    }
+
+    public function testNulByteInDatabaseName(): void
+    {
+        $client = self::createTestClient();
+
+        $this->expectException(InvalidArgumentException::class);
+        $client->getDatabase("foo\0bar")->getCollection('coll')->insertOne([]);
+    }
+
+    public function testNulByteInCollectionName(): void
+    {
+        $client = self::createTestClient();
+
+        $this->expectException(InvalidArgumentException::class);
+        $client->getDatabase('db')->getCollection("foo\0bar")->insertOne([]);
+    }
+
+    public function testNulByteInBulkWriteDatabaseName(): void
+    {
+        $client = self::createTestClient();
+
+        $this->expectException(InvalidArgumentException::class);
+        ClientBulkWrite::createWithCollection($client->getCollection("foo\0bar", 'coll'))
+            ->insertOne([]);
+    }
+
+    public function testNulByteInBulkWriteCollectionName(): void
+    {
+        $client = self::createTestClient();
+
+        $this->expectException(InvalidArgumentException::class);
+        ClientBulkWrite::createWithCollection($client->getCollection('db', "foo\0bar"))
+            ->insertOne([]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -159,6 +159,15 @@ OUTPUT;
         return self::wrapValuesForDataProvider(self::getInvalidStringValues());
     }
 
+    final public static function provideInvalidDatabaseAndCollectionNames(): array
+    {
+        return [
+            'dot in databaseName' => ['foo.bar', 'coll'],
+            'NUL byte in databaseName' => ["foo\0bar", 'coll'],
+            'NUL byte in collectionName' => ['db', "foo\0bar"],
+        ];
+    }
+
     protected function assertDeprecated(callable $execution): mixed
     {
         return $this->assertError(E_USER_DEPRECATED | E_DEPRECATED, $execution);


### PR DESCRIPTION
Database and collection names were only checked for being non-empty. A "." in a database name, or a NUL byte in a database or collection name, shifts the namespace split performed by the server, so operations end up targeting a different database or collection than the caller intended.

Reject "." and NUL bytes in database names, and NUL bytes in collection names. Dots remain legal in collection names.

Add a create_namespace() helper that validates both names and returns the concatenated namespace, and use it in Collection, Database, and all Operation classes that build a namespace by concatenating database and collection names (BulkWrite, Delete, Find, InsertMany, InsertOne, RenameCollection, Update).

Move the shared invalid name data provider to the base TestCase, and add prose test 17 for database and collection name validation.