### PR TITLE
PHPLIB-1929: Use exact match for file ID in GridFS queries

### DIFF
--- a/src/GridFS/CollectionWrapper.php
+++ b/src/GridFS/CollectionWrapper.php
@@ -68,7 +68,7 @@ class CollectionWrapper
      */
     public function deleteChunksByFilesId(mixed $id): void
     {
-        $this->chunksCollection->deleteMany(['files_id' => $id]);
+        $this->chunksCollection->deleteMany(['files_id' => ['$eq' => $id]]);
     }
 
     /**
@@ -99,8 +99,8 @@ class CollectionWrapper
      */
     public function deleteFileAndChunksById(mixed $id): void
     {
-        $this->filesCollection->deleteOne(['_id' => $id]);
-        $this->chunksCollection->deleteMany(['files_id' => $id]);
+        $this->filesCollection->deleteOne(['_id' => ['$eq' => $id]]);
+        $this->chunksCollection->deleteMany(['files_id' => ['$eq' => $id]]);
     }
 
     /**
@@ -123,7 +123,7 @@ class CollectionWrapper
     {
         return $this->chunksCollection->find(
             [
-                'files_id' => $id,
+                'files_id' => ['$eq' => $id],
                 'n' => ['$gte' => $fromChunk],
             ],
             [
@@ -177,7 +177,7 @@ class CollectionWrapper
     public function findFileById(mixed $id): ?object
     {
         $file = $this->filesCollection->findOne(
-            ['_id' => $id],
+            ['_id' => ['$eq' => $id]],
             ['typeMap' => ['root' => 'stdClass']],
         );
         assert(is_object($file) || $file === null);
@@ -277,7 +277,7 @@ class CollectionWrapper
     public function updateFilenameForId(mixed $id, string $filename): UpdateResult
     {
         return $this->filesCollection->updateOne(
-            ['_id' => $id],
+            ['_id' => ['$eq' => $id]],
             ['$set' => ['filename' => $filename]],
         );
     }

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -3,6 +3,7 @@
 namespace MongoDB\Tests\GridFS;
 
 use MongoDB\BSON\Binary;
+use MongoDB\BSON\MinKey;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Collection;
 use MongoDB\Driver\ReadConcern;
@@ -17,6 +18,7 @@ use MongoDB\GridFS\Exception\StreamException;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Model\IndexInfo;
 use MongoDB\Operation\ListIndexes;
+use MongoDB\Tests\CommandObserver;
 use MongoDB\Tests\Fixtures\Codec\TestDocumentCodec;
 use MongoDB\Tests\Fixtures\Codec\TestFileCodec;
 use MongoDB\Tests\Fixtures\Document\TestFile;
@@ -160,6 +162,44 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->assertCollectionCount($this->chunksCollection, 0);
     }
 
+    public function testDeleteUsesEqOperatorForId(): void
+    {
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
+
+        (new CommandObserver())->observe(
+            function () use ($id): void {
+                $this->bucket->delete($id);
+            },
+            function (array $event) use ($id): void {
+                if ($event['started']->getCommandName() !== 'delete') {
+                    return;
+                }
+
+                $query = $event['started']->getCommand()->deletes[0]->q;
+                $field = isset($query->_id) ? '_id' : 'files_id';
+
+                $this->assertEquals(['$eq' => $id], (array) $query->$field);
+            },
+        );
+    }
+
+    public function testDeleteWithQueryOperatorIdDoesNotDeleteAnyFile(): void
+    {
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
+
+        $this->assertCollectionCount($this->filesCollection, 1);
+        $this->assertCollectionCount($this->chunksCollection, 1);
+
+        $this->expectException(FileNotFoundException::class);
+
+        try {
+            $this->bucket->delete(['$gt' => new MinKey()]);
+        } finally {
+            $this->assertCollectionCount($this->filesCollection, 1);
+            $this->assertCollectionCount($this->chunksCollection, 1);
+        }
+    }
+
     public function testDeleteByName(): void
     {
         $this->bucket->uploadFromStream('filename', self::createStream('foobar1'));
@@ -235,6 +275,34 @@ class BucketFunctionalTest extends FunctionalTestCase
         $this->bucket->downloadToStream($id, $destination);
 
         $this->assertStreamContents($input, $destination);
+    }
+
+    public function testDownloadToStreamUsesEqOperatorForId(): void
+    {
+        $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
+        $destination = self::createStream();
+
+        (new CommandObserver())->observe(
+            function () use ($id, $destination): void {
+                $this->bucket->downloadToStream($id, $destination);
+            },
+            function (array $event) use ($id): void {
+                $this->assertEquals('find', $event['started']->getCommandName());
+
+                $filter = $event['started']->getCommand()->filter;
+                $field = isset($filter->_id) ? '_id' : 'files_id';
+
+                $this->assertEquals(['$eq' => $id], (array) $filter->$field);
+            },
+        );
+    }
+
+    public function testDownloadToStreamWithQueryOperatorIdDoesNotMatchAnyFile(): void
+    {
+        $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
+
+        $this->expectException(FileNotFoundException::class);
+        $this->bucket->downloadToStream(['$gt' => new MinKey()], self::createStream());
     }
 
     #[DataProvider('provideInvalidStreamValues')]
@@ -729,6 +797,37 @@ class BucketFunctionalTest extends FunctionalTestCase
 
         $this->assertSameDocument(['filename' => 'b'], $fileDocument);
         $this->assertStreamContents('foo', $this->bucket->openDownloadStreamByName('b'));
+    }
+
+    public function testRenameUsesEqOperatorForId(): void
+    {
+        $id = $this->bucket->uploadFromStream('a', self::createStream('foo'));
+
+        (new CommandObserver())->observe(
+            function () use ($id): void {
+                $this->bucket->rename($id, 'b');
+            },
+            function (array $event) use ($id): void {
+                $this->assertEquals('update', $event['started']->getCommandName());
+                $this->assertEquals(
+                    ['$eq' => $id],
+                    (array) $event['started']->getCommand()->updates[0]->q->_id,
+                );
+            },
+        );
+    }
+
+    public function testRenameWithQueryOperatorIdDoesNotRenameAnyFile(): void
+    {
+        $this->bucket->uploadFromStream('a', self::createStream('foo'));
+
+        $this->expectException(FileNotFoundException::class);
+
+        try {
+            $this->bucket->rename(['$gt' => new MinKey()], 'injected');
+        } finally {
+            $this->assertNull($this->bucket->findOne(['filename' => 'injected']));
+        }
     }
 
     public function testRenameShouldNotRequireFileToBeModified(): void

--- a/tests/GridFS/BucketFunctionalTest.php
+++ b/tests/GridFS/BucketFunctionalTest.php
@@ -185,6 +185,8 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testDeleteWithQueryOperatorIdDoesNotDeleteAnyFile(): void
     {
+        $this->skipIfServerVersion('>=', '8.1', 'Delete filters with query-operator file IDs are rejected by SERVER-92488');
+
         $id = $this->bucket->uploadFromStream('filename', self::createStream('foobar'));
 
         $this->assertCollectionCount($this->filesCollection, 1);
@@ -819,6 +821,8 @@ class BucketFunctionalTest extends FunctionalTestCase
 
     public function testRenameWithQueryOperatorIdDoesNotRenameAnyFile(): void
     {
+        $this->skipIfServerVersion('>=', '8.1', 'Update filters with query-operator file IDs are rejected by SERVER-92488');
+
         $this->bucket->uploadFromStream('a', self::createStream('foo'));
 
         $this->expectException(FileNotFoundException::class);

--- a/tests/GridFS/WritableStreamFunctionalTest.php
+++ b/tests/GridFS/WritableStreamFunctionalTest.php
@@ -2,11 +2,13 @@
 
 namespace MongoDB\Tests\GridFS;
 
+use MongoDB\BSON\MinKey;
 use MongoDB\Exception\InvalidArgumentException;
 use MongoDB\GridFS\CollectionWrapper;
 use MongoDB\GridFS\WritableStream;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use ReflectionMethod;
 
 use function str_repeat;
 
@@ -98,5 +100,23 @@ class WritableStreamFunctionalTest extends FunctionalTestCase
             [str_repeat('foobar', 87040), '45bfa1a9ec36728ee7338d15c5a30c13'],
             [str_repeat('foobar', 87041), '95e78f624f8e745bcfd2d11691fa601e'],
         ];
+    }
+
+    public function testAbortWithQueryOperatorIdDoesNotDeleteOtherFilesChunks(): void
+    {
+        $otherId = $this->bucket->uploadFromStream('file1', self::createStream('foobar'));
+
+        $stream = new WritableStream($this->collectionWrapper, 'file2', [
+            '_id' => ['$gt' => new MinKey()],
+            'chunkSizeBytes' => 2,
+        ]);
+        $stream->writeBytes('abcd');
+
+        (new ReflectionMethod($stream, 'abort'))->invoke($stream);
+
+        $this->assertCollectionCount($this->chunksCollection, 1);
+
+        $chunk = $this->chunksCollection->findOne([], ['typeMap' => ['root' => 'array']]);
+        $this->assertSameObjectId($otherId, $chunk['files_id']);
     }
 }

--- a/tests/UnifiedSpecTests/UnifiedSpecTest.php
+++ b/tests/UnifiedSpecTests/UnifiedSpecTest.php
@@ -38,6 +38,9 @@ class UnifiedSpecTest extends FunctionalTestCase
         'retryable-reads/retryable reads handshake failures' => 'Handshakes are not retried (CDRIVER-4532)',
         'retryable-writes/retryable writes handshake failures' => 'Handshakes are not retried (CDRIVER-4532)',
         'crud/bypassDocumentValidation' => 'bypassDocumentValidation is handled by libmongoc (PHPLIB-1576)',
+        // GridFS download now wraps file IDs in $eq; the upstream specifications do not expect this yet
+        'retryable-reads/gridfs-download:' => 'Upstream specifications not yet updated for $eq-wrapped file IDs (PHPLIB-1929)',
+        'retryable-reads/gridfs-download-serverErrors:' => 'Upstream specifications not yet updated for $eq-wrapped file IDs (PHPLIB-1929)',
     ];
 
     /** @var array<string, string> */


### PR DESCRIPTION
PHPLIB-1929: Match GridFS file IDs exactly in queries

CollectionWrapper built its files and chunks filters directly from a
caller-supplied file ID in delete, download, and rename operations. When
the ID is an array or object containing a query operator, wrapping the
value in `$eq` ensures the ID is always matched literally.

Regression tests are added for delete, download, rename, and aborting an
upload with such an ID. The equivalent unified spec scenarios will be
enabled once the upstream specifications are updated.
