### PR TITLE
Skip resume token assertion on sharded clusters in watch tests

### DIFF
--- a/tests/Operation/WatchFunctionalTest.php
+++ b/tests/Operation/WatchFunctionalTest.php
@@ -927,7 +927,11 @@ class WatchFunctionalTest extends FunctionalTestCase
             ['resumeAfter' => $resumeToken] + $options + $this->defaultOptions,
         );
         $changeStream = $operation->execute($this->getPrimaryServer());
-        $this->assertSameDocument($resumeToken, $changeStream->getResumeToken());
+
+        if (! $this->isShardedCluster()) {
+            // On a sharded cluster the initial batch may be empty: getResumeToken() is the postBatchResumeToken.
+            $this->assertSameDocument($resumeToken, $changeStream->getResumeToken());
+        }
 
         $changeStream->rewind();
 
@@ -981,7 +985,11 @@ class WatchFunctionalTest extends FunctionalTestCase
             ['resumeAfter' => $resumeToken] + $options + $this->defaultOptions,
         );
         $changeStream = $operation->execute($this->getPrimaryServer());
-        $this->assertSameDocument($resumeToken, $changeStream->getResumeToken());
+
+        if (! $this->isShardedCluster()) {
+            // On a sharded cluster the initial batch may be empty: getResumeToken() is the postBatchResumeToken.
+            $this->assertSameDocument($resumeToken, $changeStream->getResumeToken());
+        }
 
         $changeStream->rewind();
 
@@ -1029,7 +1037,11 @@ class WatchFunctionalTest extends FunctionalTestCase
             ['startAfter' => $resumeToken] + $options + $this->defaultOptions,
         );
         $changeStream = $operation->execute($this->getPrimaryServer());
-        $this->assertSameDocument($resumeToken, $changeStream->getResumeToken());
+
+        if (! $this->isShardedCluster()) {
+            // On a sharded cluster the initial batch may be empty: getResumeToken() is the postBatchResumeToken.
+            $this->assertSameDocument($resumeToken, $changeStream->getResumeToken());
+        }
 
         $changeStream->rewind();
 


### PR DESCRIPTION
On a **sharded cluster**, the initial aggregate for a change stream resumed with `resumeAfter` or `startAfter` may return an **empty first batch**. In that case, the driver caches the server's `postBatchResumeToken` (a high watermark) instead of the `resumeAfter`/`startAfter` token, so asserting that `getResumeToken()` equals the resume token right after `execute()` is invalid.

As stated in the **change streams specification prose test 14**, this scenario cannot be tested on sharded topologies, and the **Node and Python drivers** restrict the equivalent tests to non-sharded clusters.

This change guards that assertion behind `isShardedCluster()` in the three affected functional tests: **`testRewindExtractsResumeTokenAndNextResumes`**, **`testResumeAfterOption`** and **`testStartAfterOption`**. The dedicated prose test 14 implementation, `testResumeTokenBehaviour`, already skips sharded clusters. The remaining assertions of these tests, such as verifying that events are re-delivered after resuming, still run on all topologies.

This change fixes **flaky tests**. The failure below was observed in CI:

```text
1) MongoDB\Tests\Operation\WatchFunctionalTest::testResumeAfterOption with data set "Codec" ([MongoDB\Codec\DocumentCodec@anonymous/home/runner/work/mongo-php-library/mongo-php-library/tests/Operation/WatchFunctionalTest.php:66$f8 Object ()], Closure Object (...))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'{ "_data" : "826AA2C828000000012B042C0100296E5A1004E0537471B440414190C0FC97F9FD38C8463C6F7065726174696F6E54797065003C696E736572740046646F63756D656E744B657900461E5F6964002B02000004" }'
+'{ "_data" : "826AA2C828000000012B0429296E1404" }'

/home/runner/work/mongo-php-library/mongo-php-library/tests/TestCase.php:108
/home/runner/work/mongo-php-library/mongo-php-library/tests/Operation/WatchFunctionalTest.php:868
```
