### PR TITLE
Upgrade rector/rector to 2.6.4 and apply code quality fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
         "phpunit/phpunit": "^10.5.35",
-        "rector/rector": "~2.5.9",
+        "rector/rector": "~2.6.4",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "~6.14.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "ext-mongodb": "^2.4",
         "composer-runtime-api": "^2.0",
         "psr/log": "^1.1.4|^2|^3",
+        "symfony/polyfill-php84": "^1.38",
         "symfony/polyfill-php85": "^1.33"
     },
     "require-dev": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -923,7 +923,6 @@
     <MixedAssignment>
       <code><![CDATA[$element[$key]]]></code>
       <code><![CDATA[$stage]]></code>
-      <code><![CDATA[$stage]]></code>
       <code><![CDATA[$type]]></code>
       <code><![CDATA[$typeMap['fieldPaths'][$fieldPath . '.' . $existingFieldPath]]]></code>
       <code><![CDATA[$typeMap['fieldPaths'][$fieldPath]]]></code>

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr\Cast\Int_;
 use Rector\Config\RectorConfig;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
+use Rector\Php74\Rector\If_\IfToNullCoalescingAssignRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php80\Rector\Class_\StringableForToStringRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
@@ -46,6 +47,13 @@ return RectorConfig::configure()
         ClassPropertyAssignToConstructorPromotionRector::class,
         StringableForToStringRector::class => [
             __DIR__ . '/src/Model/IndexInput.php',
+        ],
+        // Psalm cannot infer the type of $options['key'] ??= $value on a plain array,
+        // unlike the equivalent if (! isset($options['key'])) { ... } form
+        IfToNullCoalescingAssignRector::class => [
+            __DIR__ . '/src/Client.php',
+            __DIR__ . '/src/Collection.php',
+            __DIR__ . '/src/Database.php',
         ],
     ])
     // phpcs:enable

--- a/src/Builder/Type/QueryObject.php
+++ b/src/Builder/Type/QueryObject.php
@@ -9,6 +9,7 @@ use MongoDB\BSON\Type;
 use MongoDB\Exception\InvalidArgumentException;
 use stdClass;
 
+use function array_any;
 use function array_is_list;
 use function array_key_first;
 use function count;
@@ -90,13 +91,6 @@ final class QueryObject implements QueryInterface
             return false;
         }
 
