### PR TITLE
Bump drivers-github-tools action to v3 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: "Create and push new release branch for non-patch release"
         if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.DEV_BRANCH == github.ref_name }}
         run: |
-          echo '🆕 Creating new release branch ${RELEASE_BRANCH} from ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          echo '🆕 Creating new release branch ${{ env.RELEASE_BRANCH }} from ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           git checkout -b ${RELEASE_BRANCH}
           git push origin ${RELEASE_BRANCH}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: echo '🎬 Release process for version ${{ inputs.version }} started by @${{ github.triggering_actor }}' >> $GITHUB_STEP_SUMMARY
 
       - name: "Generate token and checkout repository"
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -77,7 +77,7 @@ jobs:
       #
 
       - name: "Set up drivers-github-tools"
-        uses: mongodb-labs/drivers-github-tools/setup@v2
+        uses: mongodb-labs/drivers-github-tools/setup@v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
@@ -93,7 +93,7 @@ jobs:
         run: echo "RELEASE_URL=$(gh release create ${{ inputs.version }} --target ${{ github.ref_name }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"
 
       - name: "Create release tag"
-        uses: mongodb-labs/drivers-github-tools/tag-version@v2
+        uses: mongodb-labs/drivers-github-tools/tag-version@v3
         with:
           version: ${{ inputs.version }}
           tag_message_template: 'Release ${VERSION}'
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: "Generate token and checkout repository"
-        uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+        uses: mongodb-labs/drivers-github-tools/secure-checkout@v3
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -140,14 +140,14 @@ jobs:
 
       # Sets the S3_ASSETS environment variable used later
       - name: "Set up drivers-github-tools"
-        uses: mongodb-labs/drivers-github-tools/setup@v2
+        uses: mongodb-labs/drivers-github-tools/setup@v3
         with:
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
 
       - name: "Generate SSDLC Reports"
-        uses: mongodb-labs/drivers-github-tools/full-report@v2
+        uses: mongodb-labs/drivers-github-tools/full-report@v3
         with:
           product_name: "MongoDB PHP Driver (library)"
           release_version: ${{ inputs.version }}
@@ -158,7 +158,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload S3 assets
-        uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v2
+        uses: mongodb-labs/drivers-github-tools/upload-s3-assets@v3
         with:
           version: ${{ inputs.version }}
           product_name: mongo-php-library

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
       - name: "Store version numbers in env variables"
         run: |
           echo RELEASE_VERSION=${{ inputs.version }} >> $GITHUB_ENV
+          echo RELEASE_VERSION_WITHOUT_STABILITY=$(echo ${{ inputs.version }} | awk -F- '{print $1}') >> $GITHUB_ENV
           echo RELEASE_BRANCH=v$(echo ${{ inputs.version }} | cut -d '.' -f-2) >> $GITHUB_ENV
+          echo DEV_BRANCH=v$(echo ${{ inputs.version }} | cut -d '.' -f-1).x >> $GITHUB_ENV
 
       - name: "Ensure release tag does not already exist"
         run: |
@@ -66,11 +68,30 @@ jobs:
             exit 1
           fi
 
-      - name: "Fail if branch names don't match"
-        if: ${{ github.ref_name != env.RELEASE_BRANCH }}
+      # For patch releases (A.B.C where C != 0), we expect the release to be
+      # triggered from the A.B maintenance branch
+      - name: "Fail if patch release is created from wrong release branch"
+        if: ${{ !endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.RELEASE_BRANCH != github.ref_name }}
         run: |
           echo '❌ Release failed due to branch mismatch: expected ${{ inputs.version }} to be released from ${{ env.RELEASE_BRANCH }}, got ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           exit 1
+
+      # For non-patch releases (A.B.C where C == 0), we expect the release to
+      # be triggered from the A.B maintenance branch or A.x development branch
+      - name: "Fail if non-patch release is created from wrong release branch"
+        if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.RELEASE_BRANCH != github.ref_name && env.DEV_BRANCH != github.ref_name }}
+        run: |
+          echo '❌ Release failed due to branch mismatch: expected ${{ inputs.version }} to be released from ${{ env.RELEASE_BRANCH }} or ${{ env.DEV_BRANCH }}, got ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          exit 1
+
+      # If a non-patch release is created from its A.x development branch,
+      # create the A.B maintenance branch from the current one and push it
+      - name: "Create and push new release branch for non-patch release"
+        if: ${{ endsWith(env.RELEASE_VERSION_WITHOUT_STABILITY, '.0') && env.DEV_BRANCH == github.ref_name }}
+        run: |
+          echo '🆕 Creating new release branch ${RELEASE_BRANCH} from ${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
+          git checkout -b ${RELEASE_BRANCH}
+          git push origin ${RELEASE_BRANCH}
 
       #
       # Preliminary checks done - commence the release process
@@ -90,7 +111,7 @@ jobs:
           EOL
 
       - name: "Create draft release"
-        run: echo "RELEASE_URL=$(gh release create ${{ inputs.version }} --target ${{ github.ref_name }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"
+        run: echo "RELEASE_URL=$(gh release create ${{ inputs.version }} --target ${{ env.RELEASE_BRANCH }} --title "${{ inputs.version }}" --notes-file release-message --draft)" >> "$GITHUB_ENV"
 
       - name: "Create release tag"
         uses: mongodb-labs/drivers-github-tools/tag-version@v3


### PR DESCRIPTION
The scheduled release workflow run failed at the "Set up drivers-github-tools" step:

```
Error: authenticating creds for "artifactory.corp.mongodb.com": pinging container registry
artifactory.corp.mongodb.com: Get "https://artifactory.corp.mongodb.com/v2/": tls: failed to
verify certificate: x509: certificate has expired or is not yet valid:
current time 2026-08-27T14:53:25Z is after 2025-09-23T23:59:59Z
```

Run: https://github.com/mongodb/mongo-php-library/actions/runs/33084716234/job/98561123931

The release workflow on this branch still pins `mongodb-labs/drivers-github-tools@v2`, whose artifactory TLS certificate expired on 2025-09-23. The `v2.x` branch already moved to `v3` a while ago.

This backports the release workflow changes already present on `v2.x`, cherry-picked in chronological order:
- be5f634f Support creating release branches when releasing new versions (#1627)
- da665bbc Fix missing placeholder replacement in release output (#1717)
- 6bfa4115 Bump mongodb-labs/drivers-github-tools from 2 to 3 (#1775)

After this change, `.github/workflows/release.yml` on this branch matches `v2.x` exactly.