### PR TITLE
Lock rector version to 2.5.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
         "phpunit/phpunit": "^10.5.35",
-        "rector/rector": "^2.3.4",
+        "rector/rector": "~2.5.9",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "6.5.*"
     },


### PR DESCRIPTION
Locks the Rector version to prevent unexpected changes being proposed when new releases are available. Updates will only be made to the development branch.