-        /** @var mixed $value */
-        foreach ($values as $value) {
-            if ($value instanceof FieldQueryInterface) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($values, static fn ($value): bool => $value instanceof FieldQueryInterface);
     }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -964,9 +964,7 @@ class Collection implements Stringable
      */
     public function rename(string $toCollectionName, ?string $toDatabaseName = null, array $options = []): void
     {
-        if (! isset($toDatabaseName)) {
-            $toDatabaseName = $this->databaseName;
-        }
+        $toDatabaseName ??= $this->databaseName;
 
         $options = $this->inheritWriteOptions($options);
 
@@ -1188,10 +1186,8 @@ class Collection implements Stringable
     private function inheritWriteOptions(array $options): array
     {
         // WriteConcern may not change within a transaction
-        if (! is_in_transaction($options)) {
-            if (! isset($options['writeConcern'])) {
-                $options['writeConcern'] = $this->writeConcern;
-            }
+        if (! isset($options['writeConcern']) && ! is_in_transaction($options)) {
+            $options['writeConcern'] = $this->writeConcern;
         }
 
         return $options;

--- a/src/Database.php
+++ b/src/Database.php
@@ -559,9 +559,7 @@ class Database implements Stringable
      */
     public function renameCollection(string $fromCollectionName, string $toCollectionName, ?string $toDatabaseName = null, array $options = []): void
     {
-        if (! isset($toDatabaseName)) {
-            $toDatabaseName = $this->databaseName;
-        }
+        $toDatabaseName ??= $this->databaseName;
 
         $server = select_server_for_write($this->manager, $options);
 

--- a/src/Model/CachingIterator.php
+++ b/src/Model/CachingIterator.php
@@ -30,7 +30,7 @@ use function reset;
 /**
  * Iterator for wrapping a Traversable and caching its results.
  *
- * By caching results, this iterators allows a Traversable to be counted and
+ * By caching results, this iterator allows a Traversable to be counted and
  * rewound multiple times, even if the wrapped object does not natively support
  * those operations (e.g. MongoDB\Driver\Cursor).
  *

--- a/src/Model/IndexInfo.php
+++ b/src/Model/IndexInfo.php
@@ -22,7 +22,7 @@ use MongoDB\Exception\BadMethodCallException;
 use Stringable;
 
 use function array_key_exists;
-use function array_search;
+use function in_array;
 
 /**
  * Index information model class.
@@ -93,7 +93,7 @@ class IndexInfo implements ArrayAccess, Stringable
      */
     public function is2dSphere(): bool
     {
-        return array_search('2dsphere', $this->getKey(), true) !== false;
+        return in_array('2dsphere', $this->getKey(), true);
     }
 
     /**
@@ -111,7 +111,7 @@ class IndexInfo implements ArrayAccess, Stringable
      */
     public function isText(): bool
     {
-        return array_search('text', $this->getKey(), true) !== false;
+        return in_array('text', $this->getKey(), true);
     }
 
     /**

--- a/src/Operation/BulkWrite.php
+++ b/src/Operation/BulkWrite.php
@@ -324,9 +324,7 @@ final class BulkWrite
                 case self::DELETE_ONE:
                     $operation[$type][0] = $builderEncoder->encodeIfSupported($args[0]);
 
-                    if (! isset($args[1])) {
-                        $args[1] = [];
-                    }
+                    $args[1] ??= [];
 
                     if (! is_array($args[1])) {
                         throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][1]', $i, $type), $args[1], 'array');
@@ -370,9 +368,7 @@ final class BulkWrite
                         throw new InvalidArgumentException(sprintf('$operations[%d]["%s"][1] is an update pipeline', $i, $type));
                     }
 
-                    if (! isset($args[2])) {
-                        $args[2] = [];
-                    }
+                    $args[2] ??= [];
 
                     if (! is_array($args[2])) {
                         throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]', $i, $type), $args[2], 'array');
@@ -411,9 +407,7 @@ final class BulkWrite
                         throw new InvalidArgumentException(sprintf('Expected update operator(s) or non-empty pipeline for $operations[%d]["%s"][1]', $i, $type));
                     }
 
-                    if (! isset($args[2])) {
-                        $args[2] = [];
-                    }
+                    $args[2] ??= [];
 
                     if (! is_array($args[2])) {
                         throw InvalidArgumentException::invalidType(sprintf('$operations[%d]["%s"][2]', $i, $type), $args[2], 'array');

--- a/src/Operation/Explain.php
+++ b/src/Operation/Explain.php
@@ -55,7 +55,7 @@ final class Explain
      *  * session (MongoDB\Driver\Session): Client session.
      *
      *  * typeMap (array): Type map for BSON deserialization. This will be used
-     *    used for the returned command result document.
+     *    for the returned command result document.
      *
      *  * verbosity (string): The mode in which the explain command will be run.
      *

--- a/src/Operation/FindAndModify.php
+++ b/src/Operation/FindAndModify.php
@@ -92,7 +92,7 @@ final class FindAndModify implements Explainable
      *
      *  * new (boolean): When true, returns the modified document rather than
      *    the original. This option is ignored for remove operations. The
-     *    The default is false.
+     *    default is false.
      *
      *  * query (document): Query by which to filter documents.
      *

--- a/src/Operation/Update.php
+++ b/src/Operation/Update.php
@@ -50,7 +50,7 @@ final class Update implements Explainable
     private string $namespace;
 
     /**
-     * Constructs a update command.
+     * Constructs an update command.
      *
      * Supported options:
      *

--- a/src/functions.php
+++ b/src/functions.php
@@ -37,6 +37,7 @@ use ReflectionClass;
 use ReflectionException;
 use stdClass;
 
+use function array_any;
 use function array_is_list;
 use function array_key_first;
 use function assert;
@@ -333,13 +334,7 @@ function is_builder_pipeline(array $pipeline): bool
         return false;
     }
 
-    foreach ($pipeline as $stage) {
-        if (is_object($stage) && $stage instanceof StageInterface) {
-            return true;
-        }
-    }
-
-    return false;
+    return array_any($pipeline, static fn ($stage): bool => $stage instanceof StageInterface);
 }
 
 /**
@@ -414,26 +409,6 @@ function server_supports_feature(Server $server, int $feature): bool
     $minWireVersion = isset($info['minWireVersion']) ? (int) $info['minWireVersion'] : 0;
 
     return $minWireVersion <= $feature && $maxWireVersion >= $feature;
-}
-
-/**
- * Return whether the input is an array of strings.
- *
- * @internal
- */
-function is_string_array(mixed $input): bool
-{
-    if (! is_array($input)) {
-        return false;
-    }
-
-    foreach ($input as $item) {
-        if (! is_string($item)) {
-            return false;
-        }
-    }
-
-    return true;
 }
 
 /**

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -130,9 +130,7 @@ abstract class FunctionalTestCase extends TestCase
      */
     protected function assertCollectionDoesNotExist(string $collectionName, ?string $databaseName = null): void
     {
-        if (! isset($databaseName)) {
-            $databaseName = $this->getDatabaseName();
-        }
+        $databaseName ??= $this->getDatabaseName();
 
         $operation = new ListCollections($this->getDatabaseName());
         $collections = $operation->execute($this->getPrimaryServer());
@@ -160,9 +158,7 @@ abstract class FunctionalTestCase extends TestCase
      */
     protected function assertCollectionExists(string $collectionName, ?string $databaseName = null, ?callable $callback = null): void
     {
-        if (! isset($databaseName)) {
-            $databaseName = $this->getDatabaseName();
-        }
+        $databaseName ??= $this->getDatabaseName();
 
         if ($callback !== null && ! is_callable($callback)) {
             throw new InvalidArgumentException('$callback is not a callable');

--- a/tests/FunctionalTestCase.php
+++ b/tests/FunctionalTestCase.php
@@ -132,7 +132,7 @@ abstract class FunctionalTestCase extends TestCase
     {
         $databaseName ??= $this->getDatabaseName();
 
-        $operation = new ListCollections($this->getDatabaseName());
+        $operation = new ListCollections($databaseName);
         $collections = $operation->execute($this->getPrimaryServer());
 
         $foundCollection = null;

--- a/tests/Operation/BulkWriteFunctionalTest.php
+++ b/tests/Operation/BulkWriteFunctionalTest.php
@@ -75,9 +75,7 @@ class BulkWriteFunctionalTest extends FunctionalTestCase
                 $result = $operation->execute($this->getPrimaryServer());
 
                 // Replace _id placeholder if necessary
-                if ($expectedDocument->_id === null) {
-                    $expectedDocument->_id = $result->getInsertedIds()[0];
-                }
+                $expectedDocument->_id ??= $result->getInsertedIds()[0];
             },
             function (array $event) use ($expectedDocument): void {
                 $this->assertEquals($expectedDocument, $event['started']->getCommand()->documents[0] ?? null);

--- a/tests/Operation/InsertManyFunctionalTest.php
+++ b/tests/Operation/InsertManyFunctionalTest.php
@@ -64,9 +64,7 @@ class InsertManyFunctionalTest extends FunctionalTestCase
 
                 foreach ($expectedDocuments as $i => $expectedDocument) {
                     // Replace _id placeholder if necessary
-                    if ($expectedDocument->_id === null) {
-                        $expectedDocument->_id = $insertedIds[$i];
-                    }
+                    $expectedDocument->_id ??= $insertedIds[$i];
                 }
             },
             function (array $event) use ($expectedDocuments): void {

--- a/tests/Operation/InsertOneFunctionalTest.php
+++ b/tests/Operation/InsertOneFunctionalTest.php
@@ -43,9 +43,7 @@ class InsertOneFunctionalTest extends FunctionalTestCase
                 $result = $operation->execute($this->getPrimaryServer());
 
                 // Replace _id placeholder if necessary
-                if ($expectedDocument->_id === null) {
-                    $expectedDocument->_id = $result->getInsertedId();
-                }
+                $expectedDocument->_id ??= $result->getInsertedId();
             },
             function (array $event) use ($expectedDocument): void {
                 $this->assertEquals($expectedDocument, $event['started']->getCommand()->documents[0] ?? null);

--- a/tests/UnifiedSpecTests/EventCollector.php
+++ b/tests/UnifiedSpecTests/EventCollector.php
@@ -134,9 +134,7 @@ final class EventCollector implements CommandSubscriber
     {
         static $eventNamesByClass = null;
 
-        if ($eventNamesByClass === null) {
-            $eventNamesByClass = array_flip(array_filter(self::$supportedEvents));
-        }
+        $eventNamesByClass ??= array_flip(array_filter(self::$supportedEvents));
 
         return $eventNamesByClass[$event::class];
     }

--- a/tests/UnifiedSpecTests/UnifiedTestRunner.php
+++ b/tests/UnifiedSpecTests/UnifiedTestRunner.php
@@ -244,15 +244,13 @@ final class UnifiedTestRunner
         assertNotEmpty($runOnRequirements);
         assertContainsOnly('object', $runOnRequirements);
 
-        if (! isset($cachedIsSatisfiedArgs)) {
-            $cachedIsSatisfiedArgs = [
-                $this->getServerVersion(),
-                $this->getTopology(),
-                $this->serverParameterHelper,
-                $this->isAuthenticated(),
-                $this->isClientSideEncryptionSupported(),
-            ];
-        }
+        $cachedIsSatisfiedArgs ??= [
+            $this->getServerVersion(),
+            $this->getTopology(),
+            $this->serverParameterHelper,
+            $this->isAuthenticated(),
+            $this->isClientSideEncryptionSupported(),
+        ];
 
         foreach ($runOnRequirements as $o) {
             $runOnRequirement = new RunOnRequirement($o);


### PR DESCRIPTION
Bump `rector/rector` from 2.5.9 to 2.6.4 and apply the fixes it proposes.

The new `IfToNullCoalescingAssignRector` rule rewrites `if (! isset($options['key'])) { $options['key'] = $value; }` into `$options['key'] ??= $value;`. On `Client.php`, `Collection.php` and `Database.php`, this made Psalm unable to infer the assigned type (`MixedAssignment`), because Psalm desugars `??=` on an array offset into `$options['key'] = $options['key'] ?? $value`, unioning the existing `mixed` offset type with `$value`. The `if`/`isset` form does not have this issue since it only assigns `$value`. `IfToNullCoalescingAssignRector` is now skipped for these three files.

This matches an existing upstream Psalm issue: https://github.com/vimeo/psalm/issues/9615

Also included:
* Fix `assertCollectionDoesNotExist()` to use the resolved `$databaseName` instead of `TestCase::getDatabaseName()`. This parameter was added in PHPLIB-518 (#840) alongside `assertCollectionExists()`, but was never actually used.
* Simplify a few loops with `array_any()`/`in_array()` and fix a couple of docblock typos. `symfony/polyfill-php84` was added since `array_any()` requires PHP 8.4